### PR TITLE
fix: re-sync SSH deploy keys when updating site source control

### DIFF
--- a/app/Actions/Site/UpdateSourceControl.php
+++ b/app/Actions/Site/UpdateSourceControl.php
@@ -6,9 +6,11 @@ use App\Exceptions\RepositoryNotFound;
 use App\Exceptions\RepositoryPermissionDenied;
 use App\Exceptions\SourceControlIsNotConnected;
 use App\Models\Site;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
+use Throwable;
 
 class UpdateSourceControl
 {
@@ -25,6 +27,13 @@ class UpdateSourceControl
                 Rule::exists('source_controls', 'id'),
             ],
         ])->validate();
+
+        if ($site->sourceControl && isset($site->type_data['deploy_key_id'])) {
+            $site->sourceControl->provider()->deleteDeployKey(
+                $site->type_data['deploy_key_id'],
+                $site->repository,
+            );
+        }
 
         $site->source_control_id = $input['source_control'];
         try {
@@ -45,5 +54,21 @@ class UpdateSourceControl
             ]);
         }
         $site->save();
+
+        if ($site->ssh_key && $site->repository) {
+            try {
+                $keyId = $site->sourceControl->provider()->deployKey(
+                    $site->getDeployKeyName(),
+                    $site->repository,
+                    $site->ssh_key
+                );
+                $site->jsonUpdate('type_data', 'deploy_key_id', $keyId);
+            } catch (Throwable $e) {
+                Log::warning('Failed to re-deploy SSH key after source control update', [
+                    'site' => $site->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
     }
 }

--- a/app/Actions/Site/UpdateSourceControl.php
+++ b/app/Actions/Site/UpdateSourceControl.php
@@ -28,14 +28,23 @@ class UpdateSourceControl
             ],
         ])->validate();
 
-        if ($site->sourceControl && isset($site->type_data['deploy_key_id'])) {
-            $site->sourceControl->provider()->deleteDeployKey(
-                $site->type_data['deploy_key_id'],
-                $site->repository,
-            );
+        try {
+            if ($site->sourceControl && isset($site->type_data['deploy_key_id'])) {
+                $site->sourceControl->provider()->deleteDeployKey(
+                    $site->type_data['deploy_key_id'],
+                    $site->repository,
+                );
+            }
+        } catch (Throwable $e) {
+            Log::warning('Failed to delete previous deploy key during source control update', [
+                'site' => $site->id,
+                'error' => $e->getMessage(),
+            ]);
         }
 
         $site->source_control_id = $input['source_control'];
+        $site->unsetRelation('sourceControl');
+
         try {
             if ($site->sourceControl) {
                 $site->sourceControl->getRepo($site->repository);
@@ -53,6 +62,7 @@ class UpdateSourceControl
                 'repository' => 'Repository not found',
             ]);
         }
+
         $site->save();
 
         if ($site->ssh_key && $site->repository) {

--- a/app/Actions/Site/UpdateSourceControl.php
+++ b/app/Actions/Site/UpdateSourceControl.php
@@ -28,20 +28,6 @@ class UpdateSourceControl
             ],
         ])->validate();
 
-        try {
-            if ($site->sourceControl && isset($site->type_data['deploy_key_id'])) {
-                $site->sourceControl->provider()->deleteDeployKey(
-                    $site->type_data['deploy_key_id'],
-                    $site->repository,
-                );
-            }
-        } catch (Throwable $e) {
-            Log::warning('Failed to delete previous deploy key during source control update', [
-                'site' => $site->id,
-                'error' => $e->getMessage(),
-            ]);
-        }
-
         $site->source_control_id = $input['source_control'];
         $site->unsetRelation('sourceControl');
 
@@ -63,6 +49,25 @@ class UpdateSourceControl
             ]);
         }
 
+        try {
+            if ($site->sourceControl && isset($site->type_data['deploy_key_id'])) {
+                $site->unsetRelation('sourceControl');
+                $site->source_control_id = $site->getOriginal('source_control_id');
+                $site->unsetRelation('sourceControl');
+                $site->sourceControl->provider()->deleteDeployKey(
+                    $site->type_data['deploy_key_id'],
+                    $site->repository,
+                );
+            }
+        } catch (Throwable $e) {
+            Log::warning('Failed to delete previous deploy key during source control update', [
+                'site' => $site->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        $site->source_control_id = $input['source_control'];
+        $site->unsetRelation('sourceControl');
         $site->save();
 
         if ($site->ssh_key && $site->repository) {

--- a/tests/Feature/SitesTest.php
+++ b/tests/Feature/SitesTest.php
@@ -34,8 +34,7 @@ class SitesTest extends TestCase
         SSH::fake();
 
         Http::fake([
-            'https://api.github.com/repos/*' => Http::response([
-            ], 201),
+            'https://api.github.com/repos/*' => Http::response([], 201),
         ]);
 
         if (isset($inputs['database']) && isset($inputs['database_user'])) {
@@ -67,7 +66,7 @@ class SitesTest extends TestCase
             'aliases' => $this->castAsJson($inputs['aliases'] ?? []),
             'status' => SiteStatus::READY->value,
             'user' => $inputs['user'],
-            'path' => '/home/'.$inputs['user'].'/'.$inputs['domain'],
+            'path' => '/home/' . $inputs['user'] . '/' . $inputs['domain'],
         ]);
     }
 
@@ -102,8 +101,7 @@ class SitesTest extends TestCase
         SSH::fake();
 
         Http::fake([
-            'https://api.github.com/repos/*' => Http::response([
-            ], $status),
+            'https://api.github.com/repos/*' => Http::response([], $status),
         ]);
 
         $this->actingAs($this->user);
@@ -136,7 +134,7 @@ class SitesTest extends TestCase
             'server' => $this->server,
         ]))
             ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/index'));
+            ->assertInertia(fn(AssertableInertia $page) => $page->component('sites/index'));
     }
 
     public function test_delete_site(): void
@@ -192,8 +190,7 @@ class SitesTest extends TestCase
         $this->actingAs($this->user);
 
         Http::fake([
-            'https://api.github.com/repos/*' => Http::response([
-            ], 201),
+            'https://api.github.com/repos/*' => Http::response([], 201),
         ]);
 
         /** @var SourceControl $sourceControl */
@@ -214,6 +211,109 @@ class SitesTest extends TestCase
         $this->assertEquals($sourceControl->id, $this->site->source_control_id);
     }
 
+    public function test_update_source_control_deletes_old_deploy_key(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+
+        Http::fake([
+            'https://api.github.com/repos/*/keys/*' => Http::response([], 204),
+            'https://api.github.com/repos/*' => Http::response(['id' => 99], 201),
+        ]);
+
+        /** @var SourceControl $newSourceControl */
+        $newSourceControl = SourceControl::factory()->create([
+            'provider' => Github::id(),
+        ]);
+
+        $this->site->type_data = array_merge($this->site->type_data ?? [], [
+            'deploy_key_id' => '123456',
+        ]);
+        $this->site->save();
+
+        $this->patch(route('site-settings.update-source-control', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'source_control' => $newSourceControl->id,
+        ])
+            ->assertSessionDoesntHaveErrors();
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/keys/123456')
+                && $request->method() === 'DELETE';
+        });
+    }
+
+    public function test_update_source_control_registers_new_deploy_key(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+
+        Http::fake([
+            'https://api.github.com/repos/*/keys' => Http::response(['id' => 99999], 201),
+            'https://api.github.com/repos/*' => Http::response([], 200),
+        ]);
+
+        /** @var SourceControl $newSourceControl */
+        $newSourceControl = SourceControl::factory()->create([
+            'provider' => Github::id(),
+        ]);
+
+        $this->site->ssh_key = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC test@test';
+        $this->site->save();
+
+        $this->patch(route('site-settings.update-source-control', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'source_control' => $newSourceControl->id,
+        ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->site->refresh();
+
+        $this->assertEquals(99999, $this->site->type_data['deploy_key_id']);
+    }
+
+    public function test_update_source_control_succeeds_even_if_old_deploy_key_deletion_fails(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+
+        Http::fake([
+            'https://api.github.com/repos/*/keys/*' => Http::response([
+                'message' => 'Bad credentials',
+            ], 401),
+            'https://api.github.com/repos/*' => Http::response(['id' => 77777], 201),
+        ]);
+
+        /** @var SourceControl $newSourceControl */
+        $newSourceControl = SourceControl::factory()->create([
+            'provider' => Github::id(),
+        ]);
+
+        $this->site->type_data = array_merge($this->site->type_data ?? [], [
+            'deploy_key_id' => '123456',
+        ]);
+        $this->site->ssh_key = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC test@test';
+        $this->site->save();
+
+        $this->patch(route('site-settings.update-source-control', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'source_control' => $newSourceControl->id,
+        ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->site->refresh();
+        $this->assertEquals($newSourceControl->id, $this->site->source_control_id);
+    }
+
     public function test_failed_to_update_source_control(): void
     {
         SSH::fake();
@@ -221,8 +321,7 @@ class SitesTest extends TestCase
         $this->actingAs($this->user);
 
         Http::fake([
-            'https://api.github.com/repos/*' => Http::response([
-            ], 404),
+            'https://api.github.com/repos/*' => Http::response([], 404),
         ]);
 
         /** @var SourceControl $sourceControl */
@@ -267,7 +366,7 @@ class SitesTest extends TestCase
             'site' => $this->site,
         ]))
             ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/logs'));
+            ->assertInertia(fn(AssertableInertia $page) => $page->component('sites/logs'));
     }
 
     public function test_change_branch(): void

--- a/tests/Feature/SitesTest.php
+++ b/tests/Feature/SitesTest.php
@@ -66,7 +66,7 @@ class SitesTest extends TestCase
             'aliases' => $this->castAsJson($inputs['aliases'] ?? []),
             'status' => SiteStatus::READY->value,
             'user' => $inputs['user'],
-            'path' => '/home/' . $inputs['user'] . '/' . $inputs['domain'],
+            'path' => '/home/'.$inputs['user'].'/'.$inputs['domain'],
         ]);
     }
 
@@ -134,7 +134,7 @@ class SitesTest extends TestCase
             'server' => $this->server,
         ]))
             ->assertSuccessful()
-            ->assertInertia(fn(AssertableInertia $page) => $page->component('sites/index'));
+            ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/index'));
     }
 
     public function test_delete_site(): void
@@ -366,7 +366,7 @@ class SitesTest extends TestCase
             'site' => $this->site,
         ]))
             ->assertSuccessful()
-            ->assertInertia(fn(AssertableInertia $page) => $page->component('sites/logs'));
+            ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/logs'));
     }
 
     public function test_change_branch(): void


### PR DESCRIPTION
When a user updates the Source Control provider/token for an existing site (via Settings → Source Controls), the SSH deploy key is not automatically re-registered in the repository. This leads to Permission denied (publickey) errors during subsequent deployments.

This PR updates UpdateSourceControl.php to:

1. Remove the old deploy key from the previous source control provider (if it exists).
2. Register the existing SSH key with the new source control provider/token.
3. Store the new deploy_key_id in type_data to ensure DeleteSite can correctly clean it up later.

**Changes:**
Modified app/Actions/Site/UpdateSourceControl.php to include the logic for deleting the old key and creating the new one using the existing Site and SourceControl providers.

**Verification:**
1. Tested on local and production (DigitalOcean) servers.
2. Verified that keys are correctly created in GitHub with the expected {domain}-key-{id} format.
3. Verified that the previous key is removed before creating the new one to avoid clutter.