### PR TITLE
fix: Sail default container name to match docker-compose.yml

### DIFF
--- a/sail
+++ b/sail
@@ -122,7 +122,7 @@ fi
 
 # Define environment variables...
 export APP_PORT=${APP_PORT:-80}
-export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
+export APP_SERVICE=${APP_SERVICE:-"app"}
 export DB_PORT=${DB_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
 export WWWGROUP=${WWWGROUP:-$(id -g)}


### PR DESCRIPTION
By default, Sail looks for the `laravel.test` container when running `sail artisan`, but the `docker-compose.yml` in this project defines the service as `app`. This caused `sail artisan` and other Sail commands to fail locally.

Updated the `APP_SERVICE` environment variable in `sail` to default to `app` instead of `laravel.test`, ensuring consistency with the service name in `docker-compose.yml`.