### PR TITLE
Use Pdo\Mysql SSL CA constant on PHP 8.5+

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -58,7 +58,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (PHP_VERSION_ID >= 80500 ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 


### PR DESCRIPTION
This pull request updates the configuration logic for MySQL SSL certificate handling in the `config/database.php` file. The change ensures compatibility with PHP 8.5+ by using the correct constant for SSL CA attribute.

Database configuration compatibility:

* Updated the MySQL database options to use `Pdo\Mysql::ATTR_SSL_CA` for PHP 8.5 and above, while retaining `PDO::MYSQL_ATTR_SSL_CA` for older PHP versions. This prevents errors due to deprecated constants and improves forward compatibility.