### PR TITLE
Enable opcache by default for better performance.

### DIFF
--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,3 +1,12 @@
 [PHP]
 post_max_size = 100M
 upload_max_filesize = 100M
+
+
+; ----- OPCache Settings -----
+
+; Enable OPCache for performance improvement
+opcache.enable=1
+
+; Enable OPCache for CLI
+opcache.enable_cli=1


### PR DESCRIPTION
OPCache can significantly improve performance by caching precompiled script bytecode, reducing the need for repeated parsing and compiling of PHP code on each request. Having the ability to toggle this feature would provide more flexibility for users to optimize performance based on their specific use cases.