### PR TITLE
feat: display repository and branch in site details

### DIFF
--- a/app/Web/Pages/Servers/Sites/Widgets/SiteDetails.php
+++ b/app/Web/Pages/Servers/Sites/Widgets/SiteDetails.php
@@ -180,6 +180,16 @@ class SiteDetails extends Widget implements HasForms, HasInfolists
                                         });
                                     })
                             ),
+                        TextEntry::make('repository')
+                            ->label('Repository')
+                            ->visible(fn (Site $record) => $record->repository)
+                            ->formatStateUsing(fn (Site $record) => $record->repository)
+                            ->inlineLabel(),
+                        TextEntry::make('branch')
+                            ->label('Branch')
+                            ->visible(fn (Site $record) => $record->branch)
+                            ->formatStateUsing(fn (Site $record) => $record->branch)
+                            ->inlineLabel(),
                     ]),
             ])
             ->record($this->site);


### PR DESCRIPTION
Added `repository` and `branch` fields to the site details view. These fields are now visible when a site has a corresponding repository or branch and are formatted accordingly.