### PR TITLE
fix: Fix variables not being saved in database when executing a script

### DIFF
--- a/app/Web/Pages/Scripts/Executions.php
+++ b/app/Web/Pages/Scripts/Executions.php
@@ -64,7 +64,7 @@ class Executions extends Page
         ];
 
         foreach ($this->script->getVariables() as $variable) {
-            $form[] = TextInput::make($variable)
+            $form[] = TextInput::make('variables.'.$variable)
                 ->label($variable)
                 ->rules(fn (Get $get) => ExecuteScript::rules($get())['variables.*']);
         }


### PR DESCRIPTION
This PR fixes an issue where variables were not being correctly saved in the database when executing a script. The problem was caused by missing the proper key prefix for variables in the form input.