### PR TITLE
[Feat] Add Ubuntu 26 support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,3 +117,4 @@ Vito has a specific architecture. Match these patterns exactly:
 
 - Use `gh` CLI for issues/PRs.
 - Don't change dependencies or create new base folders without approval.
+- PR titles must be prefixed with `[Feat]` or `[Fix]`

--- a/app/Enums/OperatingSystem.php
+++ b/app/Enums/OperatingSystem.php
@@ -10,6 +10,7 @@ enum OperatingSystem: string implements VitoEnum
     case UBUNTU20 = 'ubuntu_20';
     case UBUNTU22 = 'ubuntu_22';
     case UBUNTU24 = 'ubuntu_24';
+    case UBUNTU26 = 'ubuntu_26';
 
     public function getColor(): string
     {
@@ -28,6 +29,7 @@ enum OperatingSystem: string implements VitoEnum
             self::UBUNTU20 => '20.04',
             self::UBUNTU22 => '22.04',
             self::UBUNTU24 => '24.04',
+            self::UBUNTU26 => '26.04',
         };
     }
 }

--- a/config/core.php
+++ b/config/core.php
@@ -59,6 +59,7 @@ return [
         OperatingSystem::UBUNTU20->value,
         OperatingSystem::UBUNTU22->value,
         OperatingSystem::UBUNTU24->value,
+        OperatingSystem::UBUNTU26->value,
     ],
 
     /*

--- a/config/serverproviders.php
+++ b/config/serverproviders.php
@@ -488,6 +488,7 @@ return [
             'ubuntu_20' => 'linode/ubuntu20.04',
             'ubuntu_22' => 'linode/ubuntu22.04',
             'ubuntu_24' => 'linode/ubuntu24.04',
+            'ubuntu_26' => 'linode/ubuntu26.04',
         ],
     ],
     'digitalocean' => [
@@ -945,6 +946,7 @@ return [
             'ubuntu_20' => 'ubuntu-20.04',
             'ubuntu_22' => 'ubuntu-22.04',
             'ubuntu_24' => 'ubuntu-24.04',
+            'ubuntu_26' => 'ubuntu-26.04',
         ],
     ],
 ];

--- a/resources/views/ssh/mise/ensure-installed.blade.php
+++ b/resources/views/ssh/mise/ensure-installed.blade.php
@@ -4,10 +4,10 @@ if command -v mise &> /dev/null; then
     exit 0
 fi
 
-sudo apt update -y && sudo apt install -y curl
+sudo apt update -y && sudo apt install -y curl gnupg
 sudo install -dm 755 /etc/apt/keyrings
-curl -fsSL https://mise.jdx.dev/gpg-key.pub | sudo tee /etc/apt/keyrings/mise-archive-keyring.pub 1> /dev/null
-echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.pub arch=amd64] https://mise.jdx.dev/deb stable main" | sudo tee /etc/apt/sources.list.d/mise.list
+curl -fsSL https://mise.jdx.dev/gpg-key.pub | sudo gpg --dearmor -o /etc/apt/keyrings/mise-archive-keyring.gpg
+echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://mise.jdx.dev/deb stable main" | sudo tee /etc/apt/sources.list.d/mise.list
 sudo apt update
 sudo apt install -y mise
 

--- a/resources/views/ssh/os/install-dependencies.blade.php
+++ b/resources/views/ssh/os/install-dependencies.blade.php
@@ -1,10 +1,10 @@
-sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y software-properties-common curl zip unzip git gcc openssl ufw cron
+sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y software-properties-common curl zip unzip git gcc openssl ufw cron gnupg
 git config --global user.email "{{ $email }}"
 git config --global user.name "{{ $name }}"
 
 # Install Mise
 sudo install -dm 755 /etc/apt/keyrings
-curl -fsSL https://mise.jdx.dev/gpg-key.pub | sudo tee /etc/apt/keyrings/mise-archive-keyring.pub 1> /dev/null
-echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.pub arch=$(dpkg --print-architecture)] https://mise.jdx.dev/deb stable main" | sudo tee /etc/apt/sources.list.d/mise.list
+curl -fsSL https://mise.jdx.dev/gpg-key.pub | sudo gpg --dearmor -o /etc/apt/keyrings/mise-archive-keyring.gpg
+echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://mise.jdx.dev/deb stable main" | sudo tee /etc/apt/sources.list.d/mise.list
 sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update
 sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y mise


### PR DESCRIPTION
Not all providers support ubuntu 26 yet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ubuntu 26 operating system is now available as a selectable option with automatic version detection
  * Ubuntu 26 image support has been added for Linode and Hetzner cloud providers
* **Documentation**
  * Added a PR title guideline requiring `[Feat]` or `[Fix]` prefixes
* **Bug Fixes**
  * Improved Debian/Ubuntu apt repository key handling and architecture detection during SSH OS setup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->