### PR TITLE
Adjust SSH heredoc wrapper

### DIFF
--- a/app/Helpers/SSH.php
+++ b/app/Helpers/SSH.php
@@ -170,8 +170,11 @@ class SSH
 
         try {
             if ($this->asUser !== null && $this->asUser !== '' && $this->asUser !== '0') {
-                $command = base64_encode((string) $command);
-                $command = "sudo su - {$this->asUser} -c 'bash -c \"echo {$command} | base64 -d | bash\"'";
+                $command = <<<BASH
+                sudo -u {$this->asUser} bash <<'EOF'
+                {$command}
+                EOF
+                BASH;
             }
 
             $this->connection->setTimeout(0);

--- a/tests/Unit/Models/ServerModelTest.php
+++ b/tests/Unit/Models/ServerModelTest.php
@@ -4,7 +4,10 @@ namespace Tests\Unit\Models;
 
 use App\Enums\ServerStatus;
 use App\Facades\SSH;
+use App\Helpers\SSH as SSHHelper;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use phpseclib3\Net\SSH2;
+use ReflectionProperty;
 use Tests\TestCase;
 
 class ServerModelTest extends TestCase
@@ -46,5 +49,62 @@ class ServerModelTest extends TestCase
             'id' => $this->server->id,
             'status' => ServerStatus::DISCONNECTED,
         ]);
+    }
+
+    public function test_exec_wraps_command_when_using_custom_user(): void
+    {
+        $ssh = (new SSHHelper)->init($this->server, 'deploy');
+
+        $connection = $this->getMockBuilder(SSH2::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['setTimeout', 'exec', 'getExitStatus', 'disconnect'])
+            ->getMock();
+
+        $executedCommand = null;
+
+        $connection->expects($this->once())
+            ->method('setTimeout')
+            ->with(0);
+
+        $connection->expects($this->once())
+            ->method('exec')
+            ->with(
+                $this->isType('string'),
+                $this->isType('callable')
+            )
+            ->willReturnCallback(function ($command, $callback) use (&$executedCommand) {
+                $executedCommand = $command;
+                $callback('');
+
+                return '';
+            });
+
+        $connection->expects($this->once())
+            ->method('getExitStatus')
+            ->willReturn(0);
+
+        $connection->method('disconnect');
+
+        $reflection = new ReflectionProperty(SSHHelper::class, 'connection');
+        $reflection->setAccessible(true);
+        $reflection->setValue($ssh, $connection);
+
+        $command = <<<'BASH'
+pwd
+ls -la
+BASH;
+
+        $output = $ssh->exec($command);
+        $ssh->disconnect();
+
+        $expected = <<<'BASH'
+sudo -u deploy bash <<'EOF'
+pwd
+ls -la
+EOF
+BASH;
+
+        $this->assertSame('', $output);
+        $this->assertSame($expected, $executedCommand);
     }
 }


### PR DESCRIPTION
trying to fix this #781 

What changed
	•	Switched to using bash with a quoted heredoc (<<'EOF') when executing commands as another user.
	•	Updated the related test case to assert the new heredoc-based command structure.
	•	Removed unnecessary base64 encoding/decoding from the execution flow.

Why this change
	•	Improves readability of executed commands.
	•	Avoids complex shell quoting and nested bash -c calls.
	•	Prevents unintended variable expansion by using a quoted heredoc.
	•	Makes the execution logic more robust and easier to reason about in tests.

Notes
	•	No functional behavior change in command execution logic, only the execution method.
	•	Tests were updated accordingly to reflect the new expected command format.