### PR TITLE
Don't escape deploy script because it converts quotes and other special character to htmlentities.

### DIFF
--- a/resources/views/ssh/os/run-script.blade.php
+++ b/resources/views/ssh/os/run-script.blade.php
@@ -2,4 +2,4 @@ if ! cd {{ $path }}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 
-{{ $script }}
+{!! $script !!}


### PR DESCRIPTION
Currently we convert `echo "Deploying $DOMAIN to $SITE_PATH"` to `echo &quot;Deploying $DOMAIN to $SITE_PATH&quot;` which doesn't work as a shell command. 
