### PR TITLE
Feat/cron job names

### DIFF
--- a/app/Actions/CronJob/CreateCronJob.php
+++ b/app/Actions/CronJob/CreateCronJob.php
@@ -29,6 +29,7 @@ class CreateCronJob
         }
 
         $cronJob = new CronJob([
+            'name' => $input['name'] ?? null,
             'server_id' => $server->id,
             'site_id' => $siteId,
             'user' => $input['user'],
@@ -58,6 +59,11 @@ class CreateCronJob
             'frequency' => [
                 'required',
                 new CronRule(acceptCustom: true),
+            ],
+            'name' => [
+                'nullable',
+                'string',
+                'max:255',
             ],
         ];
 

--- a/app/Actions/CronJob/EditCronJob.php
+++ b/app/Actions/CronJob/EditCronJob.php
@@ -38,6 +38,7 @@ class EditCronJob
 
         $cronJob->update([
             'site_id' => $siteId,
+            'name' => $input['name'] ?? null,
             'user' => $input['user'],
             'command' => $input['command'],
             'frequency' => $input['frequency'] == 'custom' ? $input['custom'] : $input['frequency'],
@@ -71,6 +72,11 @@ class EditCronJob
             'frequency' => [
                 'required',
                 new CronRule(acceptCustom: true),
+            ],
+            'name' => [
+                'nullable',
+                'string',
+                'max:255',
             ],
         ];
 

--- a/app/Http/Resources/CronJobResource.php
+++ b/app/Http/Resources/CronJobResource.php
@@ -16,6 +16,7 @@ class CronJobResource extends JsonResource
     {
         return [
             'id' => $this->id,
+            'name' => $this->name,
             'server_id' => $this->server_id,
             'site_id' => $this->site_id,
             'command' => $this->command,

--- a/app/Models/CronJob.php
+++ b/app/Models/CronJob.php
@@ -84,7 +84,7 @@ class CronJob extends AbstractModel
             ->get();
         /** @var CronJob $cronJob */
         foreach ($cronJobs as $key => $cronJob) {
-            $data .= $cronJob->frequency . ' ' . $cronJob->command;
+            $data .= $cronJob->frequency.' '.$cronJob->command;
             if ($key != count($cronJobs) - 1) {
                 $data .= "\n";
             }

--- a/app/Models/CronJob.php
+++ b/app/Models/CronJob.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $user
  * @property string $frequency
  * @property bool $hidden
+ * @property string|null $name
  * @property CronjobStatus $status
  * @property string $crontab
  * @property Server $server
@@ -32,6 +33,7 @@ class CronJob extends AbstractModel
         'frequency',
         'hidden',
         'status',
+        'name',
     ];
 
     protected $casts = [
@@ -82,7 +84,7 @@ class CronJob extends AbstractModel
             ->get();
         /** @var CronJob $cronJob */
         foreach ($cronJobs as $key => $cronJob) {
-            $data .= $cronJob->frequency.' '.$cronJob->command;
+            $data .= $cronJob->frequency . ' ' . $cronJob->command;
             if ($key != count($cronJobs) - 1) {
                 $data .= "\n";
             }

--- a/database/factories/CronJobFactory.php
+++ b/database/factories/CronJobFactory.php
@@ -16,6 +16,7 @@ class CronJobFactory extends Factory
     public function definition(): array
     {
         return [
+            'name' => $this->faker->optional()->sentence(3),
             'server_id' => 1,
             'site_id' => null,
             'command' => 'ls -la',

--- a/database/migrations/2026_01_09_170832_add_name_to_cron_jobs_table.php
+++ b/database/migrations/2026_01_09_170832_add_name_to_cron_jobs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('cron_jobs', function (Blueprint $table) {
+            $table->string('name')->nullable()->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('cron_jobs', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+    }
+};

--- a/resources/js/pages/cronjobs/components/columns.tsx
+++ b/resources/js/pages/cronjobs/components/columns.tsx
@@ -97,6 +97,15 @@ function Delete({ cronJob, site }: { cronJob: CronJob; site?: Site }) {
 function getColumns(site?: Site, sites?: Array<{ id: number; domain: string }>): ColumnDef<CronJob>[] {
   return [
     {
+      accessorKey: 'name',
+      header: 'Name',
+      enableColumnFilter: true,
+      enableSorting: true,
+      cell: ({ row }) => {
+        return <span>{row.original.name || <i className="text-muted-foreground">No name</i>}</span>;
+      },
+    },
+    {
       accessorKey: 'command',
       header: 'Command',
       enableColumnFilter: true,

--- a/resources/js/pages/cronjobs/components/form.tsx
+++ b/resources/js/pages/cronjobs/components/form.tsx
@@ -36,12 +36,14 @@ export default function CronJobForm({
   const page = usePage<SharedData & { server: Server; sites?: Array<{ id: number; domain: string }> }>();
   const [open, setOpen] = useState(false);
   const form = useForm<{
+    name: string;
     command: string;
     user: string;
     frequency: string;
     custom: string;
     site_id: string;
   }>({
+    name: cronJob?.name || '',
     command: cronJob?.command || '',
     user: cronJob?.user || '',
     frequency: cronJob ? (page.props.configs.cronjob_intervals[cronJob.frequency] ? cronJob.frequency : 'custom') : '',
@@ -84,11 +86,21 @@ export default function CronJobForm({
         </DialogHeader>
         <Form id="cronjob-form" onSubmit={submit} className="p-4">
           <FormFields>
+            {/* Name */}
+            <FormField>
+              <Label htmlFor="name">Name</Label>
+              <Input type="text" id="name" value={form.data.name} onChange={(e) => form.setData('name', e.target.value)} 
+              placeholder="Optional name for the cron job" />
+              <InputError message={form.errors.name} />
+            </FormField>
+
+            {/* Command */}
             <FormField>
               <Label htmlFor="command">Command</Label>
               <Input type="text" id="command" value={form.data.command} onChange={(e) => form.setData('command', e.target.value)} />
               <InputError message={form.errors.command} />
             </FormField>
+
 
             {/*site selection - only show if we have sites data and not in site context*/}
             {page.props.sites && !site && (

--- a/resources/js/pages/cronjobs/components/form.tsx
+++ b/resources/js/pages/cronjobs/components/form.tsx
@@ -89,8 +89,13 @@ export default function CronJobForm({
             {/* Name */}
             <FormField>
               <Label htmlFor="name">Name</Label>
-              <Input type="text" id="name" value={form.data.name} onChange={(e) => form.setData('name', e.target.value)} 
-              placeholder="Optional name for the cron job" />
+              <Input
+                type="text"
+                id="name"
+                value={form.data.name}
+                onChange={(e) => form.setData('name', e.target.value)}
+                placeholder="Optional name for the cron job"
+              />
               <InputError message={form.errors.name} />
             </FormField>
 
@@ -100,7 +105,6 @@ export default function CronJobForm({
               <Input type="text" id="command" value={form.data.command} onChange={(e) => form.setData('command', e.target.value)} />
               <InputError message={form.errors.command} />
             </FormField>
-
 
             {/*site selection - only show if we have sites data and not in site context*/}
             {page.props.sites && !site && (

--- a/resources/js/types/cronjob.d.ts
+++ b/resources/js/types/cronjob.d.ts
@@ -1,5 +1,6 @@
 export interface CronJob {
   id: number;
+  name: string | null;
   server_id: number;
   site_id: number | null;
   command: string;

--- a/tests/Feature/API/SiteCronjobTest.php
+++ b/tests/Feature/API/SiteCronjobTest.php
@@ -74,6 +74,7 @@ class SiteCronjobTest extends TestCase
             'command' => 'ls -la',
             'user' => 'vito',
             'frequency' => '* * * * *',
+            'name' => 'My Site Cronjob',
         ])
             ->assertSuccessful()
             ->assertJsonFragment([
@@ -91,6 +92,7 @@ class SiteCronjobTest extends TestCase
             'user' => 'vito',
             'frequency' => '* * * * *',
             'status' => CronjobStatus::READY,
+            'name' => 'My Site Cronjob',
         ]);
     }
 

--- a/tests/Feature/CronjobTest.php
+++ b/tests/Feature/CronjobTest.php
@@ -25,7 +25,7 @@ class CronjobTest extends TestCase
 
         $this->get(route('cronjobs', $this->server))
             ->assertSuccessful()
-            ->assertInertia(fn(AssertableInertia $page) => $page->component('cronjobs/index'));
+            ->assertInertia(fn (AssertableInertia $page) => $page->component('cronjobs/index'));
     }
 
     public function test_delete_cronjob(): void

--- a/tests/Feature/CronjobTest.php
+++ b/tests/Feature/CronjobTest.php
@@ -25,8 +25,7 @@ class CronjobTest extends TestCase
 
         $this->get(route('cronjobs', $this->server))
             ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('cronjobs/index'));
-
+            ->assertInertia(fn(AssertableInertia $page) => $page->component('cronjobs/index'));
     }
 
     public function test_delete_cronjob(): void
@@ -64,6 +63,7 @@ class CronjobTest extends TestCase
             'command' => 'ls -la',
             'user' => 'vito',
             'frequency' => '* * * * *',
+            'name' => 'My Cronjob',
         ])
             ->assertSessionDoesntHaveErrors();
 
@@ -73,6 +73,7 @@ class CronjobTest extends TestCase
             'user' => 'vito',
             'frequency' => '* * * * *',
             'status' => CronjobStatus::READY,
+            'name' => 'My Cronjob',
         ]);
 
         SSH::assertExecutedContains("echo '* * * * * ls -la' | sudo -u vito crontab -");
@@ -326,6 +327,7 @@ class CronjobTest extends TestCase
             'user' => 'vito',
             'frequency' => '* * * * *',
             'site_id' => $site->id,
+            'name' => 'Updated Cronjob',
         ])
             ->assertSessionDoesntHaveErrors();
 
@@ -333,6 +335,7 @@ class CronjobTest extends TestCase
 
         $this->assertEquals($site->id, $cronjob->site_id);
         $this->assertEquals('updated command', $cronjob->command);
+        $this->assertEquals('Updated Cronjob', $cronjob->name);
     }
 
     public function test_cannot_edit_cronjob_with_invalid_site_id(): void


### PR DESCRIPTION
Based on issue #990.

CronJob model is now able to save a name.
Name is set to optional and in default set to null, due to case when command length is not fitting in 255 char name.