### PR TITLE
Restrict Site User Management to Administrators Only

### DIFF
--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -438,4 +438,12 @@ class Site extends AbstractModel
     {
         return $this->redirects()->whereIn('status', [RedirectStatus::CREATING, RedirectStatus::READY]);
     }
+
+    /**
+     * @return BelongsToMany<User, covariant $this>
+     */
+    public function users()
+    {
+        return $this->belongsToMany(User::class, 'site_user')->withTimestamps();
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -205,6 +205,14 @@ class User extends Authenticatable implements FilamentUser
         });
     }
 
+    /**
+     * @return BelongsToMany<Site, covariant $this>
+     */
+    public function sites(): BelongsToMany
+    {
+        return $this->belongsToMany(Site::class, 'site_user')->withTimestamps();
+    }
+
     public function canAccessPanel(Panel $panel): bool
     {
         return true;

--- a/app/Policies/SitePolicy.php
+++ b/app/Policies/SitePolicy.php
@@ -13,14 +13,30 @@ class SitePolicy
 
     public function viewAny(User $user, Server $server): bool
     {
-        return ($user->isAdmin() || $server->project->users->contains($user))
+        // المسؤول يمكنه رؤية جميع المواقع
+        if ($user->isAdmin()) {
+            return $server->isReady() && $server->webserver();
+        }
+        
+        // المستخدم العادي يمكنه رؤية المواقع المرتبطة بالمشروع أو المواقع المرتبطة به مباشرة
+        return ($server->project->users->contains($user) && $user->sites()->whereHas('server', function ($query) use ($server) {
+            $query->where('id', $server->id);
+        })->exists())
             && $server->isReady()
             && $server->webserver();
     }
 
     public function view(User $user, Site $site, Server $server): bool
     {
-        return ($user->isAdmin() || $site->server->project->users->contains($user))
+        // المسؤول يمكنه رؤية أي موقع
+        if ($user->isAdmin()) {
+            return $site->server_id === $server->id
+                && $site->server->isReady()
+                && $site->server->webserver();
+        }
+        
+        // المستخدم العادي يمكنه رؤية المواقع المرتبطة بالمشروع أو المواقع المرتبطة به مباشرة
+        return ($site->server->project->users->contains($user) && $site->users->contains($user))
             && $site->server_id === $server->id
             && $site->server->isReady()
             && $site->server->webserver();
@@ -35,7 +51,15 @@ class SitePolicy
 
     public function update(User $user, Site $site, Server $server): bool
     {
-        return ($user->isAdmin() || $site->server->project->users->contains($user))
+        // المسؤول يمكنه تعديل أي موقع
+        if ($user->isAdmin()) {
+            return $site->server_id === $server->id
+                && $site->server->isReady()
+                && $site->server->webserver();
+        }
+        
+        // المستخدم العادي يمكنه تعديل المواقع المرتبطة بالمشروع أو المواقع المرتبطة به مباشرة
+        return ($site->server->project->users->contains($user) && $site->users->contains($user))
             && $site->server_id === $server->id
             && $site->server->isReady()
             && $site->server->webserver();
@@ -43,7 +67,27 @@ class SitePolicy
 
     public function delete(User $user, Site $site, Server $server): bool
     {
-        return ($user->isAdmin() || $site->server->project->users->contains($user))
+        // المسؤول يمكنه حذف أي موقع
+        if ($user->isAdmin()) {
+            return $site->server_id === $server->id
+                && $site->server->isReady()
+                && $site->server->webserver();
+        }
+        
+        // المستخدم العادي يمكنه حذف المواقع المرتبطة بالمشروع أو المواقع المرتبطة به مباشرة
+        return ($site->server->project->users->contains($user) && $site->users->contains($user))
+            && $site->server_id === $server->id
+            && $site->server->isReady()
+            && $site->server->webserver();
+    }
+
+    /**
+     * تحديد ما إذا كان المستخدم يمكنه إضافة مستخدمين آخرين للموقع
+     */
+    public function addUser(User $user, Site $site, Server $server): bool
+    {
+        // فقط المسؤول يمكنه إضافة مستخدمين آخرين للموقع
+        return $user->isAdmin()
             && $site->server_id === $server->id
             && $site->server->isReady()
             && $site->server->webserver();

--- a/app/Web/Pages/Servers/Sites/View.php
+++ b/app/Web/Pages/Servers/Sites/View.php
@@ -69,6 +69,25 @@ class View extends Page
             }
         }
 
+        /** @var User $user */
+        $user = auth()->user();
+        
+        if ($user->can('addUser', [$this->site, $this->server])) {
+            $widgets[] = [
+                Widgets\AddUser::class,
+                [
+                    'site' => $this->site,
+                ],
+            ];
+            
+            $widgets[] = [
+                Widgets\SiteUsersList::class,
+                [
+                    'site' => $this->site,
+                ],
+            ];
+        }
+        
         return $widgets;
     }
 

--- a/app/Web/Pages/Servers/Sites/Widgets/AddUser.php
+++ b/app/Web/Pages/Servers/Sites/Widgets/AddUser.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Web\Pages\Servers\Sites\Widgets;
+
+use App\Models\Site;
+use App\Models\User;
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Widgets\Widget;
+use Illuminate\Validation\Rule;
+
+class AddUser extends Widget implements HasForms
+{
+    use InteractsWithForms;
+
+    protected static string $view = 'components.form';
+
+    public Site $site;
+
+    public ?int $user = null;
+
+    public function mount(Site $site): void
+    {
+        $this->site = $site;
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Section::make()
+                    ->heading('Add User')
+                    ->schema([
+                        Select::make('user')
+                            ->name('user')
+                            ->options(fn () => User::query()
+                                ->whereNotExists(function ($query): void {
+                                    $query->select('user_id')
+                                        ->from('site_user')
+                                        ->whereColumn('users.id', 'site_user.user_id')
+                                        ->where('site_user.site_id', $this->site->id);
+                                })
+                                ->pluck('name', 'id')
+                            )
+                            ->searchable()
+                            ->rules([
+                                'required',
+                                Rule::exists('users', 'id'),
+                                Rule::unique('site_user', 'user_id')->where('site_id', $this->site->id),
+                            ]),
+                    ])
+                    ->footerActions([
+                        Action::make('add')
+                            ->label('Add')
+                            ->action(fn () => $this->submit()),
+                    ]),
+            ]);
+    }
+
+    public function submit(): void
+    {
+        // تغيير التصريح لاستخدام سياسة addUser بدلاً من update
+        $this->authorize('addUser', [$this->site, $this->site->server]);
+
+        $this->validate();
+
+        $this->site->users()->attach($this->user);
+
+        Notification::make()
+            ->title('User added!')
+            ->success()
+            ->send();
+
+        $this->user = null;
+    }
+
+    public function updated(): void
+    {
+        $this->dispatch('userAdded');
+    }
+}

--- a/app/Web/Pages/Servers/Sites/Widgets/SiteUsersList.php
+++ b/app/Web/Pages/Servers/Sites/Widgets/SiteUsersList.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Web\Pages\Servers\Sites\Widgets;
+
+use App\Models\Site;
+use App\Models\User;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as Widget;
+use Illuminate\Database\Eloquent\Builder;
+
+class SiteUsersList extends Widget
+{
+    /**
+     * @var array<string, string>
+     */
+    protected $listeners = ['userAdded' => '$refresh'];
+
+    public Site $site;
+
+    public function mount(Site $site): void
+    {
+        $this->site = $site;
+    }
+
+    /**
+     * @return Builder<User>
+     */
+    protected function getTableQuery(): Builder
+    {
+        return User::query()->whereHas('sites', function (Builder $query): void {
+            $query->where('site_id', $this->site->id);
+        });
+    }
+
+    protected function getTableColumns(): array
+    {
+        return [
+            Tables\Columns\TextColumn::make('id')->width('20%'),
+            Tables\Columns\TextColumn::make('name')->width('20%'),
+            Tables\Columns\TextColumn::make('email')->width('20%'),
+        ];
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->heading(null)
+            ->query($this->getTableQuery())
+            ->columns($this->getTableColumns())
+            ->actions([
+                Tables\Actions\DeleteAction::make()
+                    ->label('Remove')
+                    ->modalHeading('Remove user from site')
+                    ->visible(fn ($record): bool => $this->authorize('update', [$this->site, $this->site->server])->allowed() && $record->id !== auth()->id())
+                    ->using(function ($record): void {
+                        $this->site->users()->detach($record);
+                    }),
+            ])
+            ->paginated(false);
+    }
+}

--- a/database/migrations/create_site_user_table.php
+++ b/database/migrations/create_site_user_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Models\Site;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('site_user', function (Blueprint $table): void {
+            $table->foreignIdFor(Site::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
+            $table->timestamps();
+            
+            $table->primary(['site_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('site_user');
+    }
+};


### PR DESCRIPTION
This PR modifies the site user management functionality to restrict the ability to add users to sites to administrators only. Previously, any user associated with a site's project could add other users to the site, which could lead to security concerns and unintended access permissions.

## Security Benefits
- Enhances security by ensuring only administrators can control site access
- Prevents regular users from granting access to other users
- Maintains the principle of least privilege