### PR TITLE
[Domains] Edit DNS Provider

### DIFF
--- a/app/Actions/DNSProvider/EditDNSProvider.php
+++ b/app/Actions/DNSProvider/EditDNSProvider.php
@@ -15,14 +15,32 @@ class EditDNSProvider
      */
     public function edit(DNSProvider $dnsProvider, array $input): DNSProvider
     {
-        Validator::make($input, [
-            'name' => [
-                'required',
-            ],
-        ])->validate();
+        $provider = $dnsProvider->provider();
+
+        $rules = array_merge(
+            ['name' => ['required']],
+            $provider->editValidationRules($input),
+        );
+
+        Validator::make($input, $rules)->validate();
 
         $dnsProvider->name = $input['name'];
         $dnsProvider->project_id = isset($input['global']) && $input['global'] ? null : $dnsProvider->user->currentProject?->id;
+
+        [$newCredentials, $needsReconnect] = $provider->mergeEditData($input);
+
+        if ($needsReconnect) {
+            if (! $provider->connect($newCredentials)) {
+                throw ValidationException::withMessages([
+                    'provider' => [sprintf("Couldn't connect to %s. Please check your credentials.", $dnsProvider->provider)],
+                ]);
+            }
+        }
+
+        if ($newCredentials !== $dnsProvider->credentials) {
+            $dnsProvider->credentials = $newCredentials;
+        }
+
         $dnsProvider->connected = true;
         $dnsProvider->save();
 

--- a/app/DNSProviders/AbstractDNSProvider.php
+++ b/app/DNSProviders/AbstractDNSProvider.php
@@ -33,6 +33,32 @@ abstract class AbstractDNSProvider implements DNSProvider
     /**
      * @return array<string, mixed>
      */
+    public function editableData(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @return array{0: array<string, mixed>, 1: bool}
+     */
+    public function mergeEditData(array $input): array
+    {
+        return [$this->dnsProvider->credentials, false];
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @return array<string, string>
+     */
+    public function editValidationRules(array $input): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
     public function getDomains(): array
     {
         return [];

--- a/app/DNSProviders/AbstractDNSProvider.php
+++ b/app/DNSProviders/AbstractDNSProvider.php
@@ -49,7 +49,7 @@ abstract class AbstractDNSProvider implements DNSProvider
 
     /**
      * @param  array<string, mixed>  $input
-     * @return array<string, string>
+     * @return array<string, string|array<int, mixed>>
      */
     public function editValidationRules(array $input): array
     {

--- a/app/DNSProviders/Cloudflare.php
+++ b/app/DNSProviders/Cloudflare.php
@@ -45,6 +45,26 @@ class Cloudflare extends AbstractDNSProvider
         ];
     }
 
+    public function editValidationRules(array $input): array
+    {
+        return [
+            'token' => 'nullable|string',
+        ];
+    }
+
+    public function mergeEditData(array $input): array
+    {
+        $credentials = $this->dnsProvider->credentials;
+        $needsReconnect = false;
+
+        if (! empty($input['token'])) {
+            $credentials['token'] = $input['token'];
+            $needsReconnect = true;
+        }
+
+        return [$credentials, $needsReconnect];
+    }
+
     public function connect(array $credentials): bool
     {
         try {

--- a/app/DNSProviders/DNSProvider.php
+++ b/app/DNSProviders/DNSProvider.php
@@ -19,6 +19,30 @@ interface DNSProvider
     public function credentialData(array $input): array;
 
     /**
+     * Non-sensitive credential data that can be exposed for editing.
+     *
+     * @return array<string, mixed>
+     */
+    public function editableData(): array;
+
+    /**
+     * Merge edit input into existing credentials, ignoring empty optional fields.
+     * Returns [credentials, needsReconnect] tuple.
+     *
+     * @param  array<string, mixed>  $input
+     * @return array{0: array<string, mixed>, 1: bool}
+     */
+    public function mergeEditData(array $input): array;
+
+    /**
+     * Validation rules for edit form (fields are optional by default).
+     *
+     * @param  array<string, mixed>  $input
+     * @return array<string, string>
+     */
+    public function editValidationRules(array $input): array;
+
+    /**
      * @param  array<string, mixed>  $credentials
      */
     public function connect(array $credentials): bool;

--- a/app/DNSProviders/DNSProvider.php
+++ b/app/DNSProviders/DNSProvider.php
@@ -38,7 +38,7 @@ interface DNSProvider
      * Validation rules for edit form (fields are optional by default).
      *
      * @param  array<string, mixed>  $input
-     * @return array<string, string>
+     * @return array<string, string|array<int, mixed>>
      */
     public function editValidationRules(array $input): array;
 

--- a/app/Http/Resources/DNSProviderResource.php
+++ b/app/Http/Resources/DNSProviderResource.php
@@ -23,6 +23,7 @@ class DNSProviderResource extends JsonResource
             'connected' => $this->connected,
             'project_id' => $this->project_id,
             'global' => is_null($this->project_id),
+            'editable_data' => $this->provider()->editableData(),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Plugins/RegisterDNSProvider.php
+++ b/app/Plugins/RegisterDNSProvider.php
@@ -11,6 +11,7 @@ class RegisterDNSProvider
         private string $label = '',
         private string $handler = '',
         private ?DynamicForm $form = null,
+        private ?DynamicForm $editForm = null,
         private array $proxyTypes = [],
         private bool $supportsCreatedAt = true,
     ) {}
@@ -48,6 +49,13 @@ class RegisterDNSProvider
         return $this;
     }
 
+    public function editForm(DynamicForm $editForm): self
+    {
+        $this->editForm = $editForm;
+
+        return $this;
+    }
+
     public function proxyTypes(array $proxyTypes): self
     {
         $this->proxyTypes = $proxyTypes;
@@ -70,6 +78,7 @@ class RegisterDNSProvider
             'label' => $this->label,
             'handler' => $this->handler,
             'form' => $this->form ? $this->form->toArray() : [],
+            'edit_form' => $this->editForm ? $this->editForm->toArray() : [],
             'proxy_types' => $this->proxyTypes,
             'supports_created_at' => $this->supportsCreatedAt,
         ];

--- a/app/Providers/DNSProviderServiceProvider.php
+++ b/app/Providers/DNSProviderServiceProvider.php
@@ -30,6 +30,14 @@ class DNSProviderServiceProvider extends ServiceProvider
                         ->description('Create an API token with Zone:Read and DNS:Edit permissions'),
                 ])
             )
+            ->editForm(
+                DynamicForm::make([
+                    DynamicField::make('token')
+                        ->passwordWithToggle()
+                        ->label('API Token')
+                        ->description('Leave empty to keep the current token'),
+                ])
+            )
             ->proxyTypes(['A', 'AAAA', 'CNAME'])
             ->supportsCreatedAt(true)
             ->register();

--- a/resources/js/pages/dns-providers/components/columns.tsx
+++ b/resources/js/pages/dns-providers/components/columns.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { useForm } from '@inertiajs/react';
+import { useForm, usePage } from '@inertiajs/react';
 import { LoaderCircleIcon, MoreVerticalIcon } from 'lucide-react';
 import FormSuccessful from '@/components/form-successful';
 import { FormEvent, useState } from 'react';
@@ -23,24 +23,41 @@ import { Form, FormField, FormFields } from '@/components/ui/form';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
+import { SharedData } from '@/types';
+import { DynamicFieldConfig } from '@/types/dynamic-field-config';
+import DynamicFieldComponent from '@/components/ui/dynamic-field';
 
 function Edit({ dnsProvider }: { dnsProvider: DNSProvider }) {
   const [open, setOpen] = useState(false);
-  const form = useForm({
+  const page = usePage<SharedData>();
+  const providerConfig = page.props.configs.dns_provider.providers[dnsProvider.provider];
+  const editFields: DynamicFieldConfig[] = providerConfig?.edit_form || [];
+
+  const initialData: Record<string, string | boolean> = {
     name: dnsProvider.name,
     global: dnsProvider.project_id === null,
+  };
+
+  // Pre-fill editable (non-sensitive) data, leave credential fields empty
+  editFields.forEach((field) => {
+    initialData[field.name] = dnsProvider.editable_data?.[field.name] ?? '';
   });
+
+  const form = useForm(initialData);
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
-    form.patch(route('dns-providers.update', dnsProvider.id));
+    form.patch(route('dns-providers.update', dnsProvider.id), {
+      onSuccess: () => setOpen(false),
+    });
   };
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <DropdownMenuItem onSelect={(e) => e.preventDefault()}>Edit</DropdownMenuItem>
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent className="max-h-screen overflow-y-auto sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>Edit {dnsProvider.name}</DialogTitle>
           <DialogDescription className="sr-only">Edit DNS provider</DialogDescription>
@@ -49,16 +66,26 @@ function Edit({ dnsProvider }: { dnsProvider: DNSProvider }) {
           <FormFields>
             <FormField>
               <Label htmlFor="name">Name</Label>
-              <Input type="text" id="name" name="name" value={form.data.name} onChange={(e) => form.setData('name', e.target.value)} />
+              <Input type="text" id="name" name="name" value={form.data.name as string} onChange={(e) => form.setData('name', e.target.value)} />
               <InputError message={form.errors.name} />
             </FormField>
+            {editFields.map((field: DynamicFieldConfig) => (
+              <DynamicFieldComponent
+                key={`edit-field-${field.name}`}
+                value={form.data[field.name] as string}
+                onChange={(value) => form.setData(field.name, value as string)}
+                config={field}
+                error={form.errors[field.name]}
+              />
+            ))}
             <FormField>
               <div className="flex items-center space-x-3">
-                <Checkbox id="global" name="global" checked={form.data.global} onClick={() => form.setData('global', !form.data.global)} />
+                <Checkbox id="global" name="global" checked={form.data.global as boolean} onClick={() => form.setData('global', !form.data.global)} />
                 <Label htmlFor="global">Is global (accessible in all projects)</Label>
               </div>
               <InputError message={form.errors.global} />
             </FormField>
+            <InputError message={form.errors.provider} />
           </FormFields>
         </Form>
         <DialogFooter>

--- a/resources/js/pages/dns-providers/components/columns.tsx
+++ b/resources/js/pages/dns-providers/components/columns.tsx
@@ -33,7 +33,7 @@ function Edit({ dnsProvider }: { dnsProvider: DNSProvider }) {
   const providerConfig = page.props.configs.dns_provider.providers[dnsProvider.provider];
   const editFields: DynamicFieldConfig[] = providerConfig?.edit_form || [];
 
-  const initialData: Record<string, string | boolean> = {
+  const initialData: Record<string, string | number | boolean | string[]> = {
     name: dnsProvider.name,
     global: dnsProvider.project_id === null,
   };
@@ -72,8 +72,8 @@ function Edit({ dnsProvider }: { dnsProvider: DNSProvider }) {
             {editFields.map((field: DynamicFieldConfig) => (
               <DynamicFieldComponent
                 key={`edit-field-${field.name}`}
-                value={form.data[field.name] as string}
-                onChange={(value) => form.setData(field.name, value as string)}
+                value={form.data[field.name]}
+                onChange={(value) => form.setData(field.name, value)}
                 config={field}
                 error={form.errors[field.name]}
               />

--- a/resources/js/types/dns-provider.d.ts
+++ b/resources/js/types/dns-provider.d.ts
@@ -5,6 +5,7 @@ export interface DNSProvider {
   connected: boolean;
   project_id: number | null;
   global: boolean;
+  editable_data: Record<string, string>;
   created_at: string;
   updated_at: string;
 }

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -75,6 +75,7 @@ export interface Configs {
         label: string;
         handler: string;
         form?: DynamicFieldConfig[];
+        edit_form?: DynamicFieldConfig[];
         proxy_types?: string[];
         supports_created_at?: boolean;
       };

--- a/tests/Feature/API/DNSProvidersTest.php
+++ b/tests/Feature/API/DNSProvidersTest.php
@@ -542,7 +542,7 @@ class DNSProvidersTest extends TestCase
         $this->assertEquals(Cloudflare::id(), $dnsProvider->provider); // Should remain unchanged
     }
 
-    public function test_dns_provider_update_ignores_credentials_manipulation(): void
+    public function test_dns_provider_update_keeps_credentials_when_empty(): void
     {
         Sanctum::actingAs($this->user, ['read', 'write']);
 
@@ -553,7 +553,6 @@ class DNSProvidersTest extends TestCase
 
         $data = [
             'name' => 'Updated Name',
-            'token' => 'new-token', // Attempt to change credentials
         ];
 
         $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
@@ -564,7 +563,67 @@ class DNSProvidersTest extends TestCase
 
         $dnsProvider->refresh();
         $this->assertEquals('Updated Name', $dnsProvider->name);
-        $this->assertEquals(['token' => 'original-token'], $dnsProvider->credentials); // Should remain unchanged
+        $this->assertEquals(['token' => 'original-token'], $dnsProvider->credentials);
+    }
+
+    public function test_dns_provider_update_changes_credentials_when_provided(): void
+    {
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        $dnsProvider = DNSProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'credentials' => ['token' => 'original-token'],
+        ]);
+
+        Http::fake([
+            'api.cloudflare.com/*' => Http::response([
+                'success' => true,
+                'result' => [],
+            ], 200),
+        ]);
+
+        $data = [
+            'name' => 'Updated Name',
+            'token' => 'new-token',
+        ];
+
+        $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
+            ->assertSuccessful()
+            ->assertJsonFragment([
+                'name' => 'Updated Name',
+            ]);
+
+        $dnsProvider->refresh();
+        $this->assertEquals('Updated Name', $dnsProvider->name);
+        $this->assertEquals(['token' => 'new-token'], $dnsProvider->credentials);
+    }
+
+    public function test_dns_provider_update_rejects_invalid_credentials(): void
+    {
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        $dnsProvider = DNSProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'credentials' => ['token' => 'original-token'],
+        ]);
+
+        Http::fake([
+            'api.cloudflare.com/*' => Http::response([
+                'success' => false,
+                'errors' => [['message' => 'Invalid token']],
+            ], 401),
+        ]);
+
+        $data = [
+            'name' => 'Updated Name',
+            'token' => 'bad-token',
+        ];
+
+        $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
+            ->assertUnprocessable();
+
+        $dnsProvider->refresh();
+        $this->assertEquals(['token' => 'original-token'], $dnsProvider->credentials);
     }
 
     public function test_dns_provider_update_ignores_connected_manipulation(): void

--- a/tests/Feature/DNSProvidersTest.php
+++ b/tests/Feature/DNSProvidersTest.php
@@ -207,6 +207,85 @@ class DNSProvidersTest extends TestCase
         ]);
     }
 
+    public function test_dns_provider_update_keeps_credentials_when_empty(): void
+    {
+        $this->actingAs($this->user);
+
+        $dnsProvider = DNSProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'project_id' => $this->user->current_project_id,
+            'credentials' => ['token' => 'original-token'],
+        ]);
+
+        $response = $this->patch(route('dns-providers.update', $dnsProvider), [
+            'name' => 'Updated Name',
+        ]);
+
+        $response->assertRedirect();
+
+        $dnsProvider->refresh();
+        $this->assertEquals('Updated Name', $dnsProvider->name);
+        $this->assertEquals(['token' => 'original-token'], $dnsProvider->credentials);
+    }
+
+    public function test_dns_provider_update_changes_credentials_when_provided(): void
+    {
+        $this->actingAs($this->user);
+
+        $dnsProvider = DNSProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'project_id' => $this->user->current_project_id,
+            'credentials' => ['token' => 'original-token'],
+        ]);
+
+        Http::fake([
+            'api.cloudflare.com/*' => Http::response([
+                'success' => true,
+                'result' => [],
+            ], 200),
+        ]);
+
+        $response = $this->patch(route('dns-providers.update', $dnsProvider), [
+            'name' => 'Updated Name',
+            'token' => 'new-token',
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success', 'DNS provider updated.');
+
+        $dnsProvider->refresh();
+        $this->assertEquals(['token' => 'new-token'], $dnsProvider->credentials);
+    }
+
+    public function test_dns_provider_update_rejects_invalid_credentials(): void
+    {
+        $this->actingAs($this->user);
+
+        $dnsProvider = DNSProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'project_id' => $this->user->current_project_id,
+            'credentials' => ['token' => 'original-token'],
+        ]);
+
+        Http::fake([
+            'api.cloudflare.com/*' => Http::response([
+                'success' => false,
+                'errors' => [['message' => 'Invalid token']],
+            ], 401),
+        ]);
+
+        $response = $this->patch(route('dns-providers.update', $dnsProvider), [
+            'name' => 'Updated Name',
+            'token' => 'bad-token',
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHasErrors('provider');
+
+        $dnsProvider->refresh();
+        $this->assertEquals(['token' => 'original-token'], $dnsProvider->credentials);
+    }
+
     public function test_dns_provider_update_requires_name(): void
     {
         $this->actingAs($this->user);


### PR DESCRIPTION
This pull request introduces a robust and extensible *optional* system for editing DNS provider credentials, including support for custom edit forms, validation rules, and credential merging. The changes enable providers like Cloudflare to allow credential updates (such as API tokens) in a secure and user-friendly way, with proper validation and error handling. The frontend now dynamically renders editable fields based on provider configuration, and the backend ensures credentials are only updated when valid and provided, however the current credentials are NOT leaked back to the client and instead appear empty and are only updated when the details are populated.  

<img width="587" height="583" alt="CleanShot 2026-03-17 at 09 17 32" src="https://github.com/user-attachments/assets/23430a4c-0451-4ec6-890e-56910355cef6" />

Where new providers have been registered via plugins, the edit form is completely optional, and where no edit form has been provided, the current functionality of only being able to edit the name remains. 

Comprehensive tests are added to verify the new edit behavior.

**Backend: DNS Provider Edit System**

* Added new methods to the `DNSProvider` interface and base class (`editableData`, `editValidationRules`, `mergeEditData`) to support exposing, validating, and merging editable credential data for provider updates. [[1]](diffhunk://#diff-ff4eddd564fae9d72ec6282cb4cfcc6322c29a47bdf8395b903d449b97f31d54R21-R44) [[2]](diffhunk://#diff-64dce255e2d4cc56d1518197cf9d4989603d7aadeba8aff775362dc4fce85d60R33-R58)
* Updated the `EditDNSProvider` action to use provider-specific edit validation rules and credential merging logic, including reconnecting and error handling if credentials change.
* Implemented Cloudflare-specific edit validation and credential merging, allowing the API token to be updated securely.

**Frontend: Dynamic Edit Form Rendering**

* Enhanced the edit dialog in the DNS Providers UI to dynamically render editable credential fields using provider-specific `edit_form` configuration and pre-fill non-sensitive data. [[1]](diffhunk://#diff-bc7dca27d90256307dbb179d837884e51c1d4ef1c4df251ef1d867eff0c28a03R26-R60) [[2]](diffhunk://#diff-bc7dca27d90256307dbb179d837884e51c1d4ef1c4df251ef1d867eff0c28a03L52-R88)
* Added support for registering custom edit forms for providers, including Cloudflare, via the plugin system. [[1]](diffhunk://#diff-4af6b3a37f7deb9e561d4a4b0f4685d4a621fe4c2b7962171e2647a8833d86eaR14) [[2]](diffhunk://#diff-4af6b3a37f7deb9e561d4a4b0f4685d4a621fe4c2b7962171e2647a8833d86eaR52-R58) [[3]](diffhunk://#diff-4af6b3a37f7deb9e561d4a4b0f4685d4a621fe4c2b7962171e2647a8833d86eaR81) [[4]](diffhunk://#diff-69f05cf8924baf2540953f790a6f48899900716ff85f907aff33ebe1a507745aR33-R40)
* Exposed `editable_data` in the DNSProvider API resource for use in the frontend.

**Testing: Credential Edit Behavior**

* Added tests to verify that credentials are only updated when new values are provided, remain unchanged when fields are empty, and that invalid credentials are rejected with proper error handling. [[1]](diffhunk://#diff-00390a3551f60cb8151ab5bccf50bd8026630052d2ce94a914b5eb37115a5f53L545-R545) [[2]](diffhunk://#diff-00390a3551f60cb8151ab5bccf50bd8026630052d2ce94a914b5eb37115a5f53L556) [[3]](diffhunk://#diff-00390a3551f60cb8151ab5bccf50bd8026630052d2ce94a914b5eb37115a5f53L567-R626) [[4]](diffhunk://#diff-bf5735b03946256f6e288de31c80e40986e90d395996cb09062783fb86988ce7R210-R288)