### PR TITLE
make mask nullable and do a strict compare to allow firewall rules without mask

### DIFF
--- a/app/Actions/FirewallRule/CreateRule.php
+++ b/app/Actions/FirewallRule/CreateRule.php
@@ -59,7 +59,7 @@ class CreateRule
                 'ip',
             ],
             'mask' => [
-                'required',
+                'nullable',
                 'numeric',
             ],
         ];

--- a/app/SSH/Services/Firewall/Ufw.php
+++ b/app/SSH/Services/Firewall/Ufw.php
@@ -30,7 +30,7 @@ class Ufw extends AbstractFirewall
                 'protocol' => $protocol,
                 'port' => $port,
                 'source' => $source,
-                'mask' => $mask || $mask == 0 ? '/'.$mask : '',
+                'mask' => $mask || $mask === 0 ? '/'.$mask : '',
             ]),
             'add-firewall-rule'
         );
@@ -44,7 +44,7 @@ class Ufw extends AbstractFirewall
                 'protocol' => $protocol,
                 'port' => $port,
                 'source' => $source,
-                'mask' => $mask || $mask == 0 ? '/'.$mask : '',
+                'mask' => $mask || $mask === 0 ? '/'.$mask : '',
             ]),
             'remove-firewall-rule'
         );


### PR DESCRIPTION
By this change users can add firewall rules for IPs without any mask on Ubuntu 24.04. 
Existing rules are still removable when added with mask.