### PR TITLE
Add and remove versions services

### DIFF
--- a/app/Providers/ServiceTypeServiceProvider.php
+++ b/app/Providers/ServiceTypeServiceProvider.php
@@ -77,6 +77,7 @@ class ServiceTypeServiceProvider extends ServiceProvider
             ->label('MariaDB')
             ->handler(Mariadb::class)
             ->versions([
+                '11.8',
                 '11.4',
                 '10.11',
                 '10.6',
@@ -137,15 +138,6 @@ class ServiceTypeServiceProvider extends ServiceProvider
             ->versions([
                 '8.4',
                 '8.3',
-                '8.2',
-                '8.1',
-                '8.0',
-                '7.4',
-                '7.3',
-                '7.2',
-                '7.1',
-                '7.0',
-                '5.6',
             ])
             ->data([
                 'extensions' => [
@@ -168,10 +160,9 @@ class ServiceTypeServiceProvider extends ServiceProvider
             ->label('Node.js')
             ->handler(NodeJS::class)
             ->versions([
+                '24',
                 '22',
                 '20',
-                '18',
-                '16',
             ])
             ->register();
     }

--- a/resources/views/ssh/services/database/mariadb/install-118.blade.php
+++ b/resources/views/ssh/services/database/mariadb/install-118.blade.php
@@ -1,0 +1,14 @@
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+
+chmod +x mariadb_repo_setup
+
+sudo DEBIAN_FRONTEND=noninteractive ./mariadb_repo_setup \
+    --mariadb-server-version="mariadb-11.8"
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get update
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get install mariadb-server mariadb-backup -y
+
+sudo systemctl unmask mysql.service
+
+sudo service mysql start


### PR DESCRIPTION
- Removed the versions for PHP below 8.3 as they don't provide security updates anymore 
- Removed the versions for NodeJS 16 and 18 as no security updates are provided anymore 
- Added Nodejs 24
- Added MariaDB version 11.8