### PR TITLE
feat: localhost/http copyable texts

### DIFF
--- a/resources/js/components/copyable-badge.tsx
+++ b/resources/js/components/copyable-badge.tsx
@@ -1,30 +1,41 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
+import { copyToClipboard } from '@/lib/utils';
 
 export default function CopyableBadge({ text }: { text: string }) {
   const [copySuccess, setCopySuccess] = useState(false);
-  const copyToClipboard = () => {
-    navigator.clipboard.writeText(text).then(() => {
-      setCopySuccess(true);
-      setTimeout(() => {
-        setCopySuccess(false);
-      }, 2000);
-    });
+  const hiddenInputRef = useRef<HTMLInputElement>(null);
+  
+  const handleCopy = async () => {
+    const success = await copyToClipboard(text, hiddenInputRef.current || undefined);
+    setCopySuccess(true);
+    setTimeout(() => {
+      setCopySuccess(false);
+    }, 2000);
   };
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div className="inline-flex cursor-pointer justify-start space-x-2 truncate" onClick={copyToClipboard}>
-          <Badge variant={copySuccess ? 'success' : 'outline'} className="block max-w-[200px] overflow-ellipsis">
-            {text}
-          </Badge>
-        </div>
-      </TooltipTrigger>
-      <TooltipContent side="top">
-        <span className="flex items-center space-x-2">Copy</span>
-      </TooltipContent>
-    </Tooltip>
+    <>
+      <input
+        ref={hiddenInputRef}
+        value={text}
+        style={{ position: 'absolute', left: '-9999px', opacity: 0, pointerEvents: 'none' }}
+        readOnly
+        tabIndex={-1}
+      />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="inline-flex cursor-pointer justify-start space-x-2 truncate" onClick={handleCopy}>
+            <Badge variant={copySuccess ? 'success' : 'outline'} className="block max-w-[200px] overflow-ellipsis">
+              {text}
+            </Badge>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <span className="flex items-center space-x-2">Copy</span>
+        </TooltipContent>
+      </Tooltip>
+    </>
   );
 }

--- a/resources/js/lib/utils.ts
+++ b/resources/js/lib/utils.ts
@@ -31,3 +31,26 @@ export function formatDateString(dateString: string | Date): string {
   // Generate yyyy-mm-dd date string
   return year + '-' + month + '-' + day;
 }
+
+// Copy text to clipboard with fallback to text selection for localhost
+export async function copyToClipboard(text: string, inputElement?: HTMLInputElement): Promise<boolean> {
+  try {
+    // Try clipboard API first
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    // Fallback: if input element is provided, select the text so user can copy with Cmd+C
+    if (inputElement) {
+      inputElement.focus();
+      inputElement.select();
+      // Try the legacy execCommand as a last resort
+      try {
+        return document.execCommand('copy');
+      } catch {
+        // If all fails, at least the text is selected
+        return false;
+      }
+    }
+    return false;
+  }
+}

--- a/resources/js/pages/servers/components/header.tsx
+++ b/resources/js/pages/servers/components/header.tsx
@@ -2,12 +2,12 @@ import { Server } from '@/types/server';
 import { CheckIcon, CloudIcon, LoaderCircleIcon, MousePointerClickIcon, SlashIcon } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import ServerActions from '@/pages/servers/components/actions';
-import { cn } from '@/lib/utils';
+import { cn, copyToClipboard } from '@/lib/utils';
 import { Site } from '@/types/site';
 import { StatusRipple } from '@/components/status-ripple';
 import { Badge } from '@/components/ui/badge';
 import { useForm } from '@inertiajs/react';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 
 export default function ServerHeader({ server, site }: { server: Server; site?: Site }) {
   const statusForm = useForm();
@@ -21,118 +21,128 @@ export default function ServerHeader({ server, site }: { server: Server; site?: 
   };
 
   const [ipCopied, setIpCopied] = useState(false);
-  const copyIp = (ip: string) => {
-    navigator.clipboard.writeText(ip).then(() => {
-      setIpCopied(true);
-      setTimeout(() => {
-        setIpCopied(false);
-      }, 2000);
-    });
+  const hiddenInputRef = useRef<HTMLInputElement>(null);
+
+  const copyIp = async (ip: string) => {
+    await copyToClipboard(ip, hiddenInputRef.current || undefined);
+    setIpCopied(true);
+    setTimeout(() => {
+      setIpCopied(false);
+    }, 2000);
   };
 
   return (
-    <div className="flex items-center justify-between border-b px-4 py-2">
-      <div className="space-y-2">
-        <div className="flex items-center space-x-2 text-xs">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="flex items-center space-x-1">
-                <CloudIcon className="size-4" />
-                <div className="hidden lg:inline-flex">{server.provider}</div>
-              </div>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <div>
-                <span className="lg:hidden">{server.provider}</span>
-                <span className="hidden lg:inline-flex">Server Provider</span>
-              </div>
-            </TooltipContent>
-          </Tooltip>
-          <SlashIcon className="size-3" />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              {ipCopied ? (
-                <CheckIcon className="text-success size-3" />
-              ) : (
-                <div>
-                  {statusForm.processing && <LoaderCircleIcon className="size-3 animate-spin" />}
-                  {!statusForm.processing && <StatusRipple className="cursor-pointer" onClick={checkStatus} variant={server.status_color} />}
+    <>
+      <input
+        ref={hiddenInputRef}
+        value={server.ip}
+        style={{ position: 'absolute', left: '-9999px', opacity: 0, pointerEvents: 'none' }}
+        readOnly
+        tabIndex={-1}
+      />
+      <div className="flex items-center justify-between border-b px-4 py-2">
+        <div className="space-y-2">
+          <div className="flex items-center space-x-2 text-xs">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="flex items-center space-x-1">
+                  <CloudIcon className="size-4" />
+                  <div className="hidden lg:inline-flex">{server.provider}</div>
                 </div>
-              )}
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <span>{server.status}</span>
-            </TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="cursor-pointer lg:inline-flex" onClick={() => copyIp(server.ip)}>
-                {server.ip}
-              </div>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <span>Server IP</span>
-            </TooltipContent>
-          </Tooltip>
-          {['installing', 'installation_failed'].includes(server.status) && (
-            <>
-              <SlashIcon className="size-3" />
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center space-x-1">
-                    <LoaderCircleIcon className={cn('size-4', server.status === 'installing' ? 'text-brand animate-spin' : '')} />
-                    <div>%{parseInt(server.progress || '0')}</div>
-                    {server.status === 'installation_failed' && (
-                      <Badge className="ml-1" variant={server.status_color}>
-                        {server.status}
-                      </Badge>
-                    )}
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <div>
+                  <span className="lg:hidden">{server.provider}</span>
+                  <span className="hidden lg:inline-flex">Server Provider</span>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+            <SlashIcon className="size-3" />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                {ipCopied ? (
+                  <CheckIcon className="text-success size-3" />
+                ) : (
+                  <div>
+                    {statusForm.processing && <LoaderCircleIcon className="size-3 animate-spin" />}
+                    {!statusForm.processing && <StatusRipple className="cursor-pointer" onClick={checkStatus} variant={server.status_color} />}
                   </div>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Status</TooltipContent>
-              </Tooltip>
-            </>
-          )}
-          {site && (
-            <>
-              <SlashIcon className="size-3" />
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <a href={site.url} target="_blank" className="flex items-center space-x-1 truncate">
-                    <MousePointerClickIcon className="size-4" />
-                    <div className="hidden max-w-[150px] overflow-x-hidden overflow-ellipsis lg:block">{site.domain}</div>
-                  </a>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  <span>{site.domain}</span>
-                </TooltipContent>
-              </Tooltip>
-            </>
-          )}
-          {site && ['installing', 'installation_failed'].includes(site.status) && (
-            <>
-              <SlashIcon className="size-3" />
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center space-x-1">
-                    <LoaderCircleIcon className={cn('size-4', site.status === 'installing' ? 'text-brand animate-spin' : '')} />
-                    <div>%{parseInt(site.progress.toString() || '0')}</div>
-                    {site.status === 'installation_failed' && (
-                      <Badge className="ml-1" variant={site.status_color}>
-                        {site.status}
-                      </Badge>
-                    )}
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Status</TooltipContent>
-              </Tooltip>
-            </>
-          )}
+                )}
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <span>{server.status}</span>
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="cursor-pointer lg:inline-flex" onClick={() => copyIp(server.ip)}>
+                  {server.ip}
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <span>Server IP</span>
+              </TooltipContent>
+            </Tooltip>
+            {['installing', 'installation_failed'].includes(server.status) && (
+              <>
+                <SlashIcon className="size-3" />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex items-center space-x-1">
+                      <LoaderCircleIcon className={cn('size-4', server.status === 'installing' ? 'text-brand animate-spin' : '')} />
+                      <div>%{parseInt(server.progress || '0')}</div>
+                      {server.status === 'installation_failed' && (
+                        <Badge className="ml-1" variant={server.status_color}>
+                          {server.status}
+                        </Badge>
+                      )}
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Status</TooltipContent>
+                </Tooltip>
+              </>
+            )}
+            {site && (
+              <>
+                <SlashIcon className="size-3" />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <a href={site.url} target="_blank" className="flex items-center space-x-1 truncate">
+                      <MousePointerClickIcon className="size-4" />
+                      <div className="hidden max-w-[150px] overflow-x-hidden overflow-ellipsis lg:block">{site.domain}</div>
+                    </a>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <span>{site.domain}</span>
+                  </TooltipContent>
+                </Tooltip>
+              </>
+            )}
+            {site && ['installing', 'installation_failed'].includes(site.status) && (
+              <>
+                <SlashIcon className="size-3" />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex items-center space-x-1">
+                      <LoaderCircleIcon className={cn('size-4', site.status === 'installing' ? 'text-brand animate-spin' : '')} />
+                      <div>%{parseInt(site.progress.toString() || '0')}</div>
+                      {site.status === 'installation_failed' && (
+                        <Badge className="ml-1" variant={site.status_color}>
+                          {site.status}
+                        </Badge>
+                      )}
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Status</TooltipContent>
+                </Tooltip>
+              </>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center space-x-1">
+          <ServerActions server={server} />
         </div>
       </div>
-      <div className="flex items-center space-x-1">
-        <ServerActions server={server} />
-      </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
This pull request improves the copy-to-clipboard functionality for badges and server IP addresses by introducing a reusable helper with better fallback support. It refactors the relevant components to use this helper, ensuring more reliable copying across browsers and environments.

**Clipboard functionality improvements:**

* Added a new `copyToClipboard` helper in `resources/js/lib/utils.ts` that first tries the Clipboard API and falls back to selecting the text and using `execCommand('copy')` if necessary. This makes copying work more reliably, especially in environments where the Clipboard API may not be available.

**Component refactoring for clipboard usage:**

* Updated `resources/js/components/copyable-badge.tsx` to use the new `copyToClipboard` helper, replacing the previous direct use of the Clipboard API. Also added a hidden input field to facilitate fallback copying and text selection. [[1]](diffhunk://#diff-979b8584c6bac523089636b184b991e5decafb13fef0ce80cb34d9e1a603e8ecL1-R29) [[2]](diffhunk://#diff-979b8584c6bac523089636b184b991e5decafb13fef0ce80cb34d9e1a603e8ecR39)
* Updated `resources/js/pages/servers/components/header.tsx` to use the new `copyToClipboard` helper for copying the server IP address, including a hidden input for fallback support. [[1]](diffhunk://#diff-cba302c91578aee8a406a15de0f92fa0099c8fd16779eb43fae6bca6ef5d582eL5-R10) [[2]](diffhunk://#diff-cba302c91578aee8a406a15de0f92fa0099c8fd16779eb43fae6bca6ef5d582eL24-R42) [[3]](diffhunk://#diff-cba302c91578aee8a406a15de0f92fa0099c8fd16779eb43fae6bca6ef5d582eR146)… copyToClipboard utility function, enhancing clipboard functionality with fallback support. Added hidden input for better compatibility in copying text.