### PR TITLE
feat(api): add endpoint to update site aliases

### DIFF
--- a/app/Http/Controllers/API/SiteController.php
+++ b/app/Http/Controllers/API/SiteController.php
@@ -125,7 +125,7 @@ class SiteController extends Controller
 
         $this->validateRoute($project, $server, $site);
 
-        $this->validate($request, UpdateAliases::rules($site));
+        $this->validate($request, UpdateAliases::rules());
 
         app(UpdateAliases::class)->update($site, $request->all());
 

--- a/app/Http/Controllers/API/SiteController.php
+++ b/app/Http/Controllers/API/SiteController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\API;
 
 use App\Actions\Site\CreateSite;
+use App\Actions\Site\UpdateAliases;
 use App\Actions\Site\UpdateLoadBalancer;
 use App\Enums\LoadBalancerMethod;
 use App\Enums\SiteType;
@@ -23,6 +24,7 @@ use Spatie\RouteAttributes\Attributes\Get;
 use Spatie\RouteAttributes\Attributes\Middleware;
 use Spatie\RouteAttributes\Attributes\Post;
 use Spatie\RouteAttributes\Attributes\Prefix;
+use Spatie\RouteAttributes\Attributes\Put;
 
 #[Prefix('api/projects/{project}/servers/{server}/sites')]
 #[Middleware(['auth:sanctum', 'can-see-project'])]
@@ -109,6 +111,23 @@ class SiteController extends Controller
         $this->validate($request, UpdateLoadBalancer::rules($site));
 
         app(UpdateLoadBalancer::class)->update($site, $request->all());
+
+        return new SiteResource($site);
+    }
+
+    #[Put('{site}/aliases', name: 'api.projects.servers.sites.aliases', middleware: 'ability:write')]
+    #[Endpoint(title: 'aliases', description: 'Update aliases.')]
+    #[BodyParam(name: 'aliases', type: 'array', description: 'Array of aliases')]
+    #[Response(status: 200)]
+    public function updateAliases(Request $request, Project $project, Server $server, Site $site): SiteResource
+    {
+        $this->authorize('update', [$site, $server]);
+
+        $this->validateRoute($project, $server, $site);
+
+        $this->validate($request, UpdateAliases::rules($site));
+
+        app(UpdateAliases::class)->update($site, $request->all());
 
         return new SiteResource($site);
     }

--- a/tests/Feature/API/SitesTest.php
+++ b/tests/Feature/API/SitesTest.php
@@ -118,6 +118,30 @@ class SitesTest extends TestCase
             ->assertNoContent();
     }
 
+    public function test_update_aliases(): void
+    {
+        SSH::fake();
+
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        /** @var Site $site */
+        $site = Site::factory()->create([
+            'server_id' => $this->server->id,
+        ]);
+
+        $this->json('PUT', route('api.projects.servers.sites.aliases', [
+            'project' => $this->server->project,
+            'server' => $this->server,
+            'site' => $site,
+        ]), [
+            'aliases' => ['example.com', 'example.net'],
+        ])
+            ->assertSuccessful()
+            ->assertJsonFragment([
+                'aliases' => ['example.com', 'example.net'],
+            ]);
+    }
+
     public function test_update_load_balancer(): void
     {
         SSH::fake();


### PR DESCRIPTION
Allows the updating of a sites aliases using a PUT request. The request requires one property on the body, "aliases" - which is an array of strings.

I have not ran `scribe:generate` (yet) - the entire scribe directory gets rewritten and I'm not familiar enough with scribe to know if this is the correct behaviour.

I intend to continue adding more API functionality, but this is something that has a particular priority for me currently (hence PRing this alone first).