### PR TITLE
fix the branch required validation rule for create-site on first loading

### DIFF
--- a/resources/js/pages/sites/components/create-site.tsx
+++ b/resources/js/pages/sites/components/create-site.tsx
@@ -38,6 +38,7 @@ export default function CreateSite({ server, children }: { server?: Server; chil
     aliases: [],
     php_version: '',
     source_control: '',
+    branch: 'main',
     user: '',
   });
 


### PR DESCRIPTION
On the create-site screen first loading, although the branch field is set as "main", the actual form value is empty (missing). 

![2](https://github.com/user-attachments/assets/79c86b78-2323-4598-93aa-a459d5d9d130)
![Screenshot 2025-06-06 104756](https://github.com/user-attachments/assets/484384c7-768c-4b47-aa7e-113b036bfc60)

That's why the branch required validation rule does not pass. It displays "The branch field is required." after submitting.

https://github.com/user-attachments/assets/35b21105-aeac-49c5-84e0-0e37adb129cc

I've set "main" as the default branch in the form.