### PR TITLE
fix: prevent "null" from appearing in console after user selection (#501)

### DIFF
--- a/app/Http/Controllers/ConsoleController.php
+++ b/app/Http/Controllers/ConsoleController.php
@@ -63,7 +63,7 @@ class ConsoleController extends Controller
     public function workingDir(Server $server)
     {
         return response()->json([
-            'dir' => Cache::get('console.'.$server->id.'.dir'),
+            'dir' => Cache::get('console.'.$server->id.'.dir', '~'),
         ]);
     }
 }


### PR DESCRIPTION
Ensure a default working directory is returned when fetching the console working directory. Previously, if a user is switched before running any commands, `Cache::get` would return `null`. Now, it defaults to `'~'` if no value exists.

Closes #501.