### PR TITLE
added overflow to dropdown projects list

### DIFF
--- a/resources/views/components/dropdown.blade.php
+++ b/resources/views/components/dropdown.blade.php
@@ -57,7 +57,7 @@
         style="display: none"
         @if ($closeOnClick) @click="open = false" @endif
     >
-        <div class="{{ $contentClasses }} rounded-md">
+        <div class="{{ $contentClasses }} rounded-md max-h-80 overflow-y-auto">
             {{ $content }}
         </div>
     </div>

--- a/resources/views/components/dropdown.blade.php
+++ b/resources/views/components/dropdown.blade.php
@@ -57,7 +57,7 @@
         style="display: none"
         @if ($closeOnClick) @click="open = false" @endif
     >
-        <div class="{{ $contentClasses }} rounded-md max-h-80 overflow-y-auto">
+        <div class="{{ $contentClasses }} max-h-80 overflow-y-auto rounded-md">
             {{ $content }}
         </div>
     </div>


### PR DESCRIPTION
Fixing project list dropdown

Issue: when you create a lot of projects, list projects dropdown is not showing the rest of the list.

Before
![image](https://github.com/user-attachments/assets/e9152a64-a333-42b5-a8d3-effed819090e)


After
![image](https://github.com/user-attachments/assets/0b662526-2f9b-4117-9cfc-b57e9541c175)
