### PR TITLE
Add 8.5 to php versions array

### DIFF
--- a/app/Providers/ServiceTypeServiceProvider.php
+++ b/app/Providers/ServiceTypeServiceProvider.php
@@ -177,6 +177,7 @@ class ServiceTypeServiceProvider extends ServiceProvider
             ->label('PHP')
             ->handler(PHP::class)
             ->versions([
+                '8.5',
                 '8.4',
                 '8.3',
                 '8.2',


### PR DESCRIPTION
Been running `ppa:ondrej/php@8.5` on a VitoDeploy managed server for a few weeks, installed via UI with this change. Haven't seen any issues or tests that need updated, figured I'd toss in but let me know if you'd prefer to hold off or other changes are needed ✌️

* Adds `8.5` to `versions` array in `ServiceTypeServiceProvider` class for PHP.
* Does not adjust PHP for VIto itself.

[Website docs PR here](https://github.com/vitodeploy/vitodeploy.com/pull/7).