### PR TITLE
fix: Fix regex in File Manager to support hyphenated usernames and groups

### DIFF
--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -103,7 +103,7 @@ class File extends AbstractModel
         array_shift($lines);
 
         foreach ($lines as $line) {
-            if (preg_match('/^([drwx\-]+)\s+(\d+)\s+(\w+)\s+(\w+)\s+(\d+)\s+([\w\s:\-]+)\s+(.+)$/', $line, $matches)) {
+            if (preg_match('/^([drwx\-]+)\s+(\d+)\s+([\w\-]+)\s+([\w\-]+)\s+(\d+)\s+([\w\s:\-]+)\s+(.+)$/', $line, $matches)) {
                 $type = match ($matches[1][0]) {
                     '-' => 'file',
                     'd' => 'directory',


### PR DESCRIPTION
Fix regex in File Manager to support hyphenated usernames and groups

Why this is needed:

Previously, the regex used \w+ for matching usernames and groups, which only allowed alphanumeric characters and underscores. However, usernames and groups can contain hyphens (-), causing the regex to fail for entries like:

`drwxr-xr-x 2 test-test-test test-test-test 4096 Feb 28 18:07 tmp`

By updating the regex to use [\w\-]+, it now correctly captures usernames and groups with hyphens, ensuring proper parsing of ls -l output.