### PR TITLE
[FIX] v3.x: Match synced MySQL users by (username, host) to avoid collapsing multi-host accounts

### DIFF
--- a/app/Actions/Database/SyncDatabaseUsers.php
+++ b/app/Actions/Database/SyncDatabaseUsers.php
@@ -28,10 +28,17 @@ class SyncDatabaseUsers
         foreach ($users as $user) {
             $databases = $user[2] != 'NULL' ? explode(',', $user[2]) : [];
 
+            $query = $server->databaseUsers()->where('username', $user[0]);
+
+            // MySQL/MariaDB distinguish users by (username, host); match both to avoid
+            // collapsing distinct accounts onto a single row. PostgreSQL's get-users-list
+            // returns an empty host (roles are host-agnostic), so only filter when present.
+            if ($user[1] !== '') {
+                $query->where('host', $user[1]);
+            }
+
             /** @var ?DatabaseUser $databaseUser */
-            $databaseUser = $server->databaseUsers()
-                ->where('username', $user[0])
-                ->first();
+            $databaseUser = $query->first();
 
             if ($databaseUser === null) {
                 $server->databaseUsers()->create([

--- a/tests/Feature/DatabaseUserTest.php
+++ b/tests/Feature/DatabaseUserTest.php
@@ -4,9 +4,12 @@ namespace Tests\Feature;
 
 use App\Enums\DatabaseUserPermission;
 use App\Enums\DatabaseUserStatus;
+use App\Enums\ServiceStatus;
 use App\Facades\SSH;
 use App\Models\Database;
 use App\Models\DatabaseUser;
+use App\Services\Database\Mysql;
+use App\Services\Database\Postgresql;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
@@ -285,5 +288,106 @@ class DatabaseUserTest extends TestCase
         $databaseUser->refresh();
 
         $this->assertEquals(DatabaseUserPermission::READ, $databaseUser->permission);
+    }
+
+    public function test_sync_database_users_creates_rows_per_host_for_mysql(): void
+    {
+        $this->actingAs($this->user);
+
+        $mysqlFakeOutput = implode("\n", [
+            "User\tHost\tPrivileges",
+            "app\tlocalhost\tappdb",
+            "app\t127.0.0.1\tappdb,devdb",
+        ]);
+
+        SSH::fake($mysqlFakeOutput);
+
+        $this->patch(route('database-users.sync', ['server' => $this->server]))
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('database_users', [
+            'server_id' => $this->server->id,
+            'username' => 'app',
+            'host' => 'localhost',
+            'databases' => $this->castAsJson(['appdb']),
+        ]);
+
+        $this->assertDatabaseHas('database_users', [
+            'server_id' => $this->server->id,
+            'username' => 'app',
+            'host' => '127.0.0.1',
+            'databases' => $this->castAsJson(['appdb', 'devdb']),
+        ]);
+
+        $this->assertSame(
+            2,
+            DatabaseUser::where('server_id', $this->server->id)->where('username', 'app')->count(),
+        );
+    }
+
+    public function test_sync_database_users_is_idempotent_for_mysql_multi_host(): void
+    {
+        $this->actingAs($this->user);
+
+        $mysqlFakeOutput = implode("\n", [
+            "User\tHost\tPrivileges",
+            "app\tlocalhost\tappdb",
+            "app\t127.0.0.1\tappdb,devdb",
+        ]);
+
+        SSH::fake($mysqlFakeOutput);
+
+        $this->patch(route('database-users.sync', ['server' => $this->server]));
+        $this->patch(route('database-users.sync', ['server' => $this->server]));
+
+        $this->assertSame(
+            2,
+            DatabaseUser::where('server_id', $this->server->id)->where('username', 'app')->count(),
+        );
+    }
+
+    public function test_sync_database_users_does_not_duplicate_postgresql_rows(): void
+    {
+        $this->actingAs($this->user);
+
+        $this->server->services()->where('type', Mysql::type())->delete();
+        $this->server->services()->create([
+            'type' => Postgresql::type(),
+            'name' => Postgresql::id(),
+            'version' => '15',
+            'status' => ServiceStatus::READY,
+        ]);
+        $this->server->refresh();
+
+        DatabaseUser::factory()->create([
+            'server_id' => $this->server->id,
+            'username' => 'appuser',
+            'host' => 'localhost',
+            'databases' => [],
+        ]);
+
+        $pgFakeOutput = implode("\n", [
+            ' username | host | databases',
+            '----------+------+-----------',
+            ' appuser  |      | appdb',
+            '(1 row)',
+        ]);
+
+        SSH::fake($pgFakeOutput);
+
+        $this->patch(route('database-users.sync', ['server' => $this->server]));
+        $this->patch(route('database-users.sync', ['server' => $this->server]));
+
+        $this->assertSame(
+            1,
+            DatabaseUser::where('server_id', $this->server->id)->where('username', 'appuser')->count(),
+        );
+
+        $this->assertDatabaseHas('database_users', [
+            'server_id' => $this->server->id,
+            'username' => 'appuser',
+            'host' => 'localhost',
+            'databases' => $this->castAsJson(['appdb']),
+        ]);
     }
 }


### PR DESCRIPTION
Closes #1074

`SyncDatabaseUsers` was looking up existing rows by username only, so on a server with both `'app'@'localhost'` and `'app'@'127.0.0.1'` one row kept being overwritten on every sync and the second one was never inserted. The Vito UI then ended up showing a `databases` list that didn't match the host above it.

Fix is one extra `where('host', ...)` when the handler returns a non-empty host. Postgres is left on the username-only path because its `get-users-list` view returns `''` for host (roles are host-agnostic) and an unconditional composite filter would insert a duplicate `(rolname, '')` row on every sync.

```diff
  /** @var ?DatabaseUser $databaseUser */
- $databaseUser = $server->databaseUsers()
-     ->where('username', $user[0])
-     ->first();
+ $query = $server->databaseUsers()->where('username', $user[0]);
+ if ($user[1] !== '') {
+     $query->where('host', $user[1]);
+ }
+ $databaseUser = $query->first();
```

`vendor/bin/phpunit tests/Feature/DatabaseUserTest.php` -> 15/15 green; three new tests cover the multi-host case, idempotent re-sync, and the Postgres no-duplicate regression. `CreateDatabaseUser`, `UpdateDatabaseUser`, and `DeleteDatabaseUser` already scope by `(username, host)`, so this just brings sync in line.

No migration. A composite unique index on `(server_id, username, host)` would be a natural follow-up but felt out of scope.
