### PR TITLE
Fix #279 - Privileges for `public` Schema in PostgreSQL 15+ 

### DIFF
--- a/app/SSH/Services/Database/AbstractDatabase.php
+++ b/app/SSH/Services/Database/AbstractDatabase.php
@@ -117,6 +117,7 @@ abstract class AbstractDatabase extends AbstractService implements Database
     public function link(string $username, string $host, array $databases): void
     {
         $ssh = $this->service->server->ssh();
+        $version = $this->service->version;
 
         foreach ($databases as $database) {
             $ssh->exec(
@@ -124,6 +125,7 @@ abstract class AbstractDatabase extends AbstractService implements Database
                     'username' => $username,
                     'host' => $host,
                     'database' => $database,
+                    'version' => $version,
                 ]),
                 'link-user-to-database'
             );
@@ -132,10 +134,13 @@ abstract class AbstractDatabase extends AbstractService implements Database
 
     public function unlink(string $username, string $host): void
     {
+        $version = $this->service->version;
+
         $this->service->server->ssh()->exec(
             $this->getScript($this->getScriptsDir().'/unlink.sh', [
                 'username' => $username,
                 'host' => $host,
+                'version' => $version,
             ]),
             'unlink-user-from-databases'
         );

--- a/app/SSH/Services/Database/scripts/postgresql/link.sh
+++ b/app/SSH/Services/Database/scripts/postgresql/link.sh
@@ -1,5 +1,16 @@
-if ! sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE __database__ TO __username__;"; then
+USER_TO_LINK='__username__'
+DB_NAME='__database__'
+DB_VERSION='__version__'
+
+if ! sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE \"$DB_NAME\" TO $USER_TO_LINK;"; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 
-echo "Linking to __database__ finished"
+# Check if PostgreSQL version is 15 or greater
+if [ "$DB_VERSION" -ge 15 ]; then
+    if ! sudo -u postgres psql -d "$DB_NAME" -c "GRANT USAGE, CREATE ON SCHEMA public TO $USER_TO_LINK;"; then
+        echo 'VITO_SSH_ERROR' && exit 1
+    fi
+fi
+
+echo "Linking to $DB_NAME finished"

--- a/app/SSH/Services/Database/scripts/postgresql/unlink.sh
+++ b/app/SSH/Services/Database/scripts/postgresql/unlink.sh
@@ -1,10 +1,16 @@
 USER_TO_REVOKE='__username__'
+DB_VERSION='__version__'
 
 DATABASES=$(sudo -u postgres psql -t -c "SELECT datname FROM pg_database WHERE datistemplate = false;")
 
 for DB in $DATABASES; do
     echo "Revoking privileges in database: $DB"
     sudo -u postgres psql -d "$DB" -c "REVOKE ALL PRIVILEGES ON DATABASE \"$DB\" FROM $USER_TO_REVOKE;"
+
+    # Check if PostgreSQL version is 15 or greater
+    if [ "$DB_VERSION" -ge 15 ]; then
+        sudo -u postgres psql -d "$DB" -c "REVOKE USAGE, CREATE ON SCHEMA public FROM $USER_TO_REVOKE;"
+    fi
 done
 
 echo "Privileges revoked from $USER_TO_REVOKE"


### PR DESCRIPTION
This PR checks the database version for PostgreSQL services and grants USAGE and CREATE permissions for the public schema if the version is 15 or higher.

This is required for Laravel migrations to work since, by default, the search_path for the `pgsql` driver is `public` 