### PR TITLE
Update CreateServer action

### DIFF
--- a/app/Actions/Server/CreateServer.php
+++ b/app/Actions/Server/CreateServer.php
@@ -15,6 +15,7 @@ use Exception;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
@@ -60,19 +61,19 @@ class CreateServer
             $this->server->save();
 
             // create firewall rules
-            $this->createFirewallRules($this->server);
-
-            // create instance
-            $this->server->provider()->create();
+            $this->createFirewallRules();
 
             // create services
             $this->createServices();
 
-            // install server
-            dispatch(function (): void {
+            dispatch(function () {
+                // create a server (from a specific provider such as Hetzner or DigitalOcean)
+                $this->server->provider()->create();
+
+                Sleep::for(30)->seconds();
+
                 app(InstallServer::class)->run($this->server);
-            })
-                ->catch(function (Throwable $e): void {
+            })->onConnection('ssh')->catch(function (Throwable $e): void {
                     $this->server->update([
                         'status' => ServerStatus::INSTALLATION_FAILED,
                     ]);
@@ -80,8 +81,7 @@ class CreateServer
                     Log::error('server-installation-error', [
                         'error' => (string) $e,
                     ]);
-                })
-                ->onConnection('ssh');
+                });
 
             return $this->server;
         } catch (Exception $e) {
@@ -162,9 +162,9 @@ class CreateServer
         return $server->provider()->createRules($input);
     }
 
-    public function createFirewallRules(Server $server): void
+    public function createFirewallRules(): void
     {
-        $server->firewallRules()->createMany([
+        $this->server->firewallRules()->createMany([
             [
                 'type' => 'allow',
                 'name' => 'SSH',


### PR DESCRIPTION
I'm using Windows for PHP development at my current company. I'm using Herd to serve HTTP requests, and docker for running queue workers. If SSH key files are created by docker containers, everything will work fine. But, if they are created via HTTP requests (Windows environment), it won't work. I have to manually fix private key files permission.

Therefore, I'd like to make an update here. Instead of calling `$this->server->provider()->create()` right in a HTTP request, we can call it inside a background job. SSH keys will be created by queue workers in Debian docker containers. We won't need to care about file permission on Windows anymore.

Here is a quick review:

```php
// Storing data into database in HTTP requests as usual
$this->server->save();
$this->createFirewallRules();
$this->createServices();

dispatch(function () {
    // Create SSH files and store in our filesystem
    // Call third-party API to add SSH public key to cloud provider
    // Call third-party API to create a real server from cloud provider
    $this->server->provider()->create();

    // Wait for 30 seconds before checking if SSH connection is available
    Sleep::for(30)->seconds();

    // Do server installation
    app(InstallServer::class)->run($this->server);
})
```

It's just a small change but does not break current behavior, but support development on Windows.