### PR TITLE
[FIX] Use server SSH port for default Firewall Rules

### DIFF
--- a/app/Services/Firewall/AbstractFirewall.php
+++ b/app/Services/Firewall/AbstractFirewall.php
@@ -14,7 +14,7 @@ abstract class AbstractFirewall extends AbstractService implements Firewall
                 'type' => 'allow',
                 'name' => 'SSH',
                 'protocol' => 'tcp',
-                'port' => 22,
+                'port' => $this->service->server->port ?? 22,
                 'source' => null,
                 'mask' => null,
                 'status' => FirewallRuleStatus::READY,

--- a/app/Services/Firewall/Ufw.php
+++ b/app/Services/Firewall/Ufw.php
@@ -30,7 +30,9 @@ class Ufw extends AbstractFirewall
         $this->createBasicFirewallRules();
 
         $this->service->server->ssh()->exec(
-            view('ssh.services.firewall.ufw.install-ufw'),
+            view('ssh.services.firewall.ufw.install-ufw', [
+                'sshPort' => $this->service->server->port ?? 22,
+            ]),
             'install-ufw'
         );
         event('service.installed', $this->service);

--- a/resources/views/ssh/services/firewall/ufw/install-ufw.blade.php
+++ b/resources/views/ssh/services/firewall/ufw/install-ufw.blade.php
@@ -6,7 +6,7 @@ if ! sudo ufw default allow outgoing; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 
-if ! sudo ufw allow from 0.0.0.0/0 to any proto tcp port 22; then
+if ! sudo ufw allow from 0.0.0.0/0 to any proto tcp port {{ $sshPort }}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/tests/Unit/SSH/Services/Firewall/UfwInstallTest.php
+++ b/tests/Unit/SSH/Services/Firewall/UfwInstallTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Unit\SSH\Services\Firewall;
+
+use App\Facades\SSH;
+use App\Services\Firewall\Ufw;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UfwInstallTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_install_seeds_ssh_rule_with_custom_server_port(): void
+    {
+        SSH::fake();
+
+        $this->server->update(['port' => 22022]);
+
+        /** @var Ufw $ufw */
+        $ufw = $this->server->services()
+            ->where('type', Ufw::type())
+            ->firstOrFail()
+            ->handler();
+
+        $ufw->install();
+
+        $this->assertDatabaseHas('firewall_rules', [
+            'server_id' => $this->server->id,
+            'name' => 'SSH',
+            'port' => 22022,
+        ]);
+
+        $this->assertDatabaseMissing('firewall_rules', [
+            'server_id' => $this->server->id,
+            'name' => 'SSH',
+            'port' => 22,
+        ]);
+    }
+
+    public function test_install_seeds_ssh_rule_with_default_port_when_unchanged(): void
+    {
+        SSH::fake();
+
+        $this->server->update(['port' => 22]);
+
+        /** @var Ufw $ufw */
+        $ufw = $this->server->services()
+            ->where('type', Ufw::type())
+            ->firstOrFail()
+            ->handler();
+
+        $ufw->install();
+
+        $this->assertDatabaseHas('firewall_rules', [
+            'server_id' => $this->server->id,
+            'name' => 'SSH',
+            'port' => 22,
+        ]);
+    }
+
+    public function test_install_seeds_http_and_https_rules_unchanged(): void
+    {
+        SSH::fake();
+
+        $this->server->update(['port' => 22022]);
+
+        /** @var Ufw $ufw */
+        $ufw = $this->server->services()
+            ->where('type', Ufw::type())
+            ->firstOrFail()
+            ->handler();
+
+        $ufw->install();
+
+        $this->assertDatabaseHas('firewall_rules', [
+            'server_id' => $this->server->id,
+            'name' => 'HTTP',
+            'port' => 80,
+        ]);
+        $this->assertDatabaseHas('firewall_rules', [
+            'server_id' => $this->server->id,
+            'name' => 'HTTPS',
+            'port' => 443,
+        ]);
+    }
+}


### PR DESCRIPTION
This pull request updates the way the SSH port is handled during firewall rule creation and UFW installation, allowing for custom SSH ports instead of assuming the default port 22. It also adds comprehensive tests to ensure this behavior is correct. The main improvements are grouped into logic updates, template changes, and new tests.

**Firewall logic and behavior updates:**

* The SSH firewall rule now uses the server's custom SSH port if set, defaulting to 22 otherwise, in `AbstractFirewall.php`.
* The UFW installation process now passes the correct SSH port to the installation script, using the server's configured port or defaulting to 22, in `Ufw.php`.

**Template/script changes:**

* The UFW install script template (`install-ufw.blade.php`) now dynamically uses the provided SSH port instead of hardcoding port 22.

**Testing improvements:**

* Added a new test suite (`UfwInstallTest.php`) to verify that:
  - The SSH firewall rule uses a custom port if set, or 22 by default.
  - HTTP/HTTPS rules remain unchanged regardless of SSH port configuration.

Resolves #1082 