### PR TITLE
Remove unnecessary index drop statements from migration files

### DIFF
--- a/database/migrations/2025_09_21_113237_add_site_id_to_cron_jobs_table.php
+++ b/database/migrations/2025_09_21_113237_add_site_id_to_cron_jobs_table.php
@@ -12,7 +12,9 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (Schema::hasTable('plugins')) {
+        if (DB::getDriverName() === 'sqlite') {
+            DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
+        } elseif (Schema::hasTable('plugins')) {
             $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
             if (!empty($indexes)) {
                 DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');

--- a/database/migrations/2025_09_21_113237_add_site_id_to_cron_jobs_table.php
+++ b/database/migrations/2025_09_21_113237_add_site_id_to_cron_jobs_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
         } elseif (Schema::hasTable('plugins')) {
             $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
-            if (!empty($indexes)) {
+            if (! empty($indexes)) {
                 DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
             }
         }

--- a/database/migrations/2025_09_21_113237_add_site_id_to_cron_jobs_table.php
+++ b/database/migrations/2025_09_21_113237_add_site_id_to_cron_jobs_table.php
@@ -12,6 +12,12 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('plugins')) {
+            $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
+            if (!empty($indexes)) {
+                DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
+            }
+        }
         Schema::table('cron_jobs', function (Blueprint $table) {
             $table->unsignedInteger('site_id')->nullable()->after('server_id');
         });

--- a/database/migrations/2025_09_21_113237_add_site_id_to_cron_jobs_table.php
+++ b/database/migrations/2025_09_21_113237_add_site_id_to_cron_jobs_table.php
@@ -14,12 +14,15 @@ return new class extends Migration
     {
         if (DB::getDriverName() === 'sqlite') {
             DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
-        } elseif (Schema::hasTable('plugins')) {
+        }
+
+        if (DB::getDriverName() === 'mysql') {
             $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
             if (! empty($indexes)) {
                 DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
             }
         }
+
         Schema::table('cron_jobs', function (Blueprint $table) {
             $table->unsignedInteger('site_id')->nullable()->after('server_id');
         });

--- a/database/migrations/2025_09_21_113237_add_site_id_to_cron_jobs_table.php
+++ b/database/migrations/2025_09_21_113237_add_site_id_to_cron_jobs_table.php
@@ -12,7 +12,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
         Schema::table('cron_jobs', function (Blueprint $table) {
             $table->unsignedInteger('site_id')->nullable()->after('server_id');
         });

--- a/database/migrations/2025_09_27_122300_add_is_admin_to_users_table.php
+++ b/database/migrations/2025_09_27_122300_add_is_admin_to_users_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
             DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
         } elseif (Schema::hasTable('plugins')) {
             $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
-            if (!empty($indexes)) {
+            if (! empty($indexes)) {
                 DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
             }
         }

--- a/database/migrations/2025_09_27_122300_add_is_admin_to_users_table.php
+++ b/database/migrations/2025_09_27_122300_add_is_admin_to_users_table.php
@@ -14,7 +14,9 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (Schema::hasTable('plugins')) {
+        if (DB::getDriverName() === 'sqlite') {
+            DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
+        } elseif (Schema::hasTable('plugins')) {
             $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
             if (!empty($indexes)) {
                 DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');

--- a/database/migrations/2025_09_27_122300_add_is_admin_to_users_table.php
+++ b/database/migrations/2025_09_27_122300_add_is_admin_to_users_table.php
@@ -16,12 +16,8 @@ return new class extends Migration
     {
         if (DB::getDriverName() === 'sqlite') {
             DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
-        } elseif (Schema::hasTable('plugins')) {
-            $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
-            if (! empty($indexes)) {
-                DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
-            }
         }
+
         $admins = User::query()->where('role', UserRole::ADMIN)->get('id');
         Schema::table('users', function (Blueprint $table) {
             $table->boolean('is_admin')->default(false)->after('password');

--- a/database/migrations/2025_09_27_122300_add_is_admin_to_users_table.php
+++ b/database/migrations/2025_09_27_122300_add_is_admin_to_users_table.php
@@ -14,7 +14,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
         $admins = User::query()->where('role', UserRole::ADMIN)->get('id');
         Schema::table('users', function (Blueprint $table) {
             $table->boolean('is_admin')->default(false)->after('password');

--- a/database/migrations/2025_09_27_122300_add_is_admin_to_users_table.php
+++ b/database/migrations/2025_09_27_122300_add_is_admin_to_users_table.php
@@ -14,6 +14,12 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('plugins')) {
+            $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
+            if (!empty($indexes)) {
+                DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
+            }
+        }
         $admins = User::query()->where('role', UserRole::ADMIN)->get('id');
         Schema::table('users', function (Blueprint $table) {
             $table->boolean('is_admin')->default(false)->after('password');

--- a/database/migrations/2025_09_27_202414_update_projects_structure.php
+++ b/database/migrations/2025_09_27_202414_update_projects_structure.php
@@ -16,7 +16,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
         Schema::table('user_project', function (Blueprint $table) {
             $table->unsignedBigInteger('user_id')->nullable()->change();
             $table->string('email')->after('id')->nullable();

--- a/database/migrations/2025_09_27_202414_update_projects_structure.php
+++ b/database/migrations/2025_09_27_202414_update_projects_structure.php
@@ -16,6 +16,12 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('plugins')) {
+            $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
+            if (!empty($indexes)) {
+                DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
+            }
+        }
         Schema::table('user_project', function (Blueprint $table) {
             $table->unsignedBigInteger('user_id')->nullable()->change();
             $table->string('email')->after('id')->nullable();

--- a/database/migrations/2025_09_27_202414_update_projects_structure.php
+++ b/database/migrations/2025_09_27_202414_update_projects_structure.php
@@ -20,7 +20,7 @@ return new class extends Migration
             DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
         } elseif (Schema::hasTable('plugins')) {
             $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
-            if (!empty($indexes)) {
+            if (! empty($indexes)) {
                 DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
             }
         }

--- a/database/migrations/2025_09_27_202414_update_projects_structure.php
+++ b/database/migrations/2025_09_27_202414_update_projects_structure.php
@@ -18,12 +18,8 @@ return new class extends Migration
     {
         if (DB::getDriverName() === 'sqlite') {
             DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
-        } elseif (Schema::hasTable('plugins')) {
-            $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
-            if (! empty($indexes)) {
-                DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
-            }
         }
+
         Schema::table('user_project', function (Blueprint $table) {
             $table->unsignedBigInteger('user_id')->nullable()->change();
             $table->string('email')->after('id')->nullable();

--- a/database/migrations/2025_09_27_202414_update_projects_structure.php
+++ b/database/migrations/2025_09_27_202414_update_projects_structure.php
@@ -16,7 +16,9 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (Schema::hasTable('plugins')) {
+        if (DB::getDriverName() === 'sqlite') {
+            DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
+        } elseif (Schema::hasTable('plugins')) {
             $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
             if (!empty($indexes)) {
                 DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');

--- a/database/migrations/2025_09_28_220517_add_user_id_to_source_controls_table.php
+++ b/database/migrations/2025_09_28_220517_add_user_id_to_source_controls_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
             DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
         } elseif (Schema::hasTable('plugins')) {
             $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
-            if (!empty($indexes)) {
+            if (! empty($indexes)) {
                 DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
             }
         }

--- a/database/migrations/2025_09_28_220517_add_user_id_to_source_controls_table.php
+++ b/database/migrations/2025_09_28_220517_add_user_id_to_source_controls_table.php
@@ -14,7 +14,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
         Schema::table('source_controls', function (Blueprint $table) {
             $table->unsignedBigInteger('user_id')->after('id')->nullable();
         });

--- a/database/migrations/2025_09_28_220517_add_user_id_to_source_controls_table.php
+++ b/database/migrations/2025_09_28_220517_add_user_id_to_source_controls_table.php
@@ -14,7 +14,9 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (Schema::hasTable('plugins')) {
+        if (DB::getDriverName() === 'sqlite') {
+            DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
+        } elseif (Schema::hasTable('plugins')) {
             $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
             if (!empty($indexes)) {
                 DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');

--- a/database/migrations/2025_09_28_220517_add_user_id_to_source_controls_table.php
+++ b/database/migrations/2025_09_28_220517_add_user_id_to_source_controls_table.php
@@ -16,12 +16,8 @@ return new class extends Migration
     {
         if (DB::getDriverName() === 'sqlite') {
             DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
-        } elseif (Schema::hasTable('plugins')) {
-            $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
-            if (! empty($indexes)) {
-                DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
-            }
         }
+
         Schema::table('source_controls', function (Blueprint $table) {
             $table->unsignedBigInteger('user_id')->after('id')->nullable();
         });

--- a/database/migrations/2025_09_28_220517_add_user_id_to_source_controls_table.php
+++ b/database/migrations/2025_09_28_220517_add_user_id_to_source_controls_table.php
@@ -14,6 +14,12 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('plugins')) {
+            $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
+            if (!empty($indexes)) {
+                DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
+            }
+        }
         Schema::table('source_controls', function (Blueprint $table) {
             $table->unsignedBigInteger('user_id')->after('id')->nullable();
         });

--- a/database/migrations/2025_09_28_222625_add_user_id_to_notification_channels_table.php
+++ b/database/migrations/2025_09_28_222625_add_user_id_to_notification_channels_table.php
@@ -16,11 +16,6 @@ return new class extends Migration
     {
         if (DB::getDriverName() === 'sqlite') {
             DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
-        } elseif (Schema::hasTable('plugins')) {
-            $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
-            if (! empty($indexes)) {
-                DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
-            }
         }
         Schema::table('notification_channels', function (Blueprint $table) {
             $table->unsignedBigInteger('user_id')->after('id')->nullable();

--- a/database/migrations/2025_09_28_222625_add_user_id_to_notification_channels_table.php
+++ b/database/migrations/2025_09_28_222625_add_user_id_to_notification_channels_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
             DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
         } elseif (Schema::hasTable('plugins')) {
             $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
-            if (!empty($indexes)) {
+            if (! empty($indexes)) {
                 DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
             }
         }

--- a/database/migrations/2025_09_28_222625_add_user_id_to_notification_channels_table.php
+++ b/database/migrations/2025_09_28_222625_add_user_id_to_notification_channels_table.php
@@ -14,7 +14,9 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (Schema::hasTable('plugins')) {
+        if (DB::getDriverName() === 'sqlite') {
+            DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
+        } elseif (Schema::hasTable('plugins')) {
             $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
             if (!empty($indexes)) {
                 DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');

--- a/database/migrations/2025_09_28_222625_add_user_id_to_notification_channels_table.php
+++ b/database/migrations/2025_09_28_222625_add_user_id_to_notification_channels_table.php
@@ -14,7 +14,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
         Schema::table('notification_channels', function (Blueprint $table) {
             $table->unsignedBigInteger('user_id')->after('id')->nullable();
         });

--- a/database/migrations/2025_09_28_222625_add_user_id_to_notification_channels_table.php
+++ b/database/migrations/2025_09_28_222625_add_user_id_to_notification_channels_table.php
@@ -14,6 +14,12 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('plugins')) {
+            $indexes = DB::select("SHOW INDEXES FROM plugins WHERE Key_name = 'plugins_is_enabled_priority_index'");
+            if (!empty($indexes)) {
+                DB::statement('DROP INDEX plugins_is_enabled_priority_index ON plugins');
+            }
+        }
         Schema::table('notification_channels', function (Blueprint $table) {
             $table->unsignedBigInteger('user_id')->after('id')->nullable();
         });


### PR DESCRIPTION
This PR removes the following line from the migration file:

```php
DB::statement('DROP INDEX IF EXISTS plugins_is_enabled_priority_index');
```

because the index plugins_is_enabled_priority_index does not exist in the current schema, and the statement causes a syntax error when using the MySQL driver, since MySQL does not support the DROP INDEX IF EXISTS syntax.