### PR TITLE
fix: vito agent localhost url issue

### DIFF
--- a/app/Actions/Service/Install.php
+++ b/app/Actions/Service/Install.php
@@ -28,7 +28,6 @@ class Install
         $service->type_data = $service->handler()->creationData($input);
         $service->save();
 
-
         dispatch(function () use ($service) {
             $service->handler()->install();
             $service->status = ServiceStatus::READY;

--- a/app/Actions/Service/Install.php
+++ b/app/Actions/Service/Install.php
@@ -23,10 +23,11 @@ class Install
         ]);
 
         Validator::make($input, $service->handler()->creationRules($input))->validate();
+        $service->save();
 
         $service->type_data = $service->handler()->creationData($input);
-
         $service->save();
+
 
         dispatch(function () use ($service) {
             $service->handler()->install();

--- a/app/SSH/Services/Monitoring/VitoAgent/VitoAgent.php
+++ b/app/SSH/Services/Monitoring/VitoAgent/VitoAgent.php
@@ -2,22 +2,22 @@
 
 namespace App\SSH\Services\Monitoring\VitoAgent;
 
-use Closure;
-use Ramsey\Uuid\Uuid;
 use App\Models\Metric;
 use App\SSH\HasScripts;
+use App\SSH\Services\AbstractService;
+use Closure;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
-use Illuminate\Support\Facades\Http;
-use App\SSH\Services\AbstractService;
+use Ramsey\Uuid\Uuid;
 
 class VitoAgent extends AbstractService
 {
     use HasScripts;
 
-    public const TAGS_URL = 'https://api.github.com/repos/vitodeploy/agent/tags';
+    const TAGS_URL = 'https://api.github.com/repos/vitodeploy/agent/tags';
 
-    public const DOWNLOAD_URL = 'https://github.com/vitodeploy/agent/releases/download/%s';
+    const DOWNLOAD_URL = 'https://github.com/vitodeploy/agent/releases/download/%s';
 
     public function creationRules(array $input): array
     {
@@ -92,9 +92,9 @@ class VitoAgent extends AbstractService
         $urlHost = rescue(fn () => parse_url($appUrl, PHP_URL_HOST));
 
         // If app.url is empty or localhost, set it to the current request URL
-        if(empty($urlHost) || Str::contains($urlHost, 'localhost')) {
+        if (empty($urlHost) || Str::contains($urlHost, 'localhost')) {
             config([
-                'app.url' => sprintf('%s://%s', request()->getScheme(), request()->getHttpHost())
+                'app.url' => sprintf('%s://%s', request()->getScheme(), request()->getHttpHost()),
             ]);
         }
 


### PR DESCRIPTION
### Issue: 

When .env APP_URL is empty, vito agent url is installed on the server as "http://localhost/api/servers/4/agent/33" as in the picture. Since it is installed in this way, it cannot send metrics. 

<img width="461" alt="image" src="https://github.com/user-attachments/assets/f1f8295b-fc8a-4b5c-b263-c4992582478d">

### Solution:

When installing vito agent service, config app.url is checked and if it is empty or localhost, temporary url is created with request schema and request url host and add this url into service type_data.

