### PR TITLE
fix: Composer path for plugin installation

### DIFF
--- a/app/Plugins/Plugins.php
+++ b/app/Plugins/Plugins.php
@@ -58,7 +58,7 @@ class Plugins
         $output = $result->output();
 
         if ($result->failed()) {
-            throw new Exception($output);
+            throw new Exception($result->errorOutput());
         }
 
         $output .= $this->load();
@@ -97,7 +97,7 @@ class Plugins
                         $result = Process::timeout(0)
                             ->env(['PATH' => dirname($phpPath).':'.dirname($composerPath)])
                             ->path(base_path())
-                            ->run(composer_path()." require $name");
+                            ->run("composer require $name");
                         if ($result->failed()) {
                             throw new Exception($result->errorOutput());
                         }

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ProcessUtils;
 use Symfony\Component\Process\PhpExecutableFinder;
+
 use function Illuminate\Support\php_binary;
 
 function generate_public_key(string $privateKeyPath, string $publicKeyPath): void

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -4,6 +4,9 @@ use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ProcessUtils;
+use Symfony\Component\Process\PhpExecutableFinder;
+use function Illuminate\Support\php_binary;
 
 function generate_public_key(string $privateKeyPath, string $publicKeyPath): void
 {
@@ -256,14 +259,13 @@ function composer_path(): ?string
 
 function php_path(): ?string
 {
-    $paths = [
-        '/usr/local/bin/php',
-        '/usr/bin/php',
-        '/opt/homebrew/bin/php',
-        trim((string) shell_exec('which php')),
-    ];
+    $phpBinary = function_exists('Illuminate\Support\php_binary')
+        ? php_binary()
+        : (new PhpExecutableFinder)->find(false);
 
-    return array_find($paths, fn ($path) => is_executable($path));
+    return $phpBinary !== false
+        ? ProcessUtils::escapeArgument($phpBinary)
+        : null;
 }
 
 function git_path(): ?string


### PR DESCRIPTION
The composer path was being included in the PATH, but also included once again in the command, removing this from the command resolves any issues where the path to the composer binary is non-standard (for example, has a space within one of the folders).

This allows plugins to be installed when using Herd or other non-standard setups. 