### PR TITLE
set server_tokens off for every created server

### DIFF
--- a/app/SSH/Services/Webserver/scripts/nginx/nginx.conf
+++ b/app/SSH/Services/Webserver/scripts/nginx/nginx.conf
@@ -19,7 +19,7 @@ http {
 	tcp_nodelay on;
 	keepalive_timeout 65;
 	types_hash_max_size 2048;
-	# server_tokens off;
+	server_tokens off;
 
 	# server_names_hash_bucket_size 64;
 	# server_name_in_redirect off;


### PR DESCRIPTION
To remove the nginx version from responses the server_tokens variable should be set for every created server by vito.

before:
![CleanShot 2024-12-30 at 14 23 51@2x](https://github.com/user-attachments/assets/60c11e93-b29f-42d1-94a7-6170bc2ac6ce)

after:
![CleanShot 2024-12-30 at 14 24 06@2x](https://github.com/user-attachments/assets/daae2da9-8afc-4f1a-876f-25327e7ce8e5)
