### PR TITLE
Fix Discord connection check

### DIFF
--- a/app/NotificationChannels/Discord.php
+++ b/app/NotificationChannels/Discord.php
@@ -56,7 +56,7 @@ class Discord extends AbstractNotificationChannel
             'content' => '*'.$subject.'*'."\n".$text,
         ]);
 
-        return $connect->ok();
+        return $connect->successful();
     }
 
     public function send(object $notifiable, NotificationInterface $notification): void


### PR DESCRIPTION
Use the `successful()` method to allow 2xx responses by Discord.