### PR TITLE
Move server installation progress "%" to after number

### DIFF
--- a/resources/js/pages/servers/components/header.tsx
+++ b/resources/js/pages/servers/components/header.tsx
@@ -84,7 +84,7 @@ export default function ServerHeader({ server, site }: { server: Server; site?: 
                 <TooltipTrigger asChild>
                   <div className="flex items-center space-x-1">
                     <LoaderCircleIcon className={cn('size-4', server.status === 'installing' ? 'text-brand animate-spin' : '')} />
-                    <div>%{parseInt(server.progress || '0')}</div>
+                    <div>{parseInt(server.progress || '0')}%</div>
                     {server.status === 'installation_failed' && (
                       <Badge className="ml-1" variant={server.status_color}>
                         {server.status}


### PR DESCRIPTION
Currently, server installation progress is shown in the breadcrumb as `%number` instead of `number%`
<img width="739" height="141" alt="image" src="https://github.com/user-attachments/assets/732fab0b-70a9-4b02-b00f-86d89fcb3717" />

This is a simple PR that moves the `%` to after the number. So e.g. "%15" becomes "15%"