### PR TITLE
Allow ws_url for local development

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -19,7 +19,7 @@ class EventsController extends Controller
             'project_id' => $request->user()->current_project_id,
         ]);
 
-        $appUrl = parse_url(config('app.url'));
+        $appUrl = parse_url(config('app.ws_url', config('app.url')));
         $isSecure = ($appUrl['scheme'] ?? 'http') === 'https';
         $wsProtocol = $isSecure ? 'wss' : 'ws';
         $host = $appUrl['host'] ?? 'localhost';

--- a/config/app.php
+++ b/config/app.php
@@ -55,6 +55,7 @@ return [
     */
 
     'url' => env('APP_URL', 'http://localhost'),
+    'ws_url' => env('WS_URL'),
 
     'asset_url' => env('ASSET_URL'),
 


### PR DESCRIPTION
This pull request introduces support for a configurable WebSocket URL separate from the main application URL. The main change is to allow overriding the WebSocket host and protocol via a new configuration option, improving local development flexibility.

Configuration enhancements:

* Added a new `ws_url` configuration option to `config/app.php`, which can be set via the `WS_URL` environment variable.

WebSocket URL handling:

* Updated the `EventsController` to use the new `ws_url` configuration value (falling back to `app.url` if not set) when determining the WebSocket host and protocol.