### PR TITLE
Use Site PHP Version to Run Composer Install

### DIFF
--- a/app/SSH/Composer/Composer.php
+++ b/app/SSH/Composer/Composer.php
@@ -14,6 +14,7 @@ class Composer
         $site->server->ssh()->exec(
             $this->getScript('composer-install.sh', [
                 'path' => $site->path,
+                'php_version' => $site->php_version,
             ]),
             'composer-install',
             $site->id

--- a/app/SSH/Composer/scripts/composer-install.sh
+++ b/app/SSH/Composer/scripts/composer-install.sh
@@ -2,6 +2,6 @@ if ! cd __path__; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 
-if ! composer install --no-interaction --prefer-dist --optimize-autoloader --no-dev; then
+if ! php__php_version__ /usr/local/bin/composer install --no-interaction --prefer-dist --optimize-autoloader --no-dev; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi


### PR DESCRIPTION
As mentioned by @maxcelos When creating a new site with the "Run composer install --no-dev" flag, it runs with the default PHP CLI, ignoring the PHP version selected in the form. It should use the selected PHP version.

This should pass the php_version to the getScript function to be used in the composer-install.sh

![image](https://github.com/vitodeploy/vito/assets/20325487/f74999a8-1e69-470e-a32d-9600fcca3765)
![image](https://github.com/vitodeploy/vito/assets/20325487/c3a05f33-1aba-4a82-8fef-56dc843d1452)


