### PR TITLE
Fix Server stats

### DIFF
--- a/app/Web/Pages/Servers/Metrics/Widgets/Metrics.php
+++ b/app/Web/Pages/Servers/Metrics/Widgets/Metrics.php
@@ -37,10 +37,10 @@ class Metrics extends BaseWidget
             Stat::make('CPU Load', $lastMetric?->load ?? 0)
                 ->color('success')
                 ->chart($metrics->pluck('load')->toArray()),
-            Stat::make('Memory Usage', Number::fileSize($lastMetric?->memory_used_in_bytes || 0, 2))
+            Stat::make('Memory Usage', Number::fileSize($lastMetric?->memory_used_in_bytes ?? 0, 2))
                 ->color('warning')
                 ->chart($metrics->pluck('memory_used')->toArray()),
-            Stat::make('Disk Usage', Number::fileSize($lastMetric?->disk_used_in_bytes || 0, 2))
+            Stat::make('Disk Usage', Number::fileSize($lastMetric?->disk_used_in_bytes ?? 0, 2))
                 ->color('primary')
                 ->chart($metrics->pluck('disk_used')->toArray()),
         ];


### PR DESCRIPTION
This pull request resolves issue [[#373](https://github.com/vitodeploy/vito/issues/373)] by fixing the memory usage fallback logic on the metrics page.


#### Screenshots  
**Before:**  
[
<img width="771" alt="Screenshot 2024-11-27 at 6 31 34 PM" src="https://github.com/user-attachments/assets/f975bddb-7c4b-4fb2-8910-56c672150107">
](url)
**After:**  
<img width="776" alt="Screenshot 2024-11-27 at 6 31 19 PM" src="https://github.com/user-attachments/assets/4d4bc6be-7f98-4198-8f61-397f595195a6">


This ensures accurate memory usage display in the metrics chart.