### PR TITLE
Source Control Migration Fix

### DIFF
--- a/database/migrations/2024_08_03_084747_modify_source_controls_table_provider_data.php
+++ b/database/migrations/2024_08_03_084747_modify_source_controls_table_provider_data.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('source_controls', function (Blueprint $table) {
+            $table->longText('provider_data')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('source_controls', function (Blueprint $table) {
+            $table->json('provider_data')->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
provider_data column in source_controls table is set as json. But in the model the cast is mentioned as encrypted array. So I have modified it to longtext in the new migration