### PR TITLE
Fix load balancer Nginx config breaking Reverb

### DIFF
--- a/resources/views/ssh/services/webserver/nginx/vhost-blocks/load-balancer.blade.php
+++ b/resources/views/ssh/services/webserver/nginx/vhost-blocks/load-balancer.blade.php
@@ -4,7 +4,14 @@
 @endphp
 location / {
     proxy_pass http://{{ $backendName }}$request_uri;
-    proxy_set_header Host $host;
+
+    proxy_http_version 1.1;
+    proxy_set_header Host $http_host;
+    proxy_set_header Scheme $scheme;
+    proxy_set_header SERVER_PORT $server_port;
+    proxy_set_header REMOTE_ADDR $remote_addr;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;

--- a/resources/views/ssh/services/webserver/nginx/vhost-blocks/load-balancer.blade.php
+++ b/resources/views/ssh/services/webserver/nginx/vhost-blocks/load-balancer.blade.php
@@ -11,7 +11,7 @@ location / {
     proxy_set_header SERVER_PORT $server_port;
     proxy_set_header REMOTE_ADDR $remote_addr;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "Upgrade";
+    proxy_set_header Connection $http_connection;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
This PR is fixing the issue described here: https://github.com/vitodeploy/vito/issues/892

Reverb needs `Upgrade` and `Connection` headers to establish a connection correctly. Here's some discussion of it: https://github.com/laravel/reverb/issues/212