### PR TITLE
fix: add missing php-intl package when installing php

### DIFF
--- a/resources/views/ssh/services/php/install-php.blade.php
+++ b/resources/views/ssh/services/php/install-php.blade.php
@@ -2,7 +2,7 @@ sudo add-apt-repository ppa:ondrej/php -y
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get update
 
-if ! sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php{{ $version }} php{{ $version }}-fpm php{{ $version }}-mbstring php{{ $version }}-mysql php{{ $version }}-gd php{{ $version }}-xml php{{ $version }}-curl php{{ $version }}-gettext php{{ $version }}-zip php{{ $version }}-bcmath php{{ $version }}-soap php{{ $version }}-redis php{{ $version }}-sqlite3 php{{ $version }}-tokenizer php{{ $version }}-pgsql php{{ $version }}-pdo; then
+if ! sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php{{ $version }} php{{ $version }}-fpm php{{ $version }}-mbstring php{{ $version }}-mysql php{{ $version }}-gd php{{ $version }}-xml php{{ $version }}-curl php{{ $version }}-gettext php{{ $version }}-zip php{{ $version }}-bcmath php{{ $version }}-soap php{{ $version }}-redis php{{ $version }}-sqlite3 php{{ $version }}-tokenizer php{{ $version }}-pgsql php{{ $version }}-pdo php{{ $version }}-intl; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 


### PR DESCRIPTION
Added `php{{ $version }}-intl` to the php installation list as it was missing. This package is a standard component in most projects and should be included by default.