### PR TITLE
Revert "fix: add missing backticks in Blade for MySQL/MariaDB database names with hyphens"

### DIFF
--- a/resources/views/ssh/services/database/mariadb/backup.blade.php
+++ b/resources/views/ssh/services/database/mariadb/backup.blade.php
@@ -1,4 +1,4 @@
-if ! sudo DEBIAN_FRONTEND=noninteractive mysqldump -u root \`{{ $database }}\` > {{ $file }}.sql; then
+if ! sudo DEBIAN_FRONTEND=noninteractive mysqldump -u root {{ $database }} > {{ $file }}.sql; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/mariadb/create.blade.php
+++ b/resources/views/ssh/services/database/mariadb/create.blade.php
@@ -1,4 +1,4 @@
-if ! sudo mariadb -e "CREATE DATABASE IF NOT EXISTS \`{{ $name }}\` CHARACTER SET '{{ $charset }}' COLLATE '{{ $collation }}'"; then
+if ! sudo mariadb -e "CREATE DATABASE IF NOT EXISTS {{ $name }} CHARACTER SET '{{ $charset }}' COLLATE '{{ $collation }}'"; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/mariadb/delete.blade.php
+++ b/resources/views/ssh/services/database/mariadb/delete.blade.php
@@ -1,4 +1,4 @@
-if ! sudo mariadb -e "DROP DATABASE IF EXISTS \`{{ $name }}\`"; then
+if ! sudo mariadb -e "DROP DATABASE IF EXISTS {{ $name }}"; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/mariadb/link.blade.php
+++ b/resources/views/ssh/services/database/mariadb/link.blade.php
@@ -1,4 +1,4 @@
-if ! sudo mariadb -e "GRANT ALL PRIVILEGES ON \`{{ $database }}\`.* TO '{{ $username }}'@'{{ $host }}'"; then
+if ! sudo mariadb -e "GRANT ALL PRIVILEGES ON {{ $database }}.* TO '{{ $username }}'@'{{ $host }}'"; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/mariadb/restore.blade.php
+++ b/resources/views/ssh/services/database/mariadb/restore.blade.php
@@ -2,7 +2,7 @@ if ! DEBIAN_FRONTEND=noninteractive unzip {{ $file }}.zip; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 
-if ! sudo DEBIAN_FRONTEND=noninteractive mariadb -u root \`{{ $database }}\` < {{ $file }}.sql; then
+if ! sudo DEBIAN_FRONTEND=noninteractive mariadb -u root {{ $database }} < {{ $file }}.sql; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/mysql/backup.blade.php
+++ b/resources/views/ssh/services/database/mysql/backup.blade.php
@@ -1,4 +1,4 @@
-if ! sudo DEBIAN_FRONTEND=noninteractive mysqldump -u root \`{{ $database }}\` > {{ $file }}.sql; then
+if ! sudo DEBIAN_FRONTEND=noninteractive mysqldump -u root {{ $database }} > {{ $file }}.sql; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/mysql/create.blade.php
+++ b/resources/views/ssh/services/database/mysql/create.blade.php
@@ -1,4 +1,4 @@
-if ! sudo mysql -e "CREATE DATABASE IF NOT EXISTS \`{{ $name }}\` CHARACTER SET '{{ $charset }}' COLLATE '{{ $collation }}'"; then
+if ! sudo mysql -e "CREATE DATABASE IF NOT EXISTS {{ $name }} CHARACTER SET '{{ $charset }}' COLLATE '{{ $collation }}'"; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/mysql/delete.blade.php
+++ b/resources/views/ssh/services/database/mysql/delete.blade.php
@@ -1,4 +1,4 @@
-if ! sudo mysql -e "DROP DATABASE IF EXISTS \`{{ $name }}\`"; then
+if ! sudo mysql -e "DROP DATABASE IF EXISTS {{ $name }}"; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/mysql/link.blade.php
+++ b/resources/views/ssh/services/database/mysql/link.blade.php
@@ -1,4 +1,4 @@
-if ! sudo mysql -e "GRANT ALL PRIVILEGES ON \`{{ $database }}\`.* TO '{{ $username }}'@'{{ $host }}'"; then
+if ! sudo mysql -e "GRANT ALL PRIVILEGES ON {{ $database }}.* TO '{{ $username }}'@'{{ $host }}'"; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/mysql/restore.blade.php
+++ b/resources/views/ssh/services/database/mysql/restore.blade.php
@@ -2,7 +2,7 @@ if ! DEBIAN_FRONTEND=noninteractive unzip {{ $file }}.zip; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 
-if ! sudo DEBIAN_FRONTEND=noninteractive mysql -u root \`{{ $database }}\` < {{ $file }}.sql; then
+if ! sudo DEBIAN_FRONTEND=noninteractive mysql -u root {{ $database }} < {{ $file }}.sql; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 


### PR DESCRIPTION
Reverts vitodeploy/vito#523

Currently this is causing a backup issue on MySQL.

Backups are failing with this error

```
mysqldump: Got error: 1049: Unknown database '`dbname`' when selecting the database
```