### PR TITLE
Update nginx.conf

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -8,7 +8,7 @@ server {
     add_header X-Content-Type-Options "nosniff";
 
     index index.php;
-
+    client_max_body_size 512M;
     charset utf-8;
 
     location / {


### PR DESCRIPTION
added client_max_body_size 512M; 
Without this uploading anything on a WordPress site returns an NGINX error.