### PR TITLE
Add project scoping for API keys

### DIFF
--- a/app/Actions/ApiKey/CreateApiKey.php
+++ b/app/Actions/ApiKey/CreateApiKey.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Actions\ApiKey;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Laravel\Sanctum\NewAccessToken;
+
+class CreateApiKey
+{
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    public function create(User $user, array $input): NewAccessToken
+    {
+        $this->validate($user, $input);
+
+        $abilities = ['read'];
+        if ($input['permission'] === 'write') {
+            $abilities[] = 'write';
+        }
+
+        if (! empty($input['projects'])) {
+            foreach ($input['projects'] as $projectId) {
+                $abilities[] = 'project:'.$projectId;
+            }
+        }
+
+        return $user->createToken($input['name'], $abilities);
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    private function validate(User $user, array $input): void
+    {
+        $projectIds = $user->projects()->pluck('projects.id')->toArray();
+
+        Validator::make($input, [
+            'name' => ['required', 'string', 'max:255'],
+            'permission' => ['required', Rule::in(['read', 'write'])],
+            'projects' => ['nullable', 'array'],
+            'projects.*' => ['required', 'integer', Rule::in($projectIds)],
+        ])->validate();
+    }
+}

--- a/app/Actions/Server/CheckConnection.php
+++ b/app/Actions/Server/CheckConnection.php
@@ -7,6 +7,7 @@ use App\Facades\Notifier;
 use App\Models\Server;
 use App\Notifications\ServerConnected;
 use App\Notifications\ServerDisconnected;
+use Illuminate\Support\Sleep;
 use Throwable;
 
 class CheckConnection
@@ -26,7 +27,7 @@ class CheckConnection
             }
         } catch (Throwable) {
             if ($retry > 0) {
-                sleep(3);
+                Sleep::sleep(3);
 
                 return $this->check($server, $retry - 1);
             }

--- a/app/Actions/Server/InstallServer.php
+++ b/app/Actions/Server/InstallServer.php
@@ -11,6 +11,7 @@ use App\Models\Server;
 use App\Notifications\ServerInstallationSucceed;
 use App\ServerProviders\Custom;
 use App\Services\PHP\PHP;
+use Illuminate\Support\Sleep;
 
 class InstallServer
 {
@@ -34,7 +35,7 @@ class InstallServer
             } catch (SSHConnectionError) {
                 // ignore
             }
-            sleep(10);
+            Sleep::sleep(10);
             $maxWait -= 10;
         }
         $this->install();

--- a/app/Http/Controllers/API/ProjectController.php
+++ b/app/Http/Controllers/API/ProjectController.php
@@ -7,6 +7,7 @@ use App\Actions\Projects\DeleteProject;
 use App\Actions\Projects\UpdateProject;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\ProjectResource;
+use App\Models\PersonalAccessToken;
 use App\Models\Project;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\ResourceCollection;
@@ -25,7 +26,17 @@ class ProjectController extends Controller
     {
         $this->authorize('viewAny', Project::class);
 
-        return ProjectResource::collection(user()->projects()->get());
+        $projects = user()->projects();
+
+        $token = $this->getToken();
+        if ($token) {
+            $scopedProjectIds = $token->getProjectIds();
+            if (! empty($scopedProjectIds)) {
+                $projects->whereIn('projects.id', $scopedProjectIds);
+            }
+        }
+
+        return ProjectResource::collection($projects->get());
     }
 
     #[Post('api/projects', name: 'api.projects.create', middleware: 'ability:write')]
@@ -43,6 +54,11 @@ class ProjectController extends Controller
     {
         $this->authorize('view', $project);
 
+        $token = $this->getToken();
+        if ($token && ! $token->hasProjectAccess($project)) {
+            abort(403, 'This token does not have access to this project.');
+        }
+
         return new ProjectResource($project);
     }
 
@@ -50,6 +66,11 @@ class ProjectController extends Controller
     public function update(Request $request, Project $project): ProjectResource
     {
         $this->authorize('update', $project);
+
+        $token = $this->getToken();
+        if ($token && ! $token->hasProjectAccess($project)) {
+            abort(403, 'This token does not have access to this project.');
+        }
 
         $project = app(UpdateProject::class)->update($project, $request->all());
 
@@ -61,10 +82,26 @@ class ProjectController extends Controller
     {
         $this->authorize('delete', $project);
 
+        $token = $this->getToken();
+        if ($token && ! $token->hasProjectAccess($project)) {
+            abort(403, 'This token does not have access to this project.');
+        }
+
         app(DeleteProject::class)->delete(user(), $project, [
             'name' => $project->name,
         ]);
 
         return response()->noContent();
+    }
+
+    private function getToken(): ?PersonalAccessToken
+    {
+        $token = user()->currentAccessToken();
+
+        if ($token instanceof PersonalAccessToken && $token->exists) {
+            return $token;
+        }
+
+        return null;
     }
 }

--- a/app/Http/Controllers/API/ProjectController.php
+++ b/app/Http/Controllers/API/ProjectController.php
@@ -28,8 +28,8 @@ class ProjectController extends Controller
 
         $projects = user()->projects();
 
-        $token = $this->getToken();
-        if ($token) {
+        $token = user()->currentAccessToken();
+        if ($token instanceof PersonalAccessToken && $token->exists) {
             $scopedProjectIds = $token->getProjectIds();
             if (! empty($scopedProjectIds)) {
                 $projects->whereIn('projects.id', $scopedProjectIds);
@@ -49,59 +49,33 @@ class ProjectController extends Controller
         return new ProjectResource($project);
     }
 
-    #[Get('api/projects/{project}', name: 'api.projects.show', middleware: 'ability:read')]
+    #[Get('api/projects/{project}', name: 'api.projects.show', middleware: ['ability:read', 'can-see-project'])]
     public function show(Project $project): ProjectResource
     {
         $this->authorize('view', $project);
 
-        $token = $this->getToken();
-        if ($token && ! $token->hasProjectAccess($project)) {
-            abort(403, 'This token does not have access to this project.');
-        }
-
         return new ProjectResource($project);
     }
 
-    #[Put('api/projects/{project}', name: 'api.projects.update', middleware: 'ability:write')]
+    #[Put('api/projects/{project}', name: 'api.projects.update', middleware: ['ability:write', 'can-see-project'])]
     public function update(Request $request, Project $project): ProjectResource
     {
         $this->authorize('update', $project);
-
-        $token = $this->getToken();
-        if ($token && ! $token->hasProjectAccess($project)) {
-            abort(403, 'This token does not have access to this project.');
-        }
 
         $project = app(UpdateProject::class)->update($project, $request->all());
 
         return new ProjectResource($project);
     }
 
-    #[Delete('api/projects/{project}', name: 'api.projects.delete', middleware: 'ability:write')]
+    #[Delete('api/projects/{project}', name: 'api.projects.delete', middleware: ['ability:write', 'can-see-project'])]
     public function delete(Project $project): Response
     {
         $this->authorize('delete', $project);
-
-        $token = $this->getToken();
-        if ($token && ! $token->hasProjectAccess($project)) {
-            abort(403, 'This token does not have access to this project.');
-        }
 
         app(DeleteProject::class)->delete(user(), $project, [
             'name' => $project->name,
         ]);
 
         return response()->noContent();
-    }
-
-    private function getToken(): ?PersonalAccessToken
-    {
-        $token = user()->currentAccessToken();
-
-        if ($token instanceof PersonalAccessToken && $token->exists) {
-            return $token;
-        }
-
-        return null;
     }
 }

--- a/app/Http/Controllers/ApiKeyController.php
+++ b/app/Http/Controllers/ApiKeyController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\ApiKey\CreateApiKey;
 use App\Http\Resources\ApiKeyResource;
+use App\Http\Resources\ProjectResource;
 use App\Models\PersonalAccessToken;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -25,6 +27,7 @@ class ApiKeyController extends Controller
 
         return Inertia::render('api-keys/index', [
             'apiKeys' => ApiKeyResource::collection(user()->tokens()->simplePaginate(config('web.pagination_size'))),
+            'projects' => ProjectResource::collection(user()->projects()->get()),
         ]);
     }
 
@@ -33,16 +36,7 @@ class ApiKeyController extends Controller
     {
         $this->authorize('create', PersonalAccessToken::class);
 
-        $this->validate($request, [
-            'name' => 'required|string|max:255',
-            'permission' => 'required|in:read,write',
-        ]);
-
-        $permissions = ['read'];
-        if ($request->input('permission') === 'write') {
-            $permissions[] = 'write';
-        }
-        $token = user()->createToken($request->input('name'), $permissions);
+        $token = app(CreateApiKey::class)->create(user(), $request->all());
 
         return back()
             ->with('success', 'Api key created.')

--- a/app/Http/Middleware/CanSeeProjectMiddleware.php
+++ b/app/Http/Middleware/CanSeeProjectMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\PersonalAccessToken;
 use App\Models\Project;
 use App\Models\User;
 use Closure;
@@ -19,6 +20,11 @@ class CanSeeProjectMiddleware
 
         if (! $user->can('view', $project)) {
             abort(403, 'You do not have permission to view this project.');
+        }
+
+        $token = $user->currentAccessToken();
+        if ($token instanceof PersonalAccessToken && $token->exists && ! $token->hasProjectAccess($project)) {
+            abort(403, 'This token does not have access to this project.');
         }
 
         return $next($request);

--- a/app/Http/Resources/ApiKeyResource.php
+++ b/app/Http/Resources/ApiKeyResource.php
@@ -17,7 +17,11 @@ class ApiKeyResource extends JsonResource
         return [
             'id' => $this->id,
             'name' => $this->name,
-            'permissions' => $this->abilities,
+            'permissions' => collect($this->abilities)
+                ->filter(fn (string $ability) => ! str_starts_with($ability, 'project:'))
+                ->values()
+                ->all(),
+            'project_ids' => $this->getProjectIds(),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Models/PersonalAccessToken.php
+++ b/app/Models/PersonalAccessToken.php
@@ -20,4 +20,33 @@ use Laravel\Sanctum\PersonalAccessToken as SanctumPersonalAccessToken;
 class PersonalAccessToken extends SanctumPersonalAccessToken
 {
     use HasTimezoneTimestamps;
+
+    /**
+     * Get the project IDs this token is scoped to.
+     *
+     * @return array<int>
+     */
+    public function getProjectIds(): array
+    {
+        return collect($this->abilities)
+            ->filter(fn (string $ability) => str_starts_with($ability, 'project:'))
+            ->map(fn (string $ability) => (int) str_replace('project:', '', $ability))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Check if the token has access to the given project.
+     * Tokens with no project restrictions have access to all projects (backward compatible).
+     */
+    public function hasProjectAccess(Project $project): bool
+    {
+        $projectIds = $this->getProjectIds();
+
+        if (empty($projectIds)) {
+            return true;
+        }
+
+        return in_array($project->id, $projectIds);
+    }
 }

--- a/resources/js/pages/api-keys/components/columns.tsx
+++ b/resources/js/pages/api-keys/components/columns.tsx
@@ -17,6 +17,8 @@ import { LoaderCircleIcon, MoreVerticalIcon } from 'lucide-react';
 import FormSuccessful from '@/components/form-successful';
 import { useState } from 'react';
 import { ApiKey } from '@/types/api-key';
+import { Badge } from '@/components/ui/badge';
+import { Project } from '@/types/project';
 
 function Delete({ apiKey }: { apiKey: ApiKey }) {
   const [open, setOpen] = useState(false);
@@ -59,51 +61,77 @@ function Delete({ apiKey }: { apiKey: ApiKey }) {
   );
 }
 
-export const columns: ColumnDef<ApiKey>[] = [
-  {
-    accessorKey: 'name',
-    header: 'Name',
-    enableColumnFilter: true,
-    enableSorting: true,
-  },
-  {
-    accessorKey: 'permissions',
-    header: 'Permissions',
-    enableColumnFilter: true,
-    enableSorting: true,
-    cell: ({ row }) => {
-      return row.original.permissions.includes('write') ? <span>read & write</span> : <span>read</span>;
+export function getColumns(projects: Project[]): ColumnDef<ApiKey>[] {
+  return [
+    {
+      accessorKey: 'name',
+      header: 'Name',
+      enableColumnFilter: true,
+      enableSorting: true,
     },
-  },
-  {
-    accessorKey: 'created_at',
-    header: 'Created at',
-    enableColumnFilter: true,
-    enableSorting: true,
-    cell: ({ row }) => {
-      return <DateTime date={row.original.created_at} />;
+    {
+      accessorKey: 'permissions',
+      header: 'Permissions',
+      enableColumnFilter: true,
+      enableSorting: true,
+      cell: ({ row }) => {
+        return row.original.permissions.includes('write') ? <span>read & write</span> : <span>read</span>;
+      },
     },
-  },
-  {
-    id: 'actions',
-    enableColumnFilter: false,
-    enableSorting: false,
-    cell: ({ row }) => {
-      return (
-        <div className="flex items-center justify-end">
-          <DropdownMenu modal={false}>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="h-8 w-8 p-0">
-                <span className="sr-only">Open menu</span>
-                <MoreVerticalIcon />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <Delete apiKey={row.original} />
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      );
+    {
+      accessorKey: 'project_ids',
+      header: 'Projects',
+      enableColumnFilter: false,
+      enableSorting: false,
+      cell: ({ row }) => {
+        const projectIds = row.original.project_ids;
+        if (!projectIds || projectIds.length === 0) {
+          return <Badge variant="outline">All projects</Badge>;
+        }
+        return (
+          <div className="flex flex-wrap gap-1">
+            {projectIds.map((id) => {
+              const project = projects.find((p) => p.id === id);
+              return (
+                <Badge key={id} variant="default">
+                  {project?.name ?? `Project #${id}`}
+                </Badge>
+              );
+            })}
+          </div>
+        );
+      },
     },
-  },
-];
+    {
+      accessorKey: 'created_at',
+      header: 'Created at',
+      enableColumnFilter: true,
+      enableSorting: true,
+      cell: ({ row }) => {
+        return <DateTime date={row.original.created_at} />;
+      },
+    },
+    {
+      id: 'actions',
+      enableColumnFilter: false,
+      enableSorting: false,
+      cell: ({ row }) => {
+        return (
+          <div className="flex items-center justify-end">
+            <DropdownMenu modal={false}>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="h-8 w-8 p-0">
+                  <span className="sr-only">Open menu</span>
+                  <MoreVerticalIcon />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <Delete apiKey={row.original} />
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        );
+      },
+    },
+  ];
+}

--- a/resources/js/pages/api-keys/components/create-api-key.tsx
+++ b/resources/js/pages/api-keys/components/create-api-key.tsx
@@ -17,13 +17,16 @@ import InputError from '@/components/ui/input-error';
 import { Form, FormField, FormFields } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Project } from '@/types/project';
+import { MultiSelect } from '@/components/multi-select';
 
 type ApiKeyForm = {
   name: string;
   permission: string;
+  projects: string[];
 };
 
-export default function CreateApiKey({ children }: { children: ReactNode }) {
+export default function CreateApiKey({ children, projects }: { children: ReactNode; projects: Project[] }) {
   const [open, setOpen] = useState(false);
   const [token, setToken] = useState<string | undefined>();
   const tokenInputRef = useRef<HTMLInputElement>(null);
@@ -41,6 +44,7 @@ export default function CreateApiKey({ children }: { children: ReactNode }) {
   const form = useForm<Required<ApiKeyForm>>({
     name: '',
     permission: '',
+    projects: [],
   });
 
   const submit: FormEventHandler = (e) => {
@@ -60,6 +64,11 @@ export default function CreateApiKey({ children }: { children: ReactNode }) {
       form.reset();
     }
   };
+
+  const projectOptions = projects.map((project) => ({
+    label: project.name,
+    value: String(project.id),
+  }));
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -88,7 +97,7 @@ export default function CreateApiKey({ children }: { children: ReactNode }) {
               </FormField>
               <FormField>
                 <Label htmlFor="permission">Permission</Label>
-                <Select id="permission" name="permission" value={form.data.permission} onValueChange={(value) => form.setData('permission', value)}>
+                <Select name="permission" value={form.data.permission} onValueChange={(value) => form.setData('permission', value)}>
                   <SelectTrigger>
                     <SelectValue placeholder="Select a permission" />
                   </SelectTrigger>
@@ -104,6 +113,18 @@ export default function CreateApiKey({ children }: { children: ReactNode }) {
                   </SelectContent>
                 </Select>
                 <InputError message={form.errors.permission} />
+              </FormField>
+              <FormField>
+                <Label htmlFor="projects">Projects</Label>
+                <MultiSelect
+                  options={projectOptions}
+                  onValueChange={(value) => form.setData('projects', value)}
+                  defaultValue={form.data.projects}
+                  placeholder="All projects"
+                  maxCount={3}
+                />
+                <p className="text-muted-foreground text-xs">Leave empty for access to all projects.</p>
+                <InputError message={form.errors.projects} />
               </FormField>
             </FormFields>
           )}

--- a/resources/js/pages/api-keys/components/create-api-key.tsx
+++ b/resources/js/pages/api-keys/components/create-api-key.tsx
@@ -98,7 +98,7 @@ export default function CreateApiKey({ children, projects }: { children: ReactNo
               <FormField>
                 <Label htmlFor="permission">Permission</Label>
                 <Select name="permission" value={form.data.permission} onValueChange={(value) => form.setData('permission', value)}>
-                  <SelectTrigger>
+                  <SelectTrigger id="permission">
                     <SelectValue placeholder="Select a permission" />
                   </SelectTrigger>
                   <SelectContent>

--- a/resources/js/pages/api-keys/index.tsx
+++ b/resources/js/pages/api-keys/index.tsx
@@ -5,15 +5,21 @@ import Heading from '@/components/heading';
 import { Button } from '@/components/ui/button';
 import { DataTable } from '@/components/data-table';
 import { ApiKey } from '@/types/api-key';
-import { columns } from '@/pages/api-keys/components/columns';
+import { getColumns } from '@/pages/api-keys/components/columns';
 import CreateApiKey from '@/pages/api-keys/components/create-api-key';
 import { PaginatedData } from '@/types';
 import { BookOpenIcon, PlusIcon } from 'lucide-react';
+import { Project } from '@/types/project';
+import { useMemo } from 'react';
 
 export default function ApiKeys() {
   const page = usePage<{
     apiKeys: PaginatedData<ApiKey>;
+    projects: Project[];
   }>();
+
+  const columns = useMemo(() => getColumns(page.props.projects), [page.props.projects]);
+
   return (
     <SettingsLayout>
       <Head title="API Keys" />
@@ -27,7 +33,7 @@ export default function ApiKeys() {
                 Docs
               </Button>
             </a>
-            <CreateApiKey>
+            <CreateApiKey projects={page.props.projects}>
               <Button>
                 <PlusIcon />
                 Create

--- a/resources/js/types/api-key.d.ts
+++ b/resources/js/types/api-key.d.ts
@@ -2,6 +2,7 @@ export interface ApiKey {
   id: number;
   name: string;
   permissions: string[];
+  project_ids: number[];
   created_at: string;
   updated_at: string;
 

--- a/tests/Feature/API/ApiKeyScopeTest.php
+++ b/tests/Feature/API/ApiKeyScopeTest.php
@@ -187,6 +187,71 @@ class ApiKeyScopeTest extends TestCase
             ->assertSuccessful();
     }
 
+    public function test_scoped_token_cannot_update_unscoped_project(): void
+    {
+        /** @var Project $project2 */
+        $project2 = Project::factory()->create();
+        $project2->users()->create([
+            'user_id' => $this->user->id,
+            'role' => UserRole::ADMIN,
+        ]);
+
+        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$this->user->current_project_id]);
+
+        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+            ->json('PUT', "/api/projects/{$project2->id}", [
+                'name' => 'updated-name',
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_scoped_token_can_update_scoped_project(): void
+    {
+        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$this->user->current_project_id]);
+
+        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+            ->json('PUT', "/api/projects/{$this->user->currentProject->id}", [
+                'name' => 'updated-name',
+            ])
+            ->assertSuccessful();
+    }
+
+    public function test_scoped_token_cannot_delete_unscoped_project(): void
+    {
+        /** @var Project $project2 */
+        $project2 = Project::factory()->create();
+        $project2->users()->create([
+            'user_id' => $this->user->id,
+            'role' => UserRole::ADMIN,
+        ]);
+
+        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$this->user->current_project_id]);
+
+        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+            ->json('DELETE', "/api/projects/{$project2->id}", [
+                'name' => $project2->name,
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_scoped_token_can_delete_scoped_project(): void
+    {
+        /** @var Project $project2 */
+        $project2 = Project::factory()->create();
+        $project2->users()->create([
+            'user_id' => $this->user->id,
+            'role' => UserRole::OWNER,
+        ]);
+
+        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$project2->id]);
+
+        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+            ->json('DELETE', "/api/projects/{$project2->id}", [
+                'name' => $project2->name,
+            ])
+            ->assertSuccessful();
+    }
+
     public function test_multiple_project_scopes(): void
     {
         /** @var Project $project2 */

--- a/tests/Feature/API/ApiKeyScopeTest.php
+++ b/tests/Feature/API/ApiKeyScopeTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Tests\Feature\API;
+
+use App\Enums\UserRole;
+use App\Models\PersonalAccessToken;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ApiKeyScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_full_access_token_can_see_all_projects(): void
+    {
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        /** @var Project $project2 */
+        $project2 = Project::factory()->create();
+        $project2->users()->create([
+            'user_id' => $this->user->id,
+            'role' => UserRole::ADMIN,
+        ]);
+
+        $this->json('GET', '/api/projects')
+            ->assertSuccessful()
+            ->assertJsonFragment(['id' => $this->user->currentProject->id])
+            ->assertJsonFragment(['id' => $project2->id]);
+    }
+
+    public function test_token_with_no_project_scope_has_access_to_all(): void
+    {
+        $token = $this->user->createToken('full-access-token', ['read', 'write']);
+
+        /** @var PersonalAccessToken $accessToken */
+        $accessToken = $token->accessToken;
+
+        $this->assertTrue($accessToken->hasProjectAccess($this->user->currentProject));
+
+        /** @var Project $project2 */
+        $project2 = Project::factory()->create();
+        $this->assertTrue($accessToken->hasProjectAccess($project2));
+        $this->assertEmpty($accessToken->getProjectIds());
+    }
+
+    public function test_scoped_token_has_project_ids_in_abilities(): void
+    {
+        $projectId = $this->user->current_project_id;
+        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$projectId]);
+
+        /** @var PersonalAccessToken $accessToken */
+        $accessToken = $token->accessToken;
+
+        $this->assertEquals([$projectId], $accessToken->getProjectIds());
+        $this->assertTrue($accessToken->hasProjectAccess($this->user->currentProject));
+    }
+
+    public function test_scoped_token_denies_access_to_unscoped_project(): void
+    {
+        /** @var Project $project1 */
+        $project1 = Project::factory()->create();
+        $project1->users()->create([
+            'user_id' => $this->user->id,
+            'role' => UserRole::ADMIN,
+        ]);
+
+        /** @var Project $project2 */
+        $project2 = Project::factory()->create();
+        $project2->users()->create([
+            'user_id' => $this->user->id,
+            'role' => UserRole::ADMIN,
+        ]);
+
+        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$project1->id]);
+
+        /** @var PersonalAccessToken $accessToken */
+        $accessToken = $token->accessToken;
+
+        $this->assertTrue($accessToken->hasProjectAccess($project1));
+        $this->assertFalse($accessToken->hasProjectAccess($project2));
+    }
+
+    public function test_scoped_token_cannot_access_servers_in_unscoped_project(): void
+    {
+        /** @var Project $project2 */
+        $project2 = Project::factory()->create();
+        $project2->users()->create([
+            'user_id' => $this->user->id,
+            'role' => UserRole::ADMIN,
+        ]);
+
+        // Token scoped to project2 only
+        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$project2->id]);
+
+        // Try accessing servers in the default project (not scoped)
+        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+            ->json('GET', route('api.projects.servers', [
+                'project' => $this->user->current_project_id,
+            ]))
+            ->assertForbidden();
+    }
+
+    public function test_scoped_token_can_access_servers_in_scoped_project(): void
+    {
+        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$this->user->current_project_id]);
+
+        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+            ->json('GET', route('api.projects.servers', [
+                'project' => $this->user->current_project_id,
+            ]))
+            ->assertSuccessful();
+    }
+
+    public function test_full_access_token_can_access_any_project_servers(): void
+    {
+        $token = $this->user->createToken('full-access-token', ['read', 'write']);
+
+        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+            ->json('GET', route('api.projects.servers', [
+                'project' => $this->user->current_project_id,
+            ]))
+            ->assertSuccessful();
+    }
+
+    public function test_read_only_token_cannot_write(): void
+    {
+        $token = $this->user->createToken('read-only-token', ['read']);
+
+        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+            ->json('POST', '/api/projects', [
+                'name' => 'test-project',
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_read_only_token_can_read(): void
+    {
+        $token = $this->user->createToken('read-only-token', ['read']);
+
+        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+            ->json('GET', '/api/projects')
+            ->assertSuccessful();
+    }
+
+    public function test_scoped_token_filters_project_index(): void
+    {
+        /** @var Project $project2 */
+        $project2 = Project::factory()->create();
+        $project2->users()->create([
+            'user_id' => $this->user->id,
+            'role' => UserRole::ADMIN,
+        ]);
+
+        $token = $this->user->createToken('scoped-token', ['read', 'project:'.$project2->id]);
+
+        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+            ->json('GET', '/api/projects')
+            ->assertSuccessful()
+            ->assertJsonFragment(['id' => $project2->id])
+            ->assertJsonMissing(['id' => $this->user->currentProject->id]);
+    }
+
+    public function test_scoped_token_cannot_show_unscoped_project(): void
+    {
+        /** @var Project $project2 */
+        $project2 = Project::factory()->create();
+        $project2->users()->create([
+            'user_id' => $this->user->id,
+            'role' => UserRole::ADMIN,
+        ]);
+
+        $token = $this->user->createToken('scoped-token', ['read', 'project:'.$this->user->current_project_id]);
+
+        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+            ->json('GET', "/api/projects/{$project2->id}")
+            ->assertForbidden();
+    }
+
+    public function test_scoped_token_can_show_scoped_project(): void
+    {
+        $token = $this->user->createToken('scoped-token', ['read', 'project:'.$this->user->current_project_id]);
+
+        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+            ->json('GET', "/api/projects/{$this->user->currentProject->id}")
+            ->assertSuccessful();
+    }
+
+    public function test_multiple_project_scopes(): void
+    {
+        /** @var Project $project2 */
+        $project2 = Project::factory()->create();
+        $project2->users()->create([
+            'user_id' => $this->user->id,
+            'role' => UserRole::ADMIN,
+        ]);
+
+        $token = $this->user->createToken('multi-scoped', [
+            'read',
+            'write',
+            'project:'.$this->user->current_project_id,
+            'project:'.$project2->id,
+        ]);
+
+        /** @var PersonalAccessToken $accessToken */
+        $accessToken = $token->accessToken;
+
+        $this->assertTrue($accessToken->hasProjectAccess($this->user->currentProject));
+        $this->assertTrue($accessToken->hasProjectAccess($project2));
+        $this->assertCount(2, $accessToken->getProjectIds());
+    }
+}

--- a/tests/Feature/ApiKeyTest.php
+++ b/tests/Feature/ApiKeyTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\UserRole;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApiKeyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_api_key_with_read_permission(): void
+    {
+        $this->actingAs($this->user)
+            ->post(route('api-keys.store'), [
+                'name' => 'test-key',
+                'permission' => 'read',
+            ])
+            ->assertSessionHas('success');
+
+        $this->assertDatabaseHas('personal_access_tokens', [
+            'name' => 'test-key',
+            'tokenable_id' => $this->user->id,
+        ]);
+    }
+
+    public function test_create_api_key_with_write_permission(): void
+    {
+        $this->actingAs($this->user)
+            ->post(route('api-keys.store'), [
+                'name' => 'test-key',
+                'permission' => 'write',
+            ])
+            ->assertSessionHas('success');
+
+        $token = $this->user->tokens()->where('name', 'test-key')->first();
+        $this->assertContains('read', $token->abilities);
+        $this->assertContains('write', $token->abilities);
+    }
+
+    public function test_create_api_key_with_project_scope(): void
+    {
+        $this->actingAs($this->user)
+            ->post(route('api-keys.store'), [
+                'name' => 'scoped-key',
+                'permission' => 'read',
+                'projects' => [$this->user->current_project_id],
+            ])
+            ->assertSessionHas('success');
+
+        $token = $this->user->tokens()->where('name', 'scoped-key')->first();
+        $this->assertContains('read', $token->abilities);
+        $this->assertContains('project:'.$this->user->current_project_id, $token->abilities);
+    }
+
+    public function test_create_api_key_without_project_scope(): void
+    {
+        $this->actingAs($this->user)
+            ->post(route('api-keys.store'), [
+                'name' => 'full-access-key',
+                'permission' => 'write',
+            ])
+            ->assertSessionHas('success');
+
+        $token = $this->user->tokens()->where('name', 'full-access-key')->first();
+        $this->assertContains('read', $token->abilities);
+        $this->assertContains('write', $token->abilities);
+        $this->assertEmpty(
+            collect($token->abilities)->filter(fn ($a) => str_starts_with($a, 'project:'))->all()
+        );
+    }
+
+    public function test_create_api_key_with_multiple_projects(): void
+    {
+        /** @var Project $project2 */
+        $project2 = Project::factory()->create();
+        $project2->users()->create([
+            'user_id' => $this->user->id,
+            'role' => UserRole::ADMIN,
+        ]);
+
+        $this->actingAs($this->user)
+            ->post(route('api-keys.store'), [
+                'name' => 'multi-project-key',
+                'permission' => 'write',
+                'projects' => [$this->user->current_project_id, $project2->id],
+            ])
+            ->assertSessionHas('success');
+
+        $token = $this->user->tokens()->where('name', 'multi-project-key')->first();
+        $this->assertContains('project:'.$this->user->current_project_id, $token->abilities);
+        $this->assertContains('project:'.$project2->id, $token->abilities);
+    }
+
+    public function test_cannot_create_api_key_with_invalid_project(): void
+    {
+        $this->actingAs($this->user)
+            ->post(route('api-keys.store'), [
+                'name' => 'bad-key',
+                'permission' => 'read',
+                'projects' => [999999],
+            ])
+            ->assertSessionHasErrors('projects.0');
+    }
+
+    public function test_cannot_create_api_key_with_project_user_does_not_belong_to(): void
+    {
+        /** @var Project $otherProject */
+        $otherProject = Project::factory()->create();
+
+        $this->actingAs($this->user)
+            ->post(route('api-keys.store'), [
+                'name' => 'bad-key',
+                'permission' => 'read',
+                'projects' => [$otherProject->id],
+            ])
+            ->assertSessionHasErrors('projects.0');
+    }
+
+    public function test_delete_api_key(): void
+    {
+        $token = $this->user->createToken('delete-me', ['read']);
+
+        $this->actingAs($this->user)
+            ->delete(route('api-keys.destroy', $token->accessToken->id))
+            ->assertSessionHas('success');
+
+        $this->assertDatabaseMissing('personal_access_tokens', [
+            'id' => $token->accessToken->id,
+        ]);
+    }
+
+    public function test_index_returns_api_keys(): void
+    {
+        $this->user->createToken('test-key', ['read', 'project:'.$this->user->current_project_id]);
+
+        $this->actingAs($this->user)
+            ->get(route('api-keys'))
+            ->assertSuccessful();
+    }
+}

--- a/tests/Feature/ApiKeyTest.php
+++ b/tests/Feature/ApiKeyTest.php
@@ -140,4 +140,47 @@ class ApiKeyTest extends TestCase
             ->get(route('api-keys'))
             ->assertSuccessful();
     }
+
+    public function test_index_returns_project_ids_and_filtered_permissions(): void
+    {
+        $this->user->createToken('scoped-key', ['read', 'write', 'project:'.$this->user->current_project_id]);
+
+        $response = $this->actingAs($this->user)
+            ->get(route('api-keys'))
+            ->assertSuccessful();
+
+        $apiKeys = $response->original->getData()['page']['props']['apiKeys']['data'];
+        $key = collect($apiKeys)->firstWhere('name', 'scoped-key');
+
+        $this->assertNotNull($key);
+        $this->assertEquals(['read', 'write'], $key['permissions']);
+        $this->assertEquals([$this->user->current_project_id], $key['project_ids']);
+    }
+
+    public function test_create_api_key_with_empty_projects_array(): void
+    {
+        $this->actingAs($this->user)
+            ->post(route('api-keys.store'), [
+                'name' => 'empty-projects-key',
+                'permission' => 'read',
+                'projects' => [],
+            ])
+            ->assertSessionHas('success');
+
+        $token = $this->user->tokens()->where('name', 'empty-projects-key')->first();
+        $this->assertContains('read', $token->abilities);
+        $this->assertEmpty(
+            collect($token->abilities)->filter(fn ($a) => str_starts_with($a, 'project:'))->all()
+        );
+    }
+
+    public function test_cannot_create_api_key_with_invalid_permission(): void
+    {
+        $this->actingAs($this->user)
+            ->post(route('api-keys.store'), [
+                'name' => 'bad-key',
+                'permission' => 'admin',
+            ])
+            ->assertSessionHasErrors('permission');
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,6 +19,7 @@ use App\Services\Redis\Redis;
 use App\Services\Webserver\Nginx;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Sleep;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -42,6 +43,7 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
+        Sleep::fake();
         config()->set('queue.connections.ssh.driver', 'sync');
         config()->set('queue.connections.default.driver', 'sync');
         config()->set('filesystems.disks.key-pairs.root', storage_path('app/key-pairs-test'));

--- a/tests/Unit/MiseBunSiteTypeTest.php
+++ b/tests/Unit/MiseBunSiteTypeTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Unit;
 
-use App\Models\Server;
 use App\Models\Site;
 use App\SiteTypes\MiseBun;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -20,9 +19,8 @@ class MiseBunSiteTypeTest extends TestCase
     {
         parent::setUp();
 
-        $server = Server::factory()->create();
         $this->miseSite = Site::factory()->create([
-            'server_id' => $server->id,
+            'server_id' => $this->server->id,
             'user' => 'testuser',
             'path' => '/home/testuser/example.com',
             'type' => MiseBun::id(),
@@ -59,9 +57,8 @@ class MiseBunSiteTypeTest extends TestCase
 
     public function test_runtime_version_defaults_to_1_2(): void
     {
-        $server = Server::factory()->create();
         $site = Site::factory()->create([
-            'server_id' => $server->id,
+            'server_id' => $this->server->id,
             'user' => 'testuser',
             'path' => '/home/testuser/example.com',
             'type' => MiseBun::id(),
@@ -98,9 +95,8 @@ class MiseBunSiteTypeTest extends TestCase
 
     public function test_build_command_defaults(): void
     {
-        $server = Server::factory()->create();
         $site = Site::factory()->create([
-            'server_id' => $server->id,
+            'server_id' => $this->server->id,
             'user' => 'testuser',
             'path' => '/home/testuser/example.com',
             'type' => MiseBun::id(),
@@ -121,9 +117,8 @@ class MiseBunSiteTypeTest extends TestCase
 
     public function test_start_command_defaults(): void
     {
-        $server = Server::factory()->create();
         $site = Site::factory()->create([
-            'server_id' => $server->id,
+            'server_id' => $this->server->id,
             'user' => 'testuser',
             'path' => '/home/testuser/example.com',
             'type' => MiseBun::id(),

--- a/tests/Unit/MiseSiteTypeTest.php
+++ b/tests/Unit/MiseSiteTypeTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Unit;
 
-use App\Models\Server;
 use App\Models\Site;
 use App\SiteTypes\MiseNodeJS;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -20,9 +19,8 @@ class MiseSiteTypeTest extends TestCase
     {
         parent::setUp();
 
-        $server = Server::factory()->create();
         $this->miseSite = Site::factory()->create([
-            'server_id' => $server->id,
+            'server_id' => $this->server->id,
             'user' => 'testuser',
             'path' => '/home/testuser/example.com',
             'type' => MiseNodeJS::id(),
@@ -102,9 +100,8 @@ class MiseSiteTypeTest extends TestCase
 
     public function test_mise_shims_path_uses_different_user(): void
     {
-        $server = Server::factory()->create();
         $site = Site::factory()->create([
-            'server_id' => $server->id,
+            'server_id' => $this->server->id,
             'user' => 'anotheruser',
             'path' => '/home/anotheruser/example.com',
             'type' => MiseNodeJS::id(),


### PR DESCRIPTION
- Add project-scoped API keys: tokens can be restricted to specific projects via `project:<id>` abilities
- Enforce project scope in `CanSeeProjectMiddleware` and all API project endpoints (index, show, update, delete)
- Update API key creation UI with a multi-select for choosing projects (empty = access to all projects)

Fixes #1039