### PR TITLE
Add Vito self-backup system

### DIFF
--- a/app/Actions/VitoBackup/BackupOperations.php
+++ b/app/Actions/VitoBackup/BackupOperations.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Actions\VitoBackup;
+
+use Exception;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use ZipArchive;
+
+trait BackupOperations
+{
+    /**
+     * @var array<string, string>
+     */
+    protected array $backupPaths = [
+        '.env' => 'file',
+        'storage/ssh-public.key' => 'file',
+        'storage/ssh-private.pem' => 'file',
+        'storage/app/key-pairs' => 'directory',
+        'storage/app/server-logs' => 'directory',
+    ];
+
+    /**
+     * @throws Exception
+     */
+    protected function export(string $zipFileName): string
+    {
+        $zipPath = Storage::disk('tmp')->path($zipFileName);
+
+        $zip = new ZipArchive;
+        if ($zip->open($zipPath, ZipArchive::CREATE) !== true) {
+            throw new Exception('Could not create zip file at '.$zipPath);
+        }
+
+        // Add database export
+        $this->addDatabaseExport($zip);
+
+        // Add other files and directories
+        foreach ($this->backupPaths as $path => $type) {
+            $path = base_path($path);
+            if ($type === 'file' && File::exists($path)) {
+                $zip->addFile($path, basename($path));
+            } elseif ($type === 'directory' && File::exists($path)) {
+                $this->addDirectoryToZip($zip, $path, basename($path));
+            }
+        }
+
+        $zip->close();
+
+        return $zipPath;
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function addDatabaseExport(ZipArchive $zip): void
+    {
+        $driver = config('database.default');
+
+        switch ($driver) {
+            case 'sqlite':
+                $this->addSqliteExport($zip);
+                break;
+            default:
+                throw new Exception("Unsupported database driver: {$driver}");
+        }
+    }
+
+    protected function addSqliteExport(ZipArchive $zip): void
+    {
+        $dbPath = config('database.connections.sqlite.database');
+        if (File::exists($dbPath)) {
+            $zip->addFile($dbPath, 'database.sqlite');
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function importDatabase(string $extractPath): void
+    {
+        $driver = config('database.default');
+
+        switch ($driver) {
+            case 'sqlite':
+                $this->importSqlite($extractPath);
+                break;
+            default:
+                throw new Exception("Unsupported database driver: {$driver}");
+        }
+    }
+
+    protected function importSqlite(string $extractPath): void
+    {
+        if (File::exists($extractPath.'/database.sqlite')) {
+            File::move($extractPath.'/database.sqlite', storage_path('database.sqlite'));
+        }
+    }
+
+    protected function addDirectoryToZip(ZipArchive $zip, string $path, string $zipPath): void
+    {
+        $files = File::allFiles($path);
+
+        foreach ($files as $file) {
+            $relativePath = $zipPath.'/'.$file->getRelativePathname();
+            $zip->addFile($file->getRealPath(), $relativePath);
+        }
+    }
+}

--- a/app/Actions/VitoBackup/CreateVitoBackup.php
+++ b/app/Actions/VitoBackup/CreateVitoBackup.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Actions\VitoBackup;
+
+use App\Enums\VitoBackupStatus;
+use App\Models\VitoBackup;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+class CreateVitoBackup
+{
+    /**
+     * @param  array<string, mixed>  $input
+     *
+     * @throws ValidationException
+     */
+    public function create(array $input): VitoBackup
+    {
+        $this->validate($input);
+
+        $frequencyLabels = [
+            '0 * * * *' => 'Hourly',
+            '0 0 * * *' => 'Daily',
+            '0 0 * * 0' => 'Weekly',
+            '0 0 1 * *' => 'Monthly',
+        ];
+
+        $vitoBackup = new VitoBackup([
+            'name' => $frequencyLabels[$input['frequency']].' Vito Backup',
+            'frequency' => $input['frequency'],
+            'keep_backups' => $input['keep_backups'],
+            'storage_id' => $input['storage_id'],
+            'status' => VitoBackupStatus::PENDING,
+        ]);
+
+        $vitoBackup->save();
+
+        return $vitoBackup;
+    }
+
+    private function validate(array $input): void
+    {
+        $rules = [
+            'frequency' => [
+                'required',
+                Rule::in(['0 * * * *', '0 0 * * *', '0 0 * * 0', '0 0 1 * *']),
+            ],
+            'keep_backups' => [
+                'required',
+                'integer',
+                'min:1',
+                'max:100',
+            ],
+            'storage_id' => [
+                'required',
+                'integer',
+                Rule::exists('storage_providers', 'id')->where(function ($query) {
+                    $query->whereIn('provider', ['s3', 'dropbox', 'ftp']);
+                }),
+            ],
+        ];
+
+        Validator::make($input, $rules)->validate();
+    }
+}

--- a/app/Actions/VitoBackup/DeleteVitoBackup.php
+++ b/app/Actions/VitoBackup/DeleteVitoBackup.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Actions\VitoBackup;
+
+use App\Enums\VitoBackupStatus;
+use App\Models\VitoBackup;
+use Exception;
+
+class DeleteVitoBackup
+{
+    use StorageOperations;
+
+    public function delete(VitoBackup $vitoBackup): void
+    {
+        $vitoBackup->status = VitoBackupStatus::DELETING;
+        $vitoBackup->save();
+
+        // Delete all backup files from storage providers first
+        $vitoBackup->files()->each(function ($file) use ($vitoBackup) {
+            try {
+                // Delete from storage provider
+                $this->deleteFromStorage($vitoBackup, $file);
+            } catch (Exception $e) {
+                // Log error but continue with cleanup
+                \Illuminate\Support\Facades\Log::error('Failed to delete backup file from storage: '.$e->getMessage(), [
+                    'file_id' => $file->id,
+                    'file_path' => $file->path,
+                ]);
+            }
+
+            // Delete from database
+            $file->delete();
+        });
+
+        // Then delete the backup itself
+        $vitoBackup->delete();
+    }
+}

--- a/app/Actions/VitoBackup/RunVitoBackup.php
+++ b/app/Actions/VitoBackup/RunVitoBackup.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Actions\VitoBackup;
+
+use App\Enums\VitoBackupFileStatus;
+use App\Enums\VitoBackupStatus;
+use App\Models\VitoBackup;
+use App\Models\VitoBackupFile;
+use Exception;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+class RunVitoBackup
+{
+    use BackupOperations, StorageOperations;
+
+    /**
+     * @throws Exception
+     */
+    public function run(VitoBackup $vitoBackup): void
+    {
+        DB::transaction(function () use ($vitoBackup) {
+            $vitoBackup->status = VitoBackupStatus::RUNNING;
+            $vitoBackup->save();
+
+            try {
+                $backupName = 'vito-backup-'.date('Y-m-d-H-i-s').'.zip';
+                $backupFile = $this->createBackupFile($vitoBackup, $backupName);
+
+                $zipPath = $this->export($backupName);
+
+                // Upload to storage provider
+                $this->uploadToStorage($vitoBackup, $zipPath, $backupFile);
+
+                // Clean up old backups
+                $this->cleanupOldBackups($vitoBackup);
+
+                $vitoBackup->status = VitoBackupStatus::SUCCESS;
+                $vitoBackup->save();
+
+            } catch (Exception $e) {
+                $vitoBackup->status = VitoBackupStatus::FAILED;
+                $vitoBackup->save();
+                throw $e;
+            }
+        });
+    }
+
+    private function createBackupFile(VitoBackup $vitoBackup, string $backupName): VitoBackupFile
+    {
+        $backupFile = new VitoBackupFile([
+            'vito_backup_id' => $vitoBackup->id,
+            'name' => $backupName,
+            'size' => 0,
+            'status' => VitoBackupFileStatus::CREATING,
+        ]);
+        $backupFile->save();
+
+        return $backupFile;
+    }
+
+    private function cleanupOldBackups(VitoBackup $vitoBackup): void
+    {
+        $keepBackups = $vitoBackup->keep_backups;
+        $files = $vitoBackup->files()->orderByDesc('created_at')->get();
+
+        if ($files->count() > $keepBackups) {
+            $filesToDelete = $files->skip($keepBackups);
+
+            foreach ($filesToDelete as $file) {
+                $file->status = VitoBackupFileStatus::DELETING;
+                $file->save();
+
+                // Delete from storage provider
+                try {
+                    $this->deleteFromStorage($vitoBackup, $file);
+                } catch (Exception $e) {
+                    // Log error but continue with cleanup
+                    \Illuminate\Support\Facades\Log::error('Failed to delete backup file from storage: '.$e->getMessage(), [
+                        'file_id' => $file->id,
+                        'file_path' => $file->path,
+                    ]);
+                }
+
+                // Delete from database
+                $file->delete();
+            }
+        }
+    }
+}

--- a/app/Actions/VitoBackup/StorageOperations.php
+++ b/app/Actions/VitoBackup/StorageOperations.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace App\Actions\VitoBackup;
+
+use Exception;
+
+trait StorageOperations
+{
+    private function uploadToStorage($vitoBackup, string $zipPath, $backupFile): void
+    {
+        $storageModel = $vitoBackup->storage;
+        $storageProvider = $storageModel->provider();
+        $storagePath = 'vito-backups/'.$backupFile->name;
+
+        try {
+            $fileSize = filesize($zipPath);
+            $fileContents = file_get_contents($zipPath);
+
+            // Upload based on storage provider type
+            switch ($storageModel->provider) {
+                case 's3':
+                    $this->uploadToS3($storageModel, $fileContents, $storagePath);
+                    break;
+                case 'dropbox':
+                    $this->uploadToDropbox($storageModel, $fileContents, $storagePath);
+                    break;
+                case 'ftp':
+                    $this->uploadToFTP($storageModel, $zipPath, $storagePath);
+                    break;
+                default:
+                    throw new Exception('Unsupported storage provider: '.$storageModel->provider);
+            }
+
+            // Update backup file with actual size and path
+            $backupFile->size = $fileSize;
+            $backupFile->path = $storagePath;
+            $backupFile->status = \App\Enums\VitoBackupFileStatus::CREATED;
+            $backupFile->save();
+
+        } catch (Exception $e) {
+            $backupFile->status = \App\Enums\VitoBackupFileStatus::FAILED;
+            $backupFile->save();
+            throw $e;
+        } finally {
+            // Clean up temporary file
+            if (file_exists($zipPath)) {
+                unlink($zipPath);
+            }
+        }
+    }
+
+    private function uploadToS3($storageModel, string $fileContents, string $storagePath): void
+    {
+        $s3Provider = $storageModel->provider();
+        $s3Provider->buildClientConfig(); // Ensure client config is built
+        $s3Client = $s3Provider->getClient();
+
+        $bucket = $storageModel->credentials['bucket'];
+        $path = $this->sanitizePath($storageModel->credentials['path'] ?? '');
+        $fullPath = $path ? $path.'/'.$storagePath : $storagePath;
+
+        $s3Client->putObject([
+            'Bucket' => $bucket,
+            'Key' => $fullPath,
+            'Body' => $fileContents,
+        ]);
+    }
+
+    private function uploadToDropbox($storageModel, string $fileContents, string $storagePath): void
+    {
+        $token = $storageModel->credentials['token'];
+        $path = '/'.ltrim($storagePath, '/');
+
+        $response = \Illuminate\Support\Facades\Http::withToken($token)
+            ->withHeaders([
+                'Content-Type' => 'application/octet-stream',
+                'Dropbox-API-Arg' => json_encode(['path' => $path, 'mode' => 'overwrite']),
+            ])
+            ->withBody($fileContents, 'application/octet-stream')
+            ->post('https://content.dropboxapi.com/2/files/upload');
+
+        if (! $response->successful()) {
+            throw new Exception('Failed to upload to Dropbox: '.$response->body());
+        }
+    }
+
+    private function uploadToFTP($storageModel, string $zipPath, string $storagePath): void
+    {
+        $credentials = $storageModel->credentials;
+
+        $connection = \App\Facades\FTP::connect(
+            $credentials['host'],
+            (int) $credentials['port'],
+            (bool) $credentials['ssl']
+        );
+
+        if (! $connection) {
+            throw new Exception('Failed to connect to FTP server');
+        }
+
+        $login = \App\Facades\FTP::login(
+            $credentials['username'],
+            $credentials['password'],
+            $connection
+        );
+
+        if (! $login) {
+            \App\Facades\FTP::close($connection);
+            throw new Exception('Failed to login to FTP server');
+        }
+
+        $path = rtrim($credentials['path'], '/').'/'.$storagePath;
+        $uploaded = \App\Facades\FTP::put($connection, $path, $zipPath);
+
+        \App\Facades\FTP::close($connection);
+
+        if (! $uploaded) {
+            throw new Exception('Failed to upload file to FTP server');
+        }
+    }
+
+    private function deleteFromStorage($vitoBackup, $file): void
+    {
+        // Skip deletion if file path is null (file was never successfully uploaded)
+        if ($file->path === null) {
+            return;
+        }
+
+        $storageModel = $vitoBackup->storage;
+
+        switch ($storageModel->provider) {
+            case 's3':
+                $this->deleteFromS3($storageModel, $file->path);
+                break;
+            case 'dropbox':
+                $this->deleteFromDropbox($storageModel, $file->path);
+                break;
+            case 'ftp':
+                $this->deleteFromFTP($storageModel, $file->path);
+                break;
+            default:
+                throw new Exception('Unsupported storage provider: '.$storageModel->provider);
+        }
+    }
+
+    private function deleteFromS3($storageModel, string $path): void
+    {
+        $s3Provider = $storageModel->provider();
+        $s3Provider->buildClientConfig();
+        $s3Client = $s3Provider->getClient();
+
+        $bucket = $storageModel->credentials['bucket'];
+        $basePath = $this->sanitizePath($storageModel->credentials['path'] ?? '');
+        $fullPath = $basePath ? $basePath.'/'.$path : $path;
+
+        $s3Client->deleteObject([
+            'Bucket' => $bucket,
+            'Key' => $fullPath,
+        ]);
+    }
+
+    private function deleteFromDropbox($storageModel, string $path): void
+    {
+        $token = $storageModel->credentials['token'];
+        $fullPath = '/'.ltrim($path, '/');
+
+        $response = \Illuminate\Support\Facades\Http::withToken($token)
+            ->withHeaders(['Content-Type' => 'application/json'])
+            ->post('https://api.dropboxapi.com/2/files/delete_v2', [
+                'path' => $fullPath,
+            ]);
+
+        if (! $response->successful()) {
+            throw new Exception('Failed to delete from Dropbox: '.$response->body());
+        }
+    }
+
+    private function deleteFromFTP($storageModel, string $path): void
+    {
+        $credentials = $storageModel->credentials;
+
+        $connection = \App\Facades\FTP::connect(
+            $credentials['host'],
+            (int) $credentials['port'],
+            (bool) $credentials['ssl']
+        );
+
+        if (! $connection) {
+            throw new Exception('Failed to connect to FTP server');
+        }
+
+        $login = \App\Facades\FTP::login(
+            $credentials['username'],
+            $credentials['password'],
+            $connection
+        );
+
+        if (! $login) {
+            \App\Facades\FTP::close($connection);
+            throw new Exception('Failed to login to FTP server');
+        }
+
+        $fullPath = rtrim($credentials['path'], '/').'/'.$path;
+        $deleted = \App\Facades\FTP::delete($connection, $fullPath);
+
+        \App\Facades\FTP::close($connection);
+
+        if (! $deleted) {
+            throw new Exception('Failed to delete file from FTP server');
+        }
+    }
+
+    /**
+     * Sanitize path to prevent directory traversal attacks
+     */
+    private function sanitizePath(string $path): string
+    {
+        // Remove any directory traversal attempts
+        $path = str_replace(['../', '..\\', '..'], '', $path);
+
+        // Remove leading/trailing slashes and normalize
+        $path = trim($path, '/\\');
+
+        return $path;
+    }
+}

--- a/app/Actions/VitoBackup/UpdateVitoBackup.php
+++ b/app/Actions/VitoBackup/UpdateVitoBackup.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Actions\VitoBackup;
+
+use App\Models\VitoBackup;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+class UpdateVitoBackup
+{
+    /**
+     * @param  array<string, mixed>  $input
+     *
+     * @throws ValidationException
+     */
+    public function update(VitoBackup $vitoBackup, array $input): void
+    {
+        $this->validate($input);
+
+        $frequencyLabels = [
+            '0 * * * *' => 'Hourly',
+            '0 0 * * *' => 'Daily',
+            '0 0 * * 0' => 'Weekly',
+            '0 0 1 * *' => 'Monthly',
+        ];
+
+        $vitoBackup->name = $frequencyLabels[$input['frequency']].' Vito Backup';
+        $vitoBackup->frequency = $input['frequency'];
+        $vitoBackup->keep_backups = $input['keep_backups'];
+
+        $vitoBackup->save();
+    }
+
+    private function validate(array $input): void
+    {
+        $rules = [
+            'frequency' => [
+                'required',
+                Rule::in(['0 * * * *', '0 0 * * *', '0 0 * * 0', '0 0 1 * *']),
+            ],
+            'keep_backups' => [
+                'required',
+                'integer',
+                'min:1',
+                'max:100',
+            ],
+        ];
+
+        Validator::make($input, $rules)->validate();
+    }
+}

--- a/app/Console/Commands/RunVitoBackupsCommand.php
+++ b/app/Console/Commands/RunVitoBackupsCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\VitoBackup\RunVitoBackup;
+use App\Enums\VitoBackupStatus;
+use App\Models\VitoBackup;
+use Illuminate\Console\Command;
+
+class RunVitoBackupsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'vito-backups:run {frequency?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run Vito backups for a specific frequency or all active backups';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $frequency = $this->argument('frequency');
+
+        $query = VitoBackup::where('status', VitoBackupStatus::PENDING);
+
+        if ($frequency) {
+            $query->where('frequency', $frequency);
+        }
+
+        $backups = $query->get();
+
+        if ($backups->isEmpty()) {
+            $this->info('No backups to run.');
+
+            return;
+        }
+
+        $this->info("Running {$backups->count()} backup(s)...");
+
+        foreach ($backups as $backup) {
+            $this->info("Running backup: {$backup->name}");
+
+            try {
+                app(RunVitoBackup::class)->run($backup);
+                $this->info("✓ Backup '{$backup->name}' completed successfully.");
+            } catch (\Exception $e) {
+                $this->error("✗ Backup '{$backup->name}' failed: ".$e->getMessage());
+            }
+        }
+
+        $this->info('All backups processed.');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,10 +12,25 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
+        // ========================================
+        // Server Backups
+        // ========================================
         $schedule->command('backups:run "0 * * * *"')->hourly();
         $schedule->command('backups:run "0 0 * * *"')->daily();
         $schedule->command('backups:run "0 0 * * 0"')->weekly();
         $schedule->command('backups:run "0 0 1 * *"')->monthly();
+
+        // ========================================
+        // Vito Backups
+        // ========================================
+        $schedule->command('vito-backups:run "0 * * * *"')->hourly();
+        $schedule->command('vito-backups:run "0 0 * * *"')->daily();
+        $schedule->command('vito-backups:run "0 0 * * 0"')->weekly();
+        $schedule->command('vito-backups:run "0 0 1 * *"')->monthly();
+
+        // ========================================
+        // System Monitoring & Maintenance
+        // ========================================
         $schedule->command('metrics:delete-older-metrics')->daily();
         $schedule->command('metrics:get')->everyMinute();
         $schedule->command('servers:check')->everyFiveMinutes();

--- a/app/Enums/VitoBackupFileStatus.php
+++ b/app/Enums/VitoBackupFileStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Enums;
+
+use App\Contracts\VitoEnum;
+
+enum VitoBackupFileStatus: string implements VitoEnum
+{
+    case CREATED = 'created';
+    case CREATING = 'creating';
+    case FAILED = 'failed';
+    case DELETING = 'deleting';
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::CREATED => 'success',
+            self::CREATING,
+            self::DELETING => 'warning',
+            self::FAILED => 'danger',
+        };
+    }
+
+    public function getText(): string
+    {
+        return $this->value;
+    }
+}

--- a/app/Enums/VitoBackupStatus.php
+++ b/app/Enums/VitoBackupStatus.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Enums;
+
+use App\Contracts\VitoEnum;
+
+enum VitoBackupStatus: string implements VitoEnum
+{
+    case RUNNING = 'running';
+    case SUCCESS = 'success';
+    case FAILED = 'failed';
+    case DELETING = 'deleting';
+    case PENDING = 'pending';
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::RUNNING => 'warning',
+            self::SUCCESS => 'success',
+            self::FAILED,
+            self::PENDING => 'danger',
+            self::DELETING => 'warning',
+        };
+    }
+
+    public function getText(): string
+    {
+        return $this->value;
+    }
+}

--- a/app/Facades/FTP.php
+++ b/app/Facades/FTP.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static void close(bool|Connection $connection)
  * @method static bool passive(bool|Connection $connection, bool $passive)
  * @method static bool delete(bool|Connection $connection, string $path)
+ * @method static bool put(bool|Connection $connection, string $remoteFile, string $localFile)
+ * @method static bool get(bool|Connection $connection, string $localFile, string $remoteFile)
  * @method static void assertConnected(string $host)
  */
 class FTP extends Facade

--- a/app/Helpers/FTP.php
+++ b/app/Helpers/FTP.php
@@ -34,4 +34,14 @@ class FTP
     {
         return ftp_delete($connection, $path);
     }
+
+    public function put(Connection $connection, string $remoteFile, string $localFile): bool
+    {
+        return ftp_put($connection, $remoteFile, $localFile, FTP_BINARY);
+    }
+
+    public function get(Connection $connection, string $localFile, string $remoteFile): bool
+    {
+        return ftp_get($connection, $localFile, $remoteFile, FTP_BINARY);
+    }
 }

--- a/app/Http/Controllers/VitoBackupController.php
+++ b/app/Http/Controllers/VitoBackupController.php
@@ -1,0 +1,415 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\VitoBackup\CreateVitoBackup;
+use App\Actions\VitoBackup\DeleteVitoBackup;
+use App\Actions\VitoBackup\RunVitoBackup;
+use App\Actions\VitoBackup\UpdateVitoBackup;
+use App\Http\Resources\VitoBackupResource;
+use App\Models\StorageProvider;
+use App\Models\VitoBackup;
+use App\Models\VitoBackupFile;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+use Spatie\RouteAttributes\Attributes\Delete;
+use Spatie\RouteAttributes\Attributes\Get;
+use Spatie\RouteAttributes\Attributes\Middleware;
+use Spatie\RouteAttributes\Attributes\Post;
+use Spatie\RouteAttributes\Attributes\Prefix;
+use Spatie\RouteAttributes\Attributes\Put;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+#[Prefix('settings/vito/backups')]
+#[Middleware(['auth', 'must-be-admin', 'throttle:10,1'])]
+class VitoBackupController extends Controller
+{
+    /**
+     * Display a listing of Vito backups with their associated storage providers.
+     */
+    #[Get('/', name: 'vito-backups.index')]
+    public function index(): Response
+    {
+        $vitoBackups = VitoBackup::with(['storage', 'files'])
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        $storageProviders = StorageProvider::whereNull('project_id')
+            ->whereIn('provider', ['s3', 'dropbox', 'ftp'])
+            ->orderBy('profile')
+            ->get();
+
+        return Inertia::render('vito-settings/backups/index', [
+            'vitoBackups' => VitoBackupResource::collection($vitoBackups),
+            'storageProviders' => $storageProviders,
+        ]);
+    }
+
+    /**
+     * Store a newly created Vito backup.
+     *
+     * @throws ValidationException
+     */
+    #[Post('/', name: 'vito-backups.store')]
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'frequency' => 'required|string|in:0 * * * *,0 0 * * *,0 0 * * 0,0 0 1 * *',
+            'keep_backups' => 'required|integer|min:1|max:100',
+            'storage_id' => 'required|integer|exists:storage_providers,id',
+        ]);
+
+        try {
+            app(CreateVitoBackup::class)->create($request->all());
+
+            return redirect()->route('vito-backups.index')
+                ->with('success', 'Vito backup created successfully.');
+        } catch (ValidationException $e) {
+            return back()->withErrors($e->errors())->withInput();
+        }
+    }
+
+    /**
+     * Update the specified Vito backup.
+     *
+     * @throws ValidationException
+     */
+    #[Put('/{vitoBackup}', name: 'vito-backups.update')]
+    public function update(Request $request, VitoBackup $vitoBackup): RedirectResponse
+    {
+        $request->validate([
+            'frequency' => 'required|string|in:0 * * * *,0 0 * * *,0 0 * * 0,0 0 1 * *',
+            'keep_backups' => 'required|integer|min:1|max:100',
+        ]);
+
+        try {
+            app(UpdateVitoBackup::class)->update($vitoBackup, $request->all());
+
+            return redirect()->route('vito-backups.index')
+                ->with('success', 'Vito backup updated successfully.');
+        } catch (ValidationException $e) {
+            return back()->withErrors($e->errors())->withInput();
+        }
+    }
+
+    /**
+     * Remove the specified Vito backup from storage.
+     */
+    #[Delete('/{vitoBackup}', name: 'vito-backups.destroy')]
+    public function destroy(VitoBackup $vitoBackup): RedirectResponse
+    {
+        app(DeleteVitoBackup::class)->delete($vitoBackup);
+
+        return redirect()->route('vito-backups.index')
+            ->with('success', 'Vito backup deleted successfully.');
+    }
+
+    /**
+     * Manually trigger a Vito backup.
+     */
+    #[Post('/{vitoBackup}/run', name: 'vito-backups.run')]
+    public function run(VitoBackup $vitoBackup): RedirectResponse
+    {
+        $this->authorize('update', $vitoBackup);
+
+        try {
+            app(RunVitoBackup::class)->run($vitoBackup);
+
+            return redirect()->route('vito-backups.index')
+                ->with('success', 'Vito backup started successfully.');
+        } catch (\InvalidArgumentException $e) {
+            return redirect()->route('vito-backups.index')
+                ->with('error', 'Invalid backup configuration: '.$e->getMessage());
+        } catch (\Illuminate\Database\QueryException $e) {
+            return redirect()->route('vito-backups.index')
+                ->with('error', 'Database error during backup: '.$e->getMessage());
+        } catch (\Exception $e) {
+            return redirect()->route('vito-backups.index')
+                ->with('error', 'Failed to start backup: '.$e->getMessage());
+        }
+    }
+
+    /**
+     * Download a backup file from storage provider.
+     *
+     * @throws \Exception
+     */
+    #[Get('/files/{vitoBackupFile}/download', name: 'vito-backup-files.download')]
+    public function downloadFile(VitoBackupFile $vitoBackupFile): BinaryFileResponse
+    {
+        $this->authorize('view', $vitoBackupFile);
+
+        // Add null checks for relationships
+        $vitoBackup = $vitoBackupFile->vitoBackup;
+        if (! $vitoBackup) {
+            abort(404, 'Backup not found');
+        }
+
+        $storageModel = $vitoBackup->storage;
+        if (! $storageModel) {
+            abort(404, 'Storage provider not found');
+        }
+
+        if (! $vitoBackupFile->path) {
+            abort(404, 'Backup file not available');
+        }
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'vito-backup-');
+
+        try {
+            // Download based on storage provider type
+            switch ($storageModel->provider) {
+                case 's3':
+                    $this->downloadFromS3($storageModel, $vitoBackupFile->path, $tempFile);
+                    break;
+                case 'dropbox':
+                    $this->downloadFromDropbox($storageModel, $vitoBackupFile->path, $tempFile);
+                    break;
+                case 'ftp':
+                    $this->downloadFromFTP($storageModel, $vitoBackupFile->path, $tempFile);
+                    break;
+                default:
+                    throw new \InvalidArgumentException('Unsupported storage provider: '.$storageModel->provider);
+            }
+
+            return response()->download($tempFile, $vitoBackupFile->name)->deleteFileAfterSend();
+
+        } catch (\Exception $e) {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Download file from S3 storage provider.
+     *
+     * @param  mixed  $storageModel
+     *
+     * @throws \Exception
+     */
+    private function downloadFromS3($storageModel, string $path, string $tempFile): void
+    {
+        $s3Provider = $storageModel->provider();
+        $s3Provider->buildClientConfig(); // Ensure client config is built
+        $s3Client = $s3Provider->getClient();
+
+        $bucket = $storageModel->credentials['bucket'];
+        $fullPath = rtrim($storageModel->credentials['path'] ?? '', '/');
+        $fullPath = $fullPath ? $fullPath.'/'.$path : $path;
+
+        $result = $s3Client->getObject([
+            'Bucket' => $bucket,
+            'Key' => $fullPath,
+        ]);
+
+        file_put_contents($tempFile, $result['Body']);
+    }
+
+    /**
+     * Download file from Dropbox storage provider.
+     *
+     * @param  mixed  $storageModel
+     *
+     * @throws \Exception
+     */
+    private function downloadFromDropbox($storageModel, string $path, string $tempFile): void
+    {
+        $token = $storageModel->credentials['token'];
+        $fullPath = '/'.ltrim($path, '/');
+
+        $response = \Illuminate\Support\Facades\Http::withToken($token)
+            ->withHeaders([
+                'Dropbox-API-Arg' => json_encode(['path' => $fullPath]),
+            ])
+            ->post('https://content.dropboxapi.com/2/files/download');
+
+        if (! $response->successful()) {
+            throw new \Exception('Failed to download from Dropbox: '.$response->body());
+        }
+
+        file_put_contents($tempFile, $response->body());
+    }
+
+    /**
+     * Download file from FTP storage provider.
+     *
+     * @param  mixed  $storageModel
+     *
+     * @throws \Exception
+     */
+    private function downloadFromFTP($storageModel, string $path, string $tempFile): void
+    {
+        $credentials = $storageModel->credentials;
+
+        $connection = \App\Facades\FTP::connect(
+            $credentials['host'],
+            (int) $credentials['port'],
+            (bool) $credentials['ssl']
+        );
+
+        if (! $connection) {
+            throw new \Exception('Failed to connect to FTP server');
+        }
+
+        $login = \App\Facades\FTP::login(
+            $credentials['username'],
+            $credentials['password'],
+            $connection
+        );
+
+        if (! $login) {
+            \App\Facades\FTP::close($connection);
+            throw new \Exception('Failed to login to FTP server');
+        }
+
+        $fullPath = rtrim($credentials['path'], '/').'/'.$path;
+        $downloaded = \App\Facades\FTP::get($connection, $tempFile, $fullPath);
+
+        \App\Facades\FTP::close($connection);
+
+        if (! $downloaded) {
+            throw new \Exception('Failed to download file from FTP server');
+        }
+    }
+
+    /**
+     * Remove the specified backup file from storage and database.
+     */
+    #[Delete('/files/{vitoBackupFile}', name: 'vito-backup-files.destroy')]
+    public function destroyFile(VitoBackupFile $vitoBackupFile): RedirectResponse
+    {
+        $this->authorize('delete', $vitoBackupFile);
+
+        try {
+            // Delete from storage provider
+            $this->deleteFromStorage($vitoBackupFile);
+
+            // Delete from database
+            $vitoBackupFile->delete();
+
+            return redirect()->route('vito-backups.index')
+                ->with('success', 'Backup file deleted successfully.');
+
+        } catch (\Exception $e) {
+            return redirect()->route('vito-backups.index')
+                ->with('error', 'Failed to delete backup file: '.$e->getMessage());
+        }
+    }
+
+    /**
+     * Delete backup file from storage provider.
+     *
+     * @throws \Exception
+     */
+    private function deleteFromStorage(VitoBackupFile $vitoBackupFile): void
+    {
+        $storageModel = $vitoBackupFile->vitoBackup->storage;
+
+        switch ($storageModel->provider) {
+            case 's3':
+                $this->deleteFromS3($storageModel, $vitoBackupFile->path);
+                break;
+            case 'dropbox':
+                $this->deleteFromDropbox($storageModel, $vitoBackupFile->path);
+                break;
+            case 'ftp':
+                $this->deleteFromFTP($storageModel, $vitoBackupFile->path);
+                break;
+            default:
+                throw new \Exception('Unsupported storage provider: '.$storageModel->provider);
+        }
+    }
+
+    /**
+     * Delete file from S3 storage provider.
+     *
+     * @param  mixed  $storageModel
+     *
+     * @throws \Exception
+     */
+    private function deleteFromS3($storageModel, string $path): void
+    {
+        $s3Provider = $storageModel->provider();
+        $s3Provider->buildClientConfig(); // Ensure client config is built
+        $s3Client = $s3Provider->getClient();
+
+        $bucket = $storageModel->credentials['bucket'];
+        $fullPath = rtrim($storageModel->credentials['path'] ?? '', '/');
+        $fullPath = $fullPath ? $fullPath.'/'.$path : $path;
+
+        $s3Client->deleteObject([
+            'Bucket' => $bucket,
+            'Key' => $fullPath,
+        ]);
+    }
+
+    /**
+     * Delete file from Dropbox storage provider.
+     *
+     * @param  mixed  $storageModel
+     *
+     * @throws \Exception
+     */
+    private function deleteFromDropbox($storageModel, string $path): void
+    {
+        $token = $storageModel->credentials['token'];
+        $fullPath = '/'.ltrim($path, '/');
+
+        $response = \Illuminate\Support\Facades\Http::withToken($token)
+            ->withHeaders(['Content-Type' => 'application/json'])
+            ->post('https://api.dropboxapi.com/2/files/delete_v2', [
+                'path' => $fullPath,
+            ]);
+
+        if (! $response->successful()) {
+            throw new \Exception('Failed to delete from Dropbox: '.$response->body());
+        }
+    }
+
+    /**
+     * Delete file from FTP storage provider.
+     *
+     * @param  mixed  $storageModel
+     *
+     * @throws \Exception
+     */
+    private function deleteFromFTP($storageModel, string $path): void
+    {
+        $credentials = $storageModel->credentials;
+
+        $connection = \App\Facades\FTP::connect(
+            $credentials['host'],
+            (int) $credentials['port'],
+            (bool) $credentials['ssl']
+        );
+
+        if (! $connection) {
+            throw new \Exception('Failed to connect to FTP server');
+        }
+
+        $login = \App\Facades\FTP::login(
+            $credentials['username'],
+            $credentials['password'],
+            $connection
+        );
+
+        if (! $login) {
+            \App\Facades\FTP::close($connection);
+            throw new \Exception('Failed to login to FTP server');
+        }
+
+        $fullPath = rtrim($credentials['path'], '/').'/'.$path;
+        $deleted = \App\Facades\FTP::delete($connection, $fullPath);
+
+        \App\Facades\FTP::close($connection);
+
+        if (! $deleted) {
+            throw new \Exception('Failed to delete file from FTP server');
+        }
+    }
+}

--- a/app/Http/Controllers/VitoSettingController.php
+++ b/app/Http/Controllers/VitoSettingController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\VitoBackup\BackupOperations;
 use Exception;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -22,17 +23,7 @@ use ZipArchive;
 #[Middleware(['auth', 'must-be-admin'])]
 class VitoSettingController extends Controller
 {
-    /**
-     * @var array<string, string>
-     */
-    protected array $paths = [
-        'storage/database.sqlite' => 'file',
-        '.env' => 'file',
-        'storage/ssh-public.key' => 'file',
-        'storage/ssh-private.pem' => 'file',
-        'storage/app/key-pairs' => 'directory',
-        'storage/app/server-logs' => 'directory',
-    ];
+    use BackupOperations;
 
     #[Get('/', name: 'vito-settings')]
     public function index(): Response
@@ -50,32 +41,6 @@ class VitoSettingController extends Controller
         $export = $this->export($exportName);
 
         return response()->download($export, $exportName)->deleteFileAfterSend();
-    }
-
-    /**
-     * @throws Exception
-     */
-    private function export(string $zipFileName): string
-    {
-        $zipPath = Storage::disk('tmp')->path($zipFileName);
-
-        $zip = new ZipArchive;
-        if ($zip->open($zipPath, ZipArchive::CREATE) !== true) {
-            throw new Exception('Could not create zip file at '.$zipPath);
-        }
-
-        foreach ($this->paths as $path => $type) {
-            $path = base_path($path);
-            if ($type === 'file' && File::exists($path)) {
-                $zip->addFile($path, basename($path));
-            } elseif ($type === 'directory' && File::exists($path)) {
-                $this->addDirectoryToZip($zip, $path, basename($path));
-            }
-        }
-
-        $zip->close();
-
-        return $zipPath;
     }
 
     /**
@@ -112,8 +77,10 @@ class VitoSettingController extends Controller
         $zip->extractTo($extractPath);
         $zip->close();
 
-        // Replace files
-        File::move($extractPath.'/database.sqlite', storage_path('database.sqlite'));
+        // Import database based on current driver
+        $this->importDatabase($extractPath);
+
+        // Replace other files
         if (File::exists($extractPath.'/.env')) {
             File::move($extractPath.'/.env', base_path('.env'));
         }
@@ -130,15 +97,5 @@ class VitoSettingController extends Controller
 
         return redirect()->route('vito-settings')
             ->with('success', 'Settings imported successfully.');
-    }
-
-    private function addDirectoryToZip(ZipArchive $zip, string $path, string $zipPath): void
-    {
-        $files = File::allFiles($path);
-
-        foreach ($files as $file) {
-            $relativePath = $zipPath.'/'.$file->getRelativePathname();
-            $zip->addFile($file->getRealPath(), $relativePath);
-        }
     }
 }

--- a/app/Http/Resources/VitoBackupFileResource.php
+++ b/app/Http/Resources/VitoBackupFileResource.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\VitoBackupFile;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin VitoBackupFile
+ */
+class VitoBackupFileResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'size' => $this->size,
+            'status' => $this->status,
+            'path' => $this->path,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Http/Resources/VitoBackupResource.php
+++ b/app/Http/Resources/VitoBackupResource.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\VitoBackup;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin VitoBackup
+ */
+class VitoBackupResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'frequency' => $this->frequency,
+            'keep_backups' => $this->keep_backups,
+            'status' => $this->status,
+            'storage' => $this->whenLoaded('storage', function () {
+                return [
+                    'id' => $this->storage->id,
+                    'profile' => $this->storage->profile,
+                    'provider' => $this->storage->provider,
+                ];
+            }),
+            'files' => VitoBackupFileResource::collection($this->whenLoaded('files')),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Models/VitoBackup.php
+++ b/app/Models/VitoBackup.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\VitoBackupStatus;
+use Database\Factories\VitoBackupFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property string $name
+ * @property string $frequency
+ * @property int $keep_backups
+ * @property int $storage_id
+ * @property VitoBackupStatus $status
+ * @property StorageProvider|null $storage
+ * @property VitoBackupFile[] $files
+ */
+class VitoBackup extends AbstractModel
+{
+    /** @use HasFactory<VitoBackupFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'frequency',
+        'keep_backups',
+        'storage_id',
+        'status',
+    ];
+
+    protected $casts = [
+        'keep_backups' => 'integer',
+        'storage_id' => 'integer',
+        'status' => VitoBackupStatus::class,
+    ];
+
+    public static function boot(): void
+    {
+        parent::boot();
+
+        static::deleting(function ($backup): void {
+            /** @var VitoBackup $backup */
+            $backup->files()->each(function ($file): void {
+                /** @var VitoBackupFile $file */
+                $file->delete();
+            });
+        });
+    }
+
+    /**
+     * @return BelongsTo<StorageProvider, covariant $this>
+     */
+    public function storage(): BelongsTo
+    {
+        return $this->belongsTo(StorageProvider::class, 'storage_id');
+    }
+
+    /**
+     * @return HasMany<VitoBackupFile, covariant $this>
+     */
+    public function files(): HasMany
+    {
+        return $this->hasMany(VitoBackupFile::class, 'vito_backup_id');
+    }
+}

--- a/app/Models/VitoBackupFile.php
+++ b/app/Models/VitoBackupFile.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\VitoBackupFileStatus;
+use Database\Factories\VitoBackupFileFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $vito_backup_id
+ * @property string $name
+ * @property int $size
+ * @property VitoBackupFileStatus $status
+ * @property string|null $path
+ * @property VitoBackup|null $vitoBackup
+ */
+class VitoBackupFile extends AbstractModel
+{
+    /** @use HasFactory<VitoBackupFileFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'vito_backup_id',
+        'name',
+        'size',
+        'status',
+        'path',
+    ];
+
+    protected $casts = [
+        'vito_backup_id' => 'integer',
+        'size' => 'integer',
+        'status' => VitoBackupFileStatus::class,
+    ];
+
+    /**
+     * @return BelongsTo<VitoBackup, covariant $this>
+     */
+    public function vitoBackup(): BelongsTo
+    {
+        return $this->belongsTo(VitoBackup::class, 'vito_backup_id');
+    }
+}

--- a/app/Policies/VitoBackupFilePolicy.php
+++ b/app/Policies/VitoBackupFilePolicy.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\VitoBackupFile;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class VitoBackupFilePolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, VitoBackupFile $vitoBackupFile): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, VitoBackupFile $vitoBackupFile): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, VitoBackupFile $vitoBackupFile): bool
+    {
+        return $user->isAdmin();
+    }
+}

--- a/app/Policies/VitoBackupPolicy.php
+++ b/app/Policies/VitoBackupPolicy.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\VitoBackup;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class VitoBackupPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, VitoBackup $vitoBackup): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, VitoBackup $vitoBackup): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, VitoBackup $vitoBackup): bool
+    {
+        return $user->isAdmin();
+    }
+}

--- a/database/factories/VitoBackupFactory.php
+++ b/database/factories/VitoBackupFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\VitoBackupStatus;
+use App\Models\StorageProvider;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\VitoBackup>
+ */
+class VitoBackupFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->words(2, true).' Backup',
+            'frequency' => $this->faker->randomElement(['0 0 * * *', '0 0 * * 0', '0 0 1 * *']),
+            'keep_backups' => $this->faker->numberBetween(3, 10),
+            'storage_id' => StorageProvider::factory(),
+            'status' => VitoBackupStatus::PENDING,
+        ];
+    }
+}

--- a/database/factories/VitoBackupFileFactory.php
+++ b/database/factories/VitoBackupFileFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\VitoBackupFileStatus;
+use App\Models\VitoBackup;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\VitoBackupFile>
+ */
+class VitoBackupFileFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'vito_backup_id' => VitoBackup::factory(),
+            'name' => 'vito-backup-'.$this->faker->date('Y-m-d').'.zip',
+            'size' => $this->faker->numberBetween(1024, 10485760), // 1KB to 10MB
+            'status' => VitoBackupFileStatus::CREATED,
+            'path' => 'backups/'.$this->faker->uuid().'.zip',
+        ];
+    }
+}

--- a/database/migrations/2025_09_21_152525_create_vito_backups_table.php
+++ b/database/migrations/2025_09_21_152525_create_vito_backups_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('vito_backups', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('frequency');
+            $table->integer('keep_backups')->default(5);
+            $table->unsignedBigInteger('storage_id');
+            $table->string('status')->default('pending');
+            $table->timestamps();
+
+            $table->foreign('storage_id')->references('id')->on('storage_providers')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('vito_backups');
+    }
+};

--- a/database/migrations/2025_09_21_152858_create_vito_backup_files_table.php
+++ b/database/migrations/2025_09_21_152858_create_vito_backup_files_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('vito_backup_files', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('vito_backup_id');
+            $table->string('name');
+            $table->bigInteger('size');
+            $table->string('status')->default('created');
+            $table->string('path')->nullable();
+            $table->timestamps();
+
+            $table->foreign('vito_backup_id')->references('id')->on('vito_backups')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('vito_backup_files');
+    }
+};

--- a/resources/js/pages/vito-settings/backups/components/create-dialog.tsx
+++ b/resources/js/pages/vito-settings/backups/components/create-dialog.tsx
@@ -1,0 +1,126 @@
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter, DialogClose } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Form, FormFields, FormField } from '@/components/ui/form';
+import InputError from '@/components/ui/input-error';
+import { useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+import { StorageProvider } from '@/types/storage-provider';
+import { LoaderCircle } from 'lucide-react';
+
+interface CreateVitoBackupDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  storageProviders: StorageProvider[];
+}
+
+export default function CreateVitoBackupDialog({ open, onOpenChange, storageProviders }: CreateVitoBackupDialogProps) {
+  const form = useForm<{
+    frequency: string;
+    keep_backups: number;
+    storage_id: number;
+  }>({
+    frequency: '',
+    keep_backups: 5,
+    storage_id: 0,
+  });
+
+  const submit: FormEventHandler = (e) => {
+    e.preventDefault();
+    form.post(route('vito-backups.store'), {
+      onSuccess: () => {
+        onOpenChange(false);
+        form.reset();
+      },
+    });
+  };
+
+  const frequencyOptions = [
+    { value: '0 * * * *', label: 'Hourly' },
+    { value: '0 0 * * *', label: 'Daily' },
+    { value: '0 0 * * 0', label: 'Weekly' },
+    { value: '0 0 1 * *', label: 'Monthly' },
+  ];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Create Vito Backup</DialogTitle>
+          <DialogDescription className="sr-only">
+            Configure an automated backup that will store Vito data in your selected storage provider.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form id="create-vito-backup-form" onSubmit={submit} className="p-4">
+          <FormFields>
+            <FormField>
+              <Label htmlFor="frequency">Frequency</Label>
+              <Select value={form.data.frequency} onValueChange={(value) => form.setData('frequency', value)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select frequency" />
+                </SelectTrigger>
+                <SelectContent>
+                  {frequencyOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <InputError message={form.errors.frequency} />
+            </FormField>
+
+            <FormField>
+              <Label htmlFor="keep_backups">Keep Backups</Label>
+              <Input
+                id="keep_backups"
+                type="number"
+                min="1"
+                max="100"
+                value={form.data.keep_backups}
+                onChange={(e) => form.setData('keep_backups', parseInt(e.target.value))}
+                required
+              />
+              <InputError message={form.errors.keep_backups} />
+            </FormField>
+
+            <FormField>
+              <Label htmlFor="storage_id">Storage Provider</Label>
+              <Select value={form.data.storage_id?.toString() || ''} onValueChange={(value) => form.setData('storage_id', parseInt(value))}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select storage provider" />
+                </SelectTrigger>
+                <SelectContent>
+                  {storageProviders.map((provider) => (
+                    <SelectItem key={provider.id} value={provider.id.toString()}>
+                      {`${provider.profile} (${provider.provider})`}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-muted-foreground text-sm">
+                Only global storage providers are available for Vito backups. Project-specific storage providers cannot be used.
+              </p>
+              <InputError message={form.errors.storage_id} />
+            </FormField>
+          </FormFields>
+        </Form>
+
+        <DialogFooter>
+          <div className="flex items-center gap-2">
+            <Button form="create-vito-backup-form" type="button" onClick={submit} disabled={form.processing}>
+              {form.processing && <LoaderCircle className="animate-spin" />}
+              Create Backup
+            </Button>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/pages/vito-settings/backups/components/delete-dialog.tsx
+++ b/resources/js/pages/vito-settings/backups/components/delete-dialog.tsx
@@ -1,0 +1,49 @@
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter, DialogClose } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useForm } from '@inertiajs/react';
+import { VitoBackup } from '@/types';
+import { LoaderCircle } from 'lucide-react';
+
+interface DeleteVitoBackupDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  backup: VitoBackup;
+}
+
+export default function DeleteVitoBackupDialog({ open, onOpenChange, backup }: DeleteVitoBackupDialogProps) {
+  const form = useForm();
+
+  const submit = () => {
+    form.delete(route('vito-backups.destroy', { vitoBackup: backup.id }), {
+      onSuccess: () => {
+        onOpenChange(false);
+      },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Delete Vito Backup</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete the backup "{backup.name}"? This action cannot be undone. All backup files associated with this
+            configuration will also be deleted from your storage provider.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="destructive" onClick={submit} disabled={form.processing}>
+              {form.processing && <LoaderCircle className="animate-spin" />}
+              Delete Backup
+            </Button>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/pages/vito-settings/backups/components/edit-dialog.tsx
+++ b/resources/js/pages/vito-settings/backups/components/edit-dialog.tsx
@@ -1,0 +1,119 @@
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter, DialogClose } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Form, FormFields, FormField } from '@/components/ui/form';
+import InputError from '@/components/ui/input-error';
+import { useForm } from '@inertiajs/react';
+import { FormEventHandler, useEffect } from 'react';
+import { VitoBackup } from '@/types';
+import { LoaderCircle } from 'lucide-react';
+
+interface EditVitoBackupDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  backup: VitoBackup;
+}
+
+export default function EditVitoBackupDialog({ open, onOpenChange, backup }: EditVitoBackupDialogProps) {
+  const form = useForm<{
+    frequency: string;
+    keep_backups: number;
+  }>({
+    frequency: backup.frequency,
+    keep_backups: backup.keep_backups,
+  });
+
+  useEffect(() => {
+    if (open) {
+      form.setData({
+        frequency: backup.frequency,
+        keep_backups: backup.keep_backups,
+      });
+    }
+  }, [open, backup]);
+
+  const submit: FormEventHandler = (e) => {
+    e.preventDefault();
+    form.put(route('vito-backups.update', { vitoBackup: backup.id }), {
+      onSuccess: () => {
+        onOpenChange(false);
+      },
+      onError: (errors) => {
+        console.error('Form submission errors:', errors);
+      },
+    });
+  };
+
+  const frequencyOptions = [
+    { value: '0 * * * *', label: 'Hourly' },
+    { value: '0 0 * * *', label: 'Daily' },
+    { value: '0 0 * * 0', label: 'Weekly' },
+    { value: '0 0 1 * *', label: 'Monthly' },
+  ];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit Vito Backup</DialogTitle>
+          <DialogDescription className="sr-only">Update the backup configuration settings.</DialogDescription>
+        </DialogHeader>
+
+        <Form id="edit-vito-backup-form" onSubmit={submit} className="p-4">
+          <FormFields>
+            <FormField>
+              <Label htmlFor="frequency">Frequency</Label>
+              <Select value={form.data.frequency} onValueChange={(value) => form.setData('frequency', value)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select frequency" />
+                </SelectTrigger>
+                <SelectContent>
+                  {frequencyOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <InputError message={form.errors.frequency} />
+            </FormField>
+
+            <FormField>
+              <Label htmlFor="keep_backups">Keep Backups</Label>
+              <Input
+                id="keep_backups"
+                type="number"
+                min="1"
+                max="100"
+                value={form.data.keep_backups}
+                onChange={(e) => form.setData('keep_backups', parseInt(e.target.value))}
+                required
+              />
+              <InputError message={form.errors.keep_backups} />
+            </FormField>
+
+            <FormField>
+              <Label htmlFor="storage_id">Storage Provider</Label>
+              <Input id="storage_id" value={`${backup.storage?.profile} (${backup.storage?.provider})`} disabled className="bg-muted" />
+              <p className="text-muted-foreground text-sm">Storage provider cannot be changed after backup creation</p>
+            </FormField>
+          </FormFields>
+        </Form>
+
+        <DialogFooter>
+          <div className="flex items-center gap-2">
+            <Button form="edit-vito-backup-form" type="submit" disabled={form.processing}>
+              {form.processing && <LoaderCircle className="animate-spin" />}
+              Update Backup
+            </Button>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/pages/vito-settings/backups/components/files-dialog.tsx
+++ b/resources/js/pages/vito-settings/backups/components/files-dialog.tsx
@@ -1,0 +1,118 @@
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { DownloadIcon, MoreHorizontalIcon, TrashIcon } from 'lucide-react';
+import { VitoBackup } from '@/types';
+import { router } from '@inertiajs/react';
+
+interface BackupFilesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  backup: VitoBackup;
+}
+
+export default function BackupFilesDialog({ open, onOpenChange, backup }: BackupFilesDialogProps) {
+  const formatFileSize = (bytes: number) => {
+    if (bytes === 0) return '0 Bytes';
+    const k = 1024;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+  };
+
+  const getFileStatusColor = (status: string) => {
+    const colors = {
+      created: 'bg-green-100 text-green-800',
+      creating: 'bg-yellow-100 text-yellow-800',
+      failed: 'bg-red-100 text-red-800',
+      deleting: 'bg-yellow-100 text-yellow-800',
+    };
+    return colors[status as keyof typeof colors] || 'bg-gray-100 text-gray-800';
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Backup Files - {backup.name}</DialogTitle>
+          <DialogDescription>Manage individual backup files for this backup configuration.</DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-96 overflow-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Size</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead>Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {backup.files && backup.files.length > 0 ? (
+                backup.files.map((file) => (
+                  <TableRow key={file.id}>
+                    <TableCell className="font-medium">{file.name}</TableCell>
+                    <TableCell>{formatFileSize(file.size)}</TableCell>
+                    <TableCell>
+                      <Badge className={getFileStatusColor(file.status)}>{file.status}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      {new Date(file.created_at).toLocaleDateString()} {new Date(file.created_at).toLocaleTimeString()}
+                    </TableCell>
+                    <TableCell>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button size="sm" variant="ghost" className="h-8 w-8 p-0">
+                            <MoreHorizontalIcon className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={() => {
+                              window.open(route('vito-backup-files.download', { vitoBackupFile: file.id }), '_blank');
+                            }}
+                          >
+                            <DownloadIcon className="mr-2 h-4 w-4" />
+                            Download
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => {
+                              if (confirm('Are you sure you want to delete this backup file?')) {
+                                router.delete(route('vito-backup-files.destroy', { vitoBackupFile: file.id }), {
+                                  onSuccess: () => {
+                                    // Reload the current page data using Inertia
+                                    router.reload();
+                                    // Close the modal
+                                    onOpenChange(false);
+                                  },
+                                });
+                              }
+                            }}
+                            className="text-red-600"
+                          >
+                            <TrashIcon className="mr-2 h-4 w-4" />
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-muted-foreground text-center">
+                    No backup files found.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/pages/vito-settings/backups/index.tsx
+++ b/resources/js/pages/vito-settings/backups/index.tsx
@@ -1,0 +1,135 @@
+import SettingsLayout from '@/layouts/settings/layout';
+import { Head, usePage, useForm } from '@inertiajs/react';
+import Container from '@/components/container';
+import Heading from '@/components/heading';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { PlusIcon, PlayIcon, TrashIcon, FileIcon } from 'lucide-react';
+import React, { useState } from 'react';
+import { VitoBackup } from '@/types';
+import { StorageProvider } from '@/types/storage-provider';
+import CreateVitoBackupDialog from './components/create-dialog';
+import EditVitoBackupDialog from './components/edit-dialog';
+import DeleteVitoBackupDialog from './components/delete-dialog';
+import BackupFilesDialog from './components/files-dialog';
+
+function RunBackupButton({ backup }: { backup: VitoBackup }) {
+  const form = useForm();
+
+  const runBackup = () => {
+    form.post(route('vito-backups.run', { vitoBackup: backup.id }));
+  };
+
+  return (
+    <Button size="sm" variant="outline" onClick={runBackup} disabled={form.processing}>
+      <PlayIcon />
+    </Button>
+  );
+}
+
+type Page = {
+  vitoBackups: VitoBackup[];
+  storageProviders: StorageProvider[];
+};
+
+export default function VitoBackups() {
+  const page = usePage<Page>();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editBackup, setEditBackup] = useState<VitoBackup | null>(null);
+  const [deleteBackup, setDeleteBackup] = useState<VitoBackup | null>(null);
+  const [filesBackup, setFilesBackup] = useState<VitoBackup | null>(null);
+
+  const getStatusColor = (status: string) => {
+    const colors = {
+      running: 'bg-blue-100 text-blue-800',
+      success: 'bg-green-100 text-green-800',
+      pending: 'bg-gray-100 text-gray-800',
+      failed: 'bg-red-100 text-red-800',
+      deleting: 'bg-yellow-100 text-yellow-800',
+    };
+    return colors[status as keyof typeof colors] || 'bg-gray-100 text-gray-800';
+  };
+
+  return (
+    <SettingsLayout>
+      <Head title="Vito Backups" />
+
+      <Container className="max-w-5xl">
+        <div className="flex items-start justify-between">
+          <Heading title="Vito Backups" description="Manage automated backups of Vito data" />
+          <Button onClick={() => setCreateOpen(true)}>
+            <PlusIcon />
+            Create Backup
+          </Button>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Backup Configurations</CardTitle>
+            <CardDescription>Configure automated backups that will be stored in your selected storage providers.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Storage Provider</TableHead>
+                  <TableHead>Keep Backups</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Files</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {page.props.vitoBackups.map((backup) => (
+                  <TableRow key={backup.id}>
+                    <TableCell className="font-medium">{backup.name}</TableCell>
+                    <TableCell>{backup.storage?.profile}</TableCell>
+                    <TableCell>{backup.keep_backups}</TableCell>
+                    <TableCell>
+                      <Badge className={getStatusColor(backup.status)}>{backup.status}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Button variant="outline" size="sm" onClick={() => setFilesBackup(backup)} className="flex items-center gap-2">
+                        <FileIcon className="h-4 w-4" />
+                        {backup.files?.length || 0} file{(backup.files?.length || 0) !== 1 ? 's' : ''}
+                      </Button>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <RunBackupButton backup={backup} />
+                        <Button size="sm" variant="outline" onClick={() => setEditBackup(backup)}>
+                          Edit
+                        </Button>
+                        <Button size="sm" variant="outline" onClick={() => setDeleteBackup(backup)}>
+                          <TrashIcon />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {page.props.vitoBackups.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-muted-foreground text-center">
+                      No backups configured yet.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        <CreateVitoBackupDialog open={createOpen} onOpenChange={setCreateOpen} storageProviders={page.props.storageProviders} />
+
+        {editBackup && <EditVitoBackupDialog open={!!editBackup} onOpenChange={() => setEditBackup(null)} backup={editBackup} />}
+
+        {deleteBackup && <DeleteVitoBackupDialog open={!!deleteBackup} onOpenChange={() => setDeleteBackup(null)} backup={deleteBackup} />}
+
+        {filesBackup && <BackupFilesDialog open={!!filesBackup} onOpenChange={() => setFilesBackup(null)} backup={filesBackup} />}
+      </Container>
+    </SettingsLayout>
+  );
+}

--- a/resources/js/pages/vito-settings/index.tsx
+++ b/resources/js/pages/vito-settings/index.tsx
@@ -4,9 +4,11 @@ import Container from '@/components/container';
 import Heading from '@/components/heading';
 import { Card, CardContent, CardRow } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
+import { Button } from '@/components/ui/button';
 import React from 'react';
 import ExportVito from '@/pages/vito-settings/components/export';
 import ImportVito from '@/pages/vito-settings/components/import';
+import { DatabaseIcon } from 'lucide-react';
 
 export default function Users() {
   return (
@@ -28,6 +30,19 @@ export default function Users() {
             <CardRow>
               <span>Import</span>
               <ImportVito />
+            </CardRow>
+            <Separator />
+            <CardRow>
+              <div className="flex flex-col">
+                <span>Vito Backups</span>
+                <span className="text-muted-foreground text-sm">Automated backups of Vito data</span>
+              </div>
+              <Button variant="outline" asChild>
+                <a href={route('vito-backups.index')}>
+                  <DatabaseIcon />
+                  Manage Backups
+                </a>
+              </Button>
             </CardRow>
           </CardContent>
         </Card>

--- a/resources/js/types/vito-backup.d.ts
+++ b/resources/js/types/vito-backup.d.ts
@@ -1,0 +1,26 @@
+export interface VitoBackup {
+  id: number;
+  name: string;
+  frequency: string;
+  keep_backups: number;
+  status: string;
+  storage_id: number;
+  storage?: {
+    id: number;
+    profile: string;
+    provider: string;
+  };
+  files?: VitoBackupFile[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface VitoBackupFile {
+  id: number;
+  name: string;
+  size: number;
+  status: string;
+  path?: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/tests/Feature/VitoBackupControllerTest.php
+++ b/tests/Feature/VitoBackupControllerTest.php
@@ -1,0 +1,376 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Actions\VitoBackup\RunVitoBackup;
+use App\Enums\VitoBackupFileStatus;
+use App\Enums\VitoBackupStatus;
+use App\Http\Resources\VitoBackupFileResource;
+use App\Http\Resources\VitoBackupResource;
+use App\Models\StorageProvider;
+use App\Models\VitoBackup;
+use App\Models\VitoBackupFile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class VitoBackupControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_returns_vito_backups_page(): void
+    {
+        $storageProvider = StorageProvider::factory()->create([
+            'provider' => 's3',
+            'project_id' => null,
+        ]);
+
+        $vitoBackup = VitoBackup::factory()->create([
+            'storage_id' => $storageProvider->id,
+        ]);
+
+        $this->actingAs($this->user)
+            ->get(route('vito-backups.index'))
+            ->assertSuccessful()
+            ->assertInertia(fn ($page) => $page
+                ->component('vito-settings/backups/index')
+                ->has('vitoBackups', 1)
+                ->has('storageProviders')
+                ->where('vitoBackups.0.id', $vitoBackup->id)
+                ->where('vitoBackups.0.name', $vitoBackup->name)
+            );
+    }
+
+    public function test_store_creates_vito_backup_successfully(): void
+    {
+        $storageProvider = StorageProvider::factory()->create([
+            'provider' => 's3',
+            'project_id' => null,
+        ]);
+
+        $input = [
+            'frequency' => '0 0 * * *',
+            'keep_backups' => 5,
+            'storage_id' => $storageProvider->id,
+        ];
+
+        $this->actingAs($this->user)
+            ->post(route('vito-backups.store'), $input)
+            ->assertRedirect(route('vito-backups.index'))
+            ->assertSessionHas('success', 'Vito backup created successfully.');
+
+        $this->assertDatabaseHas('vito_backups', [
+            'name' => 'Daily Vito Backup',
+            'frequency' => '0 0 * * *',
+            'keep_backups' => 5,
+            'storage_id' => $storageProvider->id,
+            'status' => VitoBackupStatus::PENDING->value,
+        ]);
+    }
+
+    public function test_store_returns_validation_errors_on_invalid_input(): void
+    {
+        $input = [
+            'frequency' => 'invalid-cron',
+            'keep_backups' => 150,
+            'storage_id' => 999,
+        ];
+
+        $this->actingAs($this->user)
+            ->post(route('vito-backups.store'), $input)
+            ->assertRedirect()
+            ->assertSessionHasErrors(['frequency', 'keep_backups', 'storage_id']);
+    }
+
+    public function test_update_modifies_vito_backup_successfully(): void
+    {
+        $storageProvider = StorageProvider::factory()->create([
+            'provider' => 's3',
+            'project_id' => null,
+        ]);
+
+        $vitoBackup = VitoBackup::factory()->create([
+            'storage_id' => $storageProvider->id,
+        ]);
+
+        $input = [
+            'frequency' => '0 * * * *',
+            'keep_backups' => 10,
+        ];
+
+        $this->actingAs($this->user)
+            ->put(route('vito-backups.update', $vitoBackup), $input)
+            ->assertRedirect(route('vito-backups.index'))
+            ->assertSessionHas('success', 'Vito backup updated successfully.');
+
+        $vitoBackup->refresh();
+
+        $this->assertEquals('Hourly Vito Backup', $vitoBackup->name);
+        $this->assertEquals('0 * * * *', $vitoBackup->frequency);
+        $this->assertEquals(10, $vitoBackup->keep_backups);
+    }
+
+    public function test_update_returns_validation_errors_on_invalid_input(): void
+    {
+        $storageProvider = StorageProvider::factory()->create([
+            'provider' => 's3',
+            'project_id' => null,
+        ]);
+
+        $vitoBackup = VitoBackup::factory()->create([
+            'storage_id' => $storageProvider->id,
+        ]);
+
+        $input = [
+            'frequency' => 'invalid-cron',
+            'keep_backups' => 0,
+        ];
+
+        $this->actingAs($this->user)
+            ->put(route('vito-backups.update', $vitoBackup), $input)
+            ->assertRedirect()
+            ->assertSessionHasErrors(['frequency', 'keep_backups']);
+    }
+
+    public function test_destroy_deletes_vito_backup_successfully(): void
+    {
+        $storageProvider = StorageProvider::factory()->create([
+            'provider' => 's3',
+            'project_id' => null,
+        ]);
+
+        $vitoBackup = VitoBackup::factory()->create([
+            'storage_id' => $storageProvider->id,
+        ]);
+
+        $this->actingAs($this->user)
+            ->delete(route('vito-backups.destroy', $vitoBackup))
+            ->assertRedirect(route('vito-backups.index'))
+            ->assertSessionHas('success', 'Vito backup deleted successfully.');
+
+        $this->assertDatabaseMissing('vito_backups', ['id' => $vitoBackup->id]);
+    }
+
+    public function test_run_starts_backup_successfully(): void
+    {
+        $storageProvider = StorageProvider::factory()->create([
+            'provider' => 's3',
+            'project_id' => null,
+        ]);
+
+        $vitoBackup = VitoBackup::factory()->create([
+            'storage_id' => $storageProvider->id,
+        ]);
+
+        $this->mock(RunVitoBackup::class, function ($mock) use ($vitoBackup) {
+            $mock->shouldReceive('run')
+                ->with(\Mockery::on(function ($backup) use ($vitoBackup) {
+                    return $backup->id === $vitoBackup->id;
+                }))
+                ->once();
+        });
+
+        $this->actingAs($this->user)
+            ->post(route('vito-backups.run', $vitoBackup))
+            ->assertRedirect(route('vito-backups.index'))
+            ->assertSessionHas('success', 'Vito backup started successfully.');
+    }
+
+    public function test_run_handles_backup_failure(): void
+    {
+        $storageProvider = StorageProvider::factory()->create([
+            'provider' => 's3',
+            'project_id' => null,
+        ]);
+
+        $vitoBackup = VitoBackup::factory()->create([
+            'storage_id' => $storageProvider->id,
+        ]);
+
+        $this->mock(RunVitoBackup::class, function ($mock) use ($vitoBackup) {
+            $mock->shouldReceive('run')
+                ->with(\Mockery::on(function ($backup) use ($vitoBackup) {
+                    return $backup->id === $vitoBackup->id;
+                }))
+                ->once()
+                ->andThrow(new \Exception('Backup failed'));
+        });
+
+        $this->actingAs($this->user)
+            ->post(route('vito-backups.run', $vitoBackup))
+            ->assertRedirect(route('vito-backups.index'))
+            ->assertSessionHas('error', 'Failed to start backup: Backup failed');
+    }
+
+    public function test_index_includes_storage_providers(): void
+    {
+        $s3Provider = StorageProvider::factory()->create([
+            'provider' => 's3',
+            'profile' => 'S3 Provider',
+            'project_id' => null,
+        ]);
+
+        $dropboxProvider = StorageProvider::factory()->create([
+            'provider' => 'dropbox',
+            'profile' => 'Dropbox Provider',
+            'project_id' => null,
+        ]);
+
+        $ftpProvider = StorageProvider::factory()->create([
+            'provider' => 'ftp',
+            'profile' => 'FTP Provider',
+            'project_id' => null,
+        ]);
+
+        // Create a provider that should not be included (not in supported list)
+        StorageProvider::factory()->create([
+            'provider' => 'local',
+            'project_id' => null,
+        ]);
+
+        $this->actingAs($this->user)
+            ->get(route('vito-backups.index'))
+            ->assertSuccessful()
+            ->assertInertia(fn ($page) => $page
+                ->has('storageProviders', 3)
+                ->where('storageProviders.0.provider', 'dropbox')
+                ->where('storageProviders.1.provider', 'ftp')
+                ->where('storageProviders.2.provider', 's3')
+            );
+    }
+
+    // HTTP Resource Tests
+    public function test_vito_backup_resource_transforms_correctly(): void
+    {
+        $storageProvider = StorageProvider::factory()->create([
+            'provider' => 's3',
+            'profile' => 'Test S3',
+            'project_id' => null,
+        ]);
+
+        $vitoBackup = VitoBackup::factory()->create([
+            'name' => 'Test Backup',
+            'frequency' => '0 0 * * *',
+            'keep_backups' => 5,
+            'storage_id' => $storageProvider->id,
+        ]);
+
+        $resource = new VitoBackupResource($vitoBackup);
+        $array = $resource->toArray(request());
+
+        $this->assertEquals($vitoBackup->id, $array['id']);
+        $this->assertEquals('Test Backup', $array['name']);
+        $this->assertEquals('0 0 * * *', $array['frequency']);
+        $this->assertEquals(5, $array['keep_backups']);
+        $this->assertEquals($vitoBackup->status, $array['status']);
+        $this->assertEquals($vitoBackup->created_at, $array['created_at']);
+        $this->assertEquals($vitoBackup->updated_at, $array['updated_at']);
+    }
+
+    public function test_vito_backup_resource_includes_storage_when_loaded(): void
+    {
+        $storageProvider = StorageProvider::factory()->create([
+            'provider' => 's3',
+            'profile' => 'Test S3',
+            'project_id' => null,
+        ]);
+
+        $vitoBackup = VitoBackup::factory()->create([
+            'storage_id' => $storageProvider->id,
+        ]);
+
+        $vitoBackup->load('storage');
+
+        $resource = new VitoBackupResource($vitoBackup);
+        $array = $resource->toArray(request());
+
+        $this->assertArrayHasKey('storage', $array);
+        $this->assertEquals($storageProvider->id, $array['storage']['id']);
+        $this->assertEquals('Test S3', $array['storage']['profile']);
+        $this->assertEquals('s3', $array['storage']['provider']);
+    }
+
+    public function test_vito_backup_resource_includes_files_when_loaded(): void
+    {
+        $storageProvider = StorageProvider::factory()->create([
+            'provider' => 's3',
+            'project_id' => null,
+        ]);
+
+        $vitoBackup = VitoBackup::factory()->create([
+            'storage_id' => $storageProvider->id,
+        ]);
+
+        $file1 = VitoBackupFile::factory()->create([
+            'vito_backup_id' => $vitoBackup->id,
+            'name' => 'backup1.zip',
+        ]);
+
+        $file2 = VitoBackupFile::factory()->create([
+            'vito_backup_id' => $vitoBackup->id,
+            'name' => 'backup2.zip',
+        ]);
+
+        $vitoBackup->load('files');
+
+        $resource = new VitoBackupResource($vitoBackup);
+        $array = $resource->toArray(request());
+
+        $this->assertArrayHasKey('files', $array);
+        $this->assertCount(2, $array['files']);
+        $this->assertEquals($file1->id, $array['files'][0]['id']);
+        $this->assertEquals($file2->id, $array['files'][1]['id']);
+    }
+
+    public function test_vito_backup_file_resource_transforms_correctly(): void
+    {
+        $storageProvider = StorageProvider::factory()->create([
+            'provider' => 's3',
+            'project_id' => null,
+        ]);
+
+        $vitoBackup = VitoBackup::factory()->create([
+            'storage_id' => $storageProvider->id,
+        ]);
+
+        $backupFile = VitoBackupFile::factory()->create([
+            'vito_backup_id' => $vitoBackup->id,
+            'name' => 'test-backup.zip',
+            'size' => 1024000,
+            'status' => VitoBackupFileStatus::CREATED,
+            'path' => 'vito-backups/test-backup.zip',
+        ]);
+
+        $resource = new VitoBackupFileResource($backupFile);
+        $array = $resource->toArray(request());
+
+        $this->assertEquals($backupFile->id, $array['id']);
+        $this->assertEquals('test-backup.zip', $array['name']);
+        $this->assertEquals(1024000, $array['size']);
+        $this->assertEquals($backupFile->status, $array['status']);
+        $this->assertEquals('vito-backups/test-backup.zip', $array['path']);
+        $this->assertEquals($backupFile->created_at, $array['created_at']);
+        $this->assertEquals($backupFile->updated_at, $array['updated_at']);
+    }
+
+    public function test_vito_backup_file_resource_handles_null_path(): void
+    {
+        $storageProvider = StorageProvider::factory()->create([
+            'provider' => 's3',
+            'project_id' => null,
+        ]);
+
+        $vitoBackup = VitoBackup::factory()->create([
+            'storage_id' => $storageProvider->id,
+        ]);
+
+        $backupFile = VitoBackupFile::factory()->create([
+            'vito_backup_id' => $vitoBackup->id,
+            'path' => null,
+        ]);
+
+        $resource = new VitoBackupFileResource($backupFile);
+        $array = $resource->toArray(request());
+
+        $this->assertNull($array['path']);
+    }
+}


### PR DESCRIPTION
This PR implements a self-backup feature for Vito that was previously requested by users who needed to backup their Vito instance data and configuration.

### Why this is needed:
- Users have been requesting a way to backup their Vito installations https://github.com/vitodeploy/vito/discussions/792
- Current backup systems only handle user databases, not Vito itself
- Self-backup ensures Vito configuration and data can be restored if needed

### What's included:
- Backup scheduling with cron-like frequencies (hourly, daily, weekly, monthly)
- Support for S3, Dropbox, and FTP storage providers
- Manual backup triggers and file management
- Cleanup of old backups based on retention settings

The system automatically backs up Vito's database and configuration files to the selected storage provider, giving users peace of mind that their Vito setup can be restored.

![CleanShot 2025-09-22 at 12 37 33](https://github.com/user-attachments/assets/1c8974cf-d209-4c7a-942b-7dc912bc55b1)
