### PR TITLE
feat: Allow editing of site domain in Site details

### DIFF
--- a/app/Actions/Site/UpdateDomain.php
+++ b/app/Actions/Site/UpdateDomain.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Actions\Site;
+
+use App\Models\Site;
+use App\SSH\Services\Webserver\Webserver;
+use App\ValidationRules\DomainRule;
+
+class UpdateDomain
+{
+    public function update(Site $site, array $input): void
+    {
+        $site->domain = $input['domain'];
+
+        /** @var Webserver $webserver */
+        $webserver = $site->server->webserver()->handler();
+        $webserver->updateVHost($site);
+
+        $site->save();
+    }
+
+    public static function rules(): array
+    {
+        return [
+            'domain' => [
+                new DomainRule,
+            ],
+        ];
+    }
+}

--- a/app/Web/Pages/Servers/Sites/Widgets/SiteDetails.php
+++ b/app/Web/Pages/Servers/Sites/Widgets/SiteDetails.php
@@ -3,6 +3,7 @@
 namespace App\Web\Pages\Servers\Sites\Widgets;
 
 use App\Actions\Site\UpdateAliases;
+use App\Actions\Site\UpdateDomain;
 use App\Actions\Site\UpdatePHPVersion;
 use App\Actions\Site\UpdateSourceControl;
 use App\Models\Site;
@@ -11,6 +12,7 @@ use App\Web\Pages\Settings\SourceControls\Actions\Create;
 use App\Web\Pages\Settings\Tags\Actions\EditTags;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TagsInput;
+use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Infolists\Components\Actions\Action;
@@ -100,6 +102,35 @@ class SiteDetails extends Widget implements HasForms, HasInfolists
                                             Notification::make()
                                                 ->success()
                                                 ->title('PHP version updated!')
+                                                ->send();
+                                        });
+                                    })
+                            ),
+                        TextEntry::make('domain')
+                            ->inlineLabel()
+                            ->badge()
+                            ->default($this->site->domain)
+                            ->color('primary')
+                            ->suffixAction(
+                                Action::make('edit_domain')
+                                    ->icon('heroicon-o-pencil-square')
+                                    ->tooltip('Change')
+                                    ->modalSubmitActionLabel('Save')
+                                    ->modalHeading('Update Domain')
+                                    ->modalWidth(MaxWidth::Medium)
+                                    ->form([
+                                        TextInput::make('domain')
+                                            ->default($this->site->domain)
+                                            ->rules(UpdateDomain::rules()['domain']),
+
+                                    ])
+                                    ->action(function (array $data) {
+                                        run_action($this, function () use ($data) {
+                                            app(UpdateDomain::class)->update($this->site, $data);
+
+                                            Notification::make()
+                                                ->success()
+                                                ->title('Domain updated!')
                                                 ->send();
                                         });
                                     })


### PR DESCRIPTION
Added functionality to display and edit the site domain in the site details section. This allows users to update their domain directly within the app, making it easier to manage domain changes.

![CleanShot 2025-03-01 at 11 09 07](https://github.com/user-attachments/assets/3f4a1825-cb7d-410c-b67f-46c76dfbddb8)
