### PR TITLE
Add domain editing functionality

### DIFF
--- a/app/Actions/Site/UpdateDomain.php
+++ b/app/Actions/Site/UpdateDomain.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\Actions\Site;
+
+use App\Models\Service;
+use App\Models\Site;
+use App\Services\Webserver\Webserver;
+use App\ValidationRules\DomainRule;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+
+class UpdateDomain
+{
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    public function update(Site $site, array $input): void
+    {
+        $this->validate($site, $input);
+
+        $oldDomain = $site->domain;
+        $newDomain = $input['domain'];
+
+        // If domain hasn't changed, do nothing
+        if ($oldDomain === $newDomain) {
+            return;
+        }
+
+        // Check if site is ready for domain change
+        if (! $site->isReady()) {
+            throw new \Exception('Cannot change domain while site is not ready.');
+        }
+
+        // Check if modern deployment is enabled - it would break the system
+        if ($site->modernDeploymentEnabled()) {
+            throw new \Exception('Cannot change domain while modern deployment is enabled. Please disable modern deployment first, change the domain, then re-enable it.');
+        }
+
+        // Update the domain and path in the database
+        $site->domain = $newDomain;
+        $site->path = '/home/'.$site->user.'/'.$newDomain;
+        $site->save();
+
+        // Move the physical directory on the server
+        $this->moveSiteDirectory($site, $oldDomain, $newDomain);
+
+        // Update webserver configuration files
+        $this->updateWebserverConfig($site, $oldDomain, $newDomain);
+
+        // Recreate site level workers to pick up the new site path
+        $this->recreateWorkers($site);
+    }
+
+    protected function moveSiteDirectory(Site $site, string $oldDomain, string $newDomain): void
+    {
+        $oldPath = '/home/'.$site->user.'/'.$oldDomain;
+        $newPath = '/home/'.$site->user.'/'.$newDomain;
+
+        // Move the directory from old path to new path
+        $site->server->ssh()->exec(
+            "sudo mv {$oldPath} {$newPath}",
+            'move-site-directory',
+            $site->id
+        );
+    }
+
+    protected function updateWebserverConfig(Site $site, string $oldDomain, string $newDomain): void
+    {
+        /** @var Service $service */
+        $service = $site->server->webserver();
+
+        /** @var Webserver $webserver */
+        $webserver = $service->handler();
+
+        // Move and update the virtual host file with new domain
+        $this->moveAndUpdateVirtualHost($site, $oldDomain, $newDomain, $webserver);
+    }
+
+    protected function moveAndUpdateVirtualHost(Site $site, string $oldDomain, string $newDomain, Webserver $webserver): void
+    {
+        $webserverId = $webserver::id();
+
+        if ($webserverId === 'nginx') {
+            // Move the old file to the new domain name
+            $site->server->ssh()->exec(
+                "sudo mv /etc/nginx/sites-available/{$oldDomain} /etc/nginx/sites-available/{$newDomain}",
+                'move-vhost-file',
+                $site->id
+            );
+
+            // Update the symlink if it exists
+            $site->server->ssh()->exec(
+                "sudo ln -sf /etc/nginx/sites-available/{$newDomain} /etc/nginx/sites-enabled/{$newDomain}",
+                'update-vhost-symlink',
+                $site->id
+            );
+
+            // Remove old symlink if it exists
+            $site->server->ssh()->exec(
+                "sudo rm -f /etc/nginx/sites-enabled/{$oldDomain}",
+                'remove-old-symlink',
+                $site->id
+            );
+
+        } elseif ($webserverId === 'caddy') {
+            // Move the old file to the new domain name
+            $site->server->ssh()->exec(
+                "sudo mv /etc/caddy/sites-available/{$oldDomain} /etc/caddy/sites-available/{$newDomain}",
+                'move-vhost-file',
+                $site->id
+            );
+        }
+
+        // Determine which blocks to regenerate based on site type
+        $regenerateBlocks = ['core', 'force-ssl'];
+
+        // Add load balancer blocks if this is a load balancer site
+        if ($site->type === 'load-balancer') {
+            $regenerateBlocks[] = 'load-balancer-upstream';
+            $regenerateBlocks[] = 'load-balancer';
+        }
+
+        // Update the content of the virtual host file with the new domain
+        $webserver->updateVHost($site, regenerate: $regenerateBlocks, restart: true);
+    }
+
+    protected function recreateWorkers(Site $site): void
+    {
+        if ($site->workers->isEmpty()) {
+            return;
+        }
+
+        /** @var \App\Models\Service $service */
+        $service = $site->server->processManager();
+
+        /** @var \App\Services\ProcessManager\ProcessManager $processManager */
+        $processManager = $service->handler();
+
+        // Restart all workers for this site
+        foreach ($site->workers as $worker) {
+            try {
+                $processManager->delete($worker->id, $worker->site_id);
+                $processManager->create(
+                    $worker->id,
+                    $worker->command,
+                    $worker->user,
+                    $worker->auto_start,
+                    $worker->auto_restart,
+                    $worker->numprocs,
+                    $worker->getLogFile(),
+                    $worker->site->path,
+                    $worker->site_id
+                );
+            } catch (\Throwable $e) {
+                // Log the error but continue with other workers
+                \Illuminate\Support\Facades\Log::error("Failed to restart worker {$worker->id}: ".$e->getMessage());
+            }
+        }
+    }
+
+    protected function validate(Site $site, array $input): void
+    {
+        Validator::make($input, [
+            'domain' => [
+                'required',
+                'string',
+                new DomainRule,
+                Rule::unique('sites', 'domain')
+                    ->where('server_id', $site->server_id)
+                    ->ignore($site->id),
+            ],
+        ])->validate();
+
+        // Additional validation to ensure site is ready
+        if (! $site->isReady()) {
+            $validator = validator([], []);
+            $validator->errors()->add('domain', 'Cannot change domain while site is not ready.');
+            throw new \Illuminate\Validation\ValidationException($validator);
+        }
+    }
+}

--- a/app/Http/Controllers/API/SiteController.php
+++ b/app/Http/Controllers/API/SiteController.php
@@ -6,6 +6,7 @@ use App\Actions\Site\CreateSite;
 use App\Actions\Site\Deploy;
 use App\Actions\Site\UpdateAliases;
 use App\Actions\Site\UpdateDeploymentScript;
+use App\Actions\Site\UpdateDomain;
 use App\Actions\Site\UpdateEnv;
 use App\Actions\Site\UpdateLoadBalancer;
 use App\Enums\LoadBalancerMethod;
@@ -127,6 +128,21 @@ class SiteController extends Controller
         $this->validateRoute($project, $server, $site);
 
         app(UpdateAliases::class)->update($site, $request->all());
+
+        return new SiteResource($site);
+    }
+
+    #[Put('{site}/domain', name: 'api.projects.servers.sites.domain', middleware: 'ability:write')]
+    #[Endpoint(title: 'domain', description: 'Update site domain.')]
+    #[BodyParam(name: 'domain', type: 'string', description: 'New domain name', example: 'newsite.com')]
+    #[Response(status: 200)]
+    public function updateDomain(Request $request, Project $project, Server $server, Site $site): SiteResource
+    {
+        $this->authorize('update', [$site, $server]);
+
+        $this->validateRoute($project, $server, $site);
+
+        app(UpdateDomain::class)->update($site, $request->all());
 
         return new SiteResource($site);
     }

--- a/app/Http/Controllers/SiteSettingController.php
+++ b/app/Http/Controllers/SiteSettingController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Actions\Site\DeleteSite;
 use App\Actions\Site\UpdateAliases;
 use App\Actions\Site\UpdateBranch;
+use App\Actions\Site\UpdateDomain;
 use App\Actions\Site\UpdatePHPVersion;
 use App\Actions\Site\UpdateSourceControl;
 use App\Exceptions\SSHError;
@@ -69,6 +70,19 @@ class SiteSettingController extends Controller
         app(UpdateAliases::class)->update($site, $request->input());
 
         return back()->with('success', 'Aliases updated successfully.');
+    }
+
+    /**
+     * @throws SSHError
+     */
+    #[Patch('/domain', name: 'site-settings.update-domain')]
+    public function updateDomain(Request $request, Server $server, Site $site): RedirectResponse
+    {
+        $this->authorize('update', [$site, $server]);
+
+        app(UpdateDomain::class)->update($site, $request->input());
+
+        return back()->with('success', 'Domain updated successfully.');
     }
 
     /**

--- a/resources/js/pages/site-settings/components/domain.tsx
+++ b/resources/js/pages/site-settings/components/domain.tsx
@@ -1,0 +1,144 @@
+import { FormEvent, ReactNode, useState } from 'react';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useForm } from '@inertiajs/react';
+import { Form, FormField, FormFields } from '@/components/ui/form';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import InputError from '@/components/ui/input-error';
+import { LoaderCircleIcon } from 'lucide-react';
+import { Site } from '@/types/site';
+
+export default function Domain({ site, children }: { site: Site; children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const form = useForm<{
+    domain: string;
+  }>({
+    domain: site.domain,
+  });
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+
+    // Prevent submission if modern deployment is enabled
+    if (site.modern_deployment) {
+      return;
+    }
+
+    form.patch(route('site-settings.update-domain', { server: site.server_id, site: site.id }), {
+      onSuccess: () => {
+        setOpen(false);
+      },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Update Domain</DialogTitle>
+          <DialogDescription>
+            Change the domain for your site.
+            <br />
+            <br />
+            {site.modern_deployment && (
+              <div className="mb-4 rounded-md border border-red-200 bg-red-50 p-3">
+                <div className="flex">
+                  <div className="flex-shrink-0">
+                    <svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
+                      <path
+                        fillRule="evenodd"
+                        d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div className="ml-3">
+                    <h3 className="text-sm font-medium text-red-800">Modern Deployment Detected</h3>
+                    <div className="mt-2 text-sm text-red-700">
+                      <p>
+                        You cannot change the domain while modern deployment is enabled. This would break all deployment symlinks and shared
+                        resources.
+                      </p>
+                      <p className="mt-1">
+                        <strong>Solution:</strong> Disable modern deployment first, change the domain, then re-enable it.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+            <strong>This action will:</strong>
+            <ul className="mt-2 mb-2 space-y-1 text-sm">
+              <li>
+                • Move the site directory from <code className="bg-muted rounded px-1 py-0.5 text-xs">{site.path}</code> to{' '}
+                <code className="bg-muted rounded px-1 py-0.5 text-xs">
+                  /home/{site.user}/{form.data.domain === site.domain ? '[new-domain]' : form.data.domain || '[new-domain]'}
+                </code>
+              </li>
+              <li>• Move and update virtual host files (preserving custom configurations)</li>
+              {site.type === 'load-balancer' && <li>• Update load balancer upstream configuration with new domain-based backend name</li>}
+              <li>• Recreate site level workers to pick up the new directory path</li>
+            </ul>
+            <strong className="text-amber-600">Important:</strong> After changing the domain, you may need to manually check and update:
+            <ul className="mt-2 space-y-1 text-sm">
+              <li>
+                • <strong>SSL Certificates:</strong> Existing SSL certificates are tied to the old domain and will need to be reissued for the new
+                domain
+              </li>
+              <li>
+                • <strong>Environment Variables:</strong> Check your .env file for any hardcoded domain references
+              </li>
+              <li>
+                • <strong>Cronjobs:</strong> Any cronjobs that reference the old directory path
+              </li>
+              <li>
+                • <strong>Worker Commands:</strong> Worker commands that use absolute paths or reference the old domain
+              </li>
+              <li>
+                • <strong>Custom Scripts:</strong> Any custom deployment scripts or configurations with hardcoded paths or domains
+              </li>
+            </ul>
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form id="domain-form" onSubmit={submit} className="p-4">
+          <FormFields>
+            <FormField>
+              <Label htmlFor="domain">Domain</Label>
+              <Input
+                id="domain"
+                type="text"
+                value={form.data.domain}
+                placeholder="example.com"
+                onChange={(e) => form.setData('domain', e.target.value)}
+              />
+              <InputError message={form.errors.domain} />
+            </FormField>
+          </FormFields>
+        </Form>
+
+        <DialogFooter className="gap-2">
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+
+          <Button form="domain-form" disabled={form.processing || site.modern_deployment}>
+            {form.processing && <LoaderCircleIcon className="size-4 animate-spin" />}
+            {site.modern_deployment ? 'Not available' : 'Update Domain'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/pages/site-settings/index.tsx
+++ b/resources/js/pages/site-settings/index.tsx
@@ -20,6 +20,7 @@ import DeleteSite from '@/pages/site-settings/components/delete-site';
 import VHost from '@/pages/site-settings/components/vhost';
 import ChangeSourceControl from '@/pages/site-settings/components/source-control';
 import Aliases from './components/aliases';
+import Domain from './components/domain';
 
 export default function Databases() {
   const page = usePage<{
@@ -60,9 +61,11 @@ export default function Databases() {
             <Separator />
             <div className="flex items-center justify-between p-4">
               <span>Domain</span>
-              <a href={page.props.site.url} target="_blank" className="text-muted-foreground hover:underline">
-                {page.props.site.domain}
-              </a>
+              <Domain site={page.props.site}>
+                <Button variant="outline" className="h-6">
+                  {page.props.site.domain}
+                </Button>
+              </Domain>
             </div>
             <Separator />
             <div className="flex items-center justify-between p-4">

--- a/tests/Feature/API/SitesTest.php
+++ b/tests/Feature/API/SitesTest.php
@@ -161,6 +161,33 @@ class SitesTest extends TestCase
             ]);
     }
 
+    public function test_update_domain(): void
+    {
+        SSH::fake();
+
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        /** @var Site $site */
+        $site = Site::factory()->create([
+            'server_id' => $this->server->id,
+            'domain' => 'oldsite.com',
+            'path' => '/home/vito/oldsite.com',
+        ]);
+
+        $this->json('PUT', route('api.projects.servers.sites.domain', [
+            'project' => $this->server->project,
+            'server' => $this->server,
+            'site' => $site,
+        ]), [
+            'domain' => 'newsite.com',
+        ])
+            ->assertSuccessful()
+            ->assertJsonFragment([
+                'domain' => 'newsite.com',
+                'path' => '/home/vito/newsite.com',
+            ]);
+    }
+
     public function test_update_load_balancer(): void
     {
         SSH::fake();

--- a/tests/Feature/LoadBalancerTest.php
+++ b/tests/Feature/LoadBalancerTest.php
@@ -68,4 +68,28 @@ class LoadBalancerTest extends TestCase
             'backup' => false,
         ]);
     }
+
+    public function test_update_domain_for_load_balancer_site(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-domain', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'domain' => 'loadbalancer.com',
+        ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->site->refresh();
+
+        $this->assertEquals('loadbalancer.com', $this->site->domain);
+        $this->assertEquals('/home/vito/loadbalancer.com', $this->site->path);
+
+        // Verify that load balancer configuration was regenerated
+        SSH::assertExecuted('nginx -t');
+        SSH::assertExecuted('systemctl reload nginx');
+    }
 }

--- a/tests/Feature/SitesTest.php
+++ b/tests/Feature/SitesTest.php
@@ -308,6 +308,74 @@ class SitesTest extends TestCase
         $this->assertEquals(['www.example.com', 'test.example.com'], $this->site->aliases);
     }
 
+    public function test_update_domain(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-domain', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'domain' => 'newsite.com',
+        ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->site->refresh();
+        $this->assertEquals('newsite.com', $this->site->domain);
+        $this->assertEquals('/home/vito/newsite.com', $this->site->path);
+    }
+
+    public function test_update_domain_same_domain_does_nothing(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+
+        $originalDomain = $this->site->domain;
+        $originalPath = $this->site->path;
+
+        $this->patch(route('site-settings.update-domain', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'domain' => $originalDomain,
+        ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->site->refresh();
+
+        // Domain and path should remain unchanged
+        $this->assertEquals($originalDomain, $this->site->domain);
+        $this->assertEquals($originalPath, $this->site->path);
+    }
+
+    public function test_update_domain_prevents_when_modern_deployment_enabled(): void
+    {
+        SSH::fake();
+
+        // Enable modern deployment
+        $this->site->update([
+            'type' => Laravel::id(),
+            'type_data' => [
+                'modern_deployment' => true,
+                'modern_deployment_history' => 10,
+                'modern_deployment_shared_resources' => ['.env'],
+            ],
+        ]);
+
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-domain', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'domain' => 'newsite.com',
+        ])
+            ->assertStatus(500); // Expect 500 because exception is thrown
+    }
+
     /**
      * @return array<array<int, mixed>>
      */

--- a/tests/Feature/SitesTest.php
+++ b/tests/Feature/SitesTest.php
@@ -307,6 +307,7 @@ class SitesTest extends TestCase
         $this->site->refresh();
         $this->assertEquals(['www.example.com', 'test.example.com'], $this->site->aliases);
     }
+
     public function test_update_web_directory(): void
     {
         SSH::fake();


### PR DESCRIPTION
I decided to attempt another version of my previous PR in v2 for domain editing.

**Features:**
- Domain editing modal with safety warnings
- Comprehensive validation including domain uniqueness, site readiness checks, and modern deployment blocking
- Site-level worker recreation to ensure processes run from correct directories after domain changes
- Webserver configuration updates for both Nginx and Caddy with proper file moving and symlink handling

<img width="1200" height="738" alt="CleanShot 2025-09-21 at 17 58 49" src="https://github.com/user-attachments/assets/94e2f3a6-9511-4386-9d81-a03fcf799e2a" />
