### PR TITLE
Use unique ssh key for custom server's root user

### DIFF
--- a/app/Actions/Server/InstallServer.php
+++ b/app/Actions/Server/InstallServer.php
@@ -9,6 +9,7 @@ use App\Exceptions\SSHError;
 use App\Facades\Notifier;
 use App\Models\Server;
 use App\Notifications\ServerInstallationSucceed;
+use App\ServerProviders\Custom;
 use App\Services\PHP\PHP;
 
 class InstallServer
@@ -76,11 +77,16 @@ class InstallServer
      */
     protected function createUser(): void
     {
+        // For custom servers, clear all existing keys after deploying the unique key
+        $clearKeys = $this->server->provider === Custom::id();
+
         $this->server->os()->createUser(
             $this->server->authentication['user'],
             $this->server->authentication['pass'],
-            $this->server->sshKey()['public_key']
+            $this->server->sshKey()['public_key'],
+            $clearKeys
         );
+
         $this->server->ssh_user = config('core.ssh_user');
         $this->server->save();
         $this->server->refresh();

--- a/app/SSH/OS/OS.php
+++ b/app/SSH/OS/OS.php
@@ -55,13 +55,14 @@ class OS
     /**
      * @throws SSHError
      */
-    public function createUser(string $user, string $password, string $key): void
+    public function createUser(string $user, string $password, string $key, bool $clearKeys = false): void
     {
         $this->server->ssh()->exec(
             view('ssh.os.create-user', [
                 'user' => $user,
                 'password' => $password,
                 'key' => $key,
+                'clearKeys' => $clearKeys,
             ]),
             'create-user'
         );

--- a/resources/views/ssh/os/create-user.blade.php
+++ b/resources/views/ssh/os/create-user.blade.php
@@ -1,11 +1,21 @@
 export DEBIAN_FRONTEND=noninteractive
+@if($clearKeys)
+# Clear all existing keys and add only the new unique key (for custom servers)
+echo "{{ $key }}" | sudo tee /root/.ssh/authorized_keys
+@else
 echo "{{ $key }}" | sudo tee -a /root/.ssh/authorized_keys
+@endif
 sudo useradd -p $(openssl passwd -1 {{ $password }}) {{ $user }}
 sudo usermod -aG sudo {{ $user }}
 echo "{{ $user }} ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers
 sudo mkdir /home/{{ $user }}
 sudo mkdir /home/{{ $user }}/.ssh
+@if($clearKeys)
+# Clear all existing keys for the new user and add only the new unique key
+echo "{{ $key }}" | sudo tee /home/{{ $user }}/.ssh/authorized_keys
+@else
 echo "{{ $key }}" | sudo tee -a /home/{{ $user }}/.ssh/authorized_keys
+@endif
 sudo chown -R {{ $user }}:{{ $user }} /home/{{ $user }}
 sudo chsh -s /bin/bash {{ $user }}
 sudo su - {{ $user }} -c "ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa" <<< y


### PR DESCRIPTION
Vito is already using a unique key for all servers including the custom type. However it doesn't delete the global key from the root user when it makes the first connection.

This PR deletes the global key from the root (the one user adds manually before creating the server) when Vito makes the first connection to the server.

Closes #905 
