### PR TITLE
[draft] Add load balancer server type

### DIFF
--- a/app/Enums/ServerType.php
+++ b/app/Enums/ServerType.php
@@ -7,4 +7,6 @@ final class ServerType
     const REGULAR = 'regular';
 
     const DATABASE = 'database';
+
+    const LOAD_BALANCER = 'load-balancer';
 }

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Actions\Site\CreateSite;
 use App\Actions\Site\DeleteSite;
+use App\Enums\ServerType;
 use App\Enums\SiteStatus;
 use App\Enums\SiteType;
 use App\Facades\Toast;
@@ -59,6 +60,13 @@ class SiteController extends Controller
             }
 
             return redirect()->route('servers.sites.installing', [$server, $site]);
+        }
+
+        if ($server->type === ServerType::LOAD_BALANCER) {
+            return view('sites.show-load-balancer', [
+                'server' => $server,
+                'site' => $site,
+            ]);
         }
 
         return view('sites.show', [

--- a/app/Http/Controllers/SiteSettingController.php
+++ b/app/Http/Controllers/SiteSettingController.php
@@ -45,15 +45,15 @@ class SiteSettingController extends Controller
             'vhost' => 'required|string',
         ]);
 
-        try {
+//        try {
             /** @var Webserver $handler */
             $handler = $server->webserver()->handler();
-            $handler->updateVHost($site, false, $request->input('vhost'));
+            $handler->updateVHost($site, false, null);
 
             Toast::success('VHost updated successfully!');
-        } catch (Throwable $e) {
-            Toast::error($e->getMessage());
-        }
+//        } catch (Throwable $e) {
+//            Toast::error($e->getMessage());
+//        }
 
         return back();
     }

--- a/app/Http/Controllers/SiteSettingController.php
+++ b/app/Http/Controllers/SiteSettingController.php
@@ -45,15 +45,15 @@ class SiteSettingController extends Controller
             'vhost' => 'required|string',
         ]);
 
-//        try {
+        try {
             /** @var Webserver $handler */
             $handler = $server->webserver()->handler();
-            $handler->updateVHost($site, false, null);
+            $handler->updateVHost($site, false, $request->input('vhost'));
 
             Toast::success('VHost updated successfully!');
-//        } catch (Throwable $e) {
-//            Toast::error($e->getMessage());
-//        }
+        } catch (Throwable $e) {
+            Toast::error($e->getMessage());
+        }
 
         return back();
     }

--- a/app/SSH/Services/Webserver/Nginx.php
+++ b/app/SSH/Services/Webserver/Nginx.php
@@ -186,7 +186,7 @@ class Nginx extends AbstractWebserver
             if ($ssl) {
                 $vhost = $this->getScript('nginx/reverse-vhost-ssl.conf');
             }
-            $vhost = Str::replace('__port__', (string)$site->port, $vhost);
+            $vhost = Str::replace('__port__', (string) $site->port, $vhost);
         }
 
         $vhost = Str::replace('__domain__', $site->domain, $vhost);
@@ -212,25 +212,26 @@ class Nginx extends AbstractWebserver
                 'web_directory' => $site->web_directory,
                 'ssl' => $ssl,
             ],
-            $ssl ? [
-                'certificate' => $ssl->getCertificatePath(),
-                'private_key' => $ssl->getPkPath(),
-            ] : [],
-            [
-                'servers' => [
-                    [
-                        'host' => '127.0.0.1',
-                        'port' => '20',
-                        'weight' => 1,
-                        'backup' => false,
-                        'down' => false,
-                    ]
-                ],
-                'balanceMethod' => 'ip_hash',
-            ]);
+                $ssl ? [
+                    'certificate' => $ssl->getCertificatePath(),
+                    'private_key' => $ssl->getPkPath(),
+                ] : [],
+                [
+                    'servers' => [
+                        [
+                            'host' => '127.0.0.1',
+                            'port' => '20',
+                            'weight' => 1,
+                            'backup' => false,
+                            'down' => false,
+                        ],
+                    ],
+                    'balanceMethod' => 'ip_hash',
+                ]);
 
             $vhost = view('scripts.load-balancer-vhost', $data)->toHtml();
         }
+
         return $vhost;
     }
 }

--- a/app/SSH/Services/Webserver/scripts/nginx/nginx.conf
+++ b/app/SSH/Services/Webserver/scripts/nginx/nginx.conf
@@ -31,7 +31,7 @@ http {
 	# SSL Settings
 	##
 
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_protocols TLSv1.2 TLSv1.3; # Dropping SSLv3, TLSv1, TLSv1.1, ref: POODLE
 	ssl_prefer_server_ciphers on;
 
 	##
@@ -46,13 +46,12 @@ http {
 	##
 
 	gzip on;
-
 	# gzip_vary on;
 	# gzip_proxied any;
 	# gzip_comp_level 6;
 	# gzip_buffers 16 8k;
-	# gzip_http_version 1.1;
-	# gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+	gzip_http_version 1.1;
+	gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
 	##
 	# Virtual Host Configs
@@ -61,25 +60,3 @@ http {
 	include /etc/nginx/conf.d/*.conf;
 	include /etc/nginx/sites-enabled/*;
 }
-
-
-#mail {
-#	# See sample authentication script at:
-#	# http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
-#
-#	# auth_http localhost/auth.php;
-#	# pop3_capabilities "TOP" "USER";
-#	# imap_capabilities "IMAP4rev1" "UIDPLUS";
-#
-#	server {
-#		listen     localhost:110;
-#		protocol   pop3;
-#		proxy      on;
-#	}
-#
-#	server {
-#		listen     localhost:143;
-#		protocol   imap;
-#		proxy      on;
-#	}
-#}

--- a/app/ServerTypes/LoadBalancer.php
+++ b/app/ServerTypes/LoadBalancer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\ServerTypes;
+
+class LoadBalancer extends AbstractType
+{
+    public function createRules(array $input): array
+    {
+        return [
+            'webserver' => [
+                'required',
+                'in:'.implode(',', config('core.webservers')),
+            ],
+        ];
+    }
+
+    public function data(array $input): array
+    {
+        return [];
+    }
+
+    public function createServices(array $input): void
+    {
+        $this->server->services()->forceDelete();
+        $this->addWebserver($input['webserver']);
+        $this->addUfw();
+    }
+}

--- a/app/SiteTypes/PHPSite.php
+++ b/app/SiteTypes/PHPSite.php
@@ -34,6 +34,7 @@ class PHPSite extends AbstractSiteType
                 // the load balancer to the servers.
             ];
         }
+
         return [
             'php_version' => [
                 'required',
@@ -81,9 +82,9 @@ class PHPSite extends AbstractSiteType
         $this->progress(15);
         if ($this->site->server->type === ServerType::LOAD_BALANCER) {
             $this->progress(65);
+
             return;
         }
-
         $this->deployKey();
         $this->progress(30);
         app(Git::class)->clone($this->site);

--- a/config/core.php
+++ b/config/core.php
@@ -82,10 +82,12 @@ return [
     'server_types' => [
         \App\Enums\ServerType::REGULAR,
         \App\Enums\ServerType::DATABASE,
+        \App\Enums\ServerType::LOAD_BALANCER,
     ],
     'server_types_class' => [
         \App\Enums\ServerType::REGULAR => \App\ServerTypes\Regular::class,
         \App\Enums\ServerType::DATABASE => \App\ServerTypes\Database::class,
+        \App\Enums\ServerType::LOAD_BALANCER => \App\ServerTypes\LoadBalancer::class,
     ],
     'server_providers' => [
         \App\Enums\ServerProvider::CUSTOM,

--- a/resources/views/scripts/load-balancer-vhost.blade.php
+++ b/resources/views/scripts/load-balancer-vhost.blade.php
@@ -1,0 +1,42 @@
+upstream {{ Str::slug($domain) }} {
+@if (isset($balanceMethod))
+    {{ $balanceMethod }};
+@endif
+@foreach($servers as $server)
+    server {{ $server['host'] }}:{{ $server['port'] }}@if($server['weight']) weight={{ $server['weight'] }} @endif @if($server['backup'])backup @endif @if($server['down'])down @endif;
+@endforeach
+}
+@if ($ssl)
+server {
+    listen 80;
+    server_name {{ $domain }} {{ $aliases }};
+    return 301 https://$host$request_uri;
+}
+@endif
+server {
+    listen @if ($ssl)443 ssl @else 80 @endif;
+    server_name {{ $domain }} {{ $aliases }};
+    root {{ $path }}/{{ $web_directory }};
+@if($ssl)
+    ssl_certificate {{ $certificate }};
+    ssl_certificate_key {{ $private_key }};
+@endif
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Content-Type-Options "nosniff";
+    error_page 404 /index.html;
+
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_pass http://{{ Str::slug($domain) }}/;
+    }
+
+    location ~ /\.(?!well-known).* {
+        deny all;
+    }
+
+    include conf.d/{{ $domain }}_redirects;
+}

--- a/resources/views/servers/partials/create-server.blade.php
+++ b/resources/views/servers/partials/create-server.blade.php
@@ -210,7 +210,7 @@
             </div>
 
             <div class="grid grid-cols-1 gap-3 lg:grid-cols-3">
-                <div x-show="['{{ ServerType::REGULAR }}'].includes(type)">
+                <div x-show="{{ json_encode([ServerType::REGULAR, ServerType::LOAD_BALANCER]) }}.includes(type)">
                     <x-input-label for="webserver" value="Webserver" />
                     <x-select-input id="webserver" name="webserver" class="mt-1 w-full">
                         @foreach (config("core.webservers") as $ws)
@@ -223,7 +223,7 @@
                         <x-input-error class="mt-2" :messages="$message" />
                     @enderror
                 </div>
-                <div x-show="['{{ ServerType::REGULAR }}', '{{ ServerType::DATABASE }}'].includes(type)">
+                <div x-show="{{json_encode([ServerType::REGULAR, ServerType::DATABASE])}}.includes(type)">
                     <x-input-label for="database" value="Database" />
                     <x-select-input id="database" name="database" class="mt-1 w-full">
                         @foreach (config("core.databases") as $db)
@@ -236,7 +236,7 @@
                         <x-input-error class="mt-2" :messages="$message" />
                     @enderror
                 </div>
-                <div x-show="['{{ ServerType::REGULAR }}'].includes(type)">
+                <div x-show="{{ json_encode([ServerType::REGULAR]) }}.includes(type)">
                     <x-input-label for="php" value="PHP" />
                     <x-select-input id="php" name="php" class="mt-1 w-full">
                         <option value="none" @if('none' == old('php', '8.2')) selected @endif>none</option>

--- a/resources/views/sites/partials/create-site.blade.php
+++ b/resources/views/sites/partials/create-site.blade.php
@@ -57,7 +57,9 @@
 
             @include("sites.partials.create.fields.aliases")
 
+            @if ($server->type !== \App\Enums\ServerType::LOAD_BALANCER)
             @include("sites.partials.create." . $type)
+            @endif
         </form>
         <x-slot name="actions">
             <x-primary-button id="btn-create-site" hx-disable form="create-site-form">

--- a/resources/views/sites/show-load-balancer.blade.php
+++ b/resources/views/sites/show-load-balancer.blade.php
@@ -1,0 +1,4 @@
+<x-site-layout :site="$site">
+    <x-slot name="pageTitle">{{ $site->domain }}</x-slot>
+
+</x-site-layout>


### PR DESCRIPTION
This PR aims to add a new server type for load balancing with nginx. Inspired in [part by this discussion thread](https://github.com/vitodeploy/vito/discussions/241), and my personal usage of load balancing servers 😄 

**Goal**: Deploy a Load Balancing server from the UI

**Acceptance Criteria**:
 - [x] (done) Have "load balancing" be a new server type, that configures only an nginx server
![image](https://github.com/vitodeploy/vito/assets/5355937/580625dd-27a2-47d5-8cd1-ed95f87eef8d)

 - [ ] (in progress) Have all sites under a "load balancing" server change their "application" page to reflect the load-balancer configuration.
 - [ ] (todo) Only allow load balancing to privately networked servers. (I personally use [Zerotier](https://www.zerotier.com/), when I'm not using DigitalOcean)
 - [ ] (todo) Allow configuring of the [load balancing method](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#choosing-a-load-balancing-method) (round robin, ip_hash, hash, last_conn)
 - [ ] (todo) Allow configuring the host and port of the servers we're balancing to.
 - [ ] (todo) Allow setting server as "backup" or as "down"

Optional concepts to explore:
 - Having the load balancing server auto-provision the site on servers you connect to. This would require defining the project repo, deployment script, php version, project directory, and any extra fields based on the site type when creating the site on the load balancing server.
 - <!-- Please feel welcome to add additional concepts you'd like me to check out while building this out -->


Old Laravel Forge load balancing config page to convey basic page layout. Exact style, format, or design will vary. 
![image](https://github.com/vitodeploy/vito/assets/5355937/c39c9285-5861-4e81-b273-1867202a77c5)
