### PR TITLE
Revert "fix: Avoid echoing when asking for the password"

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,7 +24,7 @@ fi
 
 if [[ -z "${V_ADMIN_PASSWORD}" ]]; then
   echo "Enter a password for Vito's dashboard:"
-  read -s V_ADMIN_PASSWORD
+  read V_ADMIN_PASSWORD
 fi
 
 if [[ -z "${V_ADMIN_PASSWORD}" ]]; then


### PR DESCRIPTION
Reverts vitodeploy/vito#255

The password is being showed anyways in the output.

You have the option of resetting the password after the login.