### PR TITLE
Update the vhost file to name the backend after the domain

### DIFF
--- a/resources/views/ssh/services/webserver/nginx/vhost.blade.php
+++ b/resources/views/ssh/services/webserver/nginx/vhost.blade.php
@@ -6,8 +6,12 @@
     }
 @endif
 
+@php
+    $backendName = preg_replace("/[^A-Za-z0-9 ]/", '', $site->domain).'_backend';
+@endphp
+
 @if ($site->type === \App\Enums\SiteType::LOAD_BALANCER)
-    upstream backend {
+    upstream {{ $backendName }} {
         @switch($site->type_data['method'] ?? \App\Enums\LoadBalancerMethod::ROUND_ROBIN)
             @case(\App\Enums\LoadBalancerMethod::LEAST_CONNECTIONS)
                 least_conn;
@@ -67,7 +71,7 @@ server {
 
     @if ($site->type === \App\Enums\SiteType::LOAD_BALANCER)
         location / {
-            proxy_pass http://backend$request_uri;
+            proxy_pass http://{{ $backendName }}$request_uri;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This is my naive attempt to add support for more than 2 sites on a single server each using the load-balancer configuration; to fix this bug https://github.com/vitodeploy/vito/issues/468

Previously, if you tried to create 2 load-balanced sites on a single server Nginx would crash because you can't have 2 different upstreams share a name.

