### PR TITLE
Replace "npm install" with "npm ci"

### DIFF
--- a/resources/deployment-scripts/laravel.sh
+++ b/resources/deployment-scripts/laravel.sh
@@ -6,7 +6,7 @@ php artisan migrate --force
 php artisan optimize:clear
 php artisan optimize
 
-npm install
+npm ci
 npm run build
 
 echo "✅ Deployment completed successfully!"

--- a/resources/deployment-scripts/nodejs.sh
+++ b/resources/deployment-scripts/nodejs.sh
@@ -2,7 +2,7 @@ cd $SITE_PATH
 
 git pull origin $BRANCH
 
-npm install
+npm ci
 
 npm run build
 


### PR DESCRIPTION
Running "npm install" can lead to unexpected errors since it can in some cases write to the `package-lock.json`. This, in turn, can lead to failed deployments since there are local changes

<img width="690" height="205" alt="CleanShot 2026-01-19 at 17 05 17" src="https://github.com/user-attachments/assets/7145f58a-42c7-4890-9daf-42dc36b4b481" />

The npm docs itself recommend running `npm ci` in deployments:
https://docs.npmjs.com/cli/v11/commands/npm-ci

While this _could_ be a breaking change I would say that's a bugfix, that's why I am targeting the 3.x branch.