### PR TITLE
fix: correct spelling of "connections" in headings across multiple pages

### DIFF
--- a/resources/js/pages/notification-channels/index.tsx
+++ b/resources/js/pages/notification-channels/index.tsx
@@ -23,7 +23,7 @@ export default function NotificationChannels() {
       <Head title="Notification Channels" />
       <Container className="max-w-5xl">
         <div className="flex items-start justify-between">
-          <Heading title="Notification Channels" description="Here you can manage all of the notification channel connectinos" />
+          <Heading title="Notification Channels" description="Here you can manage all of the notification channel connections" />
           <div className="flex items-center gap-2">
             <a href="https://vitodeploy.com/docs/settings/notification-channels" target="_blank">
               <Button variant="outline">

--- a/resources/js/pages/server-providers/index.tsx
+++ b/resources/js/pages/server-providers/index.tsx
@@ -26,7 +26,7 @@ export default function ServerProviders() {
       <Head title="Server Providers" />
       <Container className="max-w-5xl">
         <div className="flex items-start justify-between">
-          <Heading title="Server Providers" description="Here you can manage all of the server provider connectinos" />
+          <Heading title="Server Providers" description="Here you can manage all of the server provider connections" />
           <div className="flex items-center gap-2">
             <a href="https://vitodeploy.com/docs/settings/server-providers" target="_blank">
               <Button variant="outline">

--- a/resources/js/pages/server-settings/index.tsx
+++ b/resources/js/pages/server-settings/index.tsx
@@ -218,7 +218,7 @@ export default function Databases() {
           </CardHeader>
           <CardContent>
             <div className="space-y-2 p-4">
-              <p>please note that this action is irreversible and will delete all data associated with the server.</p>
+              <p>This action will transfer the server to another project. All associated data will remain intact.</p>
 
               <TransferServer server={page.props.server}>
                 <Button variant="outline">Transfer server</Button>

--- a/resources/js/pages/source-controls/index.tsx
+++ b/resources/js/pages/source-controls/index.tsx
@@ -23,7 +23,7 @@ export default function SourceControls() {
       <Head title="Source Controls" />
       <Container className="max-w-5xl">
         <div className="flex items-start justify-between">
-          <Heading title="Source Controls" description="Here you can manage all of the source control connectinos" />
+          <Heading title="Source Controls" description="Here you can manage all of the source control connections" />
           <div className="flex items-center gap-2">
             <a href="https://vitodeploy.com/docs/settings/source-controls" target="_blank">
               <Button variant="outline">

--- a/resources/js/pages/storage-providers/index.tsx
+++ b/resources/js/pages/storage-providers/index.tsx
@@ -25,7 +25,7 @@ export default function StorageProviders() {
       <Head title="Storage Providers" />
       <Container className="max-w-5xl">
         <div className="flex items-start justify-between">
-          <Heading title="Storage Providers" description="Here you can manage all of the storage provider connectinos" />
+          <Heading title="Storage Providers" description="Here you can manage all of the storage provider connections" />
           <div className="flex items-center gap-2">
             <a href="https://vitodeploy.com/docs/settings/storage-providers" target="_blank">
               <Button variant="outline">


### PR DESCRIPTION
correct spelling of "connections" in headings across multiple pages