### PR TITLE
fix: improve SSH command escaping and variable expansion

### DIFF
--- a/app/Helpers/SSH.php
+++ b/app/Helpers/SSH.php
@@ -114,7 +114,7 @@ class SSH
             if ($this->asUser) {
                 // Escape single quotes in the command and wrap in single quotes
                 $escapedCommand = str_replace("'", "'\\''", $command);
-                $command = "sudo su - ".$this->asUser." -c '".$escapedCommand."'";
+                $command = 'sudo su - '.$this->asUser." -c '".$escapedCommand."'";
             }
 
             $this->connection->setTimeout(0);

--- a/app/Helpers/SSH.php
+++ b/app/Helpers/SSH.php
@@ -112,7 +112,9 @@ class SSH
 
         try {
             if ($this->asUser) {
-                $command = 'sudo su - '.$this->asUser.' -c '.'"'.addslashes($command).'"';
+                // Escape single quotes in the command and wrap in single quotes
+                $escapedCommand = str_replace("'", "'\\''", $command);
+                $command = "sudo su - ".$this->asUser." -c '".$escapedCommand."'";
             }
 
             $this->connection->setTimeout(0);


### PR DESCRIPTION
## Description
Fixes an issue where environment variables weren't being properly expanded and commands weren't being properly escaped when executing through sudo in the SSH helper.

### Problem
When executing commands through `sudo su - user -c`, two issues were present:
1. Double quotes were causing variables to be escaped incorrectly
2. Commands containing single quotes weren't properly escaped

Example of issues:
- Variable expansion: `"Deploying  to "` instead of `"Deploying dashboard.example.com to /home/dashboard-app/dashboard.example.com"`
- Quote escaping: Commands containing single quotes would break the shell syntax

### Solution
Modified the SSH helper to:
1. Use single quotes for wrapping sudo commands
2. Properly escape single quotes within commands using the `'\''` pattern
3. Preserve proper shell context for variable expansion

### Testing
- [x] Tested direct terminal execution
- [x] Tested SSH package execution
- [x] Verified variable expansion in deployment scripts
- [x] Verified handling of commands containing single quotes

### Impact
This change affects all sudo command executions through the SSH helper but should be transparent to existing code as it only modifies how commands are wrapped and escaped internally.