### PR TITLE
Enable 2FA Without QR Code

### DIFF
--- a/resources/views/profile/partials/two-factor-authentication.blade.php
+++ b/resources/views/profile/partials/two-factor-authentication.blade.php
@@ -48,7 +48,7 @@
                 </div>
 
                 <div class="mt-5">
-                    {{ __('If you are unable to scan the QR code, please use the 2FA secret instead.') }}
+                    {{ __("If you are unable to scan the QR code, please use the 2FA secret instead.") }}
                 </div>
 
                 <div class="mt-2">

--- a/resources/views/profile/partials/two-factor-authentication.blade.php
+++ b/resources/views/profile/partials/two-factor-authentication.blade.php
@@ -46,6 +46,16 @@
                 <div class="mt-5">
                     {!! auth()->user()->twoFactorQrCodeSvg() !!}
                 </div>
+
+                <div class="mt-5">
+                    {{ __('If you are unable to scan the QR code, please use the 2FA secret instead.') }}
+                </div>
+
+                <div class="mt-2">
+                    <div class="inline-block rounded-md border border-gray-100 p-2 dark:border-gray-700">
+                        {{ decrypt(auth()->user()->two_factor_secret) }}
+                    </div>
+                </div>
             @endif
 
             {{-- Show 2FA Recovery Codes --}}


### PR DESCRIPTION
This pull request addresses the feedback for the [2FA Without QR](https://vitodeploy.featurebase.app/p/2fa-without-qr) feature. With this update, users can now enable Two-Factor Authentication (2FA) by directly inputting the 2FA secret, eliminating the need to scan a QR code.