### PR TITLE
[Domains] Throw an error instead of suppressing

### DIFF
--- a/app/Actions/Domain/AddDomain.php
+++ b/app/Actions/Domain/AddDomain.php
@@ -6,6 +6,7 @@ use App\Models\DNSProvider;
 use App\Models\Domain;
 use App\Models\Project;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
@@ -34,18 +35,28 @@ class AddDomain
             ]);
         }
 
-        $domain = new Domain;
-        $domain->dns_provider_id = $dnsProvider->id;
-        $domain->user_id = $user->id;
-        $domain->project_id = $project->id;
-        $domain->domain = $domainData['name'];
-        $domain->provider_domain_id = $domainData['id'];
-        $domain->metadata = $domainData;
-        $domain->save();
+        try {
+            return DB::transaction(function () use ($user, $project, $dnsProvider, $domainData) {
+                $domain = new Domain;
+                $domain->dns_provider_id = $dnsProvider->id;
+                $domain->user_id = $user->id;
+                $domain->project_id = $project->id;
+                $domain->domain = $domainData['name'];
+                $domain->provider_domain_id = $domainData['id'];
+                $domain->metadata = $domainData;
+                $domain->save();
 
-        $domain->syncDnsRecords();
+                $domain->syncDnsRecords();
 
-        return $domain;
+                return $domain;
+            });
+        } catch (ValidationException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            throw ValidationException::withMessages([
+                'domain' => [$e->getMessage()],
+            ]);
+        }
     }
 
     private function validate(array $input): void

--- a/app/DNSProviders/Cloudflare.php
+++ b/app/DNSProviders/Cloudflare.php
@@ -152,19 +152,19 @@ class Cloudflare extends AbstractDNSProvider
         })->toArray();
     }
 
-    public function createRecord(string $domainId, array $input): array
+    public function createRecord(string $domainId, array $recordData): array
     {
         try {
             $response = $this->getClient()->post("zones/{$domainId}/dns_records", [
-                'type' => $input['type'],
-                'name' => $input['name'],
-                'content' => $input['content'],
-                'ttl' => $input['ttl'] ?? 1,
-                'proxied' => $input['proxied'] ?? false,
+                'type' => $recordData['type'],
+                'name' => $recordData['name'],
+                'content' => $recordData['content'],
+                'ttl' => $recordData['ttl'] ?? 1,
+                'proxied' => $recordData['proxied'] ?? false,
             ]);
 
             if (! $response->successful()) {
-                Log::error('Failed to create Cloudflare DNS record', ['domainId' => $domainId, 'input' => $input, 'response' => $response->json()]);
+                Log::error('Failed to create Cloudflare DNS record', ['domainId' => $domainId, 'input' => $recordData, 'response' => $response->json()]);
                 throw ValidationException::withMessages(['record' => 'Failed to create DNS record: '.($response->json('errors')[0]['message'] ?? 'Unknown error')]);
             }
 
@@ -175,19 +175,19 @@ class Cloudflare extends AbstractDNSProvider
         }
     }
 
-    public function updateRecord(string $domainId, string $recordId, array $input): array
+    public function updateRecord(string $domainId, string $recordId, array $recordData): array
     {
         try {
             $response = $this->getClient()->put("zones/{$domainId}/dns_records/{$recordId}", [
-                'type' => $input['type'],
-                'name' => $input['name'],
-                'content' => $input['content'],
-                'ttl' => $input['ttl'] ?? 1,
-                'proxied' => $input['proxied'] ?? false,
+                'type' => $recordData['type'],
+                'name' => $recordData['name'],
+                'content' => $recordData['content'],
+                'ttl' => $recordData['ttl'] ?? 1,
+                'proxied' => $recordData['proxied'] ?? false,
             ]);
 
             if (! $response->successful()) {
-                Log::error('Failed to update Cloudflare DNS record', ['domainId' => $domainId, 'recordId' => $recordId, 'input' => $input, 'response' => $response->json()]);
+                Log::error('Failed to update Cloudflare DNS record', ['domainId' => $domainId, 'recordId' => $recordId, 'input' => $recordData, 'response' => $response->json()]);
                 throw ValidationException::withMessages(['record' => 'Failed to update DNS record: '.($response->json('errors')[0]['message'] ?? 'Unknown error')]);
             }
 

--- a/app/DNSProviders/Cloudflare.php
+++ b/app/DNSProviders/Cloudflare.php
@@ -129,34 +129,27 @@ class Cloudflare extends AbstractDNSProvider
 
     public function getRecords(string $domainId): array
     {
-        try {
-            $response = $this->getClient()->get("zones/{$domainId}/dns_records", [
-                'per_page' => 100,
-            ]);
+        $response = $this->getClient()->get("zones/{$domainId}/dns_records", [
+            'per_page' => 100,
+        ]);
 
-            if (! $response->successful()) {
-                Log::error('Failed to fetch Cloudflare DNS records', ['domainId' => $domainId, 'response' => $response->json()]);
-
-                return [];
-            }
-
-            return collect($response->json('result'))->map(function (array $record) {
-                return [
-                    'id' => $record['id'],
-                    'type' => $record['type'],
-                    'name' => $record['name'],
-                    'content' => $record['content'],
-                    'ttl' => $record['ttl'],
-                    'proxied' => $record['proxied'],
-                    'created_on' => $record['created_on'],
-                    'modified_on' => $record['modified_on'],
-                ];
-            })->toArray();
-        } catch (Throwable $e) {
-            Log::error('Cloudflare getRecords exception', ['error' => $e->getMessage()]);
-
-            return [];
+        if (! $response->successful()) {
+            Log::error('Failed to fetch Cloudflare DNS records', ['domainId' => $domainId, 'response' => $response->json()]);
+            throw new \RuntimeException('Failed to fetch DNS records: '.($response->json('errors')[0]['message'] ?? 'Unknown error'));
         }
+
+        return collect($response->json('result'))->map(function (array $record) {
+            return [
+                'id' => $record['id'],
+                'type' => $record['type'],
+                'name' => $record['name'],
+                'content' => $record['content'],
+                'ttl' => $record['ttl'],
+                'proxied' => $record['proxied'],
+                'created_on' => $record['created_on'],
+                'modified_on' => $record['modified_on'],
+            ];
+        })->toArray();
     }
 
     public function createRecord(string $domainId, array $input): array

--- a/app/Http/Controllers/API/DNSRecordController.php
+++ b/app/Http/Controllers/API/DNSRecordController.php
@@ -92,7 +92,11 @@ class DNSRecordController extends Controller
         $this->authorize('update', $domain);
         $this->validateRoute($project, $domain);
 
-        $domain->syncDnsRecords();
+        try {
+            $domain->syncDnsRecords();
+        } catch (\Throwable $e) {
+            return response()->json(['message' => 'Failed to sync DNS records: '.$e->getMessage()], 422);
+        }
 
         return response()->json(['message' => 'DNS records synced successfully']);
     }

--- a/app/Http/Controllers/DNSRecordController.php
+++ b/app/Http/Controllers/DNSRecordController.php
@@ -86,7 +86,11 @@ class DNSRecordController extends Controller
     {
         $this->authorize('update', $domain);
 
-        $domain->syncDnsRecords();
+        try {
+            $domain->syncDnsRecords();
+        } catch (\Throwable $e) {
+            return back()->with('error', 'Failed to sync DNS records: '.$e->getMessage());
+        }
 
         return back()->with('success', 'DNS records synced successfully.');
     }

--- a/app/Models/Domain.php
+++ b/app/Models/Domain.php
@@ -6,6 +6,7 @@ use Database\Factories\DomainFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\DB;
 
 /**
  * @property int $dns_provider_id
@@ -73,25 +74,27 @@ class Domain extends AbstractModel
     }
 
     /**
-     * @throws \RuntimeException
+     * @throws \Throwable
      */
     public function syncDnsRecords(): void
     {
         $records = $this->dnsProvider->provider()->getRecords($this->provider_domain_id);
 
-        DNSRecord::where('domain_id', $this->id)->delete();
+        DB::transaction(function () use ($records) {
+            DNSRecord::where('domain_id', $this->id)->delete();
 
-        foreach ($records as $recordData) {
-            DNSRecord::create([
-                'domain_id' => $this->id,
-                'type' => $recordData['type'],
-                'name' => $recordData['name'],
-                'content' => $recordData['content'],
-                'ttl' => $recordData['ttl'] ?? 1,
-                'proxied' => $recordData['proxied'] ?? false,
-                'provider_record_id' => $recordData['id'],
-                'metadata' => $recordData,
-            ]);
-        }
+            foreach ($records as $recordData) {
+                DNSRecord::create([
+                    'domain_id' => $this->id,
+                    'type' => $recordData['type'],
+                    'name' => $recordData['name'],
+                    'content' => $recordData['content'],
+                    'ttl' => $recordData['ttl'] ?? 1,
+                    'proxied' => $recordData['proxied'] ?? false,
+                    'provider_record_id' => $recordData['id'],
+                    'metadata' => $recordData,
+                ]);
+            }
+        });
     }
 }

--- a/app/Models/Domain.php
+++ b/app/Models/Domain.php
@@ -6,8 +6,6 @@ use Database\Factories\DomainFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Facades\Log;
-use Throwable;
 
 /**
  * @property int $dns_provider_id
@@ -74,29 +72,25 @@ class Domain extends AbstractModel
         return $this->hasMany(DNSRecord::class);
     }
 
+    /**
+     * @throws \RuntimeException
+     */
     public function syncDnsRecords(): void
     {
-        try {
-            $records = $this->dnsProvider->provider()->getRecords($this->provider_domain_id);
+        $records = $this->dnsProvider->provider()->getRecords($this->provider_domain_id);
 
-            DNSRecord::where('domain_id', $this->id)->delete();
+        DNSRecord::where('domain_id', $this->id)->delete();
 
-            foreach ($records as $recordData) {
-                DNSRecord::create([
-                    'domain_id' => $this->id,
-                    'type' => $recordData['type'],
-                    'name' => $recordData['name'],
-                    'content' => $recordData['content'],
-                    'ttl' => $recordData['ttl'] ?? 1,
-                    'proxied' => $recordData['proxied'] ?? false,
-                    'provider_record_id' => $recordData['id'],
-                    'metadata' => $recordData,
-                ]);
-            }
-        } catch (Throwable $e) {
-            Log::error('Failed to sync DNS records for domain: '.$this->domain, [
-                'error' => $e->getMessage(),
+        foreach ($records as $recordData) {
+            DNSRecord::create([
                 'domain_id' => $this->id,
+                'type' => $recordData['type'],
+                'name' => $recordData['name'],
+                'content' => $recordData['content'],
+                'ttl' => $recordData['ttl'] ?? 1,
+                'proxied' => $recordData['proxied'] ?? false,
+                'provider_record_id' => $recordData['id'],
+                'metadata' => $recordData,
             ]);
         }
     }

--- a/resources/js/pages/domains/components/add-domain.tsx
+++ b/resources/js/pages/domains/components/add-domain.tsx
@@ -145,6 +145,7 @@ export default function AddDomain({ children }: { children: ReactNode }) {
               </Select>
               <InputError message={form.errors.provider_domain_id} />
             </FormField>
+            <InputError message={(form.errors as Record<string, string>).domain} />
           </FormFields>
         </Form>
         <DialogFooter>

--- a/tests/Feature/API/DNSRecordTest.php
+++ b/tests/Feature/API/DNSRecordTest.php
@@ -752,6 +752,33 @@ class DNSRecordTest extends TestCase
         ]);
     }
 
+    public function test_sync_dns_records_returns_error_when_provider_fails(): void
+    {
+        Sanctum::actingAs($this->user, ['write']);
+
+        $dnsProvider = DNSProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'project_id' => $this->user->current_project_id,
+        ]);
+
+        $domain = Domain::factory()->create([
+            'user_id' => $this->user->id,
+            'dns_provider_id' => $dnsProvider->id,
+            'project_id' => $this->user->current_project_id,
+            'provider_domain_id' => 'test-domain-id',
+        ]);
+
+        // Mock the DNS provider API call to throw an exception
+        Http::fake(function () {
+            throw new \RuntimeException('Domain is not opted in to API access.');
+        });
+
+        $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/sync");
+
+        $response->assertStatus(422);
+        $this->assertStringContainsString('Failed to sync DNS records', $response->json('message'));
+    }
+
     public function test_user_cannot_sync_dns_records_for_other_users_domain(): void
     {
         Sanctum::actingAs($this->user, ['write']);

--- a/tests/Feature/API/DomainsTest.php
+++ b/tests/Feature/API/DomainsTest.php
@@ -172,8 +172,12 @@ class DomainsTest extends TestCase
             'project_id' => $this->user->current_project_id,
         ]);
 
-        // Mock the DNS provider API call
+        // Mock the DNS provider API calls (getDomain + getRecords)
         Http::fake([
+            'api.cloudflare.com/client/v4/zones/test-domain-id/dns_records*' => Http::response([
+                'result' => [],
+                'success' => true,
+            ], 200),
             'api.cloudflare.com/*' => Http::response([
                 'result' => [
                     'id' => 'test-domain-id',
@@ -210,6 +214,52 @@ class DomainsTest extends TestCase
         $this->assertDatabaseHas('domains', [
             'user_id' => $this->user->id,
             'dns_provider_id' => $dnsProvider->id,
+            'provider_domain_id' => 'test-domain-id',
+        ]);
+    }
+
+    public function test_create_domain_fails_when_record_sync_fails(): void
+    {
+        Sanctum::actingAs($this->user, ['write']);
+
+        $dnsProvider = DNSProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'project_id' => $this->user->current_project_id,
+        ]);
+
+        $callCount = 0;
+
+        // First call (getDomain) succeeds, subsequent calls throw
+        Http::fake(function () use (&$callCount) {
+            $callCount++;
+            if ($callCount === 1) {
+                return Http::response([
+                    'result' => [
+                        'id' => 'test-domain-id',
+                        'name' => 'example.com',
+                        'status' => 'active',
+                        'created_on' => '2023-01-01T00:00:00Z',
+                        'modified_on' => '2023-01-01T00:00:00Z',
+                    ],
+                    'success' => true,
+                ], 200);
+            }
+
+            throw new \RuntimeException('Domain is not opted in to API access.');
+        });
+
+        $domainData = [
+            'dns_provider_id' => $dnsProvider->id,
+            'provider_domain_id' => 'test-domain-id',
+        ];
+
+        $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains", $domainData);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors('domain');
+
+        // Domain should not have been persisted due to transaction rollback
+        $this->assertDatabaseMissing('domains', [
             'provider_domain_id' => 'test-domain-id',
         ]);
     }

--- a/tests/Feature/DomainsTest.php
+++ b/tests/Feature/DomainsTest.php
@@ -1122,6 +1122,13 @@ class DomainsTest extends TestCase
 
         $response->assertRedirect()
             ->assertSessionHas('error');
+
+        // Existing record should remain intact after a failed sync
+        $this->assertDatabaseHas('dns_records', [
+            'id' => $existingRecord->id,
+            'domain_id' => $domain->id,
+            'name' => 'existing',
+        ]);
     }
 
     public function test_add_domain_fails_when_record_sync_fails(): void

--- a/tests/Feature/DomainsTest.php
+++ b/tests/Feature/DomainsTest.php
@@ -252,8 +252,12 @@ class DomainsTest extends TestCase
             'project_id' => $this->user->current_project_id,
         ]);
 
-        // Mock the DNS provider API call
+        // Mock the DNS provider API calls (getDomain + getRecords)
         Http::fake([
+            'api.cloudflare.com/client/v4/zones/test-domain-id/dns_records*' => Http::response([
+                'result' => [],
+                'success' => true,
+            ], 200),
             'api.cloudflare.com/*' => Http::response([
                 'result' => [
                     'id' => 'test-domain-id',
@@ -1083,6 +1087,86 @@ class DomainsTest extends TestCase
             'type' => 'CNAME',
             'name' => 'mail',
             'content' => 'example.com',
+        ]);
+    }
+
+    public function test_sync_dns_records_returns_error_when_provider_fails(): void
+    {
+        $this->actingAs($this->user);
+
+        $dnsProvider = DNSProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'project_id' => $this->user->current_project_id,
+        ]);
+
+        $domain = Domain::factory()->create([
+            'user_id' => $this->user->id,
+            'dns_provider_id' => $dnsProvider->id,
+            'project_id' => $this->user->current_project_id,
+            'provider_domain_id' => 'test-domain-id',
+        ]);
+
+        $existingRecord = DNSRecord::factory()->create([
+            'domain_id' => $domain->id,
+            'type' => 'A',
+            'name' => 'existing',
+            'content' => '192.168.1.1',
+        ]);
+
+        // Mock the DNS provider API call to throw an exception
+        Http::fake(function () {
+            throw new \RuntimeException('Domain is not opted in to API access.');
+        });
+
+        $response = $this->post("/domains/{$domain->id}/records/sync");
+
+        $response->assertRedirect()
+            ->assertSessionHas('error');
+    }
+
+    public function test_add_domain_fails_when_record_sync_fails(): void
+    {
+        $this->actingAs($this->user);
+
+        $dnsProvider = DNSProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'project_id' => $this->user->current_project_id,
+        ]);
+
+        $callCount = 0;
+
+        // First call (getDomain) succeeds, subsequent calls throw
+        Http::fake(function () use (&$callCount) {
+            $callCount++;
+            if ($callCount === 1) {
+                return Http::response([
+                    'result' => [
+                        'id' => 'test-domain-id',
+                        'name' => 'example.com',
+                        'status' => 'active',
+                        'created_on' => '2023-01-01T00:00:00Z',
+                        'modified_on' => '2023-01-01T00:00:00Z',
+                    ],
+                    'success' => true,
+                ], 200);
+            }
+
+            throw new \RuntimeException('Domain is not opted in to API access.');
+        });
+
+        $domainData = [
+            'dns_provider_id' => $dnsProvider->id,
+            'provider_domain_id' => 'test-domain-id',
+        ];
+
+        $response = $this->post('/domains', $domainData);
+
+        $response->assertRedirect()
+            ->assertSessionHasErrors('domain');
+
+        // Domain should not have been persisted due to transaction rollback
+        $this->assertDatabaseMissing('domains', [
+            'provider_domain_id' => 'test-domain-id',
         ]);
     }
 

--- a/tests/Unit/DNSProviders/CloudflareTest.php
+++ b/tests/Unit/DNSProviders/CloudflareTest.php
@@ -317,12 +317,18 @@ class CloudflareTest extends TestCase
         $domainId = 'invalid-zone';
 
         Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records*" => Http::response([], 404),
+            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records*" => Http::response([
+                'success' => false,
+                'errors' => [
+                    ['message' => 'Zone not found'],
+                ],
+            ], 404),
         ]);
 
-        $records = $this->cloudflare->getRecords($domainId);
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Failed to fetch DNS records: Zone not found');
 
-        $this->assertSame([], $records);
+        $this->cloudflare->getRecords($domainId);
     }
 
     public function test_get_records_exception(): void
@@ -333,9 +339,10 @@ class CloudflareTest extends TestCase
             throw new \Exception('Network error');
         });
 
-        $records = $this->cloudflare->getRecords($domainId);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Network error');
 
-        $this->assertSame([], $records);
+        $this->cloudflare->getRecords($domainId);
     }
 
     public function test_create_record_success(): void


### PR DESCRIPTION
This pull request improves error handling and transactional integrity for domain and DNS record operations. It ensures that failures during DNS record synchronization or domain creation are properly surfaced to the user and that domains are not persisted if DNS record sync fails. The changes also update tests to verify these new behaviors.

**Error handling and transactional integrity improvements:**

* Wrapped domain creation in a database transaction in `AddDomain.php`, ensuring that if DNS record synchronization fails, the domain is not persisted and a validation error is returned to the user. [[1]](diffhunk://#diff-e4669829c08add99b8b125b843767a6719d4396046cf6d7550e01e4419e56cccR38-R39) [[2]](diffhunk://#diff-e4669829c08add99b8b125b843767a6719d4396046cf6d7550e01e4419e56cccR52-R59)
* Updated `syncDnsRecords` in `Domain.php` to remove internal error catching, allowing exceptions to propagate and be handled at a higher level, improving error visibility and rollback behavior. [[1]](diffhunk://#diff-453c3b4c89b8617f53bb82740ad382bcf4f7a14e8dd07204c1141d331b7a6becR75-L79) [[2]](diffhunk://#diff-453c3b4c89b8617f53bb82740ad382bcf4f7a14e8dd07204c1141d331b7a6becL96-L101)
* Improved error handling in controller actions (`DNSRecordController.php`), so that sync failures return user-friendly error messages and appropriate HTTP status codes. [[1]](diffhunk://#diff-674653999dc8e558de459933b9b0d6f4fdf36cd756173d8e647108e7ac9c3082R95-R99) [[2]](diffhunk://#diff-2c7b05798a5c5df81788bb2f976e448e09e13c81cf7261d121661c122ba2d1cdR89-R93)

<img width="589" height="347" alt="CleanShot 2026-03-16 at 17 10 20" src="https://github.com/user-attachments/assets/f705715d-cf22-494b-81c2-e0c31d975e3a" />

**DNS provider error propagation:**

* Modified `Cloudflare.php` to throw exceptions when DNS record fetching fails, rather than silently returning empty results, ensuring that upstream errors are properly handled. [[1]](diffhunk://#diff-ef44586e3fb91e694f89fda189cd44eac2db0b4199d5b46ee09bb09f42298c0aL132-R138) [[2]](diffhunk://#diff-ef44586e3fb91e694f89fda189cd44eac2db0b4199d5b46ee09bb09f42298c0aL155-L159)

**Testing enhancements:**

* Added and updated feature and unit tests to verify that errors during DNS record sync or domain creation are correctly surfaced and that failed operations do not persist data. These tests also check that error messages and validation behaviors are correct. [[1]](diffhunk://#diff-78deedf8c4ca286957c0747faaf1f5142068d36fd740ebd2aeeb8d76a162b54aR755-R781) [[2]](diffhunk://#diff-49b4370823653d57e1a1e254c7ade4cd8ba10f26739f3dea06540460c46c87b4R221-R266) [[3]](diffhunk://#diff-7bdd730edbecefa5783f49677124c437b5e6168db4b4dbe3d9639c89d29395d2R1093-R1172) [[4]](diffhunk://#diff-d95f5531de00596b21baf4e02dc86b2c2edb92caed6a131a8ed0dcb3b6c1ecceL320-R331) [[5]](diffhunk://#diff-d95f5531de00596b21baf4e02dc86b2c2edb92caed6a131a8ed0dcb3b6c1ecceL336-R345)

**Test mocking improvements:**

* Updated test mocks to simulate both successful and failing DNS provider API calls, ensuring comprehensive coverage of new error handling code paths. [[1]](diffhunk://#diff-49b4370823653d57e1a1e254c7ade4cd8ba10f26739f3dea06540460c46c87b4L175-R180) [[2]](diffhunk://#diff-7bdd730edbecefa5783f49677124c437b5e6168db4b4dbe3d9639c89d29395d2L255-R260)

These changes collectively make domain and DNS record management more robust, user-friendly, and reliable in the face of external provider failures.