### PR TITLE
fixed issue using double quotes in .env

### DIFF
--- a/app/Actions/Site/UpdateEnv.php
+++ b/app/Actions/Site/UpdateEnv.php
@@ -9,6 +9,7 @@ class UpdateEnv
     public function update(Site $site, array $input): void
     {
         $env = str_replace('"', '\"', $input['env']);
+        $env = str_replace('${', '\${', $env);
 
         $site->server->os()->editFile(
             $site->path.'/.env',

--- a/app/Actions/Site/UpdateEnv.php
+++ b/app/Actions/Site/UpdateEnv.php
@@ -8,9 +8,11 @@ class UpdateEnv
 {
     public function update(Site $site, array $input): void
     {
+        $env = str_replace('"', '\"', $input['env']);
+
         $site->server->os()->editFile(
             $site->path.'/.env',
-            $input['env']
+            $env
         );
     }
 }


### PR DESCRIPTION
When double quotes are used in .env, when any update is save, the double quotes are deleted and the .env file is corrupted.

Before update
![image](https://github.com/user-attachments/assets/4e470e19-8d6f-4587-a6ba-b69ae0285528)

After update
![image](https://github.com/user-attachments/assets/a64e064f-c096-442e-98a9-2e0f647566c8)
