### PR TITLE
fix: ensure newly created branches are available for switching

### DIFF
--- a/app/Actions/Site/UpdateBranch.php
+++ b/app/Actions/Site/UpdateBranch.php
@@ -16,6 +16,7 @@ class UpdateBranch
     public function update(Site $site, array $input): void
     {
         $site->branch = $input['branch'];
+        app(Git::class)->fetchOrigin($site);
         app(Git::class)->checkout($site);
         $site->save();
     }

--- a/app/SSH/Git/Git.php
+++ b/app/SSH/Git/Git.php
@@ -39,4 +39,18 @@ class Git
             $site->id
         );
     }
+
+    /**
+     * @throws SSHError
+     */
+    public function fetchOrigin(Site $site): void
+    {
+        $site->server->ssh($site->user)->exec(
+            view('ssh.git.fetch-origin', [
+                'path' => $site->path,
+            ]),
+            'fetch-origin',
+            $site->id
+        );
+    }
 }

--- a/resources/views/ssh/git/fetch-origin.blade.php
+++ b/resources/views/ssh/git/fetch-origin.blade.php
@@ -1,0 +1,7 @@
+if ! cd {{ $path }}; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+if ! git fetch origin; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi


### PR DESCRIPTION
Fixed an issue where the "Change Branch" button didn't work when switching to a newly created remote branch after initially cloning the repository. Added `git fetch origin` to update branch references before switching.