### PR TITLE
Fix typo in 'Save template' title

### DIFF
--- a/resources/js/pages/servers/components/templates.tsx
+++ b/resources/js/pages/servers/components/templates.tsx
@@ -136,7 +136,7 @@ function Save({
       </DialogTrigger>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Save tempalte</DialogTitle>
+          <DialogTitle>Save template</DialogTitle>
           <DialogDescription className="sr-only">Save as template</DialogDescription>
         </DialogHeader>
         <Form className="p-4">


### PR DESCRIPTION
Noticed a tiny typo