### PR TITLE
[FIX] Improve .env update validation

### DIFF
--- a/app/Actions/Site/UpdateEnv.php
+++ b/app/Actions/Site/UpdateEnv.php
@@ -5,6 +5,7 @@ namespace App\Actions\Site;
 use App\Exceptions\SSHError;
 use App\Models\Site;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 
 class UpdateEnv
 {
@@ -17,11 +18,21 @@ class UpdateEnv
     {
         Validator::make($input, [
             'env' => ['required', 'string'],
-            'path' => ['nullable', 'string'],
+            'path' => ['nullable', 'string', 'regex:/^[a-zA-Z0-9\/_.\-]+$/'],
         ])->validate();
 
         $typeData = $site->type_data ?? [];
         $path = $input['path'] ?? data_get($typeData, 'env_path', $site->path.'/.env');
+
+        $storedEnvPath = data_get($typeData, 'env_path');
+        $withinSitePath = str_starts_with($path, $site->path.'/');
+        $matchesStoredPath = $storedEnvPath !== null && $path === $storedEnvPath;
+
+        if (str_contains($path, '..') || (! $withinSitePath && ! $matchesStoredPath)) {
+            throw ValidationException::withMessages([
+                'path' => __('The path must be within the site directory.'),
+            ]);
+        }
 
         $site->server->os()->write(
             $path,

--- a/tests/Feature/ApplicationTest.php
+++ b/tests/Feature/ApplicationTest.php
@@ -349,13 +349,67 @@ class ApplicationTest extends TestCase
             'site' => $this->site,
         ]), [
             'env' => 'APP_ENV="production"',
-            'path' => '/home/vito/some-path/.env',
+            'path' => $this->site->path.'/some-path/.env',
         ])
             ->assertSessionDoesntHaveErrors();
 
         $this->site->refresh();
 
-        $this->assertEquals('/home/vito/some-path/.env', data_get($this->site->type_data, 'env_path'));
+        $this->assertEquals($this->site->path.'/some-path/.env', data_get($this->site->type_data, 'env_path'));
+    }
+
+    public function test_update_env_blocks_path_outside_site_directory(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+
+        $this->put(route('application.update-env', [
+            'server' => $this->server,
+            'site' => $this->site,
+        ]), [
+            'env' => 'APP_ENV="production"',
+            'path' => '/home/vito/other-site/.env',
+        ])
+            ->assertSessionHasErrors('path');
+    }
+
+    public function test_update_env_allows_stored_env_path_outside_site_directory(): void
+    {
+        SSH::fake();
+
+        $this->site->update([
+            'type_data' => array_merge($this->site->type_data ?? [], [
+                'env_path' => '/home/vito/other-site/.env',
+            ]),
+        ]);
+
+        $this->actingAs($this->user);
+
+        $this->put(route('application.update-env', [
+            'server' => $this->server,
+            'site' => $this->site,
+        ]), [
+            'env' => 'APP_ENV="production"',
+            'path' => '/home/vito/other-site/.env',
+        ])
+            ->assertSessionDoesntHaveErrors();
+    }
+
+    public function test_update_env_blocks_path_traversal(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+
+        $this->put(route('application.update-env', [
+            'server' => $this->server,
+            'site' => $this->site,
+        ]), [
+            'env' => 'APP_ENV="production"',
+            'path' => $this->site->path.'/../../etc/passwd',
+        ])
+            ->assertSessionHasErrors('path');
     }
 
     /**


### PR DESCRIPTION
This pull request strengthens the validation logic for updating environment file paths in the `UpdateEnv` action to prevent security issues such as path traversal and writing outside the site directory. It also adds comprehensive tests to ensure the new validation behaves as expected.

**Validation and Security Improvements:**

* Enhanced the validation for the `path` field in `UpdateEnv` to require a specific regex pattern and to ensure the path is either within the site directory or matches a previously stored path, blocking directory traversal and unauthorized writes. Throws a validation exception if these conditions are not met.
* Added import for `ValidationException` to support the new validation logic.

**Testing Enhancements:**

* Updated and expanded tests in `ApplicationTest.php` to:
  - Check that environment files can only be updated within the allowed directory.
  - Ensure attempts to write outside the site directory or use path traversal are blocked.
  - Confirm that previously stored environment paths outside the site directory are still allowed.