### PR TITLE
Refactor validation rules to implement the new ValidationRule interface

### DIFF
--- a/app/ValidationRules/CronRule.php
+++ b/app/ValidationRules/CronRule.php
@@ -3,9 +3,9 @@
 namespace App\ValidationRules;
 
 use Cron\CronExpression;
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class CronRule implements Rule
+class CronRule implements ValidationRule
 {
     private bool $acceptCustom;
 
@@ -14,13 +14,14 @@ class CronRule implements Rule
         $this->acceptCustom = $acceptCustom;
     }
 
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, \Closure $fail): void
     {
-        return CronExpression::isValidExpression($value) || ($this->acceptCustom && $value === 'custom');
-    }
-
-    public function message(): string
-    {
-        return __('Invalid frequency');
+        if (CronExpression::isValidExpression($value)) {
+            return;
+        }
+        if ($this->acceptCustom && $value === 'custom') {
+            return;
+        }
+        $fail('Invalid frequency')->translate();
     }
 }

--- a/app/ValidationRules/DomainRule.php
+++ b/app/ValidationRules/DomainRule.php
@@ -2,21 +2,19 @@
 
 namespace App\ValidationRules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class DomainRule implements Rule
+class DomainRule implements ValidationRule
 {
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if ($value) {
-            return preg_match("/^(?!\-)(?:[a-zA-Z\d\-]{0,62}[a-zA-Z\d]\.){1,126}(?!\d+)[a-zA-Z\d]{1,63}$/", $value);
+        if (! $value) {
+            return;
         }
-
-        return true;
-    }
-
-    public function message(): string
-    {
-        return __('Domain is not valid');
+        if (preg_match("/^(?!\-)(?:[a-zA-Z\d\-]{0,62}[a-zA-Z\d]\.){1,126}(?!\d+)[a-zA-Z\d]{1,63}$/", $value) === 1) {
+            return;
+        }
+        $fail('Domain is not valid')->translate();
     }
 }

--- a/app/ValidationRules/RestrictedIPAddressesRule.php
+++ b/app/ValidationRules/RestrictedIPAddressesRule.php
@@ -2,27 +2,16 @@
 
 namespace App\ValidationRules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class RestrictedIPAddressesRule implements Rule
+class RestrictedIPAddressesRule implements ValidationRule
 {
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function passes($attribute, $value)
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        return ! in_array($value, config('core.restricted_ip_addresses'));
-    }
-
-    /**
-     * @return array|\Illuminate\Contracts\Translation\Translator|string|null
-     */
-    public function message()
-    {
-        return __('IP address is restricted.');
+        if (! in_array($value, config('core.restricted_ip_addresses'))) {
+            return;
+        }
+        $fail('IP address is restricted')->translate();
     }
 }

--- a/app/ValidationRules/SshKeyRule.php
+++ b/app/ValidationRules/SshKeyRule.php
@@ -2,35 +2,21 @@
 
 namespace App\ValidationRules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Exception\NoKeyLoadedException;
 
-class SshKeyRule implements Rule
+class SshKeyRule implements ValidationRule
 {
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function passes($attribute, $value)
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         try {
             PublicKeyLoader::load($value);
 
-            return true;
-        } catch (NoKeyLoadedException $e) {
-            return false;
+            return;
+        } catch (NoKeyLoadedException) {
+            $fail('Invalid key')->translate();
         }
-    }
-
-    /**
-     * @return array|\Illuminate\Contracts\Translation\Translator|string|null
-     */
-    public function message()
-    {
-        return __('Invalid key');
     }
 }


### PR DESCRIPTION
This Pr only does a bit of hygiene.
We remove the usages of the deprecated `Illuminate\Contracts\Validation\Rule` interface in favor of the new `Illuminate\Contracts\Validation\ValidationRule` interface.

Each rule is covered existing tests which can be verified by changing the validate methods temporally.