### PR TITLE
Adds current project ID to user seeder.

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,7 +22,7 @@ class DatabaseSeeder extends Seeder
         $user = User::factory()->create([
             'name' => 'Test User',
             'email' => 'user@example.com',
-            'current_project_id' => Project::factory()->create()
+            'current_project_id' => Project::factory()->create(),
         ]);
 
         $this->createResources($user);

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,6 +22,7 @@ class DatabaseSeeder extends Seeder
         $user = User::factory()->create([
             'name' => 'Test User',
             'email' => 'user@example.com',
+            'current_project_id' => Project::factory()->create()
         ]);
 
         $this->createResources($user);


### PR DESCRIPTION
From a fresh install, the seeder has an error.

Adding `'current_project_id' => Project::factory()->create()` fixes the problem.


```
  Attempt to read property "id" on null

  at database/seeders/DatabaseSeeder.php:34
     30▕     private function createResources(User $user): void
     31▕     {
     32▕         $server = Server::factory()->create([
     33▕             'user_id' => $user->id,
  ➜  34▕             'project_id' => $user->currentProject->id,
     35▕         ]);
     36▕         $server->services()->create([
     37▕             'type' => 'database',
     38▕             'name' => config('core.databases_name.mysql80'),
```