### PR TITLE
Feature/firewall default vito public ip

### DIFF
--- a/app/Actions/FirewallRule/CreateRule.php
+++ b/app/Actions/FirewallRule/CreateRule.php
@@ -59,7 +59,7 @@ class CreateRule
                 'ip',
             ],
             'mask' => [
-                'required',
+                'nullable',
                 'numeric',
             ],
         ];

--- a/app/Actions/Server/CreateServer.php
+++ b/app/Actions/Server/CreateServer.php
@@ -224,7 +224,7 @@ class CreateServer
                 'protocol' => 'tcp',
                 'port' => 22,
                 'source' => config('core.vito_public_ip'),
-                'mask' => 0,
+                'mask' => null,
                 'status' => FirewallRuleStatus::READY,
             ];
         }

--- a/app/Actions/Server/CreateServer.php
+++ b/app/Actions/Server/CreateServer.php
@@ -218,12 +218,12 @@ class CreateServer
             ],
         ];
 
-        if (config('core.vito_public_up', false)) {
+        if (config('core.vito_public_ip', false)) {
             $defaultRules[] = [
                 'type' => 'allow',
                 'protocol' => 'tcp',
                 'port' => 22,
-                'source' => config('core.vito_public_up'),
+                'source' => config('core.vito_public_ip'),
                 'mask' => 0,
                 'status' => FirewallRuleStatus::READY,
             ];

--- a/app/Actions/Server/CreateServer.php
+++ b/app/Actions/Server/CreateServer.php
@@ -191,7 +191,7 @@ class CreateServer
 
     public function createFirewallRules(Server $server): void
     {
-        $server->firewallRules()->createMany([
+        $defaultRules = [
             [
                 'type' => 'allow',
                 'protocol' => 'ssh',
@@ -216,6 +216,19 @@ class CreateServer
                 'mask' => 0,
                 'status' => FirewallRuleStatus::READY,
             ],
-        ]);
+        ];
+
+        if (config('core.vito_public_up', false)) {
+            $defaultRules[] = [
+                'type' => 'allow',
+                'protocol' => 'tcp',
+                'port' => 22,
+                'source' => config('core.vito_public_up'),
+                'mask' => 0,
+                'status' => FirewallRuleStatus::READY,
+            ];
+        }
+
+        $server->firewallRules()->createMany($defaultRules);
     }
 }

--- a/app/SSH/Services/Firewall/Ufw.php
+++ b/app/SSH/Services/Firewall/Ufw.php
@@ -30,7 +30,7 @@ class Ufw extends AbstractFirewall
                 'protocol' => $protocol,
                 'port' => $port,
                 'source' => $source,
-                'mask' => $mask || $mask == 0 ? '/'.$mask : '',
+                'mask' => $mask || $mask === 0 ? '/'.$mask : '',
             ]),
             'add-firewall-rule'
         );
@@ -44,7 +44,7 @@ class Ufw extends AbstractFirewall
                 'protocol' => $protocol,
                 'port' => $port,
                 'source' => $source,
-                'mask' => $mask || $mask == 0 ? '/'.$mask : '',
+                'mask' => $mask || $mask === 0 ? '/'.$mask : '',
             ]),
             'remove-firewall-rule'
         );

--- a/app/SSH/Services/Webserver/scripts/nginx/nginx.conf
+++ b/app/SSH/Services/Webserver/scripts/nginx/nginx.conf
@@ -19,7 +19,7 @@ http {
 	tcp_nodelay on;
 	keepalive_timeout 65;
 	types_hash_max_size 2048;
-	# server_tokens off;
+	server_tokens off;
 
 	# server_names_hash_bucket_size 64;
 	# server_name_in_redirect off;

--- a/config/core.php
+++ b/config/core.php
@@ -10,6 +10,12 @@ return [
     'logs_disk' => env('SERVER_LOGS_DISK', 'server-logs'), // should be FilesystemAdapter storage
     'key_pairs_disk' => env('KEY_PAIRS_DISK', 'key-pairs'), // should be FilesystemAdapter storage
 
+    /**
+     * Add the public ip of your Vito server to add this to
+     * the firwall as port 22 for each created server.
+     */
+    'vito_public_up' => env('PUBLIC_IP', null),
+
     /*
      * General
      */

--- a/config/core.php
+++ b/config/core.php
@@ -14,7 +14,7 @@ return [
      * Add the public ip of your Vito server to add this to
      * the firwall as port 22 for each created server.
      */
-    'vito_public_up' => env('PUBLIC_IP', null),
+    'vito_public_ip' => env('VITO_PUBLIC_IP', null),
 
     /*
      * General

--- a/tests/Feature/ServerTest.php
+++ b/tests/Feature/ServerTest.php
@@ -120,6 +120,7 @@ class ServerTest extends TestCase
             'type' => 'allow',
             'protocol' => 'tcp',
             'port' => 22,
+            'mask' => null,
             'source' => '133.0.0.7',
             'status' => ServiceStatus::READY,
         ]);

--- a/tests/Feature/ServerTest.php
+++ b/tests/Feature/ServerTest.php
@@ -89,7 +89,7 @@ class ServerTest extends TestCase
             'type' => 'allow',
             'protocol' => 'tcp',
             'port' => 22,
-            'source' => config('core.vito_public_up'),
+            'source' => config('core.vito_public_ip'),
             'status' => ServiceStatus::READY,
         ]);
     }
@@ -100,7 +100,7 @@ class ServerTest extends TestCase
 
         SSH::fake('Active: active'); // fake output for service installations
 
-        Config::set('core.vito_public_up', '133.0.0.7');
+        Config::set('core.vito_public_ip', '133.0.0.7');
 
         Livewire::test(Index::class)
             ->callAction('create', [
@@ -124,7 +124,7 @@ class ServerTest extends TestCase
             'status' => ServiceStatus::READY,
         ]);
 
-        Config::set('core.vito_public_up', null);
+        Config::set('core.vito_public_ip', null);
 
         Livewire::test(Settings::class, [
             'server' => Server::find(2),


### PR DESCRIPTION
This changes will make the firewall mask field nullable. On the add and remove rule the code checks for null or 0 and only append the subnet mask when $mask is not null.

With this the change existing servers are able to delete old rules and add new ones with or without masks.