### PR TITLE
feat(api): Add endpoint for updating site .env file

### DIFF
--- a/app/Http/Controllers/API/SiteController.php
+++ b/app/Http/Controllers/API/SiteController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API;
 
 use App\Actions\Site\CreateSite;
 use App\Actions\Site\UpdateAliases;
+use App\Actions\Site\UpdateEnv;
 use App\Actions\Site\UpdateLoadBalancer;
 use App\Enums\LoadBalancerMethod;
 use App\Enums\SiteType;
@@ -128,6 +129,25 @@ class SiteController extends Controller
         $this->validate($request, UpdateAliases::rules());
 
         app(UpdateAliases::class)->update($site, $request->all());
+
+        return new SiteResource($site);
+    }
+
+    #[Put('{site}/env', name: 'api.projects.servers.sites.env', middleware: 'ability:write')]
+    #[Endpoint(title: 'env', description: 'Update site .env file')]
+    #[BodyParam(name: 'env', type: 'string', description: 'Content of the .env file')]
+    #[Response(status: 200)]
+    public function updateEnv(Request $request, Project $project, Server $server, Site $site): SiteResource
+    {
+        $this->authorize('update', [$site, $server]);
+
+        $this->validateRoute($project, $server, $site);
+
+        $this->validate($request, [
+            'env' => ['required', 'string'],
+        ]);
+
+        app(UpdateEnv::class)->update($site, $request->all());
 
         return new SiteResource($site);
     }

--- a/tests/Feature/API/SitesTest.php
+++ b/tests/Feature/API/SitesTest.php
@@ -142,6 +142,34 @@ class SitesTest extends TestCase
             ]);
     }
 
+    public function test_update_env(): void
+    {
+        SSH::fake();
+
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        /** @var Site $site */
+        $site = Site::factory()->create([
+            'server_id' => $this->server->id,
+        ]);
+
+        $envContent = "APP_NAME=Laravel\nAPP_ENV=production";
+
+        $this->json('PUT', route('api.projects.servers.sites.env', [
+            'project' => $this->server->project,
+            'server' => $this->server,
+            'site' => $site,
+        ]), [
+            'env' => $envContent,
+        ])
+            ->assertSuccessful()
+            ->assertJsonFragment([
+                'domain' => $site->domain,
+            ]);
+
+        SSH::assertExecuted('edit-file');
+    }
+
     public function test_update_load_balancer(): void
     {
         SSH::fake();


### PR DESCRIPTION
# Add Site ENV Update API Endpoint

## Description
Adds a new API endpoint that allows updating a site's .env file through the API. This complements the existing web interface functionality and enables programmatic .env file updates.

## API Details
### New Endpoint
`PUT /api/projects/{project}/servers/{server}/sites/{site}/env`

#### Authentication
- Requires authentication token
- Requires 'write' ability

#### Request Body
```json
{
    "env": "APP_NAME=Laravel\nAPP_ENV=production"
}