### PR TITLE
[Security] Removes 'vito' elevation requirement for Composer install

### DIFF
--- a/app/Services/PHP/PHP.php
+++ b/app/Services/PHP/PHP.php
@@ -128,7 +128,7 @@ class PHP extends AbstractService
      */
     public function installComposer(): void
     {
-        $this->service->server->ssh()->exec(
+        $this->service->server->ssh('root')->exec(
             view('ssh.services.php.install-composer'),
             'install-composer'
         );

--- a/resources/views/ssh/services/php/install-composer.blade.php
+++ b/resources/views/ssh/services/php/install-composer.blade.php
@@ -2,8 +2,8 @@ cd ~
 
 curl -sS https://getcomposer.org/installer -o composer-setup.php
 
-sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+php composer-setup.php --install-dir=/usr/local/bin --filename=composer
 
 rm composer-setup.php
 
-composer
+su vito -c 'composer --version'


### PR DESCRIPTION
This pull request updates the process for installing Composer in the PHP service to improve security and ensure Composer is installed and verified under the correct user context. The most significant changes are in how SSH commands are executed and how Composer is run after installation.

**Improvements to Composer installation process:**

* Changed the SSH connection to explicitly use the `root` user when installing Composer to ensure proper permissions during installation (`app/Services/PHP/PHP.php`).
* Updated the Composer installation script to:
  - Remove the use of `sudo` when running the Composer installer, since the script is now run as root.
  - Run `composer --version` as the `vito` user after installation to verify the install and ensure correct user permissions (`install-composer.blade.php`).

This avoids the requirement for the vito user to have elevated rights for the composer installation.  Smaller PRs incoming for where this is noticed. 