### PR TITLE
Fix: Ensure `pwd` runs inside the correct shell session in Console

### DIFF
--- a/app/Http/Controllers/ConsoleController.php
+++ b/app/Http/Controllers/ConsoleController.php
@@ -37,7 +37,7 @@ class ConsoleController extends Controller
 
         return response()->stream(
             function () use ($server, $request, $ssh, $log, $currentDir) {
-                $command = 'cd '.$currentDir.' && '.$request->command.' && echo "VITO_WORKING_DIR: $(pwd)"';
+                $command = 'cd '.$currentDir.' && '.$request->command.' && echo -n "VITO_WORKING_DIR: " && pwd';
                 $output = '';
                 $ssh->exec(command: $command, log: $log, stream: true, streamCallback: function ($out) use (&$output) {
                     echo preg_replace('/^VITO_WORKING_DIR:.*(\r?\n)?/m', '', $out);


### PR DESCRIPTION
# Fix `pwd` Expansion for Root User to Reflect Correct Working Directory

## Description
This PR fixes an issue where `$(pwd)` was expanded **too early**, causing the working directory to be incorrect **when running as root** and when `$request->command` included a directory change.

### Issue
- When the user is **root**, `$(pwd)` is expanded **before** the shell executes `cd`, meaning it **always prints the old working directory**.
- This happens because `sudo su - root -c "command"` spawns a **new login shell**, and `$(pwd)` expands **before entering it**.
- As a result, if `$request->command` contained `cd /root`, the working directory printed would still be the **previous directory**.

### Fix
- **Replaced:**
```php
echo "VITO_WORKING_DIR: $(pwd)"
```

- **With:**
```php
echo -n "VITO_WORKING_DIR: " && pwd
```

Why?
	•	This ensures pwd executes after cd in the same shell session.
	•	Now, the output correctly shows the updated working directory.

Testing
	•	Ran multiple commands with cd inside $request->command.
	•	Verified that pwd now returns the correct directory.

Notes
	•	No breaking changes introduced.
	•	Improves shell command reliability.

Closes #515