### PR TITLE
Run horizon instead of default queue when using Sail

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
             XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
             XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
             IGNITION_LOCAL_SITES_PATH: '${PWD}'
-        command: 'php artisan queue:listen --sleep=3 --tries=1 --timeout=0'
+        command: 'php artisan horizon'
         restart: unless-stopped
         volumes:
             - '.:/var/www/html'


### PR DESCRIPTION
When using Sail locally, only default queue is handled.
Use horizon instead to process `default`, `ssh` and `ssh-unique` queues jobs as well.