### PR TITLE
[BUG] WordPress Install Error

### DIFF
--- a/app/SSH/Wordpress/scripts/install.sh
+++ b/app/SSH/Wordpress/scripts/install.sh
@@ -24,4 +24,4 @@ if ! wp --path=__path__ core install --url='http://__domain__' --title="__title_
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 
-print "Wordpress installed!"
+echo "Wordpress installed!"


### PR DESCRIPTION
When trying to install WordPress, the installation error returns and does not complete, due to the command not existing.

![CleanShot 2024-06-12 at 10 59 44@2x](https://github.com/vitodeploy/vito/assets/6052272/c372798f-78fa-4a3d-98c1-765acb495b51)
