### PR TITLE
Optional public ip config to add vito server to the firewall for created servers

### DIFF
--- a/app/Actions/Server/CreateServer.php
+++ b/app/Actions/Server/CreateServer.php
@@ -218,12 +218,12 @@ class CreateServer
             ],
         ];
 
-        if (config('core.vito_public_up', false)) {
+        if (config('core.vito_public_ip', false)) {
             $defaultRules[] = [
                 'type' => 'allow',
                 'protocol' => 'tcp',
                 'port' => 22,
-                'source' => config('core.vito_public_up'),
+                'source' => config('core.vito_public_ip'),
                 'mask' => 0,
                 'status' => FirewallRuleStatus::READY,
             ];

--- a/app/Actions/Server/CreateServer.php
+++ b/app/Actions/Server/CreateServer.php
@@ -191,7 +191,7 @@ class CreateServer
 
     public function createFirewallRules(Server $server): void
     {
-        $server->firewallRules()->createMany([
+        $defaultRules = [
             [
                 'type' => 'allow',
                 'protocol' => 'ssh',
@@ -216,6 +216,19 @@ class CreateServer
                 'mask' => 0,
                 'status' => FirewallRuleStatus::READY,
             ],
-        ]);
+        ];
+
+        if (config('core.vito_public_up', false)) {
+            $defaultRules[] = [
+                'type' => 'allow',
+                'protocol' => 'tcp',
+                'port' => 22,
+                'source' => config('core.vito_public_up'),
+                'mask' => 0,
+                'status' => FirewallRuleStatus::READY,
+            ];
+        }
+
+        $server->firewallRules()->createMany($defaultRules);
     }
 }

--- a/app/SSH/Services/Webserver/scripts/nginx/nginx.conf
+++ b/app/SSH/Services/Webserver/scripts/nginx/nginx.conf
@@ -19,7 +19,7 @@ http {
 	tcp_nodelay on;
 	keepalive_timeout 65;
 	types_hash_max_size 2048;
-	# server_tokens off;
+	server_tokens off;
 
 	# server_names_hash_bucket_size 64;
 	# server_name_in_redirect off;

--- a/config/core.php
+++ b/config/core.php
@@ -10,6 +10,12 @@ return [
     'logs_disk' => env('SERVER_LOGS_DISK', 'server-logs'), // should be FilesystemAdapter storage
     'key_pairs_disk' => env('KEY_PAIRS_DISK', 'key-pairs'), // should be FilesystemAdapter storage
 
+    /**
+     * Add the public ip of your Vito server to add this to
+     * the firwall as port 22 for each created server.
+     */
+    'vito_public_up' => env('PUBLIC_IP', null),
+
     /*
      * General
      */

--- a/config/core.php
+++ b/config/core.php
@@ -14,7 +14,7 @@ return [
      * Add the public ip of your Vito server to add this to
      * the firwall as port 22 for each created server.
      */
-    'vito_public_up' => env('PUBLIC_IP', null),
+    'vito_public_ip' => env('VITO_PUBLIC_IP', null),
 
     /*
      * General

--- a/tests/Feature/ServerTest.php
+++ b/tests/Feature/ServerTest.php
@@ -89,7 +89,7 @@ class ServerTest extends TestCase
             'type' => 'allow',
             'protocol' => 'tcp',
             'port' => 22,
-            'source' => config('core.vito_public_up'),
+            'source' => config('core.vito_public_ip'),
             'status' => ServiceStatus::READY,
         ]);
     }
@@ -100,7 +100,7 @@ class ServerTest extends TestCase
 
         SSH::fake('Active: active'); // fake output for service installations
 
-        Config::set('core.vito_public_up', '133.0.0.7');
+        Config::set('core.vito_public_ip', '133.0.0.7');
 
         Livewire::test(Index::class)
             ->callAction('create', [
@@ -124,7 +124,7 @@ class ServerTest extends TestCase
             'status' => ServiceStatus::READY,
         ]);
 
-        Config::set('core.vito_public_up', null);
+        Config::set('core.vito_public_ip', null);
 
         Livewire::test(Settings::class, [
             'server' => Server::find(2),


### PR DESCRIPTION
This will add a optional variable in the core config file to add the vito public ip automatically to the firewall for each created server.

Add the PUBLIC_IP to the .env file with the public IP of your vito installation. If set, after a new server is installed this IP will be added to the firewall as 22/tcp to be able to connect to all your servers even when the default rule 22/tcp any is removed manually.

This would be optional and does not change anything if not used. But it is helpfull for users that like to remove the open 22/tcp rule without the need to manually add this ip every time for each server.

By using this it could also help to not lock out of your own servers.