### PR TITLE
Add fail-on-error to Scripts

### DIFF
--- a/app/SSH/OS/OS.php
+++ b/app/SSH/OS/OS.php
@@ -237,7 +237,9 @@ class OS
         if ($serverLog instanceof ServerLog) {
             $ssh->setLog($serverLog);
         }
-        $command = "shopt -s expand_aliases\n";
+        $command = "set -e\n";
+        $command .= "set -o pipefail\n";
+        $command .= "shopt -s expand_aliases\n";
         if ($aliases !== null && $aliases !== []) {
             foreach ($aliases as $key => $alias) {
                 $command .= "alias $key=$alias\n";


### PR DESCRIPTION
## Problem

Scripts executed in `runScript()` would continue running even when a command failed. For example, if a migration failed or git pull errored, the script wouldn't stop and would keep executing subsequent commands. This could lead to incorrect deployment states.

## Solution

Added `set -e` and `set -o pipefail` at the beginning of scripts. Now when any command fails, the script stops and the SSH exec method properly throws an error.

- `set -e`: Script stops when a command returns a non-zero exit code
- `set -o pipefail`: Enables error checking in pipes as well