### PR TITLE
Fix: Database seeder not working

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Enums\ServiceStatus;
 use App\Enums\SiteType;
+use App\Models\Project;
 use App\Models\Server;
 use App\Models\Site;
 use App\Models\User;


### PR DESCRIPTION
The default database seeder not working due to Project Model didn't imported.