### PR TITLE
Add Forgejo as SourceControlProvider

### DIFF
--- a/app/Providers/SourceControlServiceProvider.php
+++ b/app/Providers/SourceControlServiceProvider.php
@@ -7,6 +7,7 @@ use App\DTOs\DynamicForm;
 use App\Plugins\RegisterSourceControl;
 use App\SourceControlProviders\Bitbucket;
 use App\SourceControlProviders\BitbucketV2;
+use App\SourceControlProviders\Forgejo;
 use App\SourceControlProviders\Gitea;
 use App\SourceControlProviders\Github;
 use App\SourceControlProviders\Gitlab;
@@ -23,6 +24,7 @@ class SourceControlServiceProvider extends ServiceProvider
         $this->bitbucket();
         $this->bitbucketV2();
         $this->gitea();
+        $this->forgejo();
     }
 
     private function github(): void
@@ -99,6 +101,24 @@ class SourceControlServiceProvider extends ServiceProvider
         RegisterSourceControl::make(Gitea::id())
             ->label('Gitea')
             ->handler(Gitea::class)
+            ->form(
+                DynamicForm::make([
+                    DynamicField::make('token')
+                        ->text()
+                        ->label('Token'),
+                    DynamicField::make('url')
+                        ->text()
+                        ->label('Self hosted URL'),
+                ])
+            )
+            ->register();
+    }
+
+    private function forgejo(): void
+    {
+        RegisterSourceControl::make(Forgejo::id())
+            ->label('Forgejo')
+            ->handler(Forgejo::class)
             ->form(
                 DynamicForm::make([
                     DynamicField::make('token')

--- a/app/SourceControlProviders/Forgejo.php
+++ b/app/SourceControlProviders/Forgejo.php
@@ -1,0 +1,317 @@
+<?php
+
+namespace App\SourceControlProviders;
+
+use App\Exceptions\FailedToDeployGitHook;
+use App\Exceptions\FailedToDeployGitKey;
+use App\Exceptions\FailedToDestroyGitHook;
+use Exception;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class Forgejo extends AbstractSourceControlProvider
+{
+    protected string $defaultApiHost = 'https://codeberg.org/';
+
+    protected string $apiVersion = 'api/v1';
+
+    private const int CACHE_TTL = 60 * 15; // 15 minutes
+
+    private const int MAX_LIMIT = 50; // Forgejo's max limit per page
+
+    private const int MAX_PAGES = 25; // Safety limit
+
+    public static function id(): string
+    {
+        return 'forgejo';
+    }
+
+    public function createRules(array $input): array
+    {
+        return [
+            'token' => 'required',
+            'url' => [
+                'nullable',
+                'url:http,https',
+                'ends_with:/',
+            ],
+        ];
+    }
+
+    public function connect(): bool
+    {
+        try {
+            $res = Http::withToken($this->data()['token'])
+                ->get($this->getApiUrl().'/repos/search');
+        } catch (Exception) {
+            return false;
+        }
+
+        return $res->successful();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getRepo(string $repo): mixed
+    {
+        $res = Http::withToken($this->data()['token'])
+            ->get($this->getApiUrl().'/repos/'.$repo);
+
+        $this->handleResponseErrors($res, $repo);
+
+        return $res->json();
+    }
+
+    public function fullRepoUrl(string $repo, string $key): string
+    {
+        $host = parse_url($this->getApiUrl())['host'] ?? 'codeberg.org';
+
+        return sprintf('git@%s-%s:%s.git', $host, $key, $repo);
+    }
+
+    /**
+     * @throws FailedToDeployGitHook
+     */
+    public function deployHook(string $repo, array $events, string $secret): array
+    {
+        try {
+            $response = Http::withToken($this->data()['token'])->post(
+                $this->getApiUrl().'/repos/'.$repo.'/hooks',
+                [
+                    'active' => true,
+                    'events' => $events,
+                    'type' => 'forgejo',
+                    'config' => [
+                        'url' => url('/api/git-hooks?secret='.$secret),
+                        'content_type' => 'json',
+                        'insecure_ssl' => '0',
+                        'secret' => $secret,
+                    ],
+                    'authorization_header' => $secret,
+                ]
+            );
+        } catch (Exception $e) {
+            throw new FailedToDeployGitHook($e->getMessage());
+        }
+
+        if ($response->status() != 201) {
+            throw new FailedToDeployGitHook($response->body());
+        }
+
+        return [
+            'hook_id' => json_decode($response->body())->id,
+            'hook_response' => json_decode($response->body()),
+        ];
+    }
+
+    /**
+     * @throws FailedToDestroyGitHook
+     */
+    public function destroyHook(string $repo, string $hookId): void
+    {
+        try {
+            $response = Http::withToken($this->data()['token'])->delete(
+                $this->getApiUrl().'/repos/'.$repo.'/hooks/'.$hookId
+            );
+        } catch (Exception $e) {
+            throw new FailedToDestroyGitHook($e->getMessage());
+        }
+
+        if ($response->status() != 204) {
+            throw new FailedToDestroyGitHook($response->body());
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getLastCommit(string $repo, string $branch): ?array
+    {
+        $res = Http::withToken($this->data()['token'])
+            ->get($this->getApiUrl().'/repos/'.$repo.'/commits?sha='.$branch);
+
+        $this->handleResponseErrors($res, $repo);
+
+        $commits = $res->json();
+        if (count($commits) > 0) {
+            return [
+                'commit_id' => $commits[0]['sha'],
+                'commit_data' => [
+                    'name' => $commits[0]['commit']['committer']['name'] ?? null,
+                    'email' => $commits[0]['commit']['committer']['email'] ?? null,
+                    'message' => $commits[0]['commit']['message'] ?? null,
+                    'url' => $commits[0]['commit']['url'] ?? null,
+                ],
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * @throws FailedToDeployGitKey
+     */
+    public function deployKey(string $title, string $repo, string $key): string
+    {
+        try {
+            $response = Http::withToken($this->data()['token'])->post(
+                $this->getApiUrl().'/repos/'.$repo.'/keys',
+                [
+                    'title' => $title,
+                    'key' => $key,
+                    'read_only' => true,
+                ]
+            );
+
+            if ($response->status() != 201) {
+                throw new FailedToDeployGitKey($response->body());
+            }
+
+            return $response->json()['id'] ?? '';
+        } catch (Exception $e) {
+            throw new FailedToDeployGitKey($e->getMessage());
+        }
+    }
+
+    public function deleteDeployKey(string $keyId, string $repo): void
+    {
+        try {
+            $response = Http::withToken($this->data()['token'])->delete(
+                $this->getApiUrl().'/repos/'.$repo.'/keys/'.$keyId
+            );
+
+            if (! $response->successful()) {
+                Log::warning('Failed to delete Forgejo deploy key', [
+                    'repo' => $repo,
+                    'key_id' => $keyId,
+                    'response' => $response->body(),
+                ]);
+            }
+
+        } catch (Throwable $e) {
+            Log::error('Error deleting Forgejo deploy key', [
+                'repo' => $repo,
+                'key_id' => $keyId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    public function getApiUrl(): string
+    {
+        $host = $this->sourceControl->url ?? $this->defaultApiHost;
+
+        return $host.$this->apiVersion;
+    }
+
+    public function getRepos(bool $useCache = true): array
+    {
+        $cacheKey = 'forgejo_repos_'.md5($this->getApiUrl().$this->data()['token']);
+
+        if ($useCache && Cache::has($cacheKey)) {
+            return Cache::get($cacheKey);
+        }
+
+        try {
+            $repos = $this->fetchAllPages('/user/repos', [
+                'limit' => self::MAX_LIMIT,
+            ]);
+
+            $repoNames = $repos->pluck('full_name')->toArray();
+            Cache::put($cacheKey, $repoNames, self::CACHE_TTL);
+
+            return $repoNames;
+
+        } catch (Throwable $e) {
+            Log::error('Failed to fetch Forgejo repositories', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+
+    public function getBranches(string $repo, bool $useCache = true): array
+    {
+        $cacheKey = 'forgejo_branches_'.md5($repo.$this->getApiUrl().$this->data()['token']);
+
+        if ($useCache && Cache::has($cacheKey)) {
+            return Cache::get($cacheKey);
+        }
+
+        try {
+            $branches = $this->fetchAllPages("/repos/$repo/branches", [
+                'limit' => self::MAX_LIMIT,
+            ]);
+
+            $branchNames = $branches->pluck('name')->toArray();
+            Cache::put($cacheKey, $branchNames, self::CACHE_TTL);
+
+            return $branchNames;
+
+        } catch (Throwable $e) {
+            Log::error('Failed to fetch Forgejo branches', [
+                'repo' => $repo,
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+
+    /**
+     * Fetch all pages from Forgejo API
+     * Forgejo uses pagination with 'page' and 'limit' parameters
+     *
+     * @param  string  $endpoint  API endpoint (without base URL)
+     * @param  array<string, mixed>  $params  Query parameters
+     * @return Collection<int, mixed>
+     */
+    private function fetchAllPages(string $endpoint, array $params = []): Collection
+    {
+        $allData = collect();
+        $page = 1;
+        $hasMore = true;
+
+        while ($hasMore) {
+            $params['page'] = $page;
+            $response = Http::withToken($this->data()['token'])
+                ->get($this->getApiUrl().$endpoint, $params);
+
+            if (! $response->successful()) {
+                Log::error('Forgejo API request failed', [
+                    'endpoint' => $endpoint,
+                    'status' => $response->status(),
+                    'body' => $response->body(),
+                ]);
+                break;
+            }
+
+            $pageData = $response->json();
+            if (empty($pageData)) {
+                $hasMore = false;
+            } else {
+                $allData = $allData->concat($pageData);
+
+                // Forgejo pagination: if we got fewer items than the limit, we're done
+                $limit = $params['limit'] ?? self::MAX_LIMIT;
+                $hasMore = count($pageData) >= $limit;
+                $page++;
+            }
+
+            if ($page > self::MAX_PAGES) {
+                Log::warning('Reached pagination limit', [
+                    'endpoint' => $endpoint,
+                    'pages_fetched' => $page - 1,
+                ]);
+                break;
+            }
+        }
+
+        return $allData;
+    }
+}

--- a/database/factories/SourceControlFactory.php
+++ b/database/factories/SourceControlFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\SourceControl;
 use App\SourceControlProviders\Bitbucket;
+use App\SourceControlProviders\Forgejo;
 use App\SourceControlProviders\Github;
 use App\SourceControlProviders\Gitlab;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -53,6 +54,16 @@ class SourceControlFactory extends Factory
     {
         return $this->state(fn (array $attributes): array => [
             'provider' => Bitbucket::id(),
+        ]);
+    }
+
+    /**
+     * @return Factory<SourceControl>
+     */
+    public function forgejo(): Factory
+    {
+        return $this->state(fn (array $attributes): array => [
+            'provider' => Forgejo::id(),
         ]);
     }
 }

--- a/database/seeders/SourceControlsSeeder.php
+++ b/database/seeders/SourceControlsSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\SourceControl;
 use App\SourceControlProviders\Bitbucket;
+use App\SourceControlProviders\Forgejo;
 use App\SourceControlProviders\Github;
 use App\SourceControlProviders\Gitlab;
 use Illuminate\Database\Seeder;
@@ -34,6 +35,14 @@ class SourceControlsSeeder extends Seeder
             'provider_data' => [
                 'username' => 'bitbucket_username',
                 'password' => 'bitbucket_password',
+            ],
+        ]);
+
+        SourceControl::factory()->create([
+            'profile' => 'Forgejo',
+            'provider' => Forgejo::id(),
+            'provider_data' => [
+                'token' => 'forgejo_token',
             ],
         ]);
     }

--- a/tests/Feature/SourceControlsTest.php
+++ b/tests/Feature/SourceControlsTest.php
@@ -6,6 +6,7 @@ use App\Models\SourceControl;
 use App\Models\User;
 use App\SourceControlProviders\Bitbucket;
 use App\SourceControlProviders\BitbucketV2;
+use App\SourceControlProviders\Forgejo;
 use App\SourceControlProviders\Github;
 use App\SourceControlProviders\Gitlab;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -290,6 +291,8 @@ class SourceControlsTest extends TestCase
             [Gitlab::id(), 'https://git.example.com/', ['token' => 'test']],
             [Bitbucket::id(), null, ['username' => 'test', 'password' => 'test']],
             [BitbucketV2::id(), null, ['key' => 'test', 'secret' => 'test']],
+            [Forgejo::id(), null, ['token' => 'test']],
+            [Forgejo::id(), 'https://forgejo.example.com/', ['token' => 'test']],
         ];
     }
 }

--- a/tests/Unit/SourceControlProviders/ForgejoTest.php
+++ b/tests/Unit/SourceControlProviders/ForgejoTest.php
@@ -1,0 +1,350 @@
+<?php
+
+namespace Tests\Unit\SourceControlProviders;
+
+use App\Models\SourceControl;
+use App\SourceControlProviders\Forgejo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class ForgejoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_id_returns_forgejo(): void
+    {
+        $this->assertSame('forgejo', Forgejo::id());
+    }
+
+    public function test_default_forgejo_url(): void
+    {
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $this->assertSame('https://codeberg.org/api/v1', $forgejo->getApiUrl());
+    }
+
+    public function test_default_forgejo_repo_url(): void
+    {
+        $repo = 'test/repo';
+        $key = 'TEST_KEY';
+
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $this->assertSame('git@codeberg.org-TEST_KEY:test/repo.git', $forgejo->fullRepoUrl($repo, $key));
+    }
+
+    #[DataProvider('customUrlData')]
+    public function test_custom_url(string $url, string $expected): void
+    {
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+                'url' => $url,
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $this->assertSame($expected, $forgejo->getApiUrl());
+    }
+
+    #[DataProvider('customRepoUrlData')]
+    public function test_custom_full_repository_url(string $url, string $expected): void
+    {
+        $repo = 'test/repo';
+        $key = 'TEST_KEY';
+
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+                'url' => $url,
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $this->assertSame($expected, $forgejo->fullRepoUrl($repo, $key));
+    }
+
+    public function test_create_rules_returns_required_token_and_optional_url(): void
+    {
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $rules = $forgejo->createRules([]);
+
+        $this->assertArrayHasKey('token', $rules);
+        $this->assertSame('required', $rules['token']);
+        $this->assertArrayHasKey('url', $rules);
+        $this->assertIsArray($rules['url']);
+        $this->assertContains('nullable', $rules['url']);
+        $this->assertContains('url:http,https', $rules['url']);
+        $this->assertContains('ends_with:/', $rules['url']);
+    }
+
+    public function test_create_data_processes_input_correctly(): void
+    {
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $input = [
+            'token' => 'my-token',
+            'url' => 'https://forgejo.example.com/',
+        ];
+
+        $data = $forgejo->createData($input);
+
+        $this->assertSame('my-token', $data['token']);
+    }
+
+    public function test_create_data_handles_missing_input(): void
+    {
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $data = $forgejo->createData([]);
+
+        $this->assertSame('', $data['token']);
+    }
+
+    public function test_data_retrieves_stored_provider_data(): void
+    {
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+                'provider_data' => [
+                    'token' => 'stored-token',
+                ],
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $data = $forgejo->data();
+
+        $this->assertSame('stored-token', $data['token']);
+    }
+
+    public function test_data_handles_missing_provider_data(): void
+    {
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+                'provider_data' => [],
+                'access_token' => null,
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $data = $forgejo->data();
+
+        $this->assertSame('', $data['token']);
+    }
+
+    public function test_get_webhook_branch_extracts_branch_from_payload(): void
+    {
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $payload = [
+            'ref' => 'refs/heads/main',
+        ];
+
+        $this->assertSame('main', $forgejo->getWebhookBranch($payload));
+    }
+
+    public function test_get_webhook_branch_returns_empty_when_missing(): void
+    {
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $this->assertSame('', $forgejo->getWebhookBranch([]));
+    }
+
+    public function test_get_repos_returns_cached_repos_when_cache_exists(): void
+    {
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+                'provider_data' => [
+                    'token' => 'test-token',
+                ],
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+        $cacheKey = 'forgejo_repos_'.md5($forgejo->getApiUrl().'test-token');
+        $cachedRepos = ['user/repo1', 'user/repo2'];
+
+        Cache::put($cacheKey, $cachedRepos, 900);
+
+        $repos = $forgejo->getRepos();
+
+        $this->assertSame($cachedRepos, $repos);
+    }
+
+    public function test_get_repos_fetches_from_api_when_cache_missing(): void
+    {
+        Http::fake([
+            'codeberg.org/api/v1/user/repos*' => Http::response([
+                ['full_name' => 'user/repo1'],
+                ['full_name' => 'user/repo2'],
+            ], 200),
+        ]);
+
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+                'provider_data' => [
+                    'token' => 'test-token',
+                ],
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $repos = $forgejo->getRepos(false);
+
+        $this->assertSame(['user/repo1', 'user/repo2'], $repos);
+    }
+
+    public function test_get_repos_returns_empty_array_on_error(): void
+    {
+        Http::fake([
+            'codeberg.org/api/v1/user/repos*' => Http::response([], 500),
+        ]);
+
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+                'provider_data' => [
+                    'token' => 'test-token',
+                ],
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $repos = $forgejo->getRepos(false);
+
+        $this->assertSame([], $repos);
+    }
+
+    public function test_get_branches_returns_cached_branches_when_cache_exists(): void
+    {
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+                'provider_data' => [
+                    'token' => 'test-token',
+                ],
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+        $repo = 'user/repo';
+        $cacheKey = 'forgejo_branches_'.md5($repo.$forgejo->getApiUrl().'test-token');
+        $cachedBranches = ['main', 'develop'];
+
+        Cache::put($cacheKey, $cachedBranches, 900);
+
+        $branches = $forgejo->getBranches($repo);
+
+        $this->assertSame($cachedBranches, $branches);
+    }
+
+    public function test_get_branches_fetches_from_api_when_cache_missing(): void
+    {
+        Http::fake([
+            'codeberg.org/api/v1/repos/user/repo/branches*' => Http::response([
+                ['name' => 'main'],
+                ['name' => 'develop'],
+            ], 200),
+        ]);
+
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+                'provider_data' => [
+                    'token' => 'test-token',
+                ],
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $branches = $forgejo->getBranches('user/repo', false);
+
+        $this->assertSame(['main', 'develop'], $branches);
+    }
+
+    public function test_get_branches_returns_empty_array_on_error(): void
+    {
+        Http::fake([
+            'codeberg.org/api/v1/repos/user/repo/branches*' => Http::response([], 500),
+        ]);
+
+        $sourceControlModel = SourceControl::factory()
+            ->create([
+                'provider' => Forgejo::id(),
+                'provider_data' => [
+                    'token' => 'test-token',
+                ],
+            ]);
+
+        $forgejo = new Forgejo($sourceControlModel);
+
+        $branches = $forgejo->getBranches('user/repo', false);
+
+        $this->assertSame([], $branches);
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public static function customRepoUrlData(): array
+    {
+        return [
+            ['https://forgejo.example.com/', 'git@forgejo.example.com-TEST_KEY:test/repo.git'],
+            ['https://forgejo.test.example.com/', 'git@forgejo.test.example.com-TEST_KEY:test/repo.git'],
+            ['https://forgejo.example.co.uk/', 'git@forgejo.example.co.uk-TEST_KEY:test/repo.git'],
+        ];
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public static function customUrlData(): array
+    {
+        return [
+            ['https://forgejo.example.com/', 'https://forgejo.example.com/api/v1'],
+            ['https://forgejo.test.example.com/', 'https://forgejo.test.example.com/api/v1'],
+            ['https://forgejo.example.co.uk/', 'https://forgejo.example.co.uk/api/v1'],
+        ];
+    }
+}


### PR DESCRIPTION
This adds support for repositories hosted on [Codeberg](https://codeberg.org) by adding [Forgejo](https://codeberg.org/forgejo/forgejo) as a possible Source Control Provider.

While the API looks to be the same, Forgejo is a hard-fork of Gitea so we can't use the Gitea SourceControlProvider for repositories hosted on a Forgejo instance.