### PR TITLE
feat(git): Add support for checking out GitHub pull requests

### DIFF
--- a/resources/views/ssh/git/checkout.blade.php
+++ b/resources/views/ssh/git/checkout.blade.php
@@ -1,7 +1,13 @@
 if ! cd {{ $path }}; then
-    echo 'VITO_SSH_ERROR' && exit 1
+echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+if [[ {{ $branch }} =~ ^pr-[0-9]+$ ]] && ! git rev-parse --verify {{ $branch }}; then
+if ! git fetch origin "pull/{{ substr($branch, 3) }}/head:{{ $branch }}"; then
+echo 'VITO_SSH_ERROR' && exit 1
+fi
 fi
 
 if ! git checkout -f {{ $branch }}; then
-    echo 'VITO_SSH_ERROR' && exit 1
+echo 'VITO_SSH_ERROR' && exit 1
 fi


### PR DESCRIPTION
![CleanShot 2025-03-23 at 10 44 38](https://github.com/user-attachments/assets/43197ba5-e33a-45e4-b730-1de5b8355f43)

# Add GitHub Pull Request Checkout Support

## Description
This PR adds the ability to checkout GitHub pull requests directly using a `pr-{number}` branch format. This makes it easier to test and review pull requests without manual branch fetching.

## Features
- Checkout PRs using format `pr-123`
- Safe handling of existing branches
- PR number validation
- Prevents accidental overwrites

## Implementation Details
The checkout script now:
1. Detects `pr-{number}` pattern
2. Validates PR number format
3. Checks if branch exists locally first
4. Fetches PR only if branch doesn't exist

## Why It's Needed
Makes PR testing more accessible
Improves developer workflow