### PR TITLE
[Feat] GitHub App Provider

### DIFF
--- a/app/Actions/GithubApp/CreateGithubAppFromManifest.php
+++ b/app/Actions/GithubApp/CreateGithubAppFromManifest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Actions\GithubApp;
+
+use App\Models\GithubApp;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Validation\ValidationException;
+
+class CreateGithubAppFromManifest
+{
+    public function create(string $code): GithubApp
+    {
+        if (GithubApp::query()->exists()) {
+            throw ValidationException::withMessages([
+                'github_app' => __('A GitHub App is already configured for this instance.'),
+            ]);
+        }
+
+        $response = Http::withHeaders([
+            'Accept' => 'application/vnd.github+json',
+            'X-GitHub-Api-Version' => '2022-11-28',
+        ])->post("https://api.github.com/app-manifests/{$code}/conversions");
+
+        if (! $response->successful()) {
+            throw ValidationException::withMessages([
+                'github_app' => __('Failed to convert manifest (HTTP :status).', [
+                    'status' => $response->status(),
+                ]),
+            ]);
+        }
+
+        $data = $response->json();
+
+        $app = new GithubApp([
+            'app_id' => (int) ($data['id'] ?? 0),
+            'app_slug' => (string) ($data['slug'] ?? ''),
+            'name' => (string) ($data['name'] ?? ''),
+            'client_id' => (string) ($data['client_id'] ?? ''),
+            'client_secret' => (string) ($data['client_secret'] ?? ''),
+            'webhook_secret' => (string) ($data['webhook_secret'] ?? ''),
+            'private_key' => (string) ($data['pem'] ?? ''),
+            'html_url' => $data['html_url'] ?? null,
+        ]);
+
+        $app->save();
+
+        return $app;
+    }
+}

--- a/app/Actions/GithubApp/CreateGithubAppManually.php
+++ b/app/Actions/GithubApp/CreateGithubAppManually.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Actions\GithubApp;
+
+use App\Models\GithubApp;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+
+class CreateGithubAppManually
+{
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    public function create(array $input): GithubApp
+    {
+        if (GithubApp::query()->exists()) {
+            throw ValidationException::withMessages([
+                'github_app' => __('A GitHub App is already configured for this instance.'),
+            ]);
+        }
+
+        Validator::make($input, [
+            'app_id' => ['required', 'integer'],
+            'app_slug' => ['required', 'string', 'max:255'],
+            'name' => ['nullable', 'string', 'max:255'],
+            'client_id' => ['required', 'string', 'max:255'],
+            'client_secret' => ['required', 'string'],
+            'webhook_secret' => ['required', 'string'],
+            'private_key' => ['required', 'string'],
+            'html_url' => ['nullable', 'string', 'max:500'],
+        ])->validate();
+
+        $privateKey = trim((string) $input['private_key']);
+        if (! str_contains($privateKey, 'BEGIN') || ! str_contains($privateKey, 'PRIVATE KEY')) {
+            throw ValidationException::withMessages([
+                'private_key' => __('The private key must be a PEM-formatted RSA private key.'),
+            ]);
+        }
+
+        $resource = openssl_pkey_get_private($privateKey);
+        if ($resource === false) {
+            throw ValidationException::withMessages([
+                'private_key' => __('The private key could not be parsed.'),
+            ]);
+        }
+
+        $app = new GithubApp([
+            'app_id' => (int) $input['app_id'],
+            'app_slug' => (string) $input['app_slug'],
+            'name' => (string) ($input['name'] ?? $input['app_slug']),
+            'client_id' => (string) $input['client_id'],
+            'client_secret' => (string) $input['client_secret'],
+            'webhook_secret' => (string) $input['webhook_secret'],
+            'private_key' => $privateKey,
+            'html_url' => $input['html_url'] ?? null,
+        ]);
+
+        $app->save();
+
+        return $app;
+    }
+}

--- a/app/Actions/GithubApp/CreateGithubAppManually.php
+++ b/app/Actions/GithubApp/CreateGithubAppManually.php
@@ -69,7 +69,7 @@ class CreateGithubAppManually
 
     private function extractSlug(string $htmlUrl): ?string
     {
-        if (! preg_match('#^https?://github\.com/apps/([A-Za-z0-9._-]+)/?$#', $htmlUrl, $m)) {
+        if (! preg_match('#^https://github\.com/apps/([A-Za-z0-9._-]+)/?$#', $htmlUrl, $m)) {
             return null;
         }
 

--- a/app/Actions/GithubApp/CreateGithubAppManually.php
+++ b/app/Actions/GithubApp/CreateGithubAppManually.php
@@ -21,14 +21,21 @@ class CreateGithubAppManually
 
         Validator::make($input, [
             'app_id' => ['required', 'integer'],
-            'app_slug' => ['required', 'string', 'max:255'],
             'name' => ['nullable', 'string', 'max:255'],
             'client_id' => ['required', 'string', 'max:255'],
             'client_secret' => ['required', 'string'],
             'webhook_secret' => ['required', 'string'],
             'private_key' => ['required', 'string'],
-            'html_url' => ['nullable', 'string', 'max:500'],
+            'html_url' => ['required', 'url', 'max:500'],
         ])->validate();
+
+        $htmlUrl = rtrim((string) $input['html_url'], '/');
+        $slug = $this->extractSlug($htmlUrl);
+        if ($slug === null) {
+            throw ValidationException::withMessages([
+                'html_url' => __('The app page URL must look like https://github.com/apps/<slug>.'),
+            ]);
+        }
 
         $privateKey = trim((string) $input['private_key']);
         if (! str_contains($privateKey, 'BEGIN') || ! str_contains($privateKey, 'PRIVATE KEY')) {
@@ -46,17 +53,26 @@ class CreateGithubAppManually
 
         $app = new GithubApp([
             'app_id' => (int) $input['app_id'],
-            'app_slug' => (string) $input['app_slug'],
-            'name' => (string) ($input['name'] ?? $input['app_slug']),
+            'app_slug' => $slug,
+            'name' => (string) ($input['name'] ?? $slug),
             'client_id' => (string) $input['client_id'],
             'client_secret' => (string) $input['client_secret'],
             'webhook_secret' => (string) $input['webhook_secret'],
             'private_key' => $privateKey,
-            'html_url' => $input['html_url'] ?? null,
+            'html_url' => $htmlUrl,
         ]);
 
         $app->save();
 
         return $app;
+    }
+
+    private function extractSlug(string $htmlUrl): ?string
+    {
+        if (! preg_match('#^https?://github\.com/apps/([A-Za-z0-9._-]+)/?$#', $htmlUrl, $m)) {
+            return null;
+        }
+
+        return $m[1];
     }
 }

--- a/app/Actions/GithubApp/EditGithubAppSourceControl.php
+++ b/app/Actions/GithubApp/EditGithubAppSourceControl.php
@@ -13,7 +13,7 @@ class EditGithubAppSourceControl
     {
         $sourceControl->project_id = isset($input['global']) && $input['global']
             ? null
-            : $sourceControl->user?->currentProject?->id;
+            : $sourceControl->user->currentProject?->id;
 
         $sourceControl->save();
 

--- a/app/Actions/GithubApp/EditGithubAppSourceControl.php
+++ b/app/Actions/GithubApp/EditGithubAppSourceControl.php
@@ -1,27 +1,16 @@
 <?php
 
-namespace App\Actions\SourceControl;
+namespace App\Actions\GithubApp;
 
 use App\Models\SourceControl;
-use Illuminate\Support\Facades\Validator;
-use Illuminate\Validation\ValidationException;
 
-class EditSourceControl
+class EditGithubAppSourceControl
 {
     /**
      * @param  array<string, mixed>  $input
-     *
-     * @throws ValidationException
      */
     public function edit(SourceControl $sourceControl, array $input): SourceControl
     {
-        Validator::make($input, [
-            'name' => [
-                'required',
-            ],
-        ])->validate();
-
-        $sourceControl->profile = $input['name'];
         $sourceControl->project_id = isset($input['global']) && $input['global']
             ? null
             : $sourceControl->user?->currentProject?->id;

--- a/app/Actions/GithubApp/ImportGithubAppInstallation.php
+++ b/app/Actions/GithubApp/ImportGithubAppInstallation.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Actions\GithubApp;
+
+use App\Models\GithubApp;
+use App\Models\SourceControl;
+use App\Models\User;
+use App\SourceControlProviders\GithubApp as GithubAppProvider;
+use RuntimeException;
+
+class ImportGithubAppInstallation
+{
+    /**
+     * @param  array<string, mixed>|null  $installationData  Pre-fetched payload from GitHub
+     */
+    public function import(int $installationId, ?array $installationData = null): SourceControl
+    {
+        $app = GithubApp::current();
+        if (! $app) {
+            throw new RuntimeException('GitHub App is not configured.');
+        }
+
+        $installationData ??= $this->fetchInstallation($app, $installationId);
+
+        $account = $installationData['account'] ?? [];
+        $login = (string) ($account['login'] ?? '');
+        $accountId = (int) ($account['id'] ?? 0);
+        $accountType = (string) ($account['type'] ?? '');
+        $htmlUrl = (string) ($installationData['html_url'] ?? '');
+
+        /** @var SourceControl|null $existing */
+        $existing = SourceControl::withTrashed()
+            ->where('provider', SourceControl::PROVIDER_GITHUB_APP)
+            ->where('external_identifier', (string) $installationId)
+            ->first();
+
+        $providerData = [
+            'account_login' => $login,
+            'account_id' => $accountId,
+            'account_type' => $accountType,
+            'html_url' => $htmlUrl,
+        ];
+
+        if ($existing) {
+            $existing->fill([
+                'profile' => $login,
+                'provider_data' => $providerData,
+            ]);
+            if ($existing->trashed()) {
+                $existing->restore();
+            }
+            $existing->save();
+
+            return $existing;
+        }
+
+        $owner = User::query()->where('is_admin', true)->orderBy('id')->firstOrFail();
+
+        return SourceControl::query()->create([
+            'provider' => SourceControl::PROVIDER_GITHUB_APP,
+            'profile' => $login,
+            'user_id' => $owner->id,
+            'project_id' => null,
+            'external_identifier' => (string) $installationId,
+            'provider_data' => $providerData,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchInstallation(GithubApp $app, int $installationId): array
+    {
+        $response = GithubAppProvider::appClient($app)
+            ->get("https://api.github.com/app/installations/{$installationId}");
+
+        if (! $response->successful()) {
+            throw new RuntimeException('Failed to fetch installation (HTTP '.$response->status().')');
+        }
+
+        return $response->json();
+    }
+}

--- a/app/Actions/GithubApp/RemoveGithubApp.php
+++ b/app/Actions/GithubApp/RemoveGithubApp.php
@@ -12,6 +12,7 @@ class RemoveGithubApp
     public function remove(): void
     {
         $hasSites = SourceControl::query()
+            ->withTrashed()
             ->where('provider', SourceControl::PROVIDER_GITHUB_APP)
             ->whereHas('sites')
             ->exists();
@@ -24,6 +25,7 @@ class RemoveGithubApp
 
         DB::transaction(function (): void {
             SourceControl::query()
+                ->withTrashed()
                 ->where('provider', SourceControl::PROVIDER_GITHUB_APP)
                 ->get()
                 ->each(fn (SourceControl $sc) => $sc->forceDelete());

--- a/app/Actions/GithubApp/RemoveGithubApp.php
+++ b/app/Actions/GithubApp/RemoveGithubApp.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Actions\GithubApp;
+
+use App\Models\GithubApp;
+use App\Models\SourceControl;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class RemoveGithubApp
+{
+    public function remove(): void
+    {
+        $hasSites = SourceControl::query()
+            ->where('provider', SourceControl::PROVIDER_GITHUB_APP)
+            ->whereHas('sites')
+            ->exists();
+
+        if ($hasSites) {
+            throw ValidationException::withMessages([
+                'github_app' => __('Cannot remove the GitHub App while sites are still attached to its installations.'),
+            ]);
+        }
+
+        DB::transaction(function (): void {
+            SourceControl::query()
+                ->where('provider', SourceControl::PROVIDER_GITHUB_APP)
+                ->get()
+                ->each(fn (SourceControl $sc) => $sc->forceDelete());
+
+            GithubApp::query()->delete();
+        });
+    }
+}

--- a/app/Actions/GithubApp/SyncGithubAppInstallations.php
+++ b/app/Actions/GithubApp/SyncGithubAppInstallations.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Actions\GithubApp;
+
+use App\Models\GithubApp;
+use App\Models\SourceControl;
+use App\SourceControlProviders\GithubApp as GithubAppProvider;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+
+class SyncGithubAppInstallations
+{
+    /**
+     * @return array{added: int, removed: int, kept: int}
+     */
+    public function run(): array
+    {
+        $app = GithubApp::current();
+        if (! $app) {
+            return ['added' => 0, 'removed' => 0, 'kept' => 0];
+        }
+
+        $remote = $this->fetchAllInstallations($app);
+        $remoteIds = collect($remote)->pluck('id')->map(fn ($id): string => (string) $id)->all();
+
+        $importer = app(ImportGithubAppInstallation::class);
+        $added = 0;
+        $kept = 0;
+
+        foreach ($remote as $installation) {
+            $id = (int) ($installation['id'] ?? 0);
+            if ($id === 0) {
+                continue;
+            }
+
+            $existed = SourceControl::query()
+                ->where('provider', SourceControl::PROVIDER_GITHUB_APP)
+                ->where('external_identifier', (string) $id)
+                ->exists();
+
+            try {
+                $importer->import($id, $installation);
+                $existed ? $kept++ : $added++;
+            } catch (\Throwable $e) {
+                Log::error('Failed to import GitHub App installation', [
+                    'installation_id' => $id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        $stale = SourceControl::query()
+            ->where('provider', SourceControl::PROVIDER_GITHUB_APP)
+            ->whereNotNull('external_identifier')
+            ->when(
+                $remoteIds !== [],
+                fn ($q) => $q->whereNotIn('external_identifier', $remoteIds)
+            )
+            ->get();
+
+        $removed = 0;
+        foreach ($stale as $sourceControl) {
+            $sourceControl->delete();
+            $removed++;
+        }
+
+        return ['added' => $added, 'removed' => $removed, 'kept' => $kept];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchAllInstallations(GithubApp $app): array
+    {
+        $installations = [];
+        $page = 1;
+
+        while (true) {
+            $res = GithubAppProvider::appClient($app)->get('https://api.github.com/app/installations', [
+                'per_page' => 100,
+                'page' => $page,
+            ]);
+
+            if (! $res->successful()) {
+                throw new RuntimeException('Failed to list installations (HTTP '.$res->status().')');
+            }
+
+            $body = $res->json();
+            if (! is_array($body) || $body === []) {
+                break;
+            }
+
+            $installations = array_merge($installations, $body);
+            if (count($body) < 100) {
+                break;
+            }
+            $page++;
+            if ($page > 25) {
+                break;
+            }
+        }
+
+        return $installations;
+    }
+}

--- a/app/Actions/GithubApp/SyncGithubAppInstallations.php
+++ b/app/Actions/GithubApp/SyncGithubAppInstallations.php
@@ -5,6 +5,7 @@ namespace App\Actions\GithubApp;
 use App\Models\GithubApp;
 use App\Models\SourceControl;
 use App\SourceControlProviders\GithubApp as GithubAppProvider;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use RuntimeException;
 
@@ -60,7 +61,10 @@ class SyncGithubAppInstallations
 
         $removed = 0;
         foreach ($stale as $sourceControl) {
+            $installationId = (int) $sourceControl->external_identifier;
             $sourceControl->delete();
+            Cache::forget("github_app_token_{$installationId}");
+            Cache::forget("github_app_repos_{$installationId}");
             $removed++;
         }
 

--- a/app/Actions/SSL/GetMatchingSslCertificates.php
+++ b/app/Actions/SSL/GetMatchingSslCertificates.php
@@ -11,7 +11,7 @@ class GetMatchingSslCertificates
     /**
      * Get all server-level SSL certificates that match any of the site's hosted domains.
      *
-     * @return Collection<int, array{id: int, label: non-falsy-string, domains: array<int, string>}>
+     * @return Collection<int, array{id: int, label: string, domains: array<int, string>}>
      */
     public function get(Site $site): Collection
     {
@@ -23,7 +23,7 @@ class GetMatchingSslCertificates
     /**
      * Get all server-level SSL certificates that match a specific domain.
      *
-     * @return Collection<int, array{id: int, label: non-falsy-string, domains: array<int, string>}>
+     * @return Collection<int, array{id: int, label: string, domains: array<int, string>}>
      */
     public function forDomain(Site $site, string $domain): Collection
     {
@@ -32,7 +32,7 @@ class GetMatchingSslCertificates
 
     /**
      * @param  array<int, string>  $domains
-     * @return Collection<int, array{id: int, label: non-falsy-string, domains: array<int, string>}>
+     * @return Collection<int, array{id: int, label: string, domains: array<int, string>}>
      */
     private function filterSsls(Site $site, array $domains): Collection
     {

--- a/app/Actions/Site/UpdateSourceControl.php
+++ b/app/Actions/Site/UpdateSourceControl.php
@@ -6,8 +6,8 @@ use App\Exceptions\RepositoryNotFound;
 use App\Exceptions\RepositoryPermissionDenied;
 use App\Exceptions\SourceControlIsNotConnected;
 use App\Models\Site;
+use App\Models\SourceControl;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 
 class UpdateSourceControl
@@ -20,10 +20,7 @@ class UpdateSourceControl
     public function update(Site $site, array $input): void
     {
         Validator::make($input, [
-            'source_control' => [
-                'required',
-                Rule::exists('source_controls', 'id'),
-            ],
+            'source_control' => SourceControl::siteValidationRules(),
         ])->validate();
 
         $site->source_control_id = $input['source_control'];

--- a/app/Actions/SourceControl/ConnectSourceControl.php
+++ b/app/Actions/SourceControl/ConnectSourceControl.php
@@ -54,13 +54,18 @@ class ConnectSourceControl
 
     private function validate(array $input): void
     {
+        $connectableProviders = collect(config('source-control.providers'))
+            ->filter(fn (array $config): bool => (bool) ($config['connectable'] ?? true))
+            ->keys()
+            ->all();
+
         $rules = [
             'name' => [
                 'required',
             ],
             'provider' => [
                 'required',
-                Rule::in(array_keys(config('source-control.providers'))),
+                Rule::in($connectableProviders),
             ],
         ];
 

--- a/app/Actions/SourceControl/DeleteSourceControl.php
+++ b/app/Actions/SourceControl/DeleteSourceControl.php
@@ -9,6 +9,12 @@ class DeleteSourceControl
 {
     public function delete(SourceControl $sourceControl): void
     {
+        if ($sourceControl->isGithubApp()) {
+            throw ValidationException::withMessages([
+                'source_control' => __('GitHub App source controls cannot be deleted from Vito. Uninstall the app on GitHub instead.'),
+            ]);
+        }
+
         if ($sourceControl->sites()->exists()) {
             throw ValidationException::withMessages([
                 'source_control' => __('This source control is being used by a site.'),

--- a/app/Actions/SourceControl/EditSourceControl.php
+++ b/app/Actions/SourceControl/EditSourceControl.php
@@ -24,7 +24,7 @@ class EditSourceControl
         $sourceControl->profile = $input['name'];
         $sourceControl->project_id = isset($input['global']) && $input['global']
             ? null
-            : $sourceControl->user?->currentProject?->id;
+            : $sourceControl->user->currentProject?->id;
 
         $sourceControl->save();
 

--- a/app/Console/Commands/SyncGithubAppInstallationsCommand.php
+++ b/app/Console/Commands/SyncGithubAppInstallationsCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\GithubApp\SyncGithubAppInstallations;
+use App\Models\GithubApp;
+use Illuminate\Console\Command;
+
+class SyncGithubAppInstallationsCommand extends Command
+{
+    protected $signature = 'github-app:sync';
+
+    protected $description = 'Reconcile local GitHub App SourceControls with installations on GitHub.';
+
+    public function handle(SyncGithubAppInstallations $action): int
+    {
+        if (! GithubApp::query()->exists()) {
+            $this->info('GitHub App not configured. Nothing to sync.');
+
+            return self::SUCCESS;
+        }
+
+        $result = $action->run();
+
+        $this->info(sprintf(
+            'Sync complete. Added: %d, removed: %d, kept: %d.',
+            $result['added'],
+            $result['removed'],
+            $result['kept']
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -22,6 +22,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('domains:check-pending')->everyFiveMinutes();
         $schedule->command('ssl:renew-wildcards')->daily();
         $schedule->command('ssl:check-expiry')->daily();
+        $schedule->command('github-app:sync')->cron('0 */4 * * *');
     }
 
     /**

--- a/app/Http/Controllers/API/GithubAppWebhookController.php
+++ b/app/Http/Controllers/API/GithubAppWebhookController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Actions\GithubApp\ImportGithubAppInstallation;
+use App\Http\Controllers\Controller;
+use App\Models\GithubApp;
+use App\Models\SourceControl;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Spatie\RouteAttributes\Attributes\Post;
+use Throwable;
+
+class GithubAppWebhookController extends Controller
+{
+    #[Post('api/webhooks/github-app', name: 'api.webhooks.github-app')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $app = GithubApp::current();
+        if (! $app) {
+            abort(404);
+        }
+
+        $signature = (string) $request->header('X-Hub-Signature-256', '');
+        $raw = $request->getContent();
+
+        if (! $this->verifySignature($raw, $signature, $app->webhook_secret)) {
+            abort(401);
+        }
+
+        $event = (string) $request->header('X-GitHub-Event', '');
+        $payload = $request->json()->all();
+        $action = (string) ($payload['action'] ?? '');
+
+        try {
+            match ($event) {
+                'installation' => $this->handleInstallation($action, $payload),
+                'installation_repositories' => $this->bustRepoCache((int) ($payload['installation']['id'] ?? 0)),
+                default => null,
+            };
+        } catch (Throwable $e) {
+            Log::error('GitHub App webhook handling failed', [
+                'event' => $event,
+                'action' => $action,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return response()->json(['ok' => true]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function handleInstallation(string $action, array $payload): void
+    {
+        $installationId = (int) ($payload['installation']['id'] ?? 0);
+        if ($installationId === 0) {
+            return;
+        }
+
+        match ($action) {
+            'created', 'unsuspend', 'new_permissions_accepted' => app(ImportGithubAppInstallation::class)
+                ->import($installationId, $payload['installation'] ?? null),
+            'deleted', 'suspend' => $this->deleteInstallation($installationId),
+            default => null,
+        };
+
+        $this->bustRepoCache($installationId);
+    }
+
+    private function deleteInstallation(int $installationId): void
+    {
+        SourceControl::query()
+            ->where('provider', SourceControl::PROVIDER_GITHUB_APP)
+            ->where('external_identifier', (string) $installationId)
+            ->get()
+            ->each(fn (SourceControl $sc) => $sc->delete());
+
+        Cache::forget("github_app_token_{$installationId}");
+        $this->bustRepoCache($installationId);
+    }
+
+    private function bustRepoCache(int $installationId): void
+    {
+        if ($installationId === 0) {
+            return;
+        }
+
+        Cache::forget("github_app_repos_{$installationId}");
+    }
+
+    private function verifySignature(string $raw, string $signature, string $secret): bool
+    {
+        if ($signature === '' || ! str_starts_with($signature, 'sha256=')) {
+            return false;
+        }
+
+        $expected = 'sha256='.hash_hmac('sha256', $raw, $secret);
+
+        return hash_equals($expected, $signature);
+    }
+}

--- a/app/Http/Controllers/API/SourceControlController.php
+++ b/app/Http/Controllers/API/SourceControlController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API;
 
 use App\Actions\SourceControl\ConnectSourceControl;
 use App\Actions\SourceControl\DeleteSourceControl;
+use App\Actions\GithubApp\EditGithubAppSourceControl;
 use App\Actions\SourceControl\EditSourceControl;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\SourceControlResource;
@@ -75,7 +76,9 @@ class SourceControlController extends Controller
 
         $this->validateRoute($project, $sourceControl);
 
-        $sourceControl = app(EditSourceControl::class)->edit($sourceControl, $request->all());
+        $sourceControl = $sourceControl->isGithubApp()
+            ? app(EditGithubAppSourceControl::class)->edit($sourceControl, $request->all())
+            : app(EditSourceControl::class)->edit($sourceControl, $request->all());
 
         return new SourceControlResource($sourceControl);
     }

--- a/app/Http/Controllers/API/SourceControlController.php
+++ b/app/Http/Controllers/API/SourceControlController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\API;
 
+use App\Actions\GithubApp\EditGithubAppSourceControl;
 use App\Actions\SourceControl\ConnectSourceControl;
 use App\Actions\SourceControl\DeleteSourceControl;
-use App\Actions\GithubApp\EditGithubAppSourceControl;
 use App\Actions\SourceControl\EditSourceControl;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\SourceControlResource;

--- a/app/Http/Controllers/Admin/GithubAppController.php
+++ b/app/Http/Controllers/Admin/GithubAppController.php
@@ -168,6 +168,8 @@ class GithubAppController extends Controller
             ],
             'redirect_url' => route('github-app.manifest-callback'),
             'callback_urls' => [route('github-app.install-callback')],
+            'setup_url' => route('github-app.install-callback'),
+            'setup_on_update' => true,
             'public' => true,
             'default_permissions' => [
                 'contents' => 'read',
@@ -191,6 +193,7 @@ class GithubAppController extends Controller
             || str_ends_with($host, '.local')
             || str_starts_with($host, '127.')
             || str_starts_with($host, '192.168.')
-            || str_starts_with($host, '10.');
+            || str_starts_with($host, '10.')
+            || preg_match('/^172\.(1[6-9]|2[0-9]|3[01])\./', $host) === 1;
     }
 }

--- a/app/Http/Controllers/Admin/GithubAppController.php
+++ b/app/Http/Controllers/Admin/GithubAppController.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Actions\GithubApp\CreateGithubAppFromManifest;
+use App\Actions\GithubApp\CreateGithubAppManually;
+use App\Actions\GithubApp\ImportGithubAppInstallation;
+use App\Actions\GithubApp\RemoveGithubApp;
+use App\Actions\GithubApp\SyncGithubAppInstallations;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\SourceControlResource;
+use App\Models\GithubApp;
+use App\Models\SourceControl;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
+use Spatie\RouteAttributes\Attributes\Delete;
+use Spatie\RouteAttributes\Attributes\Get;
+use Spatie\RouteAttributes\Attributes\Middleware;
+use Spatie\RouteAttributes\Attributes\Post;
+use Spatie\RouteAttributes\Attributes\Prefix;
+
+#[Prefix('admin/github-app')]
+#[Middleware(['auth', 'must-be-admin'])]
+class GithubAppController extends Controller
+{
+    #[Get('/', name: 'github-app')]
+    public function index(Request $request): Response
+    {
+        $app = GithubApp::current();
+
+        $installations = SourceControl::query()
+            ->where('provider', SourceControl::PROVIDER_GITHUB_APP)
+            ->orderBy('profile')
+            ->get();
+
+        $manifestJson = json_encode($this->buildManifest());
+        $appUrl = rtrim((string) config('app.url'), '/');
+
+        return Inertia::render('github-app/index', [
+            'githubApp' => $app ? [
+                'app_id' => $app->app_id,
+                'app_slug' => $app->app_slug,
+                'name' => $app->name,
+                'html_url' => $app->html_url,
+                'created_at' => $app->created_at,
+            ] : null,
+            'manifest' => [
+                'manifest' => $manifestJson,
+                'submit_url' => 'https://github.com/settings/apps/new',
+            ],
+            'manualSetup' => [
+                'create_url' => 'https://github.com/settings/apps/new',
+                'webhook_url' => $appUrl.'/api/webhooks/github-app',
+                'homepage_url' => $appUrl,
+                'callback_url' => route('github-app.install-callback'),
+                'setup_url' => route('github-app.install-callback'),
+            ],
+            'installPath' => $app ? "https://github.com/apps/{$app->app_slug}/installations/new" : null,
+            'installations' => SourceControlResource::collection($installations),
+            'localUrlWarning' => $this->isLocalUrl(),
+        ]);
+    }
+
+    #[Get('/manifest-callback', name: 'github-app.manifest-callback')]
+    public function manifestCallback(Request $request, CreateGithubAppFromManifest $action): RedirectResponse
+    {
+        $code = (string) $request->query('code');
+
+        if ($code === '') {
+            return to_route('github-app')->with('error', __('GitHub did not return a manifest code.'));
+        }
+
+        try {
+            $action->create($code);
+        } catch (\Throwable $e) {
+            Log::error('GitHub App manifest conversion failed', ['error' => $e->getMessage()]);
+
+            return to_route('github-app')->with('error', __('Failed to create GitHub App: :error', ['error' => $e->getMessage()]));
+        }
+
+        return to_route('github-app')->with('success', __('GitHub App created successfully.'));
+    }
+
+    #[Post('/manual', name: 'github-app.manual')]
+    public function manual(Request $request, CreateGithubAppManually $action): RedirectResponse
+    {
+        $action->create($request->all());
+
+        return to_route('github-app')->with('success', __('GitHub App configured.'));
+    }
+
+    #[Get('/install', name: 'github-app.install')]
+    public function install(): RedirectResponse
+    {
+        $app = GithubApp::current();
+        if (! $app) {
+            return to_route('github-app')->with('error', __('GitHub App is not configured.'));
+        }
+
+        return redirect("https://github.com/apps/{$app->app_slug}/installations/new");
+    }
+
+    #[Get('/install-callback', name: 'github-app.install-callback')]
+    public function installCallback(Request $request, ImportGithubAppInstallation $action): RedirectResponse
+    {
+        $installationId = (int) $request->query('installation_id');
+        if ($installationId === 0) {
+            return to_route('source-controls')->with('error', __('Missing installation_id from GitHub.'));
+        }
+
+        $action->import($installationId);
+
+        return to_route('source-controls')->with('success', __('GitHub App installation connected.'));
+    }
+
+    #[Post('/sync', name: 'github-app.sync')]
+    public function sync(SyncGithubAppInstallations $action): RedirectResponse
+    {
+        $result = $action->run();
+
+        return to_route('github-app')->with(
+            'success',
+            __('Sync complete. :added added, :removed removed, :kept kept.', $result)
+        );
+    }
+
+    #[Delete('/', name: 'github-app.destroy')]
+    public function destroy(RemoveGithubApp $action): RedirectResponse
+    {
+        $action->remove();
+
+        return to_route('github-app')->with('success', __('GitHub App removed.'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildManifest(): array
+    {
+        $appUrl = rtrim((string) config('app.url'), '/');
+        $host = parse_url($appUrl, PHP_URL_HOST) ?: 'vito';
+
+        return [
+            'name' => "Vito ({$host})",
+            'url' => $appUrl,
+            'hook_attributes' => [
+                'url' => $appUrl.'/api/webhooks/github-app',
+            ],
+            'redirect_url' => route('github-app.manifest-callback'),
+            'callback_urls' => [route('github-app.install-callback')],
+            'public' => false,
+            'default_permissions' => [
+                'contents' => 'read',
+                'metadata' => 'read',
+            ],
+            'default_events' => [
+                'push',
+            ],
+        ];
+    }
+
+    private function isLocalUrl(): bool
+    {
+        $host = parse_url((string) config('app.url'), PHP_URL_HOST) ?: '';
+        if ($host === '') {
+            return true;
+        }
+
+        return $host === 'localhost'
+            || str_ends_with($host, '.test')
+            || str_ends_with($host, '.local')
+            || str_starts_with($host, '127.')
+            || str_starts_with($host, '192.168.')
+            || str_starts_with($host, '10.');
+    }
+}

--- a/app/Http/Controllers/Admin/GithubAppController.php
+++ b/app/Http/Controllers/Admin/GithubAppController.php
@@ -40,6 +40,8 @@ class GithubAppController extends Controller
         $manifestJson = json_encode($this->buildManifest());
         $appUrl = rtrim((string) config('app.url'), '/');
 
+        $pendingWebhookSecret = $app ? null : $this->pendingWebhookSecret($request);
+
         return Inertia::render('github-app/index', [
             'githubApp' => $app ? [
                 'app_id' => $app->app_id,
@@ -58,6 +60,7 @@ class GithubAppController extends Controller
                 'homepage_url' => $appUrl,
                 'callback_url' => route('github-app.install-callback'),
                 'setup_url' => route('github-app.install-callback'),
+                'webhook_secret' => $pendingWebhookSecret,
             ],
             'installPath' => $app ? "https://github.com/apps/{$app->app_slug}/installations/new" : null,
             'installations' => SourceControlResource::collection($installations),
@@ -90,7 +93,20 @@ class GithubAppController extends Controller
     {
         $action->create($request->all());
 
+        $request->session()->forget('github_app_pending_webhook_secret');
+
         return to_route('github-app')->with('success', __('GitHub App configured.'));
+    }
+
+    private function pendingWebhookSecret(Request $request): string
+    {
+        $secret = $request->session()->get('github_app_pending_webhook_secret');
+        if (! is_string($secret) || $secret === '') {
+            $secret = Str::random(40);
+            $request->session()->put('github_app_pending_webhook_secret', $secret);
+        }
+
+        return $secret;
     }
 
     #[Get('/install', name: 'github-app.install')]

--- a/app/Http/Controllers/Admin/GithubAppController.php
+++ b/app/Http/Controllers/Admin/GithubAppController.php
@@ -152,7 +152,7 @@ class GithubAppController extends Controller
             ],
             'redirect_url' => route('github-app.manifest-callback'),
             'callback_urls' => [route('github-app.install-callback')],
-            'public' => false,
+            'public' => true,
             'default_permissions' => [
                 'contents' => 'read',
                 'metadata' => 'read',

--- a/app/Http/Controllers/SourceControlController.php
+++ b/app/Http/Controllers/SourceControlController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\GithubApp\EditGithubAppSourceControl;
 use App\Actions\SourceControl\ConnectSourceControl;
 use App\Actions\SourceControl\DeleteSourceControl;
 use App\Actions\SourceControl\EditSourceControl;
@@ -102,7 +103,11 @@ class SourceControlController extends Controller
     {
         $this->authorize('update', $sourceControl);
 
-        app(EditSourceControl::class)->edit($sourceControl, $request->all());
+        if ($sourceControl->isGithubApp()) {
+            app(EditGithubAppSourceControl::class)->edit($sourceControl, $request->all());
+        } else {
+            app(EditSourceControl::class)->edit($sourceControl, $request->all());
+        }
 
         return back()->with('success', 'Source control updated.');
     }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -6,6 +6,7 @@ use App\Http\Resources\ProjectResource;
 use App\Http\Resources\ServerResource;
 use App\Http\Resources\SiteResource;
 use App\Http\Resources\UserResource;
+use App\Models\GithubApp;
 use App\Models\Server;
 use App\Models\Site;
 use App\Models\User;
@@ -124,6 +125,9 @@ class HandleInertiaRequests extends Middleware
                 ],
                 'dns_provider' => [
                     'providers' => config('dns-provider.providers'),
+                ],
+                'github_app' => [
+                    'installed' => GithubApp::query()->exists(),
                 ],
             ],
             'ziggy' => fn (): array => [

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,6 +12,6 @@ class VerifyCsrfToken extends Middleware
      * @var array<int, string>
      */
     protected $except = [
-        //
+        'api/webhooks/github-app',
     ];
 }

--- a/app/Http/Resources/SourceControlResource.php
+++ b/app/Http/Resources/SourceControlResource.php
@@ -14,15 +14,27 @@ class SourceControlResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        return [
+        $data = [
             'id' => $this->id,
             'project_id' => $this->project_id,
             'user_id' => $this->user_id,
             'global' => is_null($this->project_id),
             'name' => $this->profile,
             'provider' => $this->provider,
+            'external_identifier' => $this->external_identifier,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];
+
+        if ($this->isGithubApp()) {
+            $providerData = $this->provider_data ?? [];
+            $data['github_app'] = [
+                'account_login' => $providerData['account_login'] ?? null,
+                'account_type' => $providerData['account_type'] ?? null,
+                'html_url' => $providerData['html_url'] ?? null,
+            ];
+        }
+
+        return $data;
     }
 }

--- a/app/Models/GithubApp.php
+++ b/app/Models/GithubApp.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\GithubAppFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+/**
+ * @property int $app_id
+ * @property string $app_slug
+ * @property string $name
+ * @property string $client_id
+ * @property string $client_secret
+ * @property string $webhook_secret
+ * @property string $private_key
+ * @property ?string $html_url
+ */
+class GithubApp extends AbstractModel
+{
+    /** @use HasFactory<GithubAppFactory> */
+    use HasFactory;
+
+    protected $table = 'github_app';
+
+    protected $fillable = [
+        'app_id',
+        'app_slug',
+        'name',
+        'client_id',
+        'client_secret',
+        'webhook_secret',
+        'private_key',
+        'html_url',
+    ];
+
+    protected $casts = [
+        'app_id' => 'integer',
+        'client_secret' => 'encrypted',
+        'webhook_secret' => 'encrypted',
+        'private_key' => 'encrypted',
+    ];
+
+    public static function current(): ?self
+    {
+        return self::query()->first();
+    }
+}

--- a/app/Models/SourceControl.php
+++ b/app/Models/SourceControl.php
@@ -18,11 +18,14 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $access_token
  * @property ?int $project_id
  * @property int $user_id
+ * @property ?string $external_identifier
  * @property ?Project $project
  * @property User $user
  */
 class SourceControl extends AbstractModel
 {
+    public const string PROVIDER_GITHUB_APP = 'github-app';
+
     /** @use HasFactory<SourceControlFactory> */
     use HasFactory;
 
@@ -36,6 +39,7 @@ class SourceControl extends AbstractModel
         'access_token',
         'project_id',
         'user_id',
+        'external_identifier',
     ];
 
     protected $casts = [
@@ -44,6 +48,11 @@ class SourceControl extends AbstractModel
         'project_id' => 'integer',
         'user_id' => 'integer',
     ];
+
+    public function isGithubApp(): bool
+    {
+        return $this->provider === self::PROVIDER_GITHUB_APP;
+    }
 
     public function provider(): SourceControlProvider
     {

--- a/app/Models/SourceControl.php
+++ b/app/Models/SourceControl.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Validation\Rule;
 
 /**
  * @property string $provider
@@ -52,6 +53,28 @@ class SourceControl extends AbstractModel
     public function isGithubApp(): bool
     {
         return $this->provider === self::PROVIDER_GITHUB_APP;
+    }
+
+    /**
+     * Validation rules for a `source_control` site input that must reference
+     * a source control whose provider is usable for sites.
+     *
+     * @return array<int, mixed>
+     */
+    public static function siteValidationRules(): array
+    {
+        /** @var array<string, array<string, mixed>> $providers */
+        $providers = config('source-control.providers', []);
+
+        $usableProviders = array_keys(array_filter(
+            $providers,
+            fn (array $config): bool => (bool) ($config['usable_for_sites'] ?? true),
+        ));
+
+        return [
+            'required',
+            Rule::exists('source_controls', 'id')->whereIn('provider', $usableProviders),
+        ];
     }
 
     public function provider(): SourceControlProvider

--- a/app/Plugins/RegisterSourceControl.php
+++ b/app/Plugins/RegisterSourceControl.php
@@ -11,6 +11,8 @@ class RegisterSourceControl
         private string $label = '',
         private string $handler = '',
         private ?DynamicForm $form = null,
+        private bool $connectable = true,
+        private bool $usableForSites = true,
     ) {}
 
     public static function make(string $name): self
@@ -46,6 +48,20 @@ class RegisterSourceControl
         return $this;
     }
 
+    public function connectable(bool $connectable): self
+    {
+        $this->connectable = $connectable;
+
+        return $this;
+    }
+
+    public function usableForSites(bool $usableForSites): self
+    {
+        $this->usableForSites = $usableForSites;
+
+        return $this;
+    }
+
     public function register(): void
     {
         $providers = config('source-control.providers');
@@ -54,6 +70,8 @@ class RegisterSourceControl
             'label' => $this->label,
             'handler' => $this->handler,
             'form' => $this->form ? $this->form->toArray() : [],
+            'connectable' => $this->connectable,
+            'usable_for_sites' => $this->usableForSites,
         ];
 
         config(['source-control.providers' => $providers]);

--- a/app/Policies/SourceControlPolicy.php
+++ b/app/Policies/SourceControlPolicy.php
@@ -32,6 +32,10 @@ class SourceControlPolicy
 
     public function delete(User $user, SourceControl $sourceControl): bool
     {
+        if ($sourceControl->isGithubApp()) {
+            return false;
+        }
+
         return $user->id === $sourceControl->user_id;
     }
 }

--- a/app/Providers/SourceControlServiceProvider.php
+++ b/app/Providers/SourceControlServiceProvider.php
@@ -9,6 +9,7 @@ use App\SourceControlProviders\Bitbucket;
 use App\SourceControlProviders\BitbucketV2;
 use App\SourceControlProviders\Gitea;
 use App\SourceControlProviders\Github;
+use App\SourceControlProviders\GithubApp;
 use App\SourceControlProviders\Gitlab;
 use Illuminate\Support\ServiceProvider;
 
@@ -19,10 +20,21 @@ class SourceControlServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->github();
+        $this->githubApp();
         $this->gitlab();
         $this->bitbucket();
         $this->bitbucketV2();
         $this->gitea();
+    }
+
+    private function githubApp(): void
+    {
+        RegisterSourceControl::make(GithubApp::id())
+            ->label('GitHub App')
+            ->handler(GithubApp::class)
+            ->connectable(false)
+            ->usableForSites(false)
+            ->register();
     }
 
     private function github(): void

--- a/app/SiteTypes/MiseBun.php
+++ b/app/SiteTypes/MiseBun.php
@@ -7,6 +7,7 @@ use App\Actions\Worker\ManageWorker;
 use App\Exceptions\FailedToDeployGitKey;
 use App\Exceptions\SSHError;
 use App\Models\Site;
+use App\Models\SourceControl;
 use App\Models\Worker;
 use App\SSH\OS\Git;
 use Illuminate\Validation\Rule;
@@ -55,10 +56,7 @@ class MiseBun extends MiseSiteType
     public function createRules(array $input): array
     {
         return [
-            'source_control' => [
-                'required',
-                Rule::exists('source_controls', 'id'),
-            ],
+            'source_control' => SourceControl::siteValidationRules(),
             'repository' => [
                 'required',
             ],

--- a/app/SiteTypes/MiseNodeJS.php
+++ b/app/SiteTypes/MiseNodeJS.php
@@ -8,6 +8,7 @@ use App\Enums\NodePackageManager;
 use App\Exceptions\FailedToDeployGitKey;
 use App\Exceptions\SSHError;
 use App\Models\Site;
+use App\Models\SourceControl;
 use App\Models\Worker;
 use App\SSH\OS\Git;
 use Illuminate\Validation\Rule;
@@ -57,10 +58,7 @@ class MiseNodeJS extends MiseSiteType
     public function createRules(array $input): array
     {
         return [
-            'source_control' => [
-                'required',
-                Rule::exists('source_controls', 'id'),
-            ],
+            'source_control' => SourceControl::siteValidationRules(),
             'repository' => [
                 'required',
             ],

--- a/app/SiteTypes/NodeJS.php
+++ b/app/SiteTypes/NodeJS.php
@@ -7,9 +7,9 @@ use App\Actions\Worker\ManageWorker;
 use App\Exceptions\FailedToDeployGitKey;
 use App\Exceptions\SSHError;
 use App\Models\Site;
+use App\Models\SourceControl;
 use App\Models\Worker;
 use App\SSH\OS\Git;
-use Illuminate\Validation\Rule;
 
 class NodeJS extends AbstractSiteType
 {
@@ -40,10 +40,7 @@ class NodeJS extends AbstractSiteType
     public function createRules(array $input): array
     {
         return [
-            'source_control' => [
-                'required',
-                Rule::exists('source_controls', 'id'),
-            ],
+            'source_control' => SourceControl::siteValidationRules(),
             'repository' => [
                 'required',
             ],

--- a/app/SiteTypes/PHPSite.php
+++ b/app/SiteTypes/PHPSite.php
@@ -5,6 +5,7 @@ namespace App\SiteTypes;
 use App\Exceptions\FailedToDeployGitKey;
 use App\Exceptions\SSHError;
 use App\Models\Site;
+use App\Models\SourceControl;
 use App\SSH\OS\Composer;
 use App\SSH\OS\Git;
 use App\Traits\NormalizesWebDirectory;
@@ -44,10 +45,7 @@ class PHPSite extends AbstractSiteType
                 'required',
                 Rule::in($this->site->server->installedPHPVersions()),
             ],
-            'source_control' => [
-                'required',
-                Rule::exists('source_controls', 'id'),
-            ],
+            'source_control' => SourceControl::siteValidationRules(),
             'web_directory' => [
                 'nullable',
                 'string',

--- a/app/SourceControlProviders/GithubApp.php
+++ b/app/SourceControlProviders/GithubApp.php
@@ -1,0 +1,324 @@
+<?php
+
+namespace App\SourceControlProviders;
+
+use App\Exceptions\FailedToDeployGitHook;
+use App\Exceptions\FailedToDestroyGitHook;
+use App\Models\GithubApp as GithubAppModel;
+use BadMethodCallException;
+use Exception;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
+
+class GithubApp extends AbstractSourceControlProvider
+{
+    private const string API_BASE_URL = 'https://api.github.com';
+
+    private const int TOKEN_TTL = 50 * 60; // 50 minutes (GitHub installation tokens last ~60min)
+
+    private const int CACHE_TTL = 60 * 15;
+
+    private const int MAX_PER_PAGE = 100;
+
+    private const int MAX_PAGES = 25;
+
+    public static function id(): string
+    {
+        return 'github-app';
+    }
+
+    public function createRules(array $input): array
+    {
+        return [];
+    }
+
+    public function createData(array $input): array
+    {
+        return [];
+    }
+
+    public function data(): array
+    {
+        return [
+            'installation_id' => $this->sourceControl->external_identifier,
+            'account_login' => $this->sourceControl->provider_data['account_login'] ?? null,
+            'account_type' => $this->sourceControl->provider_data['account_type'] ?? null,
+            'html_url' => $this->sourceControl->provider_data['html_url'] ?? null,
+        ];
+    }
+
+    public function connect(): bool
+    {
+        try {
+            $res = $this->getClient()->get(self::API_BASE_URL.'/installation/repositories', [
+                'per_page' => 1,
+            ]);
+
+            return $res->successful();
+        } catch (Exception $e) {
+            Log::error('GitHub App connection failed', [
+                'installation_id' => $this->sourceControl->external_identifier,
+                'error' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getRepo(string $repo): mixed
+    {
+        $res = $this->getClient()->get(self::API_BASE_URL.'/repos/'.$repo);
+
+        $this->handleResponseErrors($res, $repo);
+
+        return $res->json();
+    }
+
+    public function fullRepoUrl(string $repo, string $key): string
+    {
+        throw new BadMethodCallException('fullRepoUrl is not yet implemented for the GitHub App provider.');
+    }
+
+    /**
+     * @throws FailedToDeployGitHook
+     */
+    public function deployHook(string $repo, array $events, string $secret): array
+    {
+        throw new BadMethodCallException('deployHook is not yet implemented for the GitHub App provider.');
+    }
+
+    /**
+     * @throws FailedToDestroyGitHook
+     */
+    public function destroyHook(string $repo, string $hookId): void
+    {
+        throw new BadMethodCallException('destroyHook is not yet implemented for the GitHub App provider.');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getLastCommit(string $repo, string $branch): ?array
+    {
+        $url = self::API_BASE_URL.'/repos/'.$repo.'/commits/'.$branch;
+        $res = $this->getClient()->get($url);
+        $this->handleResponseErrors($res, $repo);
+
+        $commit = $res->json();
+
+        if (isset($commit['sha'], $commit['commit'])) {
+            return [
+                'commit_id' => $commit['sha'],
+                'commit_data' => [
+                    'name' => $commit['commit']['committer']['name'] ?? null,
+                    'email' => $commit['commit']['committer']['email'] ?? null,
+                    'message' => $commit['commit']['message'] ?? null,
+                    'url' => $commit['html_url'] ?? null,
+                ],
+            ];
+        }
+
+        return null;
+    }
+
+    public function deployKey(string $title, string $repo, string $key): string
+    {
+        throw new BadMethodCallException('deployKey is not yet implemented for the GitHub App provider.');
+    }
+
+    public function deleteDeployKey(string $keyId, string $repo): void
+    {
+        throw new BadMethodCallException('deleteDeployKey is not yet implemented for the GitHub App provider.');
+    }
+
+    public function getRepos(bool $useCache = true): array
+    {
+        $installationId = $this->sourceControl->external_identifier;
+        $cacheKey = "github_app_repos_{$installationId}";
+
+        if ($useCache && Cache::has($cacheKey)) {
+            return Cache::get($cacheKey);
+        }
+
+        try {
+            $repos = $this->fetchAllPages('/installation/repositories', [
+                'per_page' => self::MAX_PER_PAGE,
+            ], wrapKey: 'repositories');
+
+            $names = $repos->pluck('full_name')->toArray();
+            Cache::put($cacheKey, $names, self::CACHE_TTL);
+
+            return $names;
+        } catch (Throwable $e) {
+            Log::error('Failed to fetch GitHub App repositories', [
+                'installation_id' => $installationId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+
+    public function getBranches(string $repo, bool $useCache = true): array
+    {
+        $installationId = $this->sourceControl->external_identifier;
+        $cacheKey = "github_app_branches_{$installationId}_".md5($repo);
+
+        if ($useCache && Cache::has($cacheKey)) {
+            return Cache::get($cacheKey);
+        }
+
+        try {
+            $branches = $this->fetchAllPages("/repos/{$repo}/branches", [
+                'per_page' => self::MAX_PER_PAGE,
+            ]);
+
+            $names = $branches->pluck('name')->toArray();
+            Cache::put($cacheKey, $names, self::CACHE_TTL);
+
+            return $names;
+        } catch (Throwable $e) {
+            Log::error('Failed to fetch GitHub App branches', [
+                'installation_id' => $installationId,
+                'repo' => $repo,
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+
+    public function installationAccessToken(): string
+    {
+        $installationId = $this->sourceControl->external_identifier;
+        if (! $installationId) {
+            throw new RuntimeException('SourceControl is missing external_identifier (installation id).');
+        }
+
+        return Cache::remember(
+            "github_app_token_{$installationId}",
+            self::TOKEN_TTL,
+            function () use ($installationId): string {
+                $app = GithubAppModel::current();
+                if (! $app) {
+                    throw new RuntimeException('GitHub App is not configured.');
+                }
+
+                $res = self::appClient($app)
+                    ->post(self::API_BASE_URL."/app/installations/{$installationId}/access_tokens");
+
+                if (! $res->successful()) {
+                    throw new RuntimeException('Failed to mint installation access token (HTTP '.$res->status().')');
+                }
+
+                $token = $res->json('token');
+                if (! is_string($token) || $token === '') {
+                    throw new RuntimeException('GitHub did not return an installation token.');
+                }
+
+                return $token;
+            }
+        );
+    }
+
+    public static function appClient(GithubAppModel $app): PendingRequest
+    {
+        return Http::withHeaders([
+            'Accept' => 'application/vnd.github+json',
+            'Authorization' => 'Bearer '.self::buildAppJwt($app),
+            'X-GitHub-Api-Version' => '2022-11-28',
+        ]);
+    }
+
+    public static function buildAppJwt(GithubAppModel $app): string
+    {
+        $now = time();
+        $header = self::base64UrlEncode((string) json_encode(['alg' => 'RS256', 'typ' => 'JWT']));
+        $payload = self::base64UrlEncode((string) json_encode([
+            'iat' => $now - 60,
+            'exp' => $now + (9 * 60),
+            'iss' => $app->app_id,
+        ]));
+
+        $signingInput = $header.'.'.$payload;
+        $signature = '';
+        $key = openssl_pkey_get_private($app->private_key);
+        if ($key === false) {
+            throw new RuntimeException('GitHub App private key could not be parsed.');
+        }
+
+        if (! openssl_sign($signingInput, $signature, $key, OPENSSL_ALGO_SHA256)) {
+            throw new RuntimeException('Failed to sign GitHub App JWT.');
+        }
+
+        return $signingInput.'.'.self::base64UrlEncode($signature);
+    }
+
+    private static function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+
+    private function getClient(): PendingRequest
+    {
+        return Http::withHeaders([
+            'Accept' => 'application/vnd.github+json',
+            'Authorization' => 'Bearer '.$this->installationAccessToken(),
+            'X-GitHub-Api-Version' => '2022-11-28',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     *
+     * @throws RequestException
+     */
+    private function fetchAllPages(string $endpoint, array $params = [], ?string $wrapKey = null): Collection
+    {
+        $allData = collect();
+        $page = 1;
+        $hasMore = true;
+
+        while ($hasMore) {
+            $params['page'] = $page;
+            $response = $this->getClient()->get(self::API_BASE_URL.$endpoint, $params);
+
+            if (! $response->successful()) {
+                throw new RequestException($response);
+            }
+
+            $body = $response->json();
+            $pageData = $wrapKey ? ($body[$wrapKey] ?? []) : $body;
+
+            if (empty($pageData)) {
+                $hasMore = false;
+            } else {
+                $allData = $allData->concat($pageData);
+
+                if (count($pageData) < $params['per_page']) {
+                    $hasMore = false;
+                }
+
+                $page++;
+            }
+
+            if ($page > self::MAX_PAGES) {
+                Log::warning('Reached pagination limit on GitHub App endpoint', [
+                    'endpoint' => $endpoint,
+                ]);
+                break;
+            }
+        }
+
+        return $allData;
+    }
+}

--- a/database/factories/GithubAppFactory.php
+++ b/database/factories/GithubAppFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\GithubApp;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<GithubApp>
+ */
+class GithubAppFactory extends Factory
+{
+    protected $model = GithubApp::class;
+
+    public function definition(): array
+    {
+        $resource = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+
+        $pem = '';
+        if ($resource !== false) {
+            openssl_pkey_export($resource, $pem);
+        }
+
+        return [
+            'app_id' => $this->faker->unique()->numberBetween(100000, 999999),
+            'app_slug' => 'vito-test-'.$this->faker->unique()->lexify('????'),
+            'name' => 'Vito Test',
+            'client_id' => 'Iv1.'.$this->faker->lexify('????????????????'),
+            'client_secret' => $this->faker->sha1,
+            'webhook_secret' => $this->faker->sha1,
+            'private_key' => $pem,
+            'html_url' => 'https://github.com/apps/vito-test',
+        ];
+    }
+}

--- a/database/factories/SourceControlFactory.php
+++ b/database/factories/SourceControlFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\SourceControl;
 use App\SourceControlProviders\Bitbucket;
 use App\SourceControlProviders\Github;
+use App\SourceControlProviders\GithubApp;
 use App\SourceControlProviders\Gitlab;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
@@ -54,5 +55,27 @@ class SourceControlFactory extends Factory
         return $this->state(fn (array $attributes): array => [
             'provider' => Bitbucket::id(),
         ]);
+    }
+
+    /**
+     * @return Factory<SourceControl>
+     */
+    public function githubApp(): Factory
+    {
+        return $this->state(function (array $attributes): array {
+            $login = $this->faker->userName;
+
+            return [
+                'provider' => GithubApp::id(),
+                'profile' => $login,
+                'external_identifier' => (string) $this->faker->unique()->numberBetween(1_000_000, 9_999_999),
+                'provider_data' => [
+                    'account_login' => $login,
+                    'account_id' => $this->faker->unique()->numberBetween(1_000_000, 9_999_999),
+                    'account_type' => 'Organization',
+                    'html_url' => 'https://github.com/organizations/'.$login.'/settings/installations/123',
+                ],
+            ];
+        });
     }
 }

--- a/database/migrations/2026_05_16_095532_create_github_app_table.php
+++ b/database/migrations/2026_05_16_095532_create_github_app_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('github_app', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('app_id');
+            $table->string('app_slug');
+            $table->string('name');
+            $table->string('client_id');
+            $table->longText('client_secret');
+            $table->longText('webhook_secret');
+            $table->longText('private_key');
+            $table->string('html_url', 500)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('github_app');
+    }
+};

--- a/database/migrations/2026_05_16_095752_add_external_identifier_to_source_controls_table.php
+++ b/database/migrations/2026_05_16_095752_add_external_identifier_to_source_controls_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('source_controls', function (Blueprint $table): void {
+            $table->string('external_identifier')->nullable();
+
+            $table->unique(
+                ['provider', 'external_identifier'],
+                'source_controls_provider_external_identifier_unique'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('source_controls', function (Blueprint $table): void {
+            $table->dropUnique('source_controls_provider_external_identifier_unique');
+            $table->dropColumn('external_identifier');
+        });
+    }
+};

--- a/public/api-docs/openapi/schemas/SourceControl.yaml
+++ b/public/api-docs/openapi/schemas/SourceControl.yaml
@@ -20,6 +20,30 @@ properties:
   provider:
     type: string
     example: 'github'
+  external_identifier:
+    type: string
+    nullable: true
+    description: 'Provider-specific external identifier (e.g. GitHub App installation ID).'
+    example: '12345678'
+  github_app:
+    type: object
+    nullable: true
+    description: 'Present only when provider is "github-app". Contains metadata about the GitHub App installation.'
+    properties:
+      account_login:
+        type: string
+        nullable: true
+        example: 'acme-org'
+      account_type:
+        type: string
+        nullable: true
+        description: 'GitHub account type, e.g. "User" or "Organization".'
+        example: 'Organization'
+      html_url:
+        type: string
+        nullable: true
+        format: uri
+        example: 'https://github.com/organizations/acme-org/settings/installations/12345678'
   created_at:
     type: string
     format: date-time

--- a/resources/js/components/copyable-field.tsx
+++ b/resources/js/components/copyable-field.tsx
@@ -4,15 +4,7 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
-export default function CopyableField({
-  value,
-  className,
-  mono = true,
-}: {
-  value: string;
-  className?: string;
-  mono?: boolean;
-}) {
+export default function CopyableField({ value, className, mono = true }: { value: string; className?: string; mono?: boolean }) {
   const [copied, setCopied] = useState(false);
 
   const copy = () => {
@@ -24,7 +16,7 @@ export default function CopyableField({
   };
 
   return (
-    <div className={cn('bg-muted/50 flex items-center gap-1 rounded-md border pl-3 pr-1 py-1', className)}>
+    <div className={cn('bg-muted/50 flex items-center gap-1 rounded-md border py-1 pr-1 pl-3', className)}>
       <span className={cn('flex-1 truncate text-xs', mono && 'font-mono')}>{value}</span>
       <Button type="button" size="icon" variant="ghost" className="h-6 w-6 shrink-0" onClick={copy} aria-label="Copy">
         {copied ? <CheckIcon className="text-success size-3.5" /> : <CopyIcon className="size-3.5" />}

--- a/resources/js/components/copyable-field.tsx
+++ b/resources/js/components/copyable-field.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { CheckIcon, CopyIcon } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export default function CopyableField({
+  value,
+  className,
+  mono = true,
+}: {
+  value: string;
+  className?: string;
+  mono?: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      toast.success('Copied to clipboard');
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <div className={cn('bg-muted/50 flex items-center gap-1 rounded-md border pl-3 pr-1 py-1', className)}>
+      <span className={cn('flex-1 truncate text-xs', mono && 'font-mono')}>{value}</span>
+      <Button type="button" size="icon" variant="ghost" className="h-6 w-6 shrink-0" onClick={copy} aria-label="Copy">
+        {copied ? <CheckIcon className="text-success size-3.5" /> : <CopyIcon className="size-3.5" />}
+      </Button>
+    </div>
+  );
+}

--- a/resources/js/layouts/admin/layout.tsx
+++ b/resources/js/layouts/admin/layout.tsx
@@ -1,5 +1,5 @@
 import { type BreadcrumbItem, type NavItem } from '@/types';
-import { PlugIcon, UsersIcon } from 'lucide-react';
+import { GithubIcon, PlugIcon, UsersIcon } from 'lucide-react';
 import { ReactNode } from 'react';
 import Layout from '@/layouts/app/layout';
 import VitoIcon from '@/icons/vito';
@@ -14,6 +14,11 @@ const sidebarNavItems: NavItem[] = [
     title: 'Plugins',
     href: route('plugins'),
     icon: PlugIcon,
+  },
+  {
+    title: 'GitHub App',
+    href: route('github-app'),
+    icon: GithubIcon,
   },
   {
     title: 'Vito Settings',

--- a/resources/js/pages/github-app/index.tsx
+++ b/resources/js/pages/github-app/index.tsx
@@ -253,6 +253,11 @@ function ManualSetupForm({ manualSetup }: { manualSetup: ManualSetup }) {
                 Where can this GitHub App be installed?: <strong>Any account</strong> (required for installing on orgs)
               </li>
             </ul>
+            <p className="text-muted-foreground pt-1 text-xs">
+              <strong>Installation</strong> and <strong>installation repositories</strong> events are delivered automatically to every GitHub App with
+              a webhook URL — they aren&apos;t in the &ldquo;Subscribe to events&rdquo; list and don&apos;t need to be selected. Vito uses these to
+              keep installed accounts and repositories in sync.
+            </p>
           </div>
 
           <p className="text-muted-foreground text-sm">

--- a/resources/js/pages/github-app/index.tsx
+++ b/resources/js/pages/github-app/index.tsx
@@ -1,0 +1,402 @@
+import AdminLayout from '@/layouts/admin/layout';
+import { Head, router, useForm, usePage } from '@inertiajs/react';
+import Container from '@/components/container';
+import Heading from '@/components/heading';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardRow } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Form, FormField, FormFields } from '@/components/ui/form';
+import InputError from '@/components/ui/input-error';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { AlertTriangleIcon, ExternalLinkIcon, GithubIcon, LoaderCircleIcon, RefreshCcwIcon, Trash2Icon } from 'lucide-react';
+import { FormEvent } from 'react';
+import { SourceControl } from '@/types/source-control';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { useState } from 'react';
+
+type GithubAppData = {
+  app_id: number;
+  app_slug: string;
+  name: string;
+  html_url: string | null;
+  created_at: string;
+};
+
+type Manifest = {
+  manifest: string;
+  submit_url: string;
+};
+
+type ManualSetup = {
+  create_url: string;
+  webhook_url: string;
+  homepage_url: string;
+  callback_url: string;
+  setup_url: string;
+};
+
+type PageProps = {
+  githubApp: GithubAppData | null;
+  manifest: Manifest;
+  manualSetup: ManualSetup;
+  installPath: string | null;
+  installations: { data: SourceControl[] };
+  localUrlWarning: boolean;
+};
+
+export default function GithubAppIndex() {
+  const page = usePage<PageProps>();
+  const { githubApp, manifest, manualSetup, installPath, installations, localUrlWarning } = page.props;
+
+  return (
+    <AdminLayout>
+      <Head title="GitHub App" />
+      <Container className="max-w-5xl">
+        <Heading
+          title="GitHub App"
+          description="Register a GitHub App for this Vito instance. Organizations install it to connect their repositories."
+        />
+
+        {localUrlWarning && (
+          <Alert>
+            <AlertTriangleIcon />
+            <AlertTitle>Vito is not publicly reachable</AlertTitle>
+            <AlertDescription>
+              Webhook events from GitHub cannot reach this instance. Installs and uninstalls will be detected on the 4-hour sync (or by clicking
+              the Sync button below).
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {!githubApp ? <CreateAppCard manifest={manifest} manualSetup={manualSetup} /> : <ConfiguredCard app={githubApp} installPath={installPath} />}
+
+        {githubApp && (
+          <Card>
+            <CardContent>
+              <div className="p-4">
+                <h3 className="text-sm font-medium">Connected installations</h3>
+                <p className="text-muted-foreground text-sm">Organizations that have installed this GitHub App.</p>
+              </div>
+              {installations.data.length === 0 ? (
+                <div className="text-muted-foreground p-4 text-sm">No installations yet. Install the app on a GitHub organization to begin.</div>
+              ) : (
+                installations.data.map((sc) => (
+                  <CardRow key={sc.id}>
+                    <div className="flex items-center gap-3">
+                      <GithubIcon className="h-4 w-4" />
+                      <span className="font-medium">{sc.github_app?.account_login || sc.name}</span>
+                      <Badge variant="outline">{sc.github_app?.account_type || 'Account'}</Badge>
+                      {sc.global ? <Badge variant="success">global</Badge> : <Badge variant="danger">project</Badge>}
+                    </div>
+                    {sc.github_app?.html_url && (
+                      <a href={sc.github_app.html_url} target="_blank" rel="noopener noreferrer">
+                        <Button variant="outline" size="sm">
+                          <ExternalLinkIcon />
+                          Manage on GitHub
+                        </Button>
+                      </a>
+                    )}
+                  </CardRow>
+                ))
+              )}
+            </CardContent>
+          </Card>
+        )}
+      </Container>
+    </AdminLayout>
+  );
+}
+
+function CreateAppCard({ manifest, manualSetup }: { manifest: Manifest; manualSetup: ManualSetup }) {
+  return (
+    <Card>
+      <CardContent>
+        <div className="space-y-4 p-4">
+          <div>
+            <h3 className="text-sm font-medium">No GitHub App configured</h3>
+            <p className="text-muted-foreground text-sm">
+              Create a GitHub App for this Vito instance. The automatic flow works when Vito is reachable on a real public domain; for local
+              development use the manual flow.
+            </p>
+          </div>
+
+          <Tabs defaultValue="automatic">
+            <TabsList>
+              <TabsTrigger value="automatic">Automatic</TabsTrigger>
+              <TabsTrigger value="manual">Manual</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="automatic" className="space-y-4 pt-4">
+              <p className="text-muted-foreground text-sm">
+                We&apos;ll send a pre-filled manifest to GitHub. GitHub creates the app, generates credentials, and redirects you back here.
+                Requires a publicly reachable hostname (not <code>.test</code> / <code>.localhost</code>).
+              </p>
+              <form method="post" action={manifest.submit_url}>
+                <input type="hidden" name="manifest" value={manifest.manifest} />
+                <Button type="submit">
+                  <GithubIcon />
+                  Create GitHub App
+                </Button>
+              </form>
+            </TabsContent>
+
+            <TabsContent value="manual" className="space-y-4 pt-4">
+              <ManualSetupForm manualSetup={manualSetup} />
+            </TabsContent>
+          </Tabs>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ManualSetupForm({ manualSetup }: { manualSetup: ManualSetup }) {
+  const form = useForm({
+    app_id: '',
+    app_slug: '',
+    name: '',
+    client_id: '',
+    client_secret: '',
+    webhook_secret: '',
+    private_key: '',
+    html_url: '',
+  });
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+    form.post(route('github-app.manual'), {
+      preserveScroll: true,
+      onSuccess: () => form.reset(),
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <Alert>
+        <AlertTitle>Step 1 — create the app on GitHub</AlertTitle>
+        <AlertDescription>
+          <div className="space-y-2">
+            <p>
+              Open{' '}
+              <a href={manualSetup.create_url} target="_blank" rel="noopener noreferrer" className="underline">
+                github.com/settings/apps/new
+              </a>{' '}
+              and fill in these fields:
+            </p>
+            <ul className="ml-5 list-disc space-y-1 text-sm">
+              <li><strong>GitHub App name:</strong> anything (e.g. Vito on your-host)</li>
+              <li><strong>Homepage URL:</strong> <code>{manualSetup.homepage_url}</code></li>
+              <li><strong>Callback URL:</strong> <code>{manualSetup.callback_url}</code></li>
+              <li><strong>Setup URL (post installation):</strong> <code>{manualSetup.setup_url}</code> — tick "Redirect on update"</li>
+              <li><strong>Webhook URL:</strong> <code>{manualSetup.webhook_url}</code> (leave Active checked)</li>
+              <li><strong>Webhook secret:</strong> generate a random string and copy it for Step 2</li>
+              <li><strong>Permissions → Repository → Contents:</strong> Read-only</li>
+              <li><strong>Permissions → Repository → Metadata:</strong> Read-only (auto-selected)</li>
+              <li><strong>Subscribe to events:</strong> Push</li>
+              <li><strong>Where can this GitHub App be installed?:</strong> "Only on this account"</li>
+            </ul>
+            <p>After creating, on the app page generate a <strong>Client secret</strong>, then a <strong>Private key</strong> (downloads as a .pem file). Note the <strong>App ID</strong> from the top of the page.</p>
+          </div>
+        </AlertDescription>
+      </Alert>
+
+      <Form id="github-app-manual" onSubmit={submit}>
+        <FormFields>
+          <div className="grid grid-cols-2 items-start gap-4">
+            <FormField>
+              <Label htmlFor="app_id">App ID</Label>
+              <Input id="app_id" type="text" inputMode="numeric" value={form.data.app_id} onChange={(e) => form.setData('app_id', e.target.value)} />
+              <InputError message={form.errors.app_id} />
+            </FormField>
+            <FormField>
+              <Label htmlFor="app_slug">App slug</Label>
+              <Input
+                id="app_slug"
+                type="text"
+                placeholder="vito-on-your-host"
+                value={form.data.app_slug}
+                onChange={(e) => form.setData('app_slug', e.target.value)}
+              />
+              <p className="text-muted-foreground text-xs">Lowercase, in the app's public URL (github.com/apps/&lt;slug&gt;).</p>
+              <InputError message={form.errors.app_slug} />
+            </FormField>
+          </div>
+          <FormField>
+            <Label htmlFor="name">Display name (optional)</Label>
+            <Input id="name" type="text" value={form.data.name} onChange={(e) => form.setData('name', e.target.value)} />
+            <InputError message={form.errors.name} />
+          </FormField>
+          <div className="grid grid-cols-2 items-start gap-4">
+            <FormField>
+              <Label htmlFor="client_id">Client ID</Label>
+              <Input id="client_id" type="text" value={form.data.client_id} onChange={(e) => form.setData('client_id', e.target.value)} />
+              <InputError message={form.errors.client_id} />
+            </FormField>
+            <FormField>
+              <Label htmlFor="client_secret">Client secret</Label>
+              <Input
+                id="client_secret"
+                type="password"
+                value={form.data.client_secret}
+                onChange={(e) => form.setData('client_secret', e.target.value)}
+              />
+              <InputError message={form.errors.client_secret} />
+            </FormField>
+          </div>
+          <FormField>
+            <Label htmlFor="webhook_secret">Webhook secret</Label>
+            <Input
+              id="webhook_secret"
+              type="password"
+              value={form.data.webhook_secret}
+              onChange={(e) => form.setData('webhook_secret', e.target.value)}
+            />
+            <InputError message={form.errors.webhook_secret} />
+          </FormField>
+          <FormField>
+            <Label htmlFor="private_key">Private key (PEM)</Label>
+            <Textarea
+              id="private_key"
+              rows={10}
+              className="font-mono text-xs"
+              placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;..."
+              value={form.data.private_key}
+              onChange={(e) => form.setData('private_key', e.target.value)}
+            />
+            <p className="text-muted-foreground text-xs">Paste the entire contents of the .pem file downloaded from GitHub.</p>
+            <InputError message={form.errors.private_key} />
+          </FormField>
+          <FormField>
+            <Label htmlFor="html_url">App page URL (optional)</Label>
+            <Input
+              id="html_url"
+              type="text"
+              placeholder="https://github.com/apps/your-slug"
+              value={form.data.html_url}
+              onChange={(e) => form.setData('html_url', e.target.value)}
+            />
+            <InputError message={form.errors.html_url} />
+          </FormField>
+          <Button type="submit" disabled={form.processing}>
+            {form.processing && <LoaderCircleIcon className="animate-spin" />}
+            Save GitHub App
+          </Button>
+        </FormFields>
+      </Form>
+    </div>
+  );
+}
+
+function ConfiguredCard({ app, installPath }: { app: GithubAppData; installPath: string | null }) {
+  return (
+    <Card>
+      <CardContent>
+        <CardRow>
+          <div>
+            <div className="font-medium">{app.name}</div>
+            <div className="text-muted-foreground text-xs">App ID {app.app_id}</div>
+          </div>
+          <div className="flex items-center gap-2">
+            {app.html_url && (
+              <a href={app.html_url} target="_blank" rel="noopener noreferrer">
+                <Button variant="outline" size="sm">
+                  <ExternalLinkIcon />
+                  Open on GitHub
+                </Button>
+              </a>
+            )}
+          </div>
+        </CardRow>
+        <Separator />
+        <CardRow>
+          <span>Install on a GitHub organization</span>
+          {installPath && (
+            <a href={route('github-app.install')}>
+              <Button>
+                <GithubIcon />
+                Install
+              </Button>
+            </a>
+          )}
+        </CardRow>
+        <Separator />
+        <CardRow>
+          <span>Sync installations from GitHub</span>
+          <SyncButton />
+        </CardRow>
+        <Separator />
+        <CardRow>
+          <span className="text-destructive">Remove GitHub App from this instance</span>
+          <RemoveButton />
+        </CardRow>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SyncButton() {
+  const form = useForm();
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+    form.post(route('github-app.sync'), {
+      preserveScroll: true,
+    });
+  };
+  return (
+    <Button type="button" variant="outline" disabled={form.processing} onClick={submit}>
+      {form.processing ? <LoaderCircleIcon className="animate-spin" /> : <RefreshCcwIcon />}
+      Sync now
+    </Button>
+  );
+}
+
+function RemoveButton() {
+  const [open, setOpen] = useState(false);
+  const submit = () => {
+    router.delete(route('github-app.destroy'), {
+      onSuccess: () => setOpen(false),
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="destructive">
+          <Trash2Icon />
+          Remove
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Remove GitHub App</DialogTitle>
+          <DialogDescription>
+            This clears the local app config. You should also delete the app on GitHub if you don&apos;t plan to reuse it. Installations with
+            attached sites cannot be removed.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button variant="destructive" onClick={submit}>
+            Remove
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/pages/github-app/index.tsx
+++ b/resources/js/pages/github-app/index.tsx
@@ -78,8 +78,8 @@ export default function GithubAppIndex() {
             <AlertTriangleIcon />
             <AlertTitle>Vito is not publicly reachable</AlertTitle>
             <AlertDescription>
-              Webhook events from GitHub cannot reach this instance. Installs and uninstalls will be detected on the 4-hour sync (or by clicking
-              the Sync button below).
+              Webhook events from GitHub cannot reach this instance. Installs and uninstalls will be detected on the 4-hour sync (or by clicking the
+              Sync button below).
             </AlertDescription>
           </Alert>
         )}
@@ -144,8 +144,8 @@ function CreateAppCard({ manifest, manualSetup }: { manifest: Manifest; manualSe
 
             <TabsContent value="automatic" className="space-y-4 pt-4">
               <p className="text-muted-foreground text-sm">
-                We&apos;ll send a pre-filled manifest to GitHub. GitHub creates the app, generates credentials, and redirects you back here.
-                Requires a publicly reachable hostname (not <code>.test</code> / <code>.localhost</code>).
+                We&apos;ll send a pre-filled manifest to GitHub. GitHub creates the app, generates credentials, and redirects you back here. Requires
+                a publicly reachable hostname (not <code>.test</code> / <code>.localhost</code>).
               </p>
               <form method="post" action={manifest.submit_url}>
                 <input type="hidden" name="manifest" value={manifest.manifest} />
@@ -169,7 +169,7 @@ function CreateAppCard({ manifest, manualSetup }: { manifest: Manifest; manualSe
 function StepHeader({ number, title, description }: { number: number; title: string; description: string }) {
   return (
     <div className="space-y-0.5">
-      <div className="text-muted-foreground text-xs font-medium uppercase tracking-wider">Step {number}</div>
+      <div className="text-muted-foreground text-xs font-medium tracking-wider uppercase">Step {number}</div>
       <h4 className="font-semibold">{title}</h4>
       <p className="text-muted-foreground text-sm">{description}</p>
     </div>
@@ -226,8 +226,8 @@ function ManualSetupForm({ manualSetup }: { manualSetup: ManualSetup }) {
           <div className="grid gap-3 sm:grid-cols-2">
             <ManualField label="Homepage URL" value={manualSetup.homepage_url} />
             <ManualField label="Callback URL" value={manualSetup.callback_url} />
-            <ManualField label="Setup URL (post installation)" value={manualSetup.setup_url} hint="Tick &quot;Redirect on update&quot;" />
-            <ManualField label="Webhook URL" value={manualSetup.webhook_url} hint="Leave &quot;Active&quot; checked" />
+            <ManualField label="Setup URL (post installation)" value={manualSetup.setup_url} hint='Tick "Redirect on update"' />
+            <ManualField label="Webhook URL" value={manualSetup.webhook_url} hint='Leave "Active" checked' />
             <div className="sm:col-span-2">
               <ManualField
                 label="Webhook secret"
@@ -238,18 +238,26 @@ function ManualSetupForm({ manualSetup }: { manualSetup: ManualSetup }) {
           </div>
 
           <div className="bg-muted/40 space-y-2 rounded-md border p-3 text-sm">
-            <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">Permissions &amp; events</div>
+            <div className="text-muted-foreground text-xs font-medium tracking-wider uppercase">Permissions &amp; events</div>
             <ul className="ml-5 list-disc space-y-1">
-              <li>Repository → Contents: <strong>Read-only</strong></li>
-              <li>Repository → Metadata: <strong>Read-only</strong> (auto-selected)</li>
-              <li>Subscribe to events: <strong>Push</strong></li>
-              <li>Where can this GitHub App be installed?: <strong>Any account</strong> (required for installing on orgs)</li>
+              <li>
+                Repository → Contents: <strong>Read-only</strong>
+              </li>
+              <li>
+                Repository → Metadata: <strong>Read-only</strong> (auto-selected)
+              </li>
+              <li>
+                Subscribe to events: <strong>Push</strong>
+              </li>
+              <li>
+                Where can this GitHub App be installed?: <strong>Any account</strong> (required for installing on orgs)
+              </li>
             </ul>
           </div>
 
           <p className="text-muted-foreground text-sm">
-            After saving, on the new app&apos;s settings page generate a <strong>Client secret</strong>, then scroll to <strong>Private keys</strong> and{' '}
-            <strong>Generate a private key</strong> (downloads as a .pem file). Note the <strong>App ID</strong> from the top of the page.
+            After saving, on the new app&apos;s settings page generate a <strong>Client secret</strong>, then scroll to <strong>Private keys</strong>{' '}
+            and <strong>Generate a private key</strong> (downloads as a .pem file). Note the <strong>App ID</strong> from the top of the page.
           </p>
         </div>
       </section>
@@ -258,18 +266,20 @@ function ManualSetupForm({ manualSetup }: { manualSetup: ManualSetup }) {
 
       {/* Step 2 */}
       <section className="space-y-4">
-        <StepHeader
-          number={2}
-          title="Paste the credentials below"
-          description="Fill in the values GitHub gave you in Step 1, then save."
-        />
+        <StepHeader number={2} title="Paste the credentials below" description="Fill in the values GitHub gave you in Step 1, then save." />
 
         <Form id="github-app-manual" onSubmit={submit}>
           <FormFields>
             <div className="grid grid-cols-2 items-start gap-4">
               <FormField>
                 <Label htmlFor="app_id">App ID</Label>
-                <Input id="app_id" type="text" inputMode="numeric" value={form.data.app_id} onChange={(e) => form.setData('app_id', e.target.value)} />
+                <Input
+                  id="app_id"
+                  type="text"
+                  inputMode="numeric"
+                  value={form.data.app_id}
+                  onChange={(e) => form.setData('app_id', e.target.value)}
+                />
                 <InputError message={form.errors.app_id} />
               </FormField>
               <FormField>
@@ -287,7 +297,9 @@ function ManualSetupForm({ manualSetup }: { manualSetup: ManualSetup }) {
                 value={form.data.html_url}
                 onChange={(e) => form.setData('html_url', e.target.value)}
               />
-              <p className="text-muted-foreground text-xs">From the address bar on the app&apos;s settings page — e.g. https://github.com/apps/vito-yourhost.</p>
+              <p className="text-muted-foreground text-xs">
+                From the address bar on the app&apos;s settings page — e.g. https://github.com/apps/vito-yourhost.
+              </p>
               <InputError message={form.errors.html_url} />
             </FormField>
             <div className="grid grid-cols-2 items-start gap-4">
@@ -315,7 +327,9 @@ function ManualSetupForm({ manualSetup }: { manualSetup: ManualSetup }) {
                 value={form.data.webhook_secret}
                 onChange={(e) => form.setData('webhook_secret', e.target.value)}
               />
-              <p className="text-muted-foreground text-xs">Pre-filled with the value from Step 1. Leave as-is unless you used something different on GitHub.</p>
+              <p className="text-muted-foreground text-xs">
+                Pre-filled with the value from Step 1. Leave as-is unless you used something different on GitHub.
+              </p>
               <InputError message={form.errors.webhook_secret} />
             </FormField>
             <FormField>
@@ -425,8 +439,8 @@ function RemoveButton() {
         <DialogHeader>
           <DialogTitle>Remove GitHub App</DialogTitle>
           <DialogDescription>
-            This clears the local app config. You should also delete the app on GitHub if you don&apos;t plan to reuse it. Installations with
-            attached sites cannot be removed.
+            This clears the local app config. You should also delete the app on GitHub if you don&apos;t plan to reuse it. Installations with attached
+            sites cannot be removed.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>

--- a/resources/js/pages/github-app/index.tsx
+++ b/resources/js/pages/github-app/index.tsx
@@ -54,7 +54,7 @@ type PageProps = {
   manifest: Manifest;
   manualSetup: ManualSetup;
   installPath: string | null;
-  installations: { data: SourceControl[] };
+  installations: SourceControl[];
   localUrlWarning: boolean;
 };
 
@@ -91,10 +91,10 @@ export default function GithubAppIndex() {
                 <h3 className="text-sm font-medium">Connected installations</h3>
                 <p className="text-muted-foreground text-sm">Organizations that have installed this GitHub App.</p>
               </div>
-              {installations.data.length === 0 ? (
+              {installations.length === 0 ? (
                 <div className="text-muted-foreground p-4 text-sm">No installations yet. Install the app on a GitHub organization to begin.</div>
               ) : (
-                installations.data.map((sc) => (
+                installations.map((sc) => (
                   <CardRow key={sc.id}>
                     <div className="flex items-center gap-3">
                       <GithubIcon className="h-4 w-4" />
@@ -207,7 +207,7 @@ function ManualSetupForm({ manualSetup }: { manualSetup: ManualSetup }) {
               <li><strong>Permissions → Repository → Contents:</strong> Read-only</li>
               <li><strong>Permissions → Repository → Metadata:</strong> Read-only (auto-selected)</li>
               <li><strong>Subscribe to events:</strong> Push</li>
-              <li><strong>Where can this GitHub App be installed?:</strong> "Only on this account"</li>
+              <li><strong>Where can this GitHub App be installed?:</strong> "Any account" — required to install on orgs you&apos;re a member of</li>
             </ul>
             <p>After creating, on the app page generate a <strong>Client secret</strong>, then a <strong>Private key</strong> (downloads as a .pem file). Note the <strong>App ID</strong> from the top of the page.</p>
           </div>

--- a/resources/js/pages/github-app/index.tsx
+++ b/resources/js/pages/github-app/index.tsx
@@ -13,6 +13,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Form, FormField, FormFields } from '@/components/ui/form';
 import InputError from '@/components/ui/input-error';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import CopyableField from '@/components/copyable-field';
 import { AlertTriangleIcon, ExternalLinkIcon, GithubIcon, LoaderCircleIcon, RefreshCcwIcon, Trash2Icon } from 'lucide-react';
 import { FormEvent } from 'react';
 import { SourceControl } from '@/types/source-control';
@@ -47,6 +48,7 @@ type ManualSetup = {
   homepage_url: string;
   callback_url: string;
   setup_url: string;
+  webhook_secret: string | null;
 };
 
 type PageProps = {
@@ -164,14 +166,33 @@ function CreateAppCard({ manifest, manualSetup }: { manifest: Manifest; manualSe
   );
 }
 
+function StepHeader({ number, title, description }: { number: number; title: string; description: string }) {
+  return (
+    <div className="space-y-0.5">
+      <div className="text-muted-foreground text-xs font-medium uppercase tracking-wider">Step {number}</div>
+      <h4 className="font-semibold">{title}</h4>
+      <p className="text-muted-foreground text-sm">{description}</p>
+    </div>
+  );
+}
+
+function ManualField({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="space-y-1">
+      <Label className="text-xs font-medium">{label}</Label>
+      <CopyableField value={value} />
+      {hint && <p className="text-muted-foreground text-xs">{hint}</p>}
+    </div>
+  );
+}
+
 function ManualSetupForm({ manualSetup }: { manualSetup: ManualSetup }) {
   const form = useForm({
     app_id: '',
-    app_slug: '',
     name: '',
     client_id: '',
     client_secret: '',
-    webhook_secret: '',
+    webhook_secret: manualSetup.webhook_secret ?? '',
     private_key: '',
     html_url: '',
   });
@@ -185,118 +206,138 @@ function ManualSetupForm({ manualSetup }: { manualSetup: ManualSetup }) {
   };
 
   return (
-    <div className="space-y-4">
-      <Alert>
-        <AlertTitle>Step 1 — create the app on GitHub</AlertTitle>
-        <AlertDescription>
-          <div className="space-y-2">
-            <p>
-              Open{' '}
-              <a href={manualSetup.create_url} target="_blank" rel="noopener noreferrer" className="underline">
-                github.com/settings/apps/new
-              </a>{' '}
-              and fill in these fields:
-            </p>
-            <ul className="ml-5 list-disc space-y-1 text-sm">
-              <li><strong>GitHub App name:</strong> anything (e.g. Vito on your-host)</li>
-              <li><strong>Homepage URL:</strong> <code>{manualSetup.homepage_url}</code></li>
-              <li><strong>Callback URL:</strong> <code>{manualSetup.callback_url}</code></li>
-              <li><strong>Setup URL (post installation):</strong> <code>{manualSetup.setup_url}</code> — tick "Redirect on update"</li>
-              <li><strong>Webhook URL:</strong> <code>{manualSetup.webhook_url}</code> (leave Active checked)</li>
-              <li><strong>Webhook secret:</strong> generate a random string and copy it for Step 2</li>
-              <li><strong>Permissions → Repository → Contents:</strong> Read-only</li>
-              <li><strong>Permissions → Repository → Metadata:</strong> Read-only (auto-selected)</li>
-              <li><strong>Subscribe to events:</strong> Push</li>
-              <li><strong>Where can this GitHub App be installed?:</strong> "Any account" — required to install on orgs you&apos;re a member of</li>
-            </ul>
-            <p>After creating, on the app page generate a <strong>Client secret</strong>, then a <strong>Private key</strong> (downloads as a .pem file). Note the <strong>App ID</strong> from the top of the page.</p>
-          </div>
-        </AlertDescription>
-      </Alert>
+    <div className="space-y-8">
+      {/* Step 1 */}
+      <section className="space-y-4">
+        <StepHeader
+          number={1}
+          title="Create the app on GitHub"
+          description="Open the link below and copy these values into the matching fields on GitHub."
+        />
 
-      <Form id="github-app-manual" onSubmit={submit}>
-        <FormFields>
-          <div className="grid grid-cols-2 items-start gap-4">
+        <div className="space-y-6">
+          <a href={manualSetup.create_url} target="_blank" rel="noopener noreferrer" className="inline-block">
+            <Button variant="outline" size="sm">
+              <ExternalLinkIcon />
+              Open GitHub App creation page
+            </Button>
+          </a>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <ManualField label="Homepage URL" value={manualSetup.homepage_url} />
+            <ManualField label="Callback URL" value={manualSetup.callback_url} />
+            <ManualField label="Setup URL (post installation)" value={manualSetup.setup_url} hint="Tick &quot;Redirect on update&quot;" />
+            <ManualField label="Webhook URL" value={manualSetup.webhook_url} hint="Leave &quot;Active&quot; checked" />
+            <div className="sm:col-span-2">
+              <ManualField
+                label="Webhook secret"
+                value={manualSetup.webhook_secret ?? ''}
+                hint="Generated for you — paste this into GitHub. The same value is pre-filled in Step 2 below."
+              />
+            </div>
+          </div>
+
+          <div className="bg-muted/40 space-y-2 rounded-md border p-3 text-sm">
+            <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">Permissions &amp; events</div>
+            <ul className="ml-5 list-disc space-y-1">
+              <li>Repository → Contents: <strong>Read-only</strong></li>
+              <li>Repository → Metadata: <strong>Read-only</strong> (auto-selected)</li>
+              <li>Subscribe to events: <strong>Push</strong></li>
+              <li>Where can this GitHub App be installed?: <strong>Any account</strong> (required for installing on orgs)</li>
+            </ul>
+          </div>
+
+          <p className="text-muted-foreground text-sm">
+            After saving, on the new app&apos;s settings page generate a <strong>Client secret</strong>, then scroll to <strong>Private keys</strong> and{' '}
+            <strong>Generate a private key</strong> (downloads as a .pem file). Note the <strong>App ID</strong> from the top of the page.
+          </p>
+        </div>
+      </section>
+
+      <Separator />
+
+      {/* Step 2 */}
+      <section className="space-y-4">
+        <StepHeader
+          number={2}
+          title="Paste the credentials below"
+          description="Fill in the values GitHub gave you in Step 1, then save."
+        />
+
+        <Form id="github-app-manual" onSubmit={submit}>
+          <FormFields>
+            <div className="grid grid-cols-2 items-start gap-4">
+              <FormField>
+                <Label htmlFor="app_id">App ID</Label>
+                <Input id="app_id" type="text" inputMode="numeric" value={form.data.app_id} onChange={(e) => form.setData('app_id', e.target.value)} />
+                <InputError message={form.errors.app_id} />
+              </FormField>
+              <FormField>
+                <Label htmlFor="name">Display name (optional)</Label>
+                <Input id="name" type="text" value={form.data.name} onChange={(e) => form.setData('name', e.target.value)} />
+                <InputError message={form.errors.name} />
+              </FormField>
+            </div>
             <FormField>
-              <Label htmlFor="app_id">App ID</Label>
-              <Input id="app_id" type="text" inputMode="numeric" value={form.data.app_id} onChange={(e) => form.setData('app_id', e.target.value)} />
-              <InputError message={form.errors.app_id} />
-            </FormField>
-            <FormField>
-              <Label htmlFor="app_slug">App slug</Label>
+              <Label htmlFor="html_url">App page URL</Label>
               <Input
-                id="app_slug"
+                id="html_url"
                 type="text"
-                placeholder="vito-on-your-host"
-                value={form.data.app_slug}
-                onChange={(e) => form.setData('app_slug', e.target.value)}
+                placeholder="https://github.com/apps/your-slug"
+                value={form.data.html_url}
+                onChange={(e) => form.setData('html_url', e.target.value)}
               />
-              <p className="text-muted-foreground text-xs">Lowercase, in the app's public URL (github.com/apps/&lt;slug&gt;).</p>
-              <InputError message={form.errors.app_slug} />
+              <p className="text-muted-foreground text-xs">From the address bar on the app&apos;s settings page — e.g. https://github.com/apps/vito-yourhost.</p>
+              <InputError message={form.errors.html_url} />
             </FormField>
-          </div>
-          <FormField>
-            <Label htmlFor="name">Display name (optional)</Label>
-            <Input id="name" type="text" value={form.data.name} onChange={(e) => form.setData('name', e.target.value)} />
-            <InputError message={form.errors.name} />
-          </FormField>
-          <div className="grid grid-cols-2 items-start gap-4">
+            <div className="grid grid-cols-2 items-start gap-4">
+              <FormField>
+                <Label htmlFor="client_id">Client ID</Label>
+                <Input id="client_id" type="text" value={form.data.client_id} onChange={(e) => form.setData('client_id', e.target.value)} />
+                <InputError message={form.errors.client_id} />
+              </FormField>
+              <FormField>
+                <Label htmlFor="client_secret">Client secret</Label>
+                <Input
+                  id="client_secret"
+                  type="password"
+                  value={form.data.client_secret}
+                  onChange={(e) => form.setData('client_secret', e.target.value)}
+                />
+                <InputError message={form.errors.client_secret} />
+              </FormField>
+            </div>
             <FormField>
-              <Label htmlFor="client_id">Client ID</Label>
-              <Input id="client_id" type="text" value={form.data.client_id} onChange={(e) => form.setData('client_id', e.target.value)} />
-              <InputError message={form.errors.client_id} />
-            </FormField>
-            <FormField>
-              <Label htmlFor="client_secret">Client secret</Label>
+              <Label htmlFor="webhook_secret">Webhook secret</Label>
               <Input
-                id="client_secret"
+                id="webhook_secret"
                 type="password"
-                value={form.data.client_secret}
-                onChange={(e) => form.setData('client_secret', e.target.value)}
+                value={form.data.webhook_secret}
+                onChange={(e) => form.setData('webhook_secret', e.target.value)}
               />
-              <InputError message={form.errors.client_secret} />
+              <p className="text-muted-foreground text-xs">Pre-filled with the value from Step 1. Leave as-is unless you used something different on GitHub.</p>
+              <InputError message={form.errors.webhook_secret} />
             </FormField>
-          </div>
-          <FormField>
-            <Label htmlFor="webhook_secret">Webhook secret</Label>
-            <Input
-              id="webhook_secret"
-              type="password"
-              value={form.data.webhook_secret}
-              onChange={(e) => form.setData('webhook_secret', e.target.value)}
-            />
-            <InputError message={form.errors.webhook_secret} />
-          </FormField>
-          <FormField>
-            <Label htmlFor="private_key">Private key (PEM)</Label>
-            <Textarea
-              id="private_key"
-              rows={10}
-              className="font-mono text-xs"
-              placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;..."
-              value={form.data.private_key}
-              onChange={(e) => form.setData('private_key', e.target.value)}
-            />
-            <p className="text-muted-foreground text-xs">Paste the entire contents of the .pem file downloaded from GitHub.</p>
-            <InputError message={form.errors.private_key} />
-          </FormField>
-          <FormField>
-            <Label htmlFor="html_url">App page URL (optional)</Label>
-            <Input
-              id="html_url"
-              type="text"
-              placeholder="https://github.com/apps/your-slug"
-              value={form.data.html_url}
-              onChange={(e) => form.setData('html_url', e.target.value)}
-            />
-            <InputError message={form.errors.html_url} />
-          </FormField>
-          <Button type="submit" disabled={form.processing}>
-            {form.processing && <LoaderCircleIcon className="animate-spin" />}
-            Save GitHub App
-          </Button>
-        </FormFields>
-      </Form>
+            <FormField>
+              <Label htmlFor="private_key">Private key (PEM)</Label>
+              <Textarea
+                id="private_key"
+                rows={10}
+                className="font-mono text-xs"
+                placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;..."
+                value={form.data.private_key}
+                onChange={(e) => form.setData('private_key', e.target.value)}
+              />
+              <p className="text-muted-foreground text-xs">Paste the entire contents of the .pem file downloaded from GitHub.</p>
+              <InputError message={form.errors.private_key} />
+            </FormField>
+            <Button type="submit" disabled={form.processing}>
+              {form.processing && <LoaderCircleIcon className="animate-spin" />}
+              Save GitHub App
+            </Button>
+          </FormFields>
+        </Form>
+      </section>
     </div>
   );
 }

--- a/resources/js/pages/source-controls/components/columns.tsx
+++ b/resources/js/pages/source-controls/components/columns.tsx
@@ -63,9 +63,7 @@ function Edit({ sourceControl }: { sourceControl: SourceControl }) {
                 disabled={isGithubApp}
                 readOnly={isGithubApp}
               />
-              {isGithubApp && (
-                <p className="text-muted-foreground text-xs">The name is the GitHub organization and cannot be changed.</p>
-              )}
+              {isGithubApp && <p className="text-muted-foreground text-xs">The name is the GitHub organization and cannot be changed.</p>}
               <InputError message={form.errors.name} />
             </FormField>
             <FormField>

--- a/resources/js/pages/source-controls/components/columns.tsx
+++ b/resources/js/pages/source-controls/components/columns.tsx
@@ -26,6 +26,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 
 function Edit({ sourceControl }: { sourceControl: SourceControl }) {
   const [open, setOpen] = useState(false);
+  const isGithubApp = sourceControl.provider === 'github-app';
   const form = useForm({
     name: sourceControl.name,
     global: sourceControl.global,
@@ -53,7 +54,18 @@ function Edit({ sourceControl }: { sourceControl: SourceControl }) {
           <FormFields>
             <FormField>
               <Label htmlFor="name">Name</Label>
-              <Input type="text" id="name" name="name" value={form.data.name} onChange={(e) => form.setData('name', e.target.value)} />
+              <Input
+                type="text"
+                id="name"
+                name="name"
+                value={form.data.name}
+                onChange={(e) => form.setData('name', e.target.value)}
+                disabled={isGithubApp}
+                readOnly={isGithubApp}
+              />
+              {isGithubApp && (
+                <p className="text-muted-foreground text-xs">The name is the GitHub organization and cannot be changed.</p>
+              )}
               <InputError message={form.errors.name} />
             </FormField>
             <FormField>
@@ -167,6 +179,7 @@ export const columns: ColumnDef<SourceControl>[] = [
     enableColumnFilter: false,
     enableSorting: false,
     cell: ({ row }) => {
+      const isGithubApp = row.original.provider === 'github-app';
       return (
         <div className="flex items-center justify-end">
           <DropdownMenu modal={false}>
@@ -178,8 +191,22 @@ export const columns: ColumnDef<SourceControl>[] = [
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <Edit sourceControl={row.original} />
-              <DropdownMenuSeparator />
-              <Delete sourceControl={row.original} />
+              {isGithubApp && row.original.github_app?.html_url && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem asChild>
+                    <a href={row.original.github_app.html_url} target="_blank" rel="noopener noreferrer">
+                      Manage permissions
+                    </a>
+                  </DropdownMenuItem>
+                </>
+              )}
+              {!isGithubApp && (
+                <>
+                  <DropdownMenuSeparator />
+                  <Delete sourceControl={row.original} />
+                </>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/resources/js/pages/source-controls/components/connect-source-control.tsx
+++ b/resources/js/pages/source-controls/components/connect-source-control.tsx
@@ -96,11 +96,13 @@ export default function ConnectSourceControl({
                 </SelectTrigger>
                 <SelectContent>
                   <SelectGroup>
-                    {Object.entries(page.props.configs.source_control.providers).map(([key, provider]) => (
-                      <SelectItem key={key} value={key}>
-                        {provider.label}
-                      </SelectItem>
-                    ))}
+                    {Object.entries(page.props.configs.source_control.providers)
+                      .filter(([, provider]) => provider.connectable !== false)
+                      .map(([key, provider]) => (
+                        <SelectItem key={key} value={key}>
+                          {provider.label}
+                        </SelectItem>
+                      ))}
                   </SelectGroup>
                 </SelectContent>
               </Select>

--- a/resources/js/pages/source-controls/index.tsx
+++ b/resources/js/pages/source-controls/index.tsx
@@ -1,5 +1,5 @@
 import SettingsLayout from '@/layouts/settings/layout';
-import { Head, Link, usePage } from '@inertiajs/react';
+import { Head, usePage } from '@inertiajs/react';
 import Container from '@/components/container';
 import Heading from '@/components/heading';
 import { Button } from '@/components/ui/button';
@@ -31,17 +31,17 @@ export default function SourceControls() {
                 <span className="hidden lg:block">Docs</span>
               </Button>
             </a>
+            {githubAppInstalled && (
+              <a href={route('github-app.install')} title="Install GitHub App on an organization">
+                <Button variant="outline" size="icon">
+                  <GithubIcon />
+                  <span className="sr-only">Install GitHub App on an organization</span>
+                </Button>
+              </a>
+            )}
             <ConnectSourceControl>
               <Button>Connect</Button>
             </ConnectSourceControl>
-            {githubAppInstalled && (
-              <Link href={route('github-app.install')}>
-                <Button variant="outline">
-                  <GithubIcon />
-                  <span className="hidden lg:block">+ Github Org</span>
-                </Button>
-              </Link>
-            )}
           </div>
         </div>
         <DataTable columns={columns} paginatedData={page.props.sourceControls} />

--- a/resources/js/pages/source-controls/index.tsx
+++ b/resources/js/pages/source-controls/index.tsx
@@ -1,5 +1,5 @@
 import SettingsLayout from '@/layouts/settings/layout';
-import { Head, usePage } from '@inertiajs/react';
+import { Head, Link, usePage } from '@inertiajs/react';
 import Container from '@/components/container';
 import Heading from '@/components/heading';
 import { Button } from '@/components/ui/button';
@@ -7,16 +7,16 @@ import ConnectSourceControl from '@/pages/source-controls/components/connect-sou
 import { DataTable } from '@/components/data-table';
 import { columns } from '@/pages/source-controls/components/columns';
 import { SourceControl } from '@/types/source-control';
-import { Configs, PaginatedData } from '@/types';
-import { BookOpenIcon } from 'lucide-react';
+import { PaginatedData, SharedData } from '@/types';
+import { BookOpenIcon, GithubIcon } from 'lucide-react';
 
-type Page = {
+type Page = SharedData & {
   sourceControls: PaginatedData<SourceControl>;
-  configs: Configs;
 };
 
 export default function SourceControls() {
   const page = usePage<Page>();
+  const githubAppInstalled = page.props.configs.github_app.installed;
 
   return (
     <SettingsLayout>
@@ -34,6 +34,14 @@ export default function SourceControls() {
             <ConnectSourceControl>
               <Button>Connect</Button>
             </ConnectSourceControl>
+            {githubAppInstalled && (
+              <Link href={route('github-app.install')}>
+                <Button variant="outline">
+                  <GithubIcon />
+                  <span className="hidden lg:block">+ Github Org</span>
+                </Button>
+              </Link>
+            )}
           </div>
         </div>
         <DataTable columns={columns} paginatedData={page.props.sourceControls} />

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -66,6 +66,8 @@ export interface Configs {
         label: string;
         handler: string;
         form?: DynamicFieldConfig[];
+        connectable?: boolean;
+        usable_for_sites?: boolean;
       };
     };
   };
@@ -105,6 +107,9 @@ export interface Configs {
     types: {
       [type: string]: SiteType;
     };
+  };
+  github_app: {
+    installed: boolean;
   };
 
   [key: string]: unknown;

--- a/resources/js/types/source-control.d.ts
+++ b/resources/js/types/source-control.d.ts
@@ -1,9 +1,17 @@
+export interface GithubAppDetails {
+  account_login: string | null;
+  account_type: string | null;
+  html_url: string | null;
+}
+
 export interface SourceControl {
   id: number;
   project_id?: number;
   global: boolean;
   name: string;
   provider: string;
+  external_identifier?: string | null;
+  github_app?: GithubAppDetails;
   created_at: string;
   updated_at: string;
 

--- a/tests/Feature/GithubAppTest.php
+++ b/tests/Feature/GithubAppTest.php
@@ -91,7 +91,6 @@ class GithubAppTest extends TestCase
         $this->actingAs($this->admin)
             ->post(route('github-app.manual'), [
                 'app_id' => 5555,
-                'app_slug' => 'manual-vito',
                 'name' => 'Manual Vito',
                 'client_id' => 'Iv1.manualclient',
                 'client_secret' => 'manualsecret',
@@ -107,16 +106,32 @@ class GithubAppTest extends TestCase
         ]);
     }
 
+    public function test_manual_creation_rejects_invalid_html_url(): void
+    {
+        $pem = $this->generatePrivateKey();
+
+        $this->actingAs($this->admin)
+            ->post(route('github-app.manual'), [
+                'app_id' => 5555,
+                'client_id' => 'x',
+                'client_secret' => 'x',
+                'webhook_secret' => 'x',
+                'private_key' => $pem,
+                'html_url' => 'https://example.com/not-an-app-url',
+            ])
+            ->assertSessionHasErrors('html_url');
+    }
+
     public function test_manual_creation_rejects_bad_private_key(): void
     {
         $this->actingAs($this->admin)
             ->post(route('github-app.manual'), [
                 'app_id' => 5555,
-                'app_slug' => 'manual-vito',
                 'client_id' => 'x',
                 'client_secret' => 'x',
                 'webhook_secret' => 'x',
                 'private_key' => 'not-a-key',
+                'html_url' => 'https://github.com/apps/manual-vito',
             ])
             ->assertSessionHasErrors('private_key');
     }

--- a/tests/Feature/GithubAppTest.php
+++ b/tests/Feature/GithubAppTest.php
@@ -1,0 +1,345 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\GithubApp;
+use App\Models\SourceControl;
+use App\Models\User;
+use App\SourceControlProviders\GithubApp as GithubAppProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class GithubAppTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['is_admin' => true]);
+        $this->admin->ensureHasDefaultProject();
+    }
+
+    public function test_non_admin_cannot_access_settings_page(): void
+    {
+        $nonAdmin = User::factory()->create(['is_admin' => false]);
+        $nonAdmin->ensureHasDefaultProject();
+
+        $this->actingAs($nonAdmin)
+            ->get(route('github-app'))
+            ->assertNotFound();
+    }
+
+    public function test_admin_can_view_settings_page_when_no_app(): void
+    {
+        $this->actingAs($this->admin)
+            ->get(route('github-app'))
+            ->assertOk();
+    }
+
+    public function test_admin_can_view_settings_page_when_app_exists(): void
+    {
+        GithubApp::factory()->create();
+
+        $this->actingAs($this->admin)
+            ->get(route('github-app'))
+            ->assertOk();
+    }
+
+    public function test_manifest_callback_creates_app(): void
+    {
+        Http::fake([
+            'api.github.com/app-manifests/test-code/conversions' => Http::response([
+                'id' => 12345,
+                'slug' => 'vito-test',
+                'name' => 'Vito Test',
+                'client_id' => 'Iv1.abc',
+                'client_secret' => 'secret',
+                'webhook_secret' => 'whsecret',
+                'pem' => $this->generatePrivateKey(),
+                'html_url' => 'https://github.com/apps/vito-test',
+            ], 201),
+        ]);
+
+        $this->actingAs($this->admin)
+            ->get(route('github-app.manifest-callback', ['code' => 'test-code']))
+            ->assertRedirect(route('github-app'));
+
+        $this->assertDatabaseHas('github_app', [
+            'app_id' => 12345,
+            'app_slug' => 'vito-test',
+        ]);
+    }
+
+    public function test_manifest_callback_rejects_missing_code(): void
+    {
+        $this->actingAs($this->admin)
+            ->get(route('github-app.manifest-callback'))
+            ->assertRedirect(route('github-app'));
+
+        $this->assertDatabaseMissing('github_app', ['app_slug' => 'vito-test']);
+    }
+
+    public function test_manual_creation_persists_app(): void
+    {
+        $pem = $this->generatePrivateKey();
+
+        $this->actingAs($this->admin)
+            ->post(route('github-app.manual'), [
+                'app_id' => 5555,
+                'app_slug' => 'manual-vito',
+                'name' => 'Manual Vito',
+                'client_id' => 'Iv1.manualclient',
+                'client_secret' => 'manualsecret',
+                'webhook_secret' => 'manualwhsecret',
+                'private_key' => $pem,
+                'html_url' => 'https://github.com/apps/manual-vito',
+            ])
+            ->assertRedirect(route('github-app'));
+
+        $this->assertDatabaseHas('github_app', [
+            'app_id' => 5555,
+            'app_slug' => 'manual-vito',
+        ]);
+    }
+
+    public function test_manual_creation_rejects_bad_private_key(): void
+    {
+        $this->actingAs($this->admin)
+            ->post(route('github-app.manual'), [
+                'app_id' => 5555,
+                'app_slug' => 'manual-vito',
+                'client_id' => 'x',
+                'client_secret' => 'x',
+                'webhook_secret' => 'x',
+                'private_key' => 'not-a-key',
+            ])
+            ->assertSessionHasErrors('private_key');
+    }
+
+    public function test_install_callback_creates_source_control(): void
+    {
+        $app = GithubApp::factory()->create();
+
+        Http::fake([
+            'api.github.com/app/installations/999' => Http::response([
+                'id' => 999,
+                'html_url' => 'https://github.com/organizations/acme/settings/installations/999',
+                'account' => [
+                    'id' => 555,
+                    'login' => 'acme',
+                    'type' => 'Organization',
+                ],
+            ], 200),
+        ]);
+
+        $this->actingAs($this->admin)
+            ->get(route('github-app.install-callback', ['installation_id' => 999]))
+            ->assertRedirect(route('source-controls'));
+
+        $this->assertDatabaseHas('source_controls', [
+            'provider' => SourceControl::PROVIDER_GITHUB_APP,
+            'external_identifier' => '999',
+            'profile' => 'acme',
+        ]);
+
+        unset($app);
+    }
+
+    public function test_install_callback_restores_soft_deleted_installation(): void
+    {
+        GithubApp::factory()->create();
+
+        $existing = SourceControl::factory()->githubApp()->create([
+            'external_identifier' => '777',
+            'user_id' => $this->admin->id,
+        ]);
+        $existing->delete();
+        $this->assertSoftDeleted($existing);
+
+        Http::fake([
+            'api.github.com/app/installations/777' => Http::response([
+                'id' => 777,
+                'html_url' => 'https://github.com/organizations/acme/settings/installations/777',
+                'account' => ['id' => 1, 'login' => 'acme', 'type' => 'Organization'],
+            ], 200),
+        ]);
+
+        $this->actingAs($this->admin)
+            ->get(route('github-app.install-callback', ['installation_id' => 777]))
+            ->assertRedirect(route('source-controls'));
+
+        $existing->refresh();
+        $this->assertNull($existing->deleted_at);
+    }
+
+    public function test_sync_removes_missing_installations_and_imports_new(): void
+    {
+        GithubApp::factory()->create();
+
+        $kept = SourceControl::factory()->githubApp()->create([
+            'external_identifier' => '111',
+            'user_id' => $this->admin->id,
+        ]);
+        $stale = SourceControl::factory()->githubApp()->create([
+            'external_identifier' => '222',
+            'user_id' => $this->admin->id,
+        ]);
+
+        Http::fake([
+            'api.github.com/app/installations*' => Http::response([
+                [
+                    'id' => 111,
+                    'html_url' => 'https://github.com/x',
+                    'account' => ['id' => 11, 'login' => 'kept-org', 'type' => 'Organization'],
+                ],
+                [
+                    'id' => 333,
+                    'html_url' => 'https://github.com/y',
+                    'account' => ['id' => 33, 'login' => 'new-org', 'type' => 'Organization'],
+                ],
+            ], 200),
+        ]);
+
+        $this->actingAs($this->admin)
+            ->post(route('github-app.sync'))
+            ->assertRedirect(route('github-app'));
+
+        $this->assertNotSoftDeleted($kept);
+        $this->assertSoftDeleted($stale);
+        $this->assertDatabaseHas('source_controls', [
+            'provider' => SourceControl::PROVIDER_GITHUB_APP,
+            'external_identifier' => '333',
+            'profile' => 'new-org',
+        ]);
+    }
+
+    public function test_cannot_manually_create_source_control_with_github_app_provider(): void
+    {
+        $this->actingAs($this->user)
+            ->from(route('source-controls'))
+            ->post(route('source-controls.store'), [
+                'name' => 'fake',
+                'provider' => SourceControl::PROVIDER_GITHUB_APP,
+            ])
+            ->assertSessionHasErrors('provider');
+    }
+
+    public function test_cannot_delete_github_app_source_control(): void
+    {
+        GithubApp::factory()->create();
+        $sc = SourceControl::factory()->githubApp()->create([
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->actingAs($this->user)
+            ->delete(route('source-controls.destroy', $sc->id))
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('source_controls', ['id' => $sc->id, 'deleted_at' => null]);
+    }
+
+    public function test_cannot_rename_github_app_source_control(): void
+    {
+        GithubApp::factory()->create();
+        $sc = SourceControl::factory()->githubApp()->create([
+            'user_id' => $this->user->id,
+            'profile' => 'acme',
+        ]);
+
+        $this->actingAs($this->user)
+            ->patch(route('source-controls.update', $sc->id), [
+                'name' => 'changed',
+                'global' => true,
+            ])
+            ->assertRedirect();
+
+        $sc->refresh();
+        $this->assertSame('acme', $sc->profile);
+        $this->assertNull($sc->project_id);
+    }
+
+    public function test_webhook_rejects_bad_signature(): void
+    {
+        GithubApp::factory()->create();
+
+        $this->postJson('/api/webhooks/github-app', ['action' => 'deleted'])
+            ->assertStatus(401);
+    }
+
+    public function test_webhook_handles_installation_deleted(): void
+    {
+        $app = GithubApp::factory()->create();
+        $sc = SourceControl::factory()->githubApp()->create([
+            'external_identifier' => '444',
+            'user_id' => $this->admin->id,
+        ]);
+
+        $payload = json_encode([
+            'action' => 'deleted',
+            'installation' => ['id' => 444],
+        ]);
+
+        $sig = 'sha256='.hash_hmac('sha256', $payload, $app->webhook_secret);
+
+        $this->call('POST', '/api/webhooks/github-app', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_HUB_SIGNATURE_256' => $sig,
+            'HTTP_X_GITHUB_EVENT' => 'installation',
+        ], $payload)->assertOk();
+
+        $this->assertSoftDeleted($sc);
+    }
+
+    public function test_webhook_handles_installation_created(): void
+    {
+        $app = GithubApp::factory()->create();
+
+        $payload = json_encode([
+            'action' => 'created',
+            'installation' => [
+                'id' => 888,
+                'html_url' => 'https://github.com/x',
+                'account' => ['id' => 1, 'login' => 'new-acme', 'type' => 'Organization'],
+            ],
+        ]);
+
+        $sig = 'sha256='.hash_hmac('sha256', $payload, $app->webhook_secret);
+
+        $this->call('POST', '/api/webhooks/github-app', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_HUB_SIGNATURE_256' => $sig,
+            'HTTP_X_GITHUB_EVENT' => 'installation',
+        ], $payload)->assertOk();
+
+        $this->assertDatabaseHas('source_controls', [
+            'provider' => SourceControl::PROVIDER_GITHUB_APP,
+            'external_identifier' => '888',
+            'profile' => 'new-acme',
+        ]);
+    }
+
+    public function test_provider_throws_for_unimplemented_methods(): void
+    {
+        $sc = SourceControl::factory()->githubApp()->create([
+            'user_id' => $this->admin->id,
+        ]);
+        $provider = new GithubAppProvider($sc);
+
+        $this->expectException(\BadMethodCallException::class);
+        $provider->deployKey('t', 'r', 'k');
+    }
+
+    private function generatePrivateKey(): string
+    {
+        $res = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+        $pem = '';
+        openssl_pkey_export($res, $pem);
+
+        return $pem;
+    }
+}

--- a/tests/Feature/GithubAppTest.php
+++ b/tests/Feature/GithubAppTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\GithubApp;
 use App\Models\SourceControl;
 use App\Models\User;
+use App\SiteTypes\Laravel;
 use App\SourceControlProviders\GithubApp as GithubAppProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
@@ -276,6 +277,80 @@ class GithubAppTest extends TestCase
         $sc->refresh();
         $this->assertSame('acme', $sc->profile);
         $this->assertNull($sc->project_id);
+    }
+
+    public function test_cannot_create_site_with_github_app_source_control(): void
+    {
+        GithubApp::factory()->create();
+        $sc = SourceControl::factory()->githubApp()->create([
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->actingAs($this->user)
+            ->post(route('sites.store', ['server' => $this->server]), [
+                'type' => Laravel::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'repository' => 'test/test',
+                'branch' => 'main',
+                'composer' => true,
+                'user' => 'example',
+                'source_control' => $sc->id,
+            ])
+            ->assertSessionHasErrors('source_control');
+    }
+
+    public function test_cannot_update_site_to_use_github_app_source_control(): void
+    {
+        GithubApp::factory()->create();
+        $sc = SourceControl::factory()->githubApp()->create([
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->actingAs($this->user)
+            ->patch(route('site-settings.update-source-control', ['server' => $this->server, 'site' => $this->site]), [
+                'source_control' => $sc->id,
+            ])
+            ->assertSessionHasErrors('source_control');
+    }
+
+    public function test_cannot_remove_github_app_when_trashed_source_control_still_has_sites(): void
+    {
+        GithubApp::factory()->create();
+
+        $sc = SourceControl::factory()->githubApp()->create([
+            'user_id' => $this->admin->id,
+            'external_identifier' => '999',
+        ]);
+        $this->site->update(['source_control_id' => $sc->id]);
+        $sc->delete();
+
+        $this->actingAs($this->admin)
+            ->from(route('github-app'))
+            ->delete(route('github-app.destroy'))
+            ->assertSessionHasErrors('github_app');
+
+        $this->assertDatabaseCount('github_app', 1);
+        $this->assertDatabaseHas('source_controls', ['id' => $sc->id]);
+    }
+
+    public function test_remove_github_app_force_deletes_trashed_source_controls(): void
+    {
+        GithubApp::factory()->create();
+
+        $sc = SourceControl::factory()->githubApp()->create([
+            'user_id' => $this->admin->id,
+            'external_identifier' => '888',
+        ]);
+        $sc->delete();
+
+        $this->actingAs($this->admin)
+            ->delete(route('github-app.destroy'))
+            ->assertRedirect(route('github-app'));
+
+        $this->assertDatabaseMissing('source_controls', ['id' => $sc->id]);
+        $this->assertDatabaseCount('github_app', 0);
     }
 
     public function test_webhook_rejects_bad_signature(): void


### PR DESCRIPTION
### DISCLAIMER

This is NOT the complete functionality.   In order to keep PRs smaller, this PR ONLY handles the registration of a GitHub app within Vito, and manages installs as Source Control records - while the listing of repos and branches DOES work, this PR does NOT include deployments (which are planned to use short-lived tokens, instead of deployment keys), as this will be another major refactor, which will come as part of a separate PR. 

### Overview

This pull request introduces comprehensive support for managing GitHub App-based source control integrations. It adds new actions for creating, editing, importing, syncing, and removing GitHub App installations, as well as a webhook controller for handling GitHub App events. The update also includes improvements to validation, command-line tools, and scheduled syncing to ensure local state remains consistent with GitHub.

**GitHub App integration and management:**

* Added `CreateGithubAppFromManifest` and `CreateGithubAppManually` actions for registering a GitHub App via manifest or manual input, with validation and error handling. 
* Added `ImportGithubAppInstallation` action to import a GitHub App installation as a `SourceControl` entry, including logic to update or restore existing records.
* Added `RemoveGithubApp` action to safely remove a GitHub App and its associated source controls, ensuring no sites are attached.
* Added `EditGithubAppSourceControl` action for editing the project association of a GitHub App source control.

**Synchronization and automation:**

* Added `SyncGithubAppInstallations` action and command (`SyncGithubAppInstallationsCommand`) to reconcile local installations with those on GitHub, tracking added, removed, and kept installations. Scheduled this sync to run every 4 hours via the console kernel.

**Webhook handling:**

* Introduced `GithubAppWebhookController` to handle GitHub App webhook events, including installation creation, deletion, suspension, and repository changes, with signature verification and error logging.

**Source control API and validation improvements:**

* Updated `SourceControlController` to delegate editing to the appropriate action based on whether the source control is a GitHub App.
* Improved validation so only connectable providers can be selected when connecting a new source control.
* Prevented deletion of GitHub App source controls from within the application, directing users to uninstall via GitHub instead.
* Made project association logic in editing actions more robust for nullable users.

### UI

* Introduces a new Admin section for registering the GitHub application against your instance of vito.
  * Supports automatic registration, where vito handles the registration, setting of permissions, downloading of secrets, etc. however, this requires webhook functionality, and will therefore only work when vito is publically accessible to the internet. 
  * Supports manual registration, where the user is guided through the process of creating the app manually in order to register it, this is suitable for non-public or local installations of vito, however, as per the previous PAT implementation, webhook functionality won't work.

| Automatic Registration |
|-|
| <img width="1059" height="519" alt="CleanShot 2026-05-16 at 13 02 10" src="https://github.com/user-attachments/assets/e1b52e55-895f-416d-a44a-f31c39f1fdac" /> |

| Manual Registration |
|-|
| <img width="1052" height="1723" alt="CleanShot 2026-05-16 at 13 06 37" src="https://github.com/user-attachments/assets/46d088a7-ccc4-453d-8f66-bb988606ed8b" /> |

