### PR TITLE
Fix Deployment Script on Windows Clients

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,6 @@
 name: tests
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/app/Actions/Site/UpdateDeploymentScript.php
+++ b/app/Actions/Site/UpdateDeploymentScript.php
@@ -12,9 +12,9 @@ class UpdateDeploymentScript
      */
     public function update(Site $site, array $input): void
     {
-        $site->deploymentScript()->update([
-            'content' => $input['script'],
-        ]);
+        $script = $site->deploymentScript;
+        $script->content = $input['script'];
+        $script->save();
     }
 
     /**

--- a/app/Models/DeploymentScript.php
+++ b/app/Models/DeploymentScript.php
@@ -15,6 +15,15 @@ class DeploymentScript extends AbstractModel
 {
     use HasFactory;
 
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::saving(function ($deploymentScript) {
+            $deploymentScript->content = str_replace("\r\n", "\n", $deploymentScript->content);
+        });
+    }
+
     protected $fillable = [
         'site_id',
         'name',

--- a/app/SSH/OS/OS.php
+++ b/app/SSH/OS/OS.php
@@ -7,6 +7,7 @@ use App\Models\Server;
 use App\Models\ServerLog;
 use App\SSH\HasScripts;
 use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Throwable;
@@ -162,12 +163,13 @@ class OS
         }
         $command = '';
         foreach ($variables as $key => $variable) {
-            $command .= "$key=$variable".PHP_EOL;
+            $command .= "$key=$variable\n";
         }
         $command .= $this->getScript('run-script.sh', [
             'path' => $path,
             'script' => $script,
         ]);
+        Log::info($command);
         $ssh->exec($command, 'run-script');
 
         info($command);

--- a/app/SSH/OS/OS.php
+++ b/app/SSH/OS/OS.php
@@ -7,7 +7,6 @@ use App\Models\Server;
 use App\Models\ServerLog;
 use App\SSH\HasScripts;
 use Illuminate\Filesystem\FilesystemAdapter;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Throwable;
@@ -169,7 +168,6 @@ class OS
             'path' => $path,
             'script' => $script,
         ]);
-        Log::info($command);
         $ssh->exec($command, 'run-script');
 
         info($command);


### PR DESCRIPTION
On windows browsers, when editing the deployment script \r\n was entered at the end of each line.  This caused an extra \r to be parsed by the linux server, causing deployment scripts to fail.

Resolves #428 