### PR TITLE
[FIX] v3.x: Preserve import flash for non-database session drivers

### DIFF
--- a/app/Http/Controllers/Admin/VitoSettingController.php
+++ b/app/Http/Controllers/Admin/VitoSettingController.php
@@ -91,7 +91,9 @@ class VitoSettingController extends Controller
         }
 
         // set session driver to file
-        config(['session.driver' => 'file']);
+        if (config('session.driver') === 'database') {
+            config(['session.driver' => 'file']);
+        }
 
         $request->validate([
             'backup_file' => 'required|file|mimes:zip',

--- a/tests/Feature/VitoSettingsTest.php
+++ b/tests/Feature/VitoSettingsTest.php
@@ -3,7 +3,11 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
 use Tests\TestCase;
+use ZipArchive;
 
 class VitoSettingsTest extends TestCase
 {
@@ -15,5 +19,109 @@ class VitoSettingsTest extends TestCase
 
         $this->get(route('vito-settings.export'))
             ->assertDownload('vito-backup-'.date('Y-m-d').'.zip');
+    }
+
+    public function test_import_keeps_session_driver_when_not_database(): void
+    {
+        $this->actingAs($this->user);
+        config(['session.driver' => 'cookie']);
+        Artisan::shouldReceive('call')->with('optimize')->once();
+
+        $zipPath = $this->buildBackupZip();
+        $snapshot = $this->snapshotImportTargets();
+
+        try {
+            $response = $this->post(route('vito-settings.import'), [
+                'backup_file' => new UploadedFile($zipPath, 'backup.zip', 'application/zip', null, true),
+            ]);
+
+            $response->assertRedirect(route('vito-settings'));
+            $response->assertSessionHas('success', 'Settings imported successfully.');
+            $this->assertSame('cookie', config('session.driver'));
+        } finally {
+            $this->restoreImportTargets($snapshot);
+            @unlink($zipPath);
+        }
+    }
+
+    public function test_import_swaps_session_driver_to_file_when_database(): void
+    {
+        $this->actingAs($this->user);
+        config(['session.driver' => 'database']);
+        Artisan::shouldReceive('call')->with('optimize')->once();
+
+        $zipPath = $this->buildBackupZip();
+        $snapshot = $this->snapshotImportTargets();
+
+        try {
+            $response = $this->post(route('vito-settings.import'), [
+                'backup_file' => new UploadedFile($zipPath, 'backup.zip', 'application/zip', null, true),
+            ]);
+
+            $response->assertRedirect(route('vito-settings'));
+            $response->assertSessionHas('success', 'Settings imported successfully.');
+            $this->assertSame('file', config('session.driver'));
+        } finally {
+            $this->restoreImportTargets($snapshot);
+            @unlink($zipPath);
+        }
+    }
+
+    private function buildBackupZip(): string
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'vito-backup-test-');
+        $zipPath = $tmp.'.zip';
+        @unlink($tmp);
+
+        $databasePath = storage_path('database.sqlite');
+        $databaseContents = File::exists($databasePath)
+            ? File::get($databasePath)
+            : '';
+
+        $zip = new ZipArchive;
+        $zip->open($zipPath, ZipArchive::CREATE);
+        $zip->addFromString('database.sqlite', $databaseContents);
+        $zip->addFromString('ssh-public.key', 'test-public-key');
+        $zip->addFromString('ssh-private.pem', 'test-private-pem');
+        $zip->close();
+
+        return $zipPath;
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    private function snapshotImportTargets(): array
+    {
+        $paths = [
+            storage_path('database.sqlite'),
+            storage_path('ssh-public.key'),
+            storage_path('ssh-private.pem'),
+        ];
+
+        $snapshot = [];
+        foreach ($paths as $path) {
+            $snapshot[$path] = File::exists($path) ? File::get($path) : null;
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * @param  array<string, string|null>  $snapshot
+     */
+    private function restoreImportTargets(array $snapshot): void
+    {
+        foreach ($snapshot as $path => $content) {
+            if ($content === null) {
+                if (File::exists($path)) {
+                    File::delete($path);
+                }
+
+                continue;
+            }
+
+            File::put($path, $content);
+        }
     }
 }


### PR DESCRIPTION
Closes #1080.

Default `SESSION_DRIVER` is `redis` (`config/session.php:21`), so any install on the defaults runs into this. The unconditional swap to the `file` driver writes the success flash to a store the next request never reads, so the redirect comes back without a toast and the user has no way to tell whether the import worked.

Limiting the swap to the `database` driver leaves every other driver untouched. Behavior on `database` is unchanged.

```
vendor/bin/phpunit tests/Feature/VitoSettingsTest.php
OK (3 tests, 11 assertions)
```
