### PR TITLE
[Fix] Site Domains Fixes

### DIFF
--- a/app/Http/Resources/SiteResource.php
+++ b/app/Http/Resources/SiteResource.php
@@ -83,14 +83,17 @@ class SiteResource extends JsonResource
                 && $hd->relationLoaded('ssl')
                 && $hd->ssl
                 && $hd->ssl->status === SslStatus::CREATED
+                && $hd->ssl->expires_at
                 && $hd->ssl->expires_at <= now()->addDays(14)
         );
+
         if ($expiring->isNotEmpty()) {
+            $earliestExpiry = $expiring->min(fn ($hd) => $hd->ssl->expires_at);
             $warnings[] = [
                 'key' => 'ssl_expiring',
                 'count' => $expiring->count(),
                 'domains' => $expiring->pluck('domain')->all(),
-                'earliest_expiry' => $expiring->min(fn ($hd) => $hd->ssl->expires_at)->toIso8601String(),
+                'earliest_expiry' => $earliestExpiry?->toIso8601String(),
             ];
         }
 

--- a/app/Models/Ssl.php
+++ b/app/Models/Ssl.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\SslStatus;
+use App\Enums\SslType;
 use Carbon\Carbon;
 use Database\Factories\SslFactory;
 use Illuminate\Database\Eloquent\Builder;
@@ -120,7 +121,10 @@ class Ssl extends AbstractModel
         return self::query()
             ->whereNull('site_id')
             ->where('server_id', $serverId)
-            ->where('status', SslStatus::CREATED);
+            ->where('status', SslStatus::CREATED)
+            ->whereNot('type', SslType::CSR)
+            ->whereNotNull('certificate_path')
+            ->whereNotNull('pk_path');
     }
 
     public function validateSetup(string $result): bool

--- a/database/factories/SslFactory.php
+++ b/database/factories/SslFactory.php
@@ -23,6 +23,8 @@ class SslFactory extends Factory
             'certificate' => $this->faker->word(),
             'pk' => $this->faker->word(),
             'ca' => $this->faker->word(),
+            'certificate_path' => '/etc/ssl/certs/'.$this->faker->word().'.pem',
+            'pk_path' => '/etc/ssl/private/'.$this->faker->word().'.pem',
             'expires_at' => Carbon::now()->addDay(),
             'status' => SslStatus::CREATED,
             'domains' => ['example.com'],

--- a/public/api-docs/openapi/schemas/SSL.yaml
+++ b/public/api-docs/openapi/schemas/SSL.yaml
@@ -11,9 +11,6 @@ properties:
     type: integer
     nullable: true
     example: 1
-  is_active:
-    type: boolean
-    example: true
   is_wildcard:
     type: boolean
     example: false


### PR DESCRIPTION
SSL certificate filtering and validation:

* Updated the `Ssl` model's `activeServerLevel` scope to exclude certificates of type `CSR` and require both `certificate_path` and `pk_path` to be present, ensuring only valid, usable server-level SSLs are returned.
* Added the `SslType` enum import to the `Ssl` model to support the above filtering.

SSL expiry warnings:

* Improved the logic for SSL expiry warnings in `SiteResource`: now checks that `expires_at` is set before comparing, and safely handles the case where no expiry date is found when determining the earliest expiry.

API schema cleanup:

* Removed the unused `is_active` property from the SSL OpenAPI schema, reflecting changes in how active SSLs are determined.