### PR TITLE
fix docker builds

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -1,9 +1,8 @@
-name: Docker
+name: Docker Latest
 
 on:
   push:
     branches:
-      - 1.x
       - 2.x
 
 jobs:
@@ -25,12 +24,11 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push Docker image
+      - name: Build and push to the latest tag
         run: |
           docker buildx build . \
             -f docker/Dockerfile \
-            -t vitodeploy/vito:${{ github.head_ref || github.ref_name }} \
-            --build-arg="RELEASE=0" \
+            -t vitodeploy/vito:latest \
             --platform linux/amd64,linux/arm64 \
             --no-cache \
             --push

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -28,17 +28,24 @@ jobs:
           docker buildx build . \
             -f docker/Dockerfile \
             -t vitodeploy/vito:${{ github.event.release.tag_name }} \
-            --build-arg="RELEASE=0" \
             --platform linux/amd64,linux/arm64 \
             --no-cache \
             --push
 
-      - name: Build and push to the latest tag
+      - name: Build and push to the 1.x tag
+        if: startsWith(github.event.release.target_commitish, '1.x')
+        run: |
+          docker buildx build . \
+            -f docker/Dockerfile \
+            -t vitodeploy/vito:1.x \
+            --platform linux/amd64,linux/arm64 \
+            --push
+
+      - name: Build and push to the 2.x tag
         if: startsWith(github.event.release.target_commitish, '2.x')
         run: |
           docker buildx build . \
             -f docker/Dockerfile \
-            -t vitodeploy/vito:latest \
-            --build-arg="RELEASE=0" \
+            -t vitodeploy/vito:2.x \
             --platform linux/amd64,linux/arm64 \
             --push


### PR DESCRIPTION
- push to the `latest` tag if anything pushed to the `2.x` branch
- push to the `2.x` tag if a new release published

This means, `2.x` must be the stable tag and `latest` will be the latest changes