### PR TITLE
Extract inline closures into dedicated Job classes

### DIFF
--- a/app/Actions/Backup/ManageBackup.php
+++ b/app/Actions/Backup/ManageBackup.php
@@ -2,10 +2,10 @@
 
 namespace App\Actions\Backup;
 
-use App\Enums\BackupFileStatus;
 use App\Enums\BackupStatus;
 use App\Enums\BackupType;
 use App\Enums\DatabaseStatus;
+use App\Jobs\Backup\DeleteJob;
 use App\Models\Backup;
 use App\Models\Server;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -56,17 +56,7 @@ class ManageBackup
         $backup->status = BackupStatus::DELETING;
         $backup->save();
 
-        dispatch(function () use ($backup): void {
-            $files = $backup->files;
-            foreach ($files as $file) {
-                $file->status = BackupFileStatus::DELETING;
-                $file->save();
-
-                $file->deleteFile();
-            }
-
-            $backup->delete();
-        })->onQueue('ssh');
+        dispatch(new DeleteJob($backup))->onQueue('ssh');
     }
 
     public function stop(Backup $backup): void

--- a/app/Actions/Backup/ManageBackupFile.php
+++ b/app/Actions/Backup/ManageBackupFile.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Backup;
 
 use App\Enums\BackupFileStatus;
+use App\Jobs\Backup\DeleteFileJob;
 use App\Models\BackupFile;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -28,8 +29,6 @@ class ManageBackupFile
         $file->status = BackupFileStatus::DELETING;
         $file->save();
 
-        dispatch(function () use ($file): void {
-            $file->deleteFile();
-        })->onQueue('ssh');
+        dispatch(new DeleteFileJob($file))->onQueue('ssh');
     }
 }

--- a/app/Actions/Backup/RestoreBackup.php
+++ b/app/Actions/Backup/RestoreBackup.php
@@ -4,10 +4,11 @@ namespace App\Actions\Backup;
 
 use App\Enums\BackupFileStatus;
 use App\Enums\BackupType;
+use App\Jobs\Backup\RestoreDatabaseJob;
+use App\Jobs\Backup\RestoreFileJob;
 use App\Models\BackupFile;
 use App\Models\Database;
 use App\Models\Server;
-use App\Models\Service;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 
@@ -39,24 +40,11 @@ class RestoreBackup
         $backupFile->restored_to = $database->name;
         $backupFile->save();
 
-        dispatch(function () use ($backupFile, $database): void {
-            /** @var Service $service */
-            $service = $database->server->database();
-            /** @var \App\Services\Database\Database $databaseHandler */
-            $databaseHandler = $service->handler();
-            $databaseHandler->restoreBackup($backupFile, $database->name);
-            $backupFile->status = BackupFileStatus::RESTORED;
-            $backupFile->restored_at = now();
-            $backupFile->save();
-        })->catch(function () use ($backupFile): void {
-            $backupFile->status = BackupFileStatus::RESTORE_FAILED;
-            $backupFile->save();
-        })->onQueue('ssh');
+        dispatch(new RestoreDatabaseJob($backupFile, $database))->onQueue('ssh');
     }
 
     private function restoreFile(BackupFile $backupFile, array $input): void
     {
-        // File backup restoration
         $restorePath = $input['path'];
         $owner = $input['owner'] ?? 'vito:vito';
         $permissions = $input['permissions'] ?? '755';
@@ -64,30 +52,7 @@ class RestoreBackup
         $backupFile->restored_to = $restorePath;
         $backupFile->save();
 
-        dispatch(function () use ($backupFile, $restorePath, $owner, $permissions): void {
-            $server = $backupFile->backup->server;
-            $tempBackupPath = $backupFile->tempPath();
-
-            // Download backup from storage provider
-            $backupFile->backup->storage->provider()->ssh($server)->download(
-                $backupFile->path(),
-                $tempBackupPath
-            );
-
-            // Extract the archive using OS service with custom owner and permissions
-            $server->os()->extractArchive($tempBackupPath, $restorePath, $owner, $permissions);
-
-            // Clean up temporary file
-            $server->os()->deleteFile($tempBackupPath);
-
-            $backupFile->status = BackupFileStatus::RESTORED;
-            $backupFile->restored_at = now();
-            $backupFile->save();
-        })->catch(function () use ($backupFile): void {
-            $backupFile->status = BackupFileStatus::RESTORE_FAILED;
-            $backupFile->save();
-            $backupFile->backup->server->os()->deleteFile($backupFile->tempPath());
-        })->onQueue('ssh');
+        dispatch(new RestoreFileJob($backupFile, $restorePath, $owner, $permissions))->onQueue('ssh');
     }
 
     private function validate(Server $server, array $input, BackupType $backupType): void

--- a/app/Actions/Backup/RunBackup.php
+++ b/app/Actions/Backup/RunBackup.php
@@ -3,12 +3,10 @@
 namespace App\Actions\Backup;
 
 use App\Enums\BackupFileStatus;
-use App\Enums\BackupStatus;
 use App\Enums\BackupType;
+use App\Jobs\Backup\RunJob;
 use App\Models\Backup;
 use App\Models\BackupFile;
-use App\Models\Service;
-use App\Services\Database\Database;
 use Illuminate\Support\Str;
 
 class RunBackup
@@ -27,32 +25,7 @@ class RunBackup
         ]);
         $file->save();
 
-        dispatch(function () use ($file, $backup): void {
-            if ($backup->type === BackupType::DATABASE) {
-                /** @var Service $service */
-                $service = $backup->server->database();
-                /** @var Database $databaseHandler */
-                $databaseHandler = $service->handler();
-                $databaseHandler->runBackup($file);
-            }
-
-            if ($backup->type === BackupType::FILE) {
-                $this->compressAndUploadFile($file, $backup);
-            }
-
-            $file->status = BackupFileStatus::CREATED;
-            $file->save();
-
-            if ($backup->status !== BackupStatus::RUNNING) {
-                $backup->status = BackupStatus::RUNNING;
-                $backup->save();
-            }
-        })->catch(function () use ($file, $backup): void {
-            $backup->status = BackupStatus::FAILED;
-            $backup->save();
-            $file->status = BackupFileStatus::FAILED;
-            $file->save();
-        })->onQueue('ssh');
+        dispatch(new RunJob($file, $backup))->onQueue('ssh');
 
         return $file;
     }

--- a/app/Actions/FirewallRule/ManageRule.php
+++ b/app/Actions/FirewallRule/ManageRule.php
@@ -3,11 +3,9 @@
 namespace App\Actions\FirewallRule;
 
 use App\Enums\FirewallRuleStatus;
+use App\Jobs\FirewallRule\ApplyRulesJob;
 use App\Models\FirewallRule;
 use App\Models\Server;
-use App\Models\Service;
-use App\Services\Firewall\Firewall;
-use Exception;
 use Illuminate\Support\Facades\Validator;
 
 class ManageRule
@@ -34,7 +32,7 @@ class ManageRule
 
         $rule->save();
 
-        dispatch(fn () => $this->applyRule($rule))->onQueue('ssh');
+        dispatch(new ApplyRulesJob($rule))->onQueue('ssh');
 
         return $rule;
     }
@@ -58,7 +56,7 @@ class ManageRule
             'status' => FirewallRuleStatus::UPDATING,
         ]);
 
-        dispatch(fn () => $this->applyRule($rule))->onQueue('ssh');
+        dispatch(new ApplyRulesJob($rule))->onQueue('ssh');
 
         return $rule;
     }
@@ -68,33 +66,7 @@ class ManageRule
         $rule->status = FirewallRuleStatus::DELETING;
         $rule->save();
 
-        dispatch(fn () => $this->applyRule($rule))->onQueue('ssh');
-    }
-
-    protected function applyRule(FirewallRule $rule): void
-    {
-        try {
-            /** @var Service $service */
-            $service = $rule->server->firewall();
-            /** @var Firewall $handler */
-            $handler = $service->handler();
-            $handler->applyRules();
-        } catch (Exception) {
-            $rule->server->firewallRules()
-                ->where('status', '!=', FirewallRuleStatus::READY)
-                ->update(['status' => FirewallRuleStatus::FAILED]);
-
-            return;
-        }
-
-        if ($rule->status === FirewallRuleStatus::DELETING) {
-            $rule->delete();
-
-            return;
-        }
-
-        $rule->status = FirewallRuleStatus::READY;
-        $rule->save();
+        dispatch(new ApplyRulesJob($rule))->onQueue('ssh');
     }
 
     private function validate(array $input): void

--- a/app/Actions/Script/ExecuteScript.php
+++ b/app/Actions/Script/ExecuteScript.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Script;
 
 use App\Enums\ScriptExecutionStatus;
+use App\Jobs\Script\ExecuteJob;
 use App\Models\Script;
 use App\Models\ScriptExecution;
 use App\Models\Server;
@@ -49,20 +50,7 @@ class ExecuteScript
         $execution->server_log_id = $log->id;
         $execution->save();
 
-        dispatch(function () use ($execution, $log): void {
-            /** @var Server $server */
-            $server = $execution->server;
-
-            $content = $execution->getContent();
-            $execution->server_log_id = $log->id;
-            $execution->save();
-            $server->os()->runScript('~/', $content, $log, $execution->user);
-            $execution->status = ScriptExecutionStatus::COMPLETED;
-            $execution->save();
-        })->catch(function () use ($execution): void {
-            $execution->status = ScriptExecutionStatus::FAILED;
-            $execution->save();
-        })->onQueue('ssh');
+        dispatch(new ExecuteJob($execution, $log))->onQueue('ssh');
 
         return $execution;
     }

--- a/app/Actions/Server/CreateServer.php
+++ b/app/Actions/Server/CreateServer.php
@@ -2,23 +2,19 @@
 
 namespace App\Actions\Server;
 
-use App\Enums\ServerStatus;
-use App\Facades\Notifier;
+use App\Jobs\Server\InstallJob;
 use App\Models\Project;
 use App\Models\Server;
 use App\Models\ServerProvider;
 use App\Models\User;
-use App\Notifications\ServerInstallationFailed;
 use App\ServerProviders\Custom;
 use App\ValidationRules\RestrictedIPAddressesRule;
 use Exception;
 use Illuminate\Database\Query\Builder;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
-use Throwable;
 
 class CreateServer
 {
@@ -73,19 +69,7 @@ class CreateServer
             $this->createServices($input);
 
             // install server
-            dispatch(function (): void {
-                app(InstallServer::class)->run($this->server);
-            })
-                ->catch(function (Throwable $e): void {
-                    $this->server->update([
-                        'status' => ServerStatus::INSTALLATION_FAILED,
-                    ]);
-                    Notifier::send($this->server, new ServerInstallationFailed($this->server));
-                    Log::error('server-installation-error', [
-                        'error' => (string) $e,
-                    ]);
-                })
-                ->onQueue('ssh');
+            dispatch(new InstallJob($this->server))->onQueue('ssh');
 
             // Ensure we get the default db values in the model
             $this->server->refresh();

--- a/app/Actions/Service/Manage.php
+++ b/app/Actions/Service/Manage.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Service;
 
 use App\Enums\ServiceStatus;
+use App\Jobs\Service\ManageJob;
 use App\Models\Service;
 use Illuminate\Validation\ValidationException;
 
@@ -13,15 +14,7 @@ class Manage
         $this->validate($service);
         $service->status = ServiceStatus::STARTING;
         $service->save();
-        dispatch(function () use ($service): void {
-            $status = $service->server->systemd()->start($service->handler()->unit());
-            if (str($status)->contains('Active: active')) {
-                $service->status = ServiceStatus::READY;
-            } else {
-                $service->status = ServiceStatus::FAILED;
-            }
-            $service->save();
-        })->onQueue('ssh');
+        dispatch(new ManageJob($service, 'start', ServiceStatus::READY))->onQueue('ssh');
     }
 
     public function stop(Service $service): void
@@ -29,15 +22,7 @@ class Manage
         $this->validate($service);
         $service->status = ServiceStatus::STOPPING;
         $service->save();
-        dispatch(function () use ($service): void {
-            $status = $service->server->systemd()->stop($service->handler()->unit());
-            if (str($status)->contains('Active: inactive')) {
-                $service->status = ServiceStatus::STOPPED;
-            } else {
-                $service->status = ServiceStatus::FAILED;
-            }
-            $service->save();
-        })->onQueue('ssh');
+        dispatch(new ManageJob($service, 'stop', ServiceStatus::STOPPED))->onQueue('ssh');
     }
 
     public function restart(Service $service): void
@@ -45,15 +30,7 @@ class Manage
         $this->validate($service);
         $service->status = ServiceStatus::RESTARTING;
         $service->save();
-        dispatch(function () use ($service): void {
-            $status = $service->server->systemd()->restart($service->handler()->unit());
-            if (str($status)->contains('Active: active')) {
-                $service->status = ServiceStatus::READY;
-            } else {
-                $service->status = ServiceStatus::FAILED;
-            }
-            $service->save();
-        })->onQueue('ssh');
+        dispatch(new ManageJob($service, 'restart', ServiceStatus::READY))->onQueue('ssh');
     }
 
     public function reload(Service $service): void
@@ -61,15 +38,7 @@ class Manage
         $this->validate($service);
         $service->status = ServiceStatus::RELOADING;
         $service->save();
-        dispatch(function () use ($service): void {
-            $status = $service->server->systemd()->reload($service->handler()->unit());
-            if (str($status)->contains('Active: active')) {
-                $service->status = ServiceStatus::READY;
-            } else {
-                $service->status = ServiceStatus::FAILED;
-            }
-            $service->save();
-        })->onQueue('ssh');
+        dispatch(new ManageJob($service, 'reload', ServiceStatus::READY))->onQueue('ssh');
     }
 
     public function enable(Service $service): void
@@ -77,15 +46,7 @@ class Manage
         $this->validate($service);
         $service->status = ServiceStatus::ENABLING;
         $service->save();
-        dispatch(function () use ($service): void {
-            $status = $service->server->systemd()->enable($service->handler()->unit());
-            if (str($status)->contains('Active: active')) {
-                $service->status = ServiceStatus::READY;
-            } else {
-                $service->status = ServiceStatus::FAILED;
-            }
-            $service->save();
-        })->onQueue('ssh');
+        dispatch(new ManageJob($service, 'enable', ServiceStatus::READY))->onQueue('ssh');
     }
 
     public function disable(Service $service): void
@@ -93,15 +54,7 @@ class Manage
         $this->validate($service);
         $service->status = ServiceStatus::DISABLING;
         $service->save();
-        dispatch(function () use ($service): void {
-            $status = $service->server->systemd()->disable($service->handler()->unit());
-            if (str($status)->contains('Active: inactive')) {
-                $service->status = ServiceStatus::DISABLED;
-            } else {
-                $service->status = ServiceStatus::FAILED;
-            }
-            $service->save();
-        })->onQueue('ssh');
+        dispatch(new ManageJob($service, 'disable', ServiceStatus::DISABLED))->onQueue('ssh');
     }
 
     private function validate(Service $service): void

--- a/app/Actions/Site/ExecuteCommand.php
+++ b/app/Actions/Site/ExecuteCommand.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Site;
 
 use App\Enums\CommandExecutionStatus;
+use App\Jobs\Site\ExecuteCommandJob;
 use App\Models\Command;
 use App\Models\CommandExecution;
 use App\Models\ServerLog;
@@ -39,24 +40,7 @@ class ExecuteCommand
         $execution->server_log_id = $log->id;
         $execution->save();
 
-        dispatch(function () use ($execution, $command, $log): void {
-            $content = $execution->getContent();
-            $execution->server_log_id = $log->id;
-            $execution->save();
-            $execution->server->os()->runScript(
-                path: $command->site->path,
-                script: $content,
-                serverLog: $log,
-                user: $command->site->user,
-                variables: $execution->variables,
-                aliases: $command->site->environmentAliases(),
-            );
-            $execution->status = CommandExecutionStatus::COMPLETED;
-            $execution->save();
-        })->catch(function () use ($execution): void {
-            $execution->status = CommandExecutionStatus::FAILED;
-            $execution->save();
-        })->onQueue('ssh');
+        dispatch(new ExecuteCommandJob($execution, $command, $log))->onQueue('ssh');
 
         return $execution;
     }

--- a/app/Actions/Worker/CreateWorker.php
+++ b/app/Actions/Worker/CreateWorker.php
@@ -3,11 +3,10 @@
 namespace App\Actions\Worker;
 
 use App\Enums\WorkerStatus;
+use App\Jobs\Worker\CreateJob;
 use App\Models\Server;
-use App\Models\Service;
 use App\Models\Site;
 use App\Models\Worker;
-use App\Services\ProcessManager\ProcessManager;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
@@ -43,28 +42,7 @@ class CreateWorker
         ]);
         $worker->save();
 
-        dispatch(function () use ($worker): void {
-            /** @var Service $service */
-            $service = $worker->server->processManager();
-            /** @var ProcessManager $processManager */
-            $processManager = $service->handler();
-            $processManager->create(
-                $worker->id,
-                $worker->command,
-                $worker->user,
-                $worker->auto_start,
-                $worker->auto_restart,
-                $worker->numprocs,
-                $worker->getLogFile(),
-                $worker->site?->path,
-                $worker->site_id,
-                $worker->environment,
-            );
-            $worker->status = WorkerStatus::RUNNING;
-            $worker->save();
-        })->catch(function () use ($worker): void {
-            $worker->delete();
-        })->onQueue('ssh');
+        dispatch(new CreateJob($worker))->onQueue('ssh');
 
         return $worker;
     }

--- a/app/Actions/Worker/EditWorker.php
+++ b/app/Actions/Worker/EditWorker.php
@@ -3,10 +3,9 @@
 namespace App\Actions\Worker;
 
 use App\Enums\WorkerStatus;
-use App\Models\Service;
+use App\Jobs\Worker\EditJob;
 use App\Models\Site;
 use App\Models\Worker;
-use App\Services\ProcessManager\ProcessManager;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
@@ -40,30 +39,7 @@ class EditWorker
         ]);
         $worker->save();
 
-        dispatch(function () use ($worker): void {
-            /** @var Service $service */
-            $service = $worker->server->processManager();
-            /** @var ProcessManager $processManager */
-            $processManager = $service->handler();
-            $processManager->delete($worker->id, $worker->site_id);
-
-            $processManager->create(
-                $worker->id,
-                $worker->command,
-                $worker->user,
-                $worker->auto_start,
-                $worker->auto_restart,
-                $worker->numprocs,
-                $worker->getLogFile(),
-                $worker->site?->path,
-                $worker->site_id
-            );
-            $worker->status = WorkerStatus::RUNNING;
-            $worker->save();
-        })->catch(function () use ($worker): void {
-            $worker->status = WorkerStatus::FAILED;
-            $worker->save();
-        })->onQueue('ssh');
+        dispatch(new EditJob($worker))->onQueue('ssh');
 
         return $worker;
     }

--- a/app/Actions/Worker/ManageWorker.php
+++ b/app/Actions/Worker/ManageWorker.php
@@ -3,9 +3,8 @@
 namespace App\Actions\Worker;
 
 use App\Enums\WorkerStatus;
-use App\Models\Service;
+use App\Jobs\Worker\ManageJob;
 use App\Models\Worker;
-use App\Services\ProcessManager\ProcessManager;
 
 class ManageWorker
 {
@@ -13,44 +12,20 @@ class ManageWorker
     {
         $worker->status = WorkerStatus::STARTING;
         $worker->save();
-        dispatch(function () use ($worker): void {
-            /** @var Service $service */
-            $service = $worker->server->processManager();
-            /** @var ProcessManager $handler */
-            $handler = $service->handler();
-            $handler->start($worker->id, $worker->site_id);
-            $worker->status = WorkerStatus::RUNNING;
-            $worker->save();
-        })->onQueue('ssh');
+        dispatch(new ManageJob($worker, 'start', WorkerStatus::RUNNING))->onQueue('ssh');
     }
 
     public function stop(Worker $worker): void
     {
         $worker->status = WorkerStatus::STOPPING;
         $worker->save();
-        dispatch(function () use ($worker): void {
-            /** @var Service $service */
-            $service = $worker->server->processManager();
-            /** @var ProcessManager $handler */
-            $handler = $service->handler();
-            $handler->stop($worker->id, $worker->site_id);
-            $worker->status = WorkerStatus::STOPPED;
-            $worker->save();
-        })->onQueue('ssh');
+        dispatch(new ManageJob($worker, 'stop', WorkerStatus::STOPPED))->onQueue('ssh');
     }
 
     public function restart(Worker $worker): void
     {
         $worker->status = WorkerStatus::RESTARTING;
         $worker->save();
-        dispatch(function () use ($worker): void {
-            /** @var Service $service */
-            $service = $worker->server->processManager();
-            /** @var ProcessManager $handler */
-            $handler = $service->handler();
-            $handler->restart($worker->id, $worker->site_id);
-            $worker->status = WorkerStatus::RUNNING;
-            $worker->save();
-        })->onQueue('ssh');
+        dispatch(new ManageJob($worker, 'restart', WorkerStatus::RUNNING))->onQueue('ssh');
     }
 }

--- a/app/Actions/Workflow/RunWorkflow.php
+++ b/app/Actions/Workflow/RunWorkflow.php
@@ -5,7 +5,7 @@ namespace App\Actions\Workflow;
 use App\DTOs\WorkflowActionDTO;
 use App\Enums\WorkflowRunStatus;
 use App\Exceptions\AppError;
-use App\Facades\SSH;
+use App\Jobs\Workflow\RunJob;
 use App\Models\User;
 use App\Models\Workflow;
 use App\Models\WorkflowRun;
@@ -39,29 +39,12 @@ class RunWorkflow
         $run->log('Starting workflow ['.$workflow->name.']');
         $run->refresh();
 
-        dispatch(function () use ($run, $user, $workflow, $executionTree, $input) {
-            // set all queue drivers to sync for underlying actions
-            config()->set('queue.connections.ssh.driver', 'sync');
-            config()->set('queue.connections.default.driver', 'sync');
-
-            if ($run->verbose && $run->log_disk && $run->log_path) {
-                SSH::useLog($run->log_disk, $run->log_path);
-            }
-            if ($input['inputs']) {
-                $executionTree->inputs = $input['inputs'];
-            }
-            $this->executeAction($run, $user, $workflow, $executionTree, $input['inputs'] ?? []);
-            $run->status = WorkflowRunStatus::COMPLETED;
-            $run->save();
-        })->catch(function () use ($run) {
-            $run->status = WorkflowRunStatus::FAILED;
-            $run->save();
-        })->onQueue('ssh');
+        dispatch(new RunJob($run, $user, $workflow, $executionTree, $input))->onQueue('ssh');
 
         return $run;
     }
 
-    private function executeAction(WorkflowRun $run, User $user, Workflow $workflow, ?WorkflowActionDTO $workflowActionDto, ?array $input): void
+    public function executeAction(WorkflowRun $run, User $user, Workflow $workflow, ?WorkflowActionDTO $workflowActionDto, ?array $input): void
     {
         if (! $workflowActionDto) {
             return;

--- a/app/Jobs/Backup/DeleteFileJob.php
+++ b/app/Jobs/Backup/DeleteFileJob.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Jobs\Backup;
+
+use App\Models\BackupFile;
+use App\Models\ServerLog;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class DeleteFileJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(protected BackupFile $file) {}
+
+    public function handle(): void
+    {
+        $this->run("backup-file-{$this->file->id}", function () {
+            $this->file->deleteFile();
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        ServerLog::log($this->file->backup->server, 'delete-backup-file-failed', $e->getMessage());
+    }
+}

--- a/app/Jobs/Backup/DeleteJob.php
+++ b/app/Jobs/Backup/DeleteJob.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Jobs\Backup;
+
+use App\Enums\BackupFileStatus;
+use App\Models\Backup;
+use App\Models\ServerLog;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class DeleteJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(protected Backup $backup) {}
+
+    public function handle(): void
+    {
+        $this->run("backup-{$this->backup->id}", function () {
+            $files = $this->backup->files;
+            foreach ($files as $file) {
+                $file->status = BackupFileStatus::DELETING;
+                $file->save();
+
+                $file->deleteFile();
+            }
+
+            $this->backup->delete();
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        ServerLog::log($this->backup->server, 'delete-backup-failed', $e->getMessage());
+    }
+}

--- a/app/Jobs/Backup/RestoreDatabaseJob.php
+++ b/app/Jobs/Backup/RestoreDatabaseJob.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Jobs\Backup;
+
+use App\Enums\BackupFileStatus;
+use App\Models\BackupFile;
+use App\Models\Database;
+use App\Models\ServerLog;
+use App\Models\Service;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class RestoreDatabaseJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(
+        protected BackupFile $backupFile,
+        protected Database $database,
+    ) {}
+
+    public function handle(): void
+    {
+        $this->run("database-{$this->database->id}", function () {
+            /** @var Service $service */
+            $service = $this->database->server->database();
+            /** @var \App\Services\Database\Database $databaseHandler */
+            $databaseHandler = $service->handler();
+            $databaseHandler->restoreBackup($this->backupFile, $this->database->name);
+            $this->backupFile->status = BackupFileStatus::RESTORED;
+            $this->backupFile->restored_at = now();
+            $this->backupFile->save();
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        $this->backupFile->status = BackupFileStatus::RESTORE_FAILED;
+        $this->backupFile->save();
+        ServerLog::log($this->database->server, 'restore-database-failed', $e->getMessage());
+    }
+}

--- a/app/Jobs/Backup/RestoreFileJob.php
+++ b/app/Jobs/Backup/RestoreFileJob.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Jobs\Backup;
+
+use App\Enums\BackupFileStatus;
+use App\Models\BackupFile;
+use App\Models\ServerLog;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class RestoreFileJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(
+        protected BackupFile $backupFile,
+        protected string $restorePath,
+        protected string $owner,
+        protected string $permissions,
+    ) {}
+
+    public function handle(): void
+    {
+        $server = $this->backupFile->backup->server;
+
+        $this->run("backup-file-{$this->backupFile->id}", function () use ($server) {
+            $tempBackupPath = $this->backupFile->tempPath();
+
+            // Download backup from storage provider
+            $this->backupFile->backup->storage->provider()->ssh($server)->download(
+                $this->backupFile->path(),
+                $tempBackupPath
+            );
+
+            // Extract the archive using OS service with custom owner and permissions
+            $server->os()->extractArchive($tempBackupPath, $this->restorePath, $this->owner, $this->permissions);
+
+            // Clean up temporary file
+            $server->os()->deleteFile($tempBackupPath);
+
+            $this->backupFile->status = BackupFileStatus::RESTORED;
+            $this->backupFile->restored_at = now();
+            $this->backupFile->save();
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        $this->backupFile->status = BackupFileStatus::RESTORE_FAILED;
+        $this->backupFile->save();
+        $this->backupFile->backup->server->os()->deleteFile($this->backupFile->tempPath());
+        ServerLog::log($this->backupFile->backup->server, 'restore-file-failed', $e->getMessage());
+    }
+}

--- a/app/Jobs/Backup/RunJob.php
+++ b/app/Jobs/Backup/RunJob.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Jobs\Backup;
+
+use App\Actions\Backup\RunBackup;
+use App\Enums\BackupFileStatus;
+use App\Enums\BackupStatus;
+use App\Enums\BackupType;
+use App\Models\Backup;
+use App\Models\BackupFile;
+use App\Models\ServerLog;
+use App\Models\Service;
+use App\Services\Database\Database;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class RunJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(
+        protected BackupFile $file,
+        protected Backup $backup,
+    ) {}
+
+    public function handle(): void
+    {
+        $this->run("backup-{$this->backup->id}", function () {
+            if ($this->backup->type === BackupType::DATABASE) {
+                /** @var Service $service */
+                $service = $this->backup->server->database();
+                /** @var Database $databaseHandler */
+                $databaseHandler = $service->handler();
+                $databaseHandler->runBackup($this->file);
+            }
+
+            if ($this->backup->type === BackupType::FILE) {
+                app(RunBackup::class)->compressAndUploadFile($this->file, $this->backup);
+            }
+
+            $this->file->status = BackupFileStatus::CREATED;
+            $this->file->save();
+
+            if ($this->backup->status !== BackupStatus::RUNNING) {
+                $this->backup->status = BackupStatus::RUNNING;
+                $this->backup->save();
+            }
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        $this->backup->status = BackupStatus::FAILED;
+        $this->backup->save();
+        $this->file->status = BackupFileStatus::FAILED;
+        $this->file->save();
+        ServerLog::log($this->backup->server, 'run-backup-failed', $e->getMessage());
+    }
+}

--- a/app/Jobs/FirewallRule/ApplyRulesJob.php
+++ b/app/Jobs/FirewallRule/ApplyRulesJob.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Jobs\FirewallRule;
+
+use App\Enums\FirewallRuleStatus;
+use App\Models\FirewallRule;
+use App\Models\ServerLog;
+use App\Models\Service;
+use App\Services\Firewall\Firewall;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class ApplyRulesJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(protected FirewallRule $rule) {}
+
+    public function handle(): void
+    {
+        $this->run("server-{$this->rule->server_id}", function () {
+            /** @var Service $service */
+            $service = $this->rule->server->firewall();
+            /** @var Firewall $handler */
+            $handler = $service->handler();
+            $handler->applyRules();
+
+            if ($this->rule->status === FirewallRuleStatus::DELETING) {
+                $this->rule->delete();
+
+                return;
+            }
+
+            $this->rule->status = FirewallRuleStatus::READY;
+            $this->rule->save();
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        $this->rule->server->firewallRules()
+            ->where('status', '!=', FirewallRuleStatus::READY)
+            ->update(['status' => FirewallRuleStatus::FAILED]);
+
+        ServerLog::log($this->rule->server, 'apply-firewall-rules-failed', $e->getMessage());
+    }
+}

--- a/app/Jobs/Script/ExecuteJob.php
+++ b/app/Jobs/Script/ExecuteJob.php
@@ -22,7 +22,7 @@ class ExecuteJob implements ShouldQueue
 
     public function handle(): void
     {
-        $this->run("script-exec-{$this->execution->id}", function () {
+        $this->run("server-{$this->execution->server_id}", function () {
             $server = $this->execution->server;
             $content = $this->execution->getContent();
             $this->execution->server_log_id = $this->log->id;

--- a/app/Jobs/Script/ExecuteJob.php
+++ b/app/Jobs/Script/ExecuteJob.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Jobs\Script;
+
+use App\Enums\ScriptExecutionStatus;
+use App\Models\ScriptExecution;
+use App\Models\ServerLog;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class ExecuteJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(
+        protected ScriptExecution $execution,
+        protected ServerLog $log,
+    ) {}
+
+    public function handle(): void
+    {
+        $this->run("script-exec-{$this->execution->id}", function () {
+            $server = $this->execution->server;
+            $content = $this->execution->getContent();
+            $this->execution->server_log_id = $this->log->id;
+            $this->execution->save();
+            $server->os()->runScript('~/', $content, $this->log, $this->execution->user);
+            $this->execution->status = ScriptExecutionStatus::COMPLETED;
+            $this->execution->save();
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        $this->execution->status = ScriptExecutionStatus::FAILED;
+        $this->execution->save();
+        ServerLog::log($this->execution->server, 'execute-script-failed', $e->getMessage());
+    }
+}

--- a/app/Jobs/Server/InstallJob.php
+++ b/app/Jobs/Server/InstallJob.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Jobs\Server;
+
+use App\Actions\Server\InstallServer;
+use App\Enums\ServerStatus;
+use App\Facades\Notifier;
+use App\Models\Server;
+use App\Models\ServerLog;
+use App\Notifications\ServerInstallationFailed;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class InstallJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(protected Server $server) {}
+
+    public function handle(): void
+    {
+        $this->run("server-{$this->server->id}", function () {
+            app(InstallServer::class)->run($this->server);
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        $this->server->update([
+            'status' => ServerStatus::INSTALLATION_FAILED,
+        ]);
+        Notifier::send($this->server, new ServerInstallationFailed($this->server));
+        ServerLog::log($this->server, 'server-installation-failed', $e->getMessage());
+    }
+}

--- a/app/Jobs/Service/ManageJob.php
+++ b/app/Jobs/Service/ManageJob.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Jobs\Service;
+
+use App\Enums\ServiceStatus;
+use App\Models\ServerLog;
+use App\Models\Service;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class ManageJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(
+        protected Service $service,
+        protected string $action,
+        protected ServiceStatus $successStatus,
+    ) {}
+
+    public function handle(): void
+    {
+        $this->run("server-{$this->service->server_id}", function () {
+            $status = $this->service->server->systemd()->{$this->action}($this->service->handler()->unit());
+            if (str($status)->contains($this->getExpectedActiveState())) {
+                $this->service->status = $this->successStatus;
+            } else {
+                $this->service->status = ServiceStatus::FAILED;
+            }
+            $this->service->save();
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        $this->service->status = ServiceStatus::FAILED;
+        $this->service->save();
+        ServerLog::log($this->service->server, "{$this->action}-service-failed", $e->getMessage());
+    }
+
+    private function getExpectedActiveState(): string
+    {
+        return in_array($this->action, ['stop', 'disable']) ? 'Active: inactive' : 'Active: active';
+    }
+}

--- a/app/Jobs/Site/DeployJob.php
+++ b/app/Jobs/Site/DeployJob.php
@@ -29,7 +29,7 @@ class DeployJob implements ShouldQueue
         $site = $this->deployment->site;
         $log = ServerLog::find($this->deployment->log_id);
 
-        $this->run("server-{$site->server_id}", function () use ($site, $log) {
+        $this->run("site-{$site->id}", function () use ($site, $log) {
             if ($this->isModern) {
                 $this->handleModernDeployment($site, $log);
             } else {

--- a/app/Jobs/Site/ExecuteCommandJob.php
+++ b/app/Jobs/Site/ExecuteCommandJob.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Jobs\Site;
+
+use App\Enums\CommandExecutionStatus;
+use App\Models\Command;
+use App\Models\CommandExecution;
+use App\Models\ServerLog;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class ExecuteCommandJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(
+        protected CommandExecution $execution,
+        protected Command $command,
+        protected ServerLog $log,
+    ) {}
+
+    public function handle(): void
+    {
+        $this->run("site-{$this->command->site_id}", function () {
+            $content = $this->execution->getContent();
+            $this->execution->server_log_id = $this->log->id;
+            $this->execution->save();
+            $this->execution->server->os()->runScript(
+                path: $this->command->site->path,
+                script: $content,
+                serverLog: $this->log,
+                user: $this->command->site->user,
+                variables: $this->execution->variables,
+                aliases: $this->command->site->environmentAliases(),
+            );
+            $this->execution->status = CommandExecutionStatus::COMPLETED;
+            $this->execution->save();
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        $this->execution->status = CommandExecutionStatus::FAILED;
+        $this->execution->save();
+        ServerLog::log($this->execution->server, 'execute-command-failed', $e->getMessage());
+    }
+}

--- a/app/Jobs/Site/RollbackJob.php
+++ b/app/Jobs/Site/RollbackJob.php
@@ -27,7 +27,7 @@ class RollbackJob implements ShouldQueue
         $site = $this->deployment->site;
         $this->current = $site->deployments()->where('active', 1)->whereNotNull('release')->first();
 
-        $this->run("server-{$site->server_id}", function () use ($site) {
+        $this->run("site-{$site->id}", function () use ($site) {
             $this->deployment->site->server->ssh($site->user)->exec(
                 view('ssh.modern-deployment.release', [
                     'site' => $site,

--- a/app/Jobs/Worker/CreateJob.php
+++ b/app/Jobs/Worker/CreateJob.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Jobs\Worker;
+
+use App\Enums\WorkerStatus;
+use App\Models\ServerLog;
+use App\Models\Service;
+use App\Models\Worker;
+use App\Services\ProcessManager\ProcessManager;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class CreateJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(protected Worker $worker) {}
+
+    public function handle(): void
+    {
+        $this->run("server-{$this->worker->server_id}", function () {
+            /** @var Service $service */
+            $service = $this->worker->server->processManager();
+            /** @var ProcessManager $processManager */
+            $processManager = $service->handler();
+            $processManager->create(
+                $this->worker->id,
+                $this->worker->command,
+                $this->worker->user,
+                $this->worker->auto_start,
+                $this->worker->auto_restart,
+                $this->worker->numprocs,
+                $this->worker->getLogFile(),
+                $this->worker->site?->path,
+                $this->worker->site_id,
+                $this->worker->environment,
+            );
+            $this->worker->status = WorkerStatus::RUNNING;
+            $this->worker->save();
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        $this->worker->delete();
+        ServerLog::log($this->worker->server, 'create-worker-failed', $e->getMessage());
+    }
+}

--- a/app/Jobs/Worker/EditJob.php
+++ b/app/Jobs/Worker/EditJob.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Jobs\Worker;
+
+use App\Enums\WorkerStatus;
+use App\Models\ServerLog;
+use App\Models\Service;
+use App\Models\Worker;
+use App\Services\ProcessManager\ProcessManager;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class EditJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(protected Worker $worker) {}
+
+    public function handle(): void
+    {
+        $this->run("server-{$this->worker->server_id}", function () {
+            /** @var Service $service */
+            $service = $this->worker->server->processManager();
+            /** @var ProcessManager $processManager */
+            $processManager = $service->handler();
+            $processManager->delete($this->worker->id, $this->worker->site_id);
+
+            $processManager->create(
+                $this->worker->id,
+                $this->worker->command,
+                $this->worker->user,
+                $this->worker->auto_start,
+                $this->worker->auto_restart,
+                $this->worker->numprocs,
+                $this->worker->getLogFile(),
+                $this->worker->site?->path,
+                $this->worker->site_id,
+            );
+            $this->worker->status = WorkerStatus::RUNNING;
+            $this->worker->save();
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        $this->worker->status = WorkerStatus::FAILED;
+        $this->worker->save();
+        ServerLog::log($this->worker->server, 'edit-worker-failed', $e->getMessage());
+    }
+}

--- a/app/Jobs/Worker/ManageJob.php
+++ b/app/Jobs/Worker/ManageJob.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Jobs\Worker;
+
+use App\Enums\WorkerStatus;
+use App\Models\ServerLog;
+use App\Models\Service;
+use App\Models\Worker;
+use App\Services\ProcessManager\ProcessManager;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class ManageJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(
+        protected Worker $worker,
+        protected string $action,
+        protected WorkerStatus $successStatus,
+    ) {}
+
+    public function handle(): void
+    {
+        $this->run("server-{$this->worker->server_id}", function () {
+            /** @var Service $service */
+            $service = $this->worker->server->processManager();
+            /** @var ProcessManager $handler */
+            $handler = $service->handler();
+            $handler->{$this->action}($this->worker->id, $this->worker->site_id);
+            $this->worker->status = $this->successStatus;
+            $this->worker->save();
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        $this->worker->status = WorkerStatus::FAILED;
+        $this->worker->save();
+        ServerLog::log($this->worker->server, "{$this->action}-worker-failed", $e->getMessage());
+    }
+}

--- a/app/Jobs/Workflow/RunJob.php
+++ b/app/Jobs/Workflow/RunJob.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Jobs\Workflow;
+
+use App\Actions\Workflow\RunWorkflow;
+use App\DTOs\WorkflowActionDTO;
+use App\Enums\WorkflowRunStatus;
+use App\Facades\SSH;
+use App\Models\User;
+use App\Models\Workflow;
+use App\Models\WorkflowRun;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+class RunJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(
+        protected WorkflowRun $run,
+        protected User $user,
+        protected Workflow $workflow,
+        protected WorkflowActionDTO $executionTree,
+        protected array $input,
+    ) {}
+
+    public function handle(): void
+    {
+        $this->run("workflow-{$this->workflow->id}", function () {
+            // set all queue drivers to sync for underlying actions
+            config()->set('queue.connections.ssh.driver', 'sync');
+            config()->set('queue.connections.default.driver', 'sync');
+
+            if ($this->run->verbose && $this->run->log_disk && $this->run->log_path) {
+                SSH::useLog($this->run->log_disk, $this->run->log_path);
+            }
+            if ($this->input['inputs']) {
+                $this->executionTree->inputs = $this->input['inputs'];
+            }
+            app(RunWorkflow::class)->executeAction(
+                $this->run,
+                $this->user,
+                $this->workflow,
+                $this->executionTree,
+                $this->input['inputs'] ?? [],
+            );
+            $this->run->status = WorkflowRunStatus::COMPLETED;
+            $this->run->save();
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        $this->run->status = WorkflowRunStatus::FAILED;
+        $this->run->save();
+        Log::error('run-workflow-failed', ['error' => $e->getMessage()]);
+    }
+}

--- a/tests/Feature/Jobs/BackupJobsTest.php
+++ b/tests/Feature/Jobs/BackupJobsTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Enums\BackupFileStatus;
+use App\Enums\BackupStatus;
+use App\Enums\BackupType;
+use App\Facades\SSH;
+use App\Jobs\Backup\DeleteFileJob;
+use App\Jobs\Backup\DeleteJob;
+use App\Jobs\Backup\RestoreDatabaseJob;
+use App\Jobs\Backup\RestoreFileJob;
+use App\Jobs\Backup\RunJob;
+use App\Models\Backup;
+use App\Models\BackupFile;
+use App\Models\Database;
+use App\Models\StorageProvider;
+use App\StorageProviders\Dropbox;
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BackupJobsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected StorageProvider $storageProvider;
+
+    protected Backup $backup;
+
+    protected BackupFile $backupFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->storageProvider = StorageProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'provider' => Dropbox::id(),
+        ]);
+
+        $this->backup = Backup::factory()->create([
+            'type' => BackupType::DATABASE,
+            'server_id' => $this->server->id,
+            'storage_id' => $this->storageProvider->id,
+            'database_id' => Database::factory()->create(['server_id' => $this->server->id])->id,
+            'status' => BackupStatus::RUNNING,
+        ]);
+
+        $this->backupFile = BackupFile::factory()->create([
+            'backup_id' => $this->backup->id,
+            'status' => BackupFileStatus::CREATING,
+        ]);
+    }
+
+    public function test_run_job_failed_sets_backup_and_file_to_failed_and_logs(): void
+    {
+        $job = new RunJob($this->backupFile, $this->backup);
+        $job->failed(new Exception('Backup failed'));
+
+        $this->backup->refresh();
+        $this->backupFile->refresh();
+
+        $this->assertEquals(BackupStatus::FAILED, $this->backup->status);
+        $this->assertEquals(BackupFileStatus::FAILED, $this->backupFile->status);
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'run-backup-failed',
+        ]);
+    }
+
+    public function test_restore_database_job_failed_sets_restore_failed_and_logs(): void
+    {
+        $database = Database::factory()->create([
+            'server_id' => $this->server->id,
+        ]);
+
+        $this->backupFile->update(['status' => BackupFileStatus::RESTORING]);
+
+        $job = new RestoreDatabaseJob($this->backupFile, $database);
+        $job->failed(new Exception('Restore failed'));
+
+        $this->backupFile->refresh();
+
+        $this->assertEquals(BackupFileStatus::RESTORE_FAILED, $this->backupFile->status);
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'restore-database-failed',
+        ]);
+    }
+
+    public function test_restore_file_job_failed_sets_restore_failed_and_logs(): void
+    {
+        SSH::fake();
+
+        $fileBackup = Backup::factory()->create([
+            'type' => BackupType::FILE,
+            'server_id' => $this->server->id,
+            'storage_id' => $this->storageProvider->id,
+            'path' => '/home/vito/app',
+            'status' => BackupStatus::RUNNING,
+        ]);
+
+        $file = BackupFile::factory()->create([
+            'backup_id' => $fileBackup->id,
+            'status' => BackupFileStatus::RESTORING,
+        ]);
+
+        $job = new RestoreFileJob($file, '/home/vito/restored', 'vito:vito', '755');
+        $job->failed(new Exception('Restore failed'));
+
+        $file->refresh();
+
+        $this->assertEquals(BackupFileStatus::RESTORE_FAILED, $file->status);
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'restore-file-failed',
+        ]);
+    }
+
+    public function test_delete_job_failed_logs(): void
+    {
+        $job = new DeleteJob($this->backup);
+        $job->failed(new Exception('Delete failed'));
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'delete-backup-failed',
+        ]);
+    }
+
+    public function test_delete_file_job_failed_logs(): void
+    {
+        $job = new DeleteFileJob($this->backupFile);
+        $job->failed(new Exception('Delete file failed'));
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'delete-backup-file-failed',
+        ]);
+    }
+}

--- a/tests/Feature/Jobs/FirewallApplyRulesJobTest.php
+++ b/tests/Feature/Jobs/FirewallApplyRulesJobTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Enums\FirewallRuleStatus;
+use App\Jobs\FirewallRule\ApplyRulesJob;
+use App\Models\FirewallRule;
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FirewallApplyRulesJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_apply_rules_job_failed_sets_non_ready_rules_to_failed_and_logs(): void
+    {
+        $creatingRule = FirewallRule::factory()->create([
+            'server_id' => $this->server->id,
+            'status' => FirewallRuleStatus::CREATING,
+        ]);
+
+        $readyRule = FirewallRule::factory()->create([
+            'server_id' => $this->server->id,
+            'status' => FirewallRuleStatus::READY,
+        ]);
+
+        $deletingRule = FirewallRule::factory()->create([
+            'server_id' => $this->server->id,
+            'status' => FirewallRuleStatus::DELETING,
+        ]);
+
+        $job = new ApplyRulesJob($creatingRule);
+        $job->failed(new Exception('Firewall error'));
+
+        $creatingRule->refresh();
+        $readyRule->refresh();
+        $deletingRule->refresh();
+
+        $this->assertEquals(FirewallRuleStatus::FAILED, $creatingRule->status);
+        $this->assertEquals(FirewallRuleStatus::READY, $readyRule->status);
+        $this->assertEquals(FirewallRuleStatus::FAILED, $deletingRule->status);
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'apply-firewall-rules-failed',
+        ]);
+    }
+}

--- a/tests/Feature/Jobs/ScriptExecuteJobTest.php
+++ b/tests/Feature/Jobs/ScriptExecuteJobTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Enums\ScriptExecutionStatus;
+use App\Jobs\Script\ExecuteJob;
+use App\Models\Script;
+use App\Models\ScriptExecution;
+use App\Models\ServerLog;
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ScriptExecuteJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_execute_job_failed_sets_status_to_failed_and_logs(): void
+    {
+        /** @var Script $script */
+        $script = Script::factory()->create([
+            'user_id' => $this->user->id,
+        ]);
+
+        /** @var ScriptExecution $execution */
+        $execution = ScriptExecution::factory()->create([
+            'script_id' => $script->id,
+            'server_id' => $this->server->id,
+            'status' => ScriptExecutionStatus::EXECUTING,
+        ]);
+
+        $log = ServerLog::newLog($this->server, 'execute-script');
+        $log->save();
+
+        $job = new ExecuteJob($execution, $log);
+        $job->failed(new Exception('Script execution timed out'));
+
+        $execution->refresh();
+
+        $this->assertEquals(ScriptExecutionStatus::FAILED, $execution->status);
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'execute-script-failed',
+        ]);
+    }
+}

--- a/tests/Feature/Jobs/ServerInstallJobTest.php
+++ b/tests/Feature/Jobs/ServerInstallJobTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Enums\ServerStatus;
+use App\Jobs\Server\InstallJob;
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class ServerInstallJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_install_job_failed_sets_status_to_installation_failed_and_logs(): void
+    {
+        Notification::fake();
+
+        $this->server->update(['status' => ServerStatus::INSTALLING]);
+
+        $job = new InstallJob($this->server);
+        $job->failed(new Exception('Installation failed'));
+
+        $this->server->refresh();
+
+        $this->assertEquals(ServerStatus::INSTALLATION_FAILED, $this->server->status);
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'server-installation-failed',
+        ]);
+    }
+}

--- a/tests/Feature/Jobs/ServiceManageJobTest.php
+++ b/tests/Feature/Jobs/ServiceManageJobTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Enums\ServiceStatus;
+use App\Facades\SSH;
+use App\Jobs\Service\ManageJob;
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ServiceManageJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_manage_job_handle_sets_ready_on_active_response(): void
+    {
+        SSH::fake('Active: active');
+
+        $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
+        $service->status = ServiceStatus::RESTARTING;
+        $service->save();
+
+        $job = new ManageJob($service, 'restart', ServiceStatus::READY);
+        $job->handle();
+
+        $service->refresh();
+
+        $this->assertEquals(ServiceStatus::READY, $service->status);
+    }
+
+    public function test_manage_job_handle_sets_failed_on_inactive_response(): void
+    {
+        SSH::fake('Active: inactive');
+
+        $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
+        $service->status = ServiceStatus::RESTARTING;
+        $service->save();
+
+        $job = new ManageJob($service, 'restart', ServiceStatus::READY);
+        $job->handle();
+
+        $service->refresh();
+
+        $this->assertEquals(ServiceStatus::FAILED, $service->status);
+    }
+
+    public function test_manage_job_stop_expects_inactive_state(): void
+    {
+        SSH::fake('Active: inactive');
+
+        $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
+        $service->status = ServiceStatus::STOPPING;
+        $service->save();
+
+        $job = new ManageJob($service, 'stop', ServiceStatus::STOPPED);
+        $job->handle();
+
+        $service->refresh();
+
+        $this->assertEquals(ServiceStatus::STOPPED, $service->status);
+    }
+
+    public function test_manage_job_disable_expects_inactive_state(): void
+    {
+        SSH::fake('Active: inactive');
+
+        $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
+        $service->status = ServiceStatus::DISABLING;
+        $service->save();
+
+        $job = new ManageJob($service, 'disable', ServiceStatus::DISABLED);
+        $job->handle();
+
+        $service->refresh();
+
+        $this->assertEquals(ServiceStatus::DISABLED, $service->status);
+    }
+
+    public function test_manage_job_failed_sets_status_to_failed_and_logs(): void
+    {
+        $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
+        $service->status = ServiceStatus::RESTARTING;
+        $service->save();
+
+        $job = new ManageJob($service, 'restart', ServiceStatus::READY);
+        $job->failed(new Exception('SSH connection failed'));
+
+        $service->refresh();
+
+        $this->assertEquals(ServiceStatus::FAILED, $service->status);
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'restart-service-failed',
+        ]);
+    }
+
+    public function test_manage_job_stop_failed_logs_correct_type(): void
+    {
+        $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
+
+        $job = new ManageJob($service, 'stop', ServiceStatus::STOPPED);
+        $job->failed(new Exception('SSH connection failed'));
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'stop-service-failed',
+        ]);
+    }
+}

--- a/tests/Feature/Jobs/SiteExecuteCommandJobTest.php
+++ b/tests/Feature/Jobs/SiteExecuteCommandJobTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Enums\CommandExecutionStatus;
+use App\Jobs\Site\ExecuteCommandJob;
+use App\Models\Command;
+use App\Models\CommandExecution;
+use App\Models\ServerLog;
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SiteExecuteCommandJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_execute_command_job_failed_sets_status_to_failed_and_logs(): void
+    {
+        /** @var Command $command */
+        $command = Command::factory()->create([
+            'site_id' => $this->site->id,
+        ]);
+
+        /** @var CommandExecution $execution */
+        $execution = CommandExecution::factory()->create([
+            'command_id' => $command->id,
+            'server_id' => $this->server->id,
+            'user_id' => $this->user->id,
+            'status' => CommandExecutionStatus::EXECUTING,
+        ]);
+
+        $log = ServerLog::newLog($this->server, 'execute-command');
+        $log->save();
+
+        $job = new ExecuteCommandJob($execution, $command, $log);
+        $job->failed(new Exception('Command execution timed out'));
+
+        $execution->refresh();
+
+        $this->assertEquals(CommandExecutionStatus::FAILED, $execution->status);
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'execute-command-failed',
+        ]);
+    }
+}

--- a/tests/Feature/Jobs/WorkerJobsTest.php
+++ b/tests/Feature/Jobs/WorkerJobsTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Enums\WorkerStatus;
+use App\Facades\SSH;
+use App\Jobs\Worker\CreateJob;
+use App\Jobs\Worker\EditJob;
+use App\Jobs\Worker\ManageJob;
+use App\Models\Worker;
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WorkerJobsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_job_failed_deletes_worker_and_logs(): void
+    {
+        SSH::fake();
+
+        $worker = Worker::factory()->create([
+            'server_id' => $this->server->id,
+            'site_id' => $this->site->id,
+            'status' => WorkerStatus::CREATING,
+        ]);
+
+        $job = new CreateJob($worker);
+        $job->failed(new Exception('SSH connection failed'));
+
+        $this->assertDatabaseMissing('workers', [
+            'id' => $worker->id,
+        ]);
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'create-worker-failed',
+        ]);
+    }
+
+    public function test_edit_job_failed_sets_status_to_failed_and_logs(): void
+    {
+        $worker = Worker::factory()->create([
+            'server_id' => $this->server->id,
+            'site_id' => $this->site->id,
+            'status' => WorkerStatus::RUNNING,
+        ]);
+
+        $job = new EditJob($worker);
+        $job->failed(new Exception('SSH connection failed'));
+
+        $worker->refresh();
+
+        $this->assertEquals(WorkerStatus::FAILED, $worker->status);
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'edit-worker-failed',
+        ]);
+    }
+
+    public function test_manage_job_start_failed_sets_status_to_failed_and_logs(): void
+    {
+        $worker = Worker::factory()->create([
+            'server_id' => $this->server->id,
+            'site_id' => $this->site->id,
+            'status' => WorkerStatus::STARTING,
+        ]);
+
+        $job = new ManageJob($worker, 'start', WorkerStatus::RUNNING);
+        $job->failed(new Exception('Process manager error'));
+
+        $worker->refresh();
+
+        $this->assertEquals(WorkerStatus::FAILED, $worker->status);
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'start-worker-failed',
+        ]);
+    }
+
+    public function test_manage_job_stop_failed_sets_status_to_failed_and_logs(): void
+    {
+        $worker = Worker::factory()->create([
+            'server_id' => $this->server->id,
+            'site_id' => $this->site->id,
+            'status' => WorkerStatus::STOPPING,
+        ]);
+
+        $job = new ManageJob($worker, 'stop', WorkerStatus::STOPPED);
+        $job->failed(new Exception('Process manager error'));
+
+        $worker->refresh();
+
+        $this->assertEquals(WorkerStatus::FAILED, $worker->status);
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'stop-worker-failed',
+        ]);
+    }
+
+    public function test_manage_job_restart_failed_sets_status_to_failed_and_logs(): void
+    {
+        $worker = Worker::factory()->create([
+            'server_id' => $this->server->id,
+            'site_id' => $this->site->id,
+            'status' => WorkerStatus::RESTARTING,
+        ]);
+
+        $job = new ManageJob($worker, 'restart', WorkerStatus::RUNNING);
+        $job->failed(new Exception('Process manager error'));
+
+        $worker->refresh();
+
+        $this->assertEquals(WorkerStatus::FAILED, $worker->status);
+
+        $this->assertDatabaseHas('server_logs', [
+            'server_id' => $this->server->id,
+            'type' => 'restart-worker-failed',
+        ]);
+    }
+}

--- a/tests/Feature/Jobs/WorkflowRunJobTest.php
+++ b/tests/Feature/Jobs/WorkflowRunJobTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\DTOs\WorkflowActionDTO;
+use App\Enums\WorkflowRunStatus;
+use App\Jobs\Workflow\RunJob;
+use App\Models\Workflow;
+use App\Models\WorkflowRun;
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class WorkflowRunJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_run_job_failed_sets_status_to_failed_and_logs(): void
+    {
+        Log::spy();
+
+        /** @var Workflow $workflow */
+        $workflow = Workflow::factory()->create([
+            'user_id' => $this->user->id,
+            'project_id' => $this->user->current_project_id,
+        ]);
+
+        /** @var WorkflowRun $run */
+        $run = WorkflowRun::factory()->create([
+            'workflow_id' => $workflow->id,
+            'user_id' => $this->user->id,
+            'status' => WorkflowRunStatus::RUNNING,
+        ]);
+
+        $executionTree = new WorkflowActionDTO(
+            label: 'Test Action',
+            handler: 'App\\WorkflowActions\\SomeAction',
+            outputs: [],
+            inputs: [],
+            id: 'node-1',
+        );
+
+        $job = new RunJob($run, $this->user, $workflow, $executionTree, ['inputs' => []]);
+        $job->failed(new Exception('Workflow execution failed'));
+
+        $run->refresh();
+
+        $this->assertEquals(WorkflowRunStatus::FAILED, $run->status);
+
+        Log::shouldHaveReceived('error')
+            ->withArgs(function (string $message, array $context) {
+                return $message === 'run-workflow-failed'
+                    && $context['error'] === 'Workflow execution failed';
+            })
+            ->once();
+    }
+}


### PR DESCRIPTION
- Replace all anonymous `dispatch(function () { ... })` closures in Actions with proper named Job classes (Backup, FirewallRule, Script, Server, Service, Site, Worker, Workflow)
- Add `failed()` handlers to each Job for structured error reporting and logging via `ServerLog`
- Add feature tests for all new Job classes covering success and failure paths

Fixes #972