### PR TITLE
fix: service versions in desc order (4.x)

### DIFF
--- a/app/Http/Controllers/ServiceController.php
+++ b/app/Http/Controllers/ServiceController.php
@@ -44,7 +44,7 @@ class ServiceController extends Controller
         $this->authorize('viewAny', [Service::class, $server]);
 
         $versions = [];
-        $services = $server->services()->where('type', $service)->get(['version']);
+        $services = $server->services()->where('type', $service)->latest('version')->get(['version']);
         /** @var Service $service */
         foreach ($services as $service) {
             $versions[] = $service->version;


### PR DESCRIPTION
Return service versions in descending order. (for the v4.x)

before:
<img width="407" height="287" alt="Captura de pantalla 2026-01-20 222024" src="https://github.com/user-attachments/assets/8c53dda8-98ea-4398-af76-1ed9851206d2" />

after:
<img width="407" height="287" alt="image" src="https://github.com/user-attachments/assets/e585e592-ce5f-4278-ab31-c91d45f5b0c3" />

Thx :) 