### PR TITLE
[Feat] Basic HTTP Auth for Sites

### DIFF
--- a/app/Actions/SSL/GetMatchingSslCertificates.php
+++ b/app/Actions/SSL/GetMatchingSslCertificates.php
@@ -11,7 +11,7 @@ class GetMatchingSslCertificates
     /**
      * Get all server-level SSL certificates that match any of the site's hosted domains.
      *
-     * @return Collection<int, array{id: int, label: string, domains: array<int, string>}>
+     * @return Collection<int, array{id: int, label: non-falsy-string, domains: array<int, string>}>
      */
     public function get(Site $site): Collection
     {
@@ -23,7 +23,7 @@ class GetMatchingSslCertificates
     /**
      * Get all server-level SSL certificates that match a specific domain.
      *
-     * @return Collection<int, array{id: int, label: string, domains: array<int, string>}>
+     * @return Collection<int, array{id: int, label: non-falsy-string, domains: array<int, string>}>
      */
     public function forDomain(Site $site, string $domain): Collection
     {
@@ -32,7 +32,7 @@ class GetMatchingSslCertificates
 
     /**
      * @param  array<int, string>  $domains
-     * @return Collection<int, array{id: int, label: string, domains: array<int, string>}>
+     * @return Collection<int, array{id: int, label: non-falsy-string, domains: array<int, string>}>
      */
     private function filterSsls(Site $site, array $domains): Collection
     {

--- a/app/Actions/SSL/GetMatchingSslCertificates.php
+++ b/app/Actions/SSL/GetMatchingSslCertificates.php
@@ -11,7 +11,7 @@ class GetMatchingSslCertificates
     /**
      * Get all server-level SSL certificates that match any of the site's hosted domains.
      *
-     * @return Collection<int, array{id: int, label: non-falsy-string, domains: array<int, string>}>
+     * @return Collection<int, array{id: int, label: string, domains: array<int, string>}>
      */
     public function get(Site $site): Collection
     {
@@ -23,7 +23,7 @@ class GetMatchingSslCertificates
     /**
      * Get all server-level SSL certificates that match a specific domain.
      *
-     * @return Collection<int, array{id: int, label: non-falsy-string, domains: array<int, string>}>
+     * @return Collection<int, array{id: int, label: string, domains: array<int, string>}>
      */
     public function forDomain(Site $site, string $domain): Collection
     {
@@ -32,7 +32,7 @@ class GetMatchingSslCertificates
 
     /**
      * @param  array<int, string>  $domains
-     * @return Collection<int, array{id: int, label: non-falsy-string, domains: array<int, string>}>
+     * @return Collection<int, array{id: int, label: string, domains: array<int, string>}>
      */
     private function filterSsls(Site $site, array $domains): Collection
     {

--- a/app/Actions/Site/UpdateBasicAuth.php
+++ b/app/Actions/Site/UpdateBasicAuth.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Actions\Site;
+
+use App\Helpers\Apr1Hasher;
+use App\Models\Site;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+
+class UpdateBasicAuth
+{
+    private const NGINX_AUTH_DIR = '/etc/nginx/auth';
+
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    public function update(Site $site, array $input): void
+    {
+        $input = $this->normaliseInput($input);
+        $this->validate($site, $input);
+
+        $existing = collect($site->type_data['basic_auth']['users'] ?? [])->keyBy('username');
+
+        $users = collect($input['users'] ?? [])
+            ->map(function (array $u) use ($existing): ?array {
+                $username = trim((string) ($u['username'] ?? ''));
+                $plain = (string) ($u['password'] ?? '');
+
+                if ($plain !== '') {
+                    return [
+                        'username' => $username,
+                        'apr1' => Apr1Hasher::hash($plain),
+                        'bcrypt' => password_hash($plain, PASSWORD_BCRYPT),
+                    ];
+                }
+
+                $prev = $existing->get($username);
+                if (! $prev) {
+                    return null;
+                }
+
+                return [
+                    'username' => $username,
+                    'apr1' => $prev['apr1'] ?? null,
+                    'bcrypt' => $prev['bcrypt'] ?? null,
+                ];
+            })
+            ->filter(fn (?array $u) => $u !== null && ! empty($u['apr1']) && ! empty($u['bcrypt']))
+            ->values()
+            ->all();
+
+        $enabled = (bool) ($input['enabled'] ?? false) && count($users) > 0;
+
+        DB::transaction(function () use ($site, $enabled, $users): void {
+            $typeData = $site->type_data ?? [];
+            $typeData['basic_auth'] = [
+                'enabled' => $enabled,
+                'users' => $users,
+            ];
+            $site->update(['type_data' => $typeData]);
+        });
+
+        $this->writeAuthFile($site, $enabled ? $users : []);
+        $site->webserver()->updateVHost($site);
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @return array<string, mixed>
+     */
+    private function normaliseInput(array $input): array
+    {
+        $input['enabled'] = filter_var($input['enabled'] ?? false, FILTER_VALIDATE_BOOLEAN);
+        $input['users'] = array_values($input['users'] ?? []);
+
+        return $input;
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    private function validate(Site $site, array $input): void
+    {
+        Validator::make($input, [
+            'enabled' => ['nullable', 'boolean'],
+            'users' => ['array'],
+            'users.*.username' => ['required', 'string', 'max:64', 'regex:/^[A-Za-z0-9._-]+$/', 'distinct'],
+            'users.*.password' => ['nullable', 'string', 'min:1', 'max:255'],
+        ])->validate();
+
+        $existing = collect($site->type_data['basic_auth']['users'] ?? [])->keyBy('username');
+        $errors = [];
+        foreach ($input['users'] as $index => $u) {
+            $username = trim((string) ($u['username'] ?? ''));
+            $plain = (string) ($u['password'] ?? '');
+            $hasExisting = $existing->has($username) && ! empty($existing[$username]['apr1']);
+            if ($plain === '' && ! $hasExisting) {
+                $errors["users.$index.password"] = 'Password is required for new users.';
+            }
+        }
+
+        if ($errors !== []) {
+            throw ValidationException::withMessages($errors);
+        }
+    }
+
+    /**
+     * @param  array<int, array<string, string>>  $users
+     */
+    private function writeAuthFile(Site $site, array $users): void
+    {
+        if ($site->webserver()::id() !== 'nginx') {
+            return;
+        }
+
+        $path = $site->htpasswdPath();
+
+        if (empty($users)) {
+            $site->server->ssh()->exec(
+                view('ssh.services.webserver.nginx.remove-basic-auth-file', ['path' => $path]),
+                'remove-basic-auth-file',
+                $site->id,
+            );
+
+            return;
+        }
+
+        $lines = array_map(fn (array $u) => $u['username'].':'.$u['apr1']."\n", $users);
+        $usernames = implode(', ', array_map(fn (array $u) => $u['username'], $users));
+
+        $site->server->ssh()->exec(
+            view('ssh.services.webserver.nginx.write-basic-auth-file', [
+                'dir' => self::NGINX_AUTH_DIR,
+                'path' => $path,
+                'lines' => $lines,
+                'userCount' => count($users),
+                'usernames' => $usernames,
+            ]),
+            'write-basic-auth-file',
+            $site->id,
+        );
+    }
+}

--- a/app/Actions/Site/UpdateBasicAuth.php
+++ b/app/Actions/Site/UpdateBasicAuth.php
@@ -4,6 +4,7 @@ namespace App\Actions\Site;
 
 use App\Helpers\Apr1Hasher;
 use App\Models\Site;
+use App\Services\Webserver\Nginx;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
@@ -72,7 +73,7 @@ class UpdateBasicAuth
     private function normaliseInput(array $input): array
     {
         $input['enabled'] = filter_var($input['enabled'] ?? false, FILTER_VALIDATE_BOOLEAN);
-        $input['users'] = array_values($input['users'] ?? []);
+        $input['users'] = is_array($input['users'] ?? null) ? array_values($input['users']) : [];
 
         return $input;
     }
@@ -86,7 +87,7 @@ class UpdateBasicAuth
             'enabled' => ['nullable', 'boolean'],
             'users' => ['array'],
             'users.*.username' => ['required', 'string', 'max:64', 'regex:/^[A-Za-z0-9._-]+$/', 'distinct'],
-            'users.*.password' => ['nullable', 'string', 'min:1', 'max:255'],
+            'users.*.password' => ['nullable', 'string', 'max:255'],
         ])->validate();
 
         $existing = collect($site->type_data['basic_auth']['users'] ?? [])->keyBy('username');
@@ -110,7 +111,7 @@ class UpdateBasicAuth
      */
     private function writeAuthFile(Site $site, array $users): void
     {
-        if ($site->webserver()::id() !== 'nginx') {
+        if ($site->webserver()::id() !== Nginx::id()) {
             return;
         }
 
@@ -136,6 +137,7 @@ class UpdateBasicAuth
                 'lines' => $lines,
                 'userCount' => count($users),
                 'usernames' => $usernames,
+                'nginxUser' => $site->server->getSshUser(),
             ]),
             'write-basic-auth-file',
             $site->id,

--- a/app/Actions/Webserver/AbstractGenerateConfig.php
+++ b/app/Actions/Webserver/AbstractGenerateConfig.php
@@ -195,6 +195,9 @@ abstract class AbstractGenerateConfig
         $isOctane = (bool) data_get($site->type_data, 'octane', false);
         $isPhp = ($siteTypeData['is_php'] ?? false) && ! $isOctane;
 
+        $basicAuth = $site->type_data['basic_auth'] ?? [];
+        $basicAuthEnabled = ! empty($basicAuth['enabled']) && ! empty($basicAuth['users']);
+
         return [
             ...$siteTypeData,
             ...$this->buildLoadBalancerData($site),
@@ -209,6 +212,10 @@ abstract class AbstractGenerateConfig
             'port' => $site->port,
             'redirects' => $this->buildRedirects($site),
             'type_data' => $site->type_data ?? [],
+            'basic_auth_enabled' => $basicAuthEnabled,
+            'basic_auth_realm' => $site->domain,
+            'basic_auth_file' => $site->htpasswdPath(),
+            'basic_auth_users' => $basicAuthEnabled ? array_values($basicAuth['users']) : [],
         ];
     }
 
@@ -232,6 +239,10 @@ abstract class AbstractGenerateConfig
             $block['php_socket'] = $data['php_socket'];
             $block['port'] = $data['port'];
             $block['redirects'] = $data['redirects'];
+            $block['basic_auth_enabled'] = $data['basic_auth_enabled'];
+            $block['basic_auth_realm'] = $data['basic_auth_realm'];
+            $block['basic_auth_file'] = $data['basic_auth_file'];
+            $block['basic_auth_users'] = $data['basic_auth_users'];
             $block = $this->enrichServerBlock($block, $data);
         }
 

--- a/app/Actions/Webserver/AbstractGenerateConfig.php
+++ b/app/Actions/Webserver/AbstractGenerateConfig.php
@@ -195,7 +195,7 @@ abstract class AbstractGenerateConfig
         $isOctane = (bool) data_get($site->type_data, 'octane', false);
         $isPhp = ($siteTypeData['is_php'] ?? false) && ! $isOctane;
 
-        $basicAuth = $site->type_data['basic_auth'] ?? [];
+        $basicAuth = data_get($site->type_data, 'basic_auth', []);
         $basicAuthEnabled = ! empty($basicAuth['enabled']) && ! empty($basicAuth['users']);
 
         return [

--- a/app/Helpers/Apr1Hasher.php
+++ b/app/Helpers/Apr1Hasher.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Helpers;
+
+/**
+ * Generates Apache APR1 ($apr1$) password hashes, the format expected by
+ * nginx's `auth_basic_user_file` directive. Pure PHP — no apache2-utils
+ * dependency required on the target server.
+ */
+class Apr1Hasher
+{
+    private const ALPHABET = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+    public static function hash(string $password, ?string $salt = null): string
+    {
+        $salt = self::sanitiseSalt($salt ?? self::randomSalt());
+
+        $bin = pack('H*', md5($password.$salt.$password));
+
+        $text = $password.'$apr1$'.$salt;
+        $passwordLen = strlen($password);
+        for ($i = $passwordLen; $i > 0; $i -= 16) {
+            $text .= substr($bin, 0, min(16, $i));
+        }
+        for ($i = $passwordLen; $i > 0; $i >>= 1) {
+            $text .= ($i & 1) ? "\0" : $password[0];
+        }
+        $bin = pack('H*', md5($text));
+
+        for ($n = 0; $n < 1000; $n++) {
+            $tmp = ($n & 1) ? $password : $bin;
+            if ($n % 3) {
+                $tmp .= $salt;
+            }
+            if ($n % 7) {
+                $tmp .= $password;
+            }
+            $tmp .= ($n & 1) ? $bin : $password;
+            $bin = pack('H*', md5($tmp));
+        }
+
+        return '$apr1$'.$salt.'$'.self::encode($bin);
+    }
+
+    private static function randomSalt(): string
+    {
+        return substr(str_replace(['+', '/', '='], '.', base64_encode(random_bytes(6))), 0, 8);
+    }
+
+    private static function sanitiseSalt(string $salt): string
+    {
+        $salt = preg_replace('/[^A-Za-z0-9.\/]/', '.', $salt) ?? '';
+
+        return substr(str_pad($salt, 8, '.'), 0, 8);
+    }
+
+    private static function encode(string $bin): string
+    {
+        $out = '';
+        $triplets = [[0, 6, 12], [1, 7, 13], [2, 8, 14], [3, 9, 15], [4, 10, 5]];
+
+        foreach ($triplets as [$a, $b, $c]) {
+            $v = (ord($bin[$a]) << 16) | (ord($bin[$b]) << 8) | ord($bin[$c]);
+            for ($i = 0; $i < 4; $i++) {
+                $out .= self::ALPHABET[$v & 0x3F];
+                $v >>= 6;
+            }
+        }
+
+        $v = ord($bin[11]);
+        for ($i = 0; $i < 2; $i++) {
+            $out .= self::ALPHABET[$v & 0x3F];
+            $v >>= 6;
+        }
+
+        return $out;
+    }
+}

--- a/app/Http/Controllers/SiteSettingController.php
+++ b/app/Http/Controllers/SiteSettingController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Actions\Site\DeleteSite;
 use App\Actions\Site\PreviewVhost;
+use App\Actions\Site\UpdateBasicAuth;
 use App\Actions\Site\UpdateBranch;
 use App\Actions\Site\UpdatePHPVersion;
 use App\Actions\Site\UpdateSourceControl;
@@ -154,6 +155,19 @@ class SiteSettingController extends Controller
         $site->webserver()->updateVHost($site);
 
         return back()->with('success', 'VHost template reset to default.');
+    }
+
+    /**
+     * @throws SSHError
+     */
+    #[Patch('/basic-auth', name: 'site-settings.update-basic-auth')]
+    public function updateBasicAuth(Request $request, Server $server, Site $site): RedirectResponse
+    {
+        $this->authorize('update', [$site, $server]);
+
+        app(UpdateBasicAuth::class)->update($site, $request->input());
+
+        return back()->with('success', 'Basic auth settings updated successfully.');
     }
 
     #[Patch('/vhost-generation', name: 'site-settings.update-vhost-generation')]

--- a/app/Http/Resources/SiteResource.php
+++ b/app/Http/Resources/SiteResource.php
@@ -24,10 +24,10 @@ class SiteResource extends JsonResource
             'type' => $this->type,
             'type_data' => $this->sanitisedTypeData(),
             'basic_auth' => [
-                'enabled' => (bool) ($this->type_data['basic_auth']['enabled'] ?? false),
+                'enabled' => (bool) data_get($this->type_data, 'basic_auth.enabled', false),
                 'users' => array_map(
                     fn (array $u) => ['username' => $u['username'] ?? ''],
-                    array_values($this->type_data['basic_auth']['users'] ?? [])
+                    array_values(data_get($this->type_data, 'basic_auth.users', []))
                 ),
             ],
             'domain' => $this->domain,

--- a/app/Http/Resources/SiteResource.php
+++ b/app/Http/Resources/SiteResource.php
@@ -22,7 +22,14 @@ class SiteResource extends JsonResource
             'server' => new ServerResource($this->whenLoaded('server')),
             'source_control_id' => $this->source_control_id,
             'type' => $this->type,
-            'type_data' => $this->type_data,
+            'type_data' => $this->sanitisedTypeData(),
+            'basic_auth' => [
+                'enabled' => (bool) ($this->type_data['basic_auth']['enabled'] ?? false),
+                'users' => array_map(
+                    fn (array $u) => ['username' => $u['username'] ?? ''],
+                    array_values($this->type_data['basic_auth']['users'] ?? [])
+                ),
+            ],
             'domain' => $this->domain,
             'web_directory' => $this->web_directory,
             'webserver' => $this->webserver()->id(),
@@ -50,6 +57,25 @@ class SiteResource extends JsonResource
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];
+    }
+
+    /**
+     * Strip basic-auth password hashes from type_data before sending to the client.
+     *
+     * @return array<string, mixed>
+     */
+    private function sanitisedTypeData(): array
+    {
+        $typeData = $this->type_data ?? [];
+
+        if (isset($typeData['basic_auth']['users']) && is_array($typeData['basic_auth']['users'])) {
+            $typeData['basic_auth']['users'] = array_map(
+                fn (array $u) => ['username' => $u['username'] ?? ''],
+                $typeData['basic_auth']['users']
+            );
+        }
+
+        return $typeData;
     }
 
     /**

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -567,6 +567,11 @@ class Site extends AbstractModel
         return preg_replace('#/current$#', '', $this->path);
     }
 
+    public function htpasswdPath(): string
+    {
+        return '/etc/nginx/auth/site-'.$this->id.'.htpasswd';
+    }
+
     public function getDeployKeyName(): string
     {
         return $this->domain.'-key-'.$this->id;

--- a/app/Services/Webserver/Nginx.php
+++ b/app/Services/Webserver/Nginx.php
@@ -164,6 +164,11 @@ class Nginx extends AbstractWebserver
     public function deleteSite(Site $site): void
     {
         $this->service->server->ssh()->exec(
+            'sudo rm -f '.$site->htpasswdPath(),
+            'remove-basic-auth-file',
+            $site->id
+        );
+        $this->service->server->ssh()->exec(
             view('ssh.services.webserver.nginx.delete-site', [
                 'domain' => $site->domain,
                 'path' => $site->basePath(),

--- a/app/Services/Webserver/Nginx.php
+++ b/app/Services/Webserver/Nginx.php
@@ -164,7 +164,9 @@ class Nginx extends AbstractWebserver
     public function deleteSite(Site $site): void
     {
         $this->service->server->ssh()->exec(
-            'sudo rm -f '.$site->htpasswdPath(),
+            view('ssh.services.webserver.nginx.remove-basic-auth-file', [
+                'path' => $site->htpasswdPath(),
+            ]),
             'remove-basic-auth-file',
             $site->id
         );

--- a/resources/js/pages/site-settings/components/basic-auth.tsx
+++ b/resources/js/pages/site-settings/components/basic-auth.tsx
@@ -1,0 +1,154 @@
+import { FormEvent, ReactNode, useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useForm } from '@inertiajs/react';
+import { Form, FormField, FormFields } from '@/components/ui/form';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
+import InputError from '@/components/ui/input-error';
+import { Switch } from '@/components/ui/switch';
+import { LoaderCircleIcon, PlusIcon, TrashIcon } from 'lucide-react';
+import { Site } from '@/types/site';
+
+type FormUser = { username: string; password: string; existing: boolean };
+
+export default function BasicAuth({ site, children }: { site: Site; children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  const initialUsers = (): FormUser[] => (site.basic_auth?.users ?? []).map((u) => ({ username: u.username, password: '', existing: true }));
+
+  const form = useForm<{
+    enabled: boolean;
+    users: FormUser[];
+  }>({
+    enabled: !!site.basic_auth?.enabled,
+    users: initialUsers(),
+  });
+
+  useEffect(() => {
+    if (open) {
+      form.setData({
+        enabled: !!site.basic_auth?.enabled,
+        users: initialUsers(),
+      });
+      form.clearErrors();
+    }
+     
+  }, [open]);
+
+  const setUser = (index: number, patch: Partial<FormUser>) => {
+    const next = form.data.users.map((u, i) => (i === index ? { ...u, ...patch } : u));
+    form.setData('users', next);
+  };
+
+  const addUser = () => {
+    form.setData('users', [...form.data.users, { username: '', password: '', existing: false }]);
+  };
+
+  const removeUser = (index: number) => {
+    const next = form.data.users.filter((_, i) => i !== index);
+    form.setData('users', next.length === 0 ? [] : next);
+    if (next.length === 0) {
+      form.setData('enabled', false);
+    }
+  };
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+    form.transform((data) => ({
+      enabled: data.enabled,
+      users: data.users.map(({ username, password }) => ({ username, password })),
+    }));
+    form.patch(route('site-settings.update-basic-auth', { server: site.server_id, site: site.id }), {
+      preserveScroll: true,
+      onSuccess: () => setOpen(false),
+    });
+  };
+
+  const hasUsers = form.data.users.length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Basic Auth</DialogTitle>
+          <DialogDescription>Protect this site with HTTP Basic Authentication.</DialogDescription>
+        </DialogHeader>
+
+        <Form id="basic-auth-form" onSubmit={submit} className="p-4">
+          <FormFields>
+            <FormField>
+              <div className="flex items-center justify-between gap-4">
+                <div className="space-y-1">
+                  <Label htmlFor="basic-auth-enabled">Enable Basic Auth</Label>
+                  <p className="text-muted-foreground text-sm">
+                    {hasUsers ? 'Require credentials to access the site.' : 'Add at least one user to enable.'}
+                  </p>
+                </div>
+                <Switch
+                  id="basic-auth-enabled"
+                  checked={form.data.enabled && hasUsers}
+                  disabled={!hasUsers}
+                  onCheckedChange={(v) => form.setData('enabled', v)}
+                />
+              </div>
+              <InputError message={form.errors.enabled} />
+            </FormField>
+
+            <FormField>
+              <Label>Users</Label>
+              <div className="space-y-2">
+                {form.data.users.length === 0 && <p className="text-muted-foreground text-sm">No users yet. Add a user to start using basic auth.</p>}
+                {form.data.users.map((u, i) => (
+                  <div key={i} className="flex items-start gap-2">
+                    <div className="flex-1">
+                      <Input placeholder="username" value={u.username} onChange={(e) => setUser(i, { username: e.target.value })} />
+                      <InputError message={(form.errors as Record<string, string>)[`users.${i}.username`]} />
+                    </div>
+                    <div className="flex-1">
+                      <PasswordInput
+                        placeholder={u.existing ? 'Leave blank to keep current' : 'password'}
+                        value={u.password}
+                        onChange={(e) => setUser(i, { password: e.target.value })}
+                      />
+                      <InputError message={(form.errors as Record<string, string>)[`users.${i}.password`]} />
+                    </div>
+                    <Button type="button" variant="outline" size="icon" onClick={() => removeUser(i)}>
+                      <TrashIcon className="size-4" />
+                    </Button>
+                  </div>
+                ))}
+                <Button type="button" variant="outline" size="sm" onClick={addUser}>
+                  <PlusIcon className="size-4" />
+                  Add user
+                </Button>
+              </div>
+              <InputError message={form.errors.users} />
+            </FormField>
+          </FormFields>
+        </Form>
+
+        <DialogFooter className="gap-2">
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button form="basic-auth-form" disabled={form.processing}>
+            {form.processing && <LoaderCircleIcon className="size-4 animate-spin" />}
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/pages/site-settings/components/basic-auth.tsx
+++ b/resources/js/pages/site-settings/components/basic-auth.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, ReactNode, useEffect, useState } from 'react';
+import { FormEvent, ReactNode, useState } from 'react';
 import {
   Dialog,
   DialogClose,
@@ -20,12 +20,15 @@ import { Switch } from '@/components/ui/switch';
 import { LoaderCircleIcon, PlusIcon, TrashIcon } from 'lucide-react';
 import { Site } from '@/types/site';
 
-type FormUser = { username: string; password: string; existing: boolean };
+type FormUser = { id: string; username: string; password: string; existing: boolean };
+
+const rowId = (): string => (typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : Math.random().toString(36).slice(2));
 
 export default function BasicAuth({ site, children }: { site: Site; children: ReactNode }) {
   const [open, setOpen] = useState(false);
 
-  const initialUsers = (): FormUser[] => (site.basic_auth?.users ?? []).map((u) => ({ username: u.username, password: '', existing: true }));
+  const initialUsers = (): FormUser[] =>
+    (site.basic_auth?.users ?? []).map((u) => ({ id: rowId(), username: u.username, password: '', existing: true }));
 
   const form = useForm<{
     enabled: boolean;
@@ -35,16 +38,16 @@ export default function BasicAuth({ site, children }: { site: Site; children: Re
     users: initialUsers(),
   });
 
-  useEffect(() => {
-    if (open) {
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
       form.setData({
         enabled: !!site.basic_auth?.enabled,
         users: initialUsers(),
       });
       form.clearErrors();
     }
-     
-  }, [open]);
+    setOpen(next);
+  };
 
   const setUser = (index: number, patch: Partial<FormUser>) => {
     const next = form.data.users.map((u, i) => (i === index ? { ...u, ...patch } : u));
@@ -52,7 +55,7 @@ export default function BasicAuth({ site, children }: { site: Site; children: Re
   };
 
   const addUser = () => {
-    form.setData('users', [...form.data.users, { username: '', password: '', existing: false }]);
+    form.setData('users', [...form.data.users, { id: rowId(), username: '', password: '', existing: false }]);
   };
 
   const removeUser = (index: number) => {
@@ -78,7 +81,7 @@ export default function BasicAuth({ site, children }: { site: Site; children: Re
   const hasUsers = form.data.users.length > 0;
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent>
         <DialogHeader>
@@ -111,7 +114,7 @@ export default function BasicAuth({ site, children }: { site: Site; children: Re
               <div className="space-y-2">
                 {form.data.users.length === 0 && <p className="text-muted-foreground text-sm">No users yet. Add a user to start using basic auth.</p>}
                 {form.data.users.map((u, i) => (
-                  <div key={i} className="flex items-start gap-2">
+                  <div key={u.id} className="flex items-start gap-2">
                     <div className="flex-1">
                       <Input placeholder="username" value={u.username} onChange={(e) => setUser(i, { username: e.target.value })} />
                       <InputError message={(form.errors as Record<string, string>)[`users.${i}.username`]} />

--- a/resources/js/pages/site-settings/index.tsx
+++ b/resources/js/pages/site-settings/index.tsx
@@ -21,6 +21,7 @@ import DeleteSite from '@/pages/site-settings/components/delete-site';
 import VHost from '@/pages/site-settings/components/vhost';
 import VHostPreview from '@/pages/site-settings/components/vhost-preview';
 import ChangeSourceControl from '@/pages/site-settings/components/source-control';
+import BasicAuth from '@/pages/site-settings/components/basic-auth';
 import WebDirectory from './components/web-directory';
 
 export default function Databases() {
@@ -122,6 +123,19 @@ export default function Databases() {
                 </Button>
               </VHost>
             </div>
+            {(page.props.site.webserver === 'nginx' || page.props.site.webserver === 'caddy') && (
+              <>
+                <Separator />
+                <div className="flex items-center justify-between p-4">
+                  <span>Basic Auth</span>
+                  <BasicAuth site={page.props.site}>
+                    <Button variant="outline" className="h-6">
+                      {page.props.site.basic_auth?.enabled ? `Enabled (${page.props.site.basic_auth.users.length})` : 'Disabled'}
+                    </Button>
+                  </BasicAuth>
+                </div>
+              </>
+            )}
             <Separator />
             <div className="flex items-center justify-between p-4">
               <span>Web directory</span>

--- a/resources/js/types/site.d.ts
+++ b/resources/js/types/site.d.ts
@@ -35,6 +35,10 @@ export interface Site {
   vhost_generation_enabled: boolean;
   features: SiteFeature[];
   modern_deployment: boolean;
+  basic_auth: {
+    enabled: boolean;
+    users: { username: string }[];
+  };
   warnings: SiteWarning[];
   created_at: string;
   updated_at: string;

--- a/resources/views/ssh/services/webserver/caddy/vhost.mustache
+++ b/resources/views/ssh/services/webserver/caddy/vhost.mustache
@@ -8,6 +8,14 @@
     tls {{ssl_certificate_path}} {{ssl_certificate_key_path}}
     {{/has_tls}}
 
+    {{#basic_auth_enabled}}
+    basic_auth {
+        {{#basic_auth_users}}
+        {{username}} {{bcrypt}}
+        {{/basic_auth_users}}
+    }
+    {{/basic_auth_enabled}}
+
     {{#is_php}}
     root * {{root}}
     try_files {path} {path}/ /index.php?{query}

--- a/resources/views/ssh/services/webserver/nginx/remove-basic-auth-file.blade.php
+++ b/resources/views/ssh/services/webserver/nginx/remove-basic-auth-file.blade.php
@@ -1,0 +1,6 @@
+if [ -f {{ $path }} ]; then
+    sudo rm -f {{ $path }}
+    echo "Removed basic auth file {{ $path }}"
+else
+    echo "Basic auth file {{ $path }} not present, nothing to remove"
+fi

--- a/resources/views/ssh/services/webserver/nginx/vhost.mustache
+++ b/resources/views/ssh/services/webserver/nginx/vhost.mustache
@@ -60,6 +60,12 @@ server {
     {{#basic_auth_enabled}}
     auth_basic "{{basic_auth_realm}}";
     auth_basic_user_file {{basic_auth_file}};
+
+    location ^~ /.well-known/acme-challenge/ {
+        auth_basic off;
+        allow all;
+        try_files $uri =404;
+    }
     {{/basic_auth_enabled}}
 
     location ~ /\.(?!well-known).* {

--- a/resources/views/ssh/services/webserver/nginx/vhost.mustache
+++ b/resources/views/ssh/services/webserver/nginx/vhost.mustache
@@ -57,6 +57,11 @@ server {
     access_log off;
     error_log  /var/log/nginx/{{primary_domain}}-error.log error;
 
+    {{#basic_auth_enabled}}
+    auth_basic "{{basic_auth_realm}}";
+    auth_basic_user_file {{basic_auth_file}};
+    {{/basic_auth_enabled}}
+
     location ~ /\.(?!well-known).* {
         deny all;
     }

--- a/resources/views/ssh/services/webserver/nginx/write-basic-auth-file.blade.php
+++ b/resources/views/ssh/services/webserver/nginx/write-basic-auth-file.blade.php
@@ -1,0 +1,19 @@
+set -e
+
+if [ ! -d {{ $dir }} ]; then
+    echo "Creating basic auth directory {{ $dir }}"
+    sudo mkdir -p {{ $dir }}
+    sudo chown root:root {{ $dir }}
+    sudo chmod 755 {{ $dir }}
+fi
+
+sudo tee {{ $path }} > /dev/null <<'BASIC_AUTH_EOF'
+@foreach ($lines as $line){!! $line !!}
+@endforeach
+BASIC_AUTH_EOF
+
+sudo chown root:root {{ $path }}
+sudo chmod 644 {{ $path }}
+
+echo "Wrote basic auth file {{ $path }} with {{ $userCount }} user(s): {{ $usernames }}"
+sudo ls -l {{ $path }}

--- a/resources/views/ssh/services/webserver/nginx/write-basic-auth-file.blade.php
+++ b/resources/views/ssh/services/webserver/nginx/write-basic-auth-file.blade.php
@@ -12,8 +12,8 @@ sudo tee {{ $path }} > /dev/null <<'BASIC_AUTH_EOF'
 @endforeach
 BASIC_AUTH_EOF
 
-sudo chown root:root {{ $path }}
-sudo chmod 644 {{ $path }}
+sudo chown root:{{ $nginxUser }} {{ $path }}
+sudo chmod 640 {{ $path }}
 
 echo "Wrote basic auth file {{ $path }} with {{ $userCount }} user(s): {{ $usernames }}"
 sudo ls -l {{ $path }}

--- a/tests/Feature/SiteSettings/BasicAuthTest.php
+++ b/tests/Feature/SiteSettings/BasicAuthTest.php
@@ -190,6 +190,29 @@ class BasicAuthTest extends TestCase
         $this->assertStringContainsString('auth_basic_user_file /etc/nginx/auth/site-'.$this->site->id.'.htpasswd', $vhost);
     }
 
+    public function test_vhost_exempts_acme_challenge_path_when_basic_auth_enabled(): void
+    {
+        HostedDomain::factory()->primary()->create([
+            'site_id' => $this->site->id,
+            'domain' => $this->site->domain,
+        ]);
+
+        $this->site->type_data = [
+            'basic_auth' => [
+                'enabled' => true,
+                'users' => [
+                    ['username' => 'alice', 'apr1' => '$apr1$saltxxxx$hashhashhashhashhashhh', 'bcrypt' => '$2y$10$bcrypthashhere'],
+                ],
+            ],
+        ];
+        $this->site->save();
+
+        $vhost = $this->site->webserver()->generateVhost($this->site);
+
+        $this->assertStringContainsString('location ^~ /.well-known/acme-challenge/', $vhost);
+        $this->assertStringContainsString('auth_basic off', $vhost);
+    }
+
     public function test_vhost_generation_omits_auth_basic_when_disabled(): void
     {
         HostedDomain::factory()->primary()->create([

--- a/tests/Feature/SiteSettings/BasicAuthTest.php
+++ b/tests/Feature/SiteSettings/BasicAuthTest.php
@@ -6,6 +6,8 @@ use App\Actions\Site\UpdateBasicAuth;
 use App\Facades\SSH;
 use App\Http\Resources\SiteResource;
 use App\Models\HostedDomain;
+use App\Models\Site;
+use App\Models\User;
 use App\Services\Webserver\Caddy;
 use App\Services\Webserver\Nginx;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -57,7 +59,7 @@ class BasicAuthTest extends TestCase
         ];
         $this->site->save();
 
-        /** @var \App\Models\Site $site */
+        /** @var Site $site */
         $site = \Mockery::mock($this->site)->makePartial();
         $site->shouldReceive('webserver->updateVHost')->andReturn();
         $site->shouldReceive('webserver->id')->andReturn(Nginx::id());
@@ -91,7 +93,7 @@ class BasicAuthTest extends TestCase
         ];
         $this->site->save();
 
-        /** @var \App\Models\Site $site */
+        /** @var Site $site */
         $site = \Mockery::mock($this->site)->makePartial();
         $site->shouldReceive('webserver->updateVHost')->andReturn();
         $site->shouldReceive('webserver->id')->andReturn(Nginx::id());
@@ -279,7 +281,7 @@ class BasicAuthTest extends TestCase
 
     public function test_authorization_requires_project_access(): void
     {
-        $otherUser = \App\Models\User::factory()->create();
+        $otherUser = User::factory()->create();
         $otherUser->ensureHasDefaultProject();
 
         $this->actingAs($otherUser);

--- a/tests/Feature/SiteSettings/BasicAuthTest.php
+++ b/tests/Feature/SiteSettings/BasicAuthTest.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace Tests\Feature\SiteSettings;
+
+use App\Actions\Site\UpdateBasicAuth;
+use App\Facades\SSH;
+use App\Http\Resources\SiteResource;
+use App\Models\HostedDomain;
+use App\Services\Webserver\Caddy;
+use App\Services\Webserver\Nginx;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BasicAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_endpoint_enables_basic_auth_with_users(): void
+    {
+        SSH::fake();
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-basic-auth', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'enabled' => true,
+            'users' => [
+                ['username' => 'alice', 'password' => 'secret123'],
+                ['username' => 'bob', 'password' => 'hunter2'],
+            ],
+        ])
+            ->assertRedirect()
+            ->assertSessionDoesntHaveErrors();
+
+        $this->site->refresh();
+        $auth = $this->site->type_data['basic_auth'];
+
+        $this->assertTrue($auth['enabled']);
+        $this->assertCount(2, $auth['users']);
+        $this->assertSame('alice', $auth['users'][0]['username']);
+        $this->assertStringStartsWith('$apr1$', $auth['users'][0]['apr1']);
+        $this->assertTrue(password_verify('secret123', $auth['users'][0]['bcrypt']));
+
+        SSH::assertExecutedContains('/etc/nginx/auth/site-'.$this->site->id.'.htpasswd');
+    }
+
+    public function test_empty_users_forces_disabled(): void
+    {
+        $this->site->type_data = [
+            'basic_auth' => [
+                'enabled' => true,
+                'users' => [
+                    ['username' => 'alice', 'apr1' => '$apr1$existing', 'bcrypt' => '$2y$10$existing'],
+                ],
+            ],
+        ];
+        $this->site->save();
+
+        /** @var \App\Models\Site $site */
+        $site = \Mockery::mock($this->site)->makePartial();
+        $site->shouldReceive('webserver->updateVHost')->andReturn();
+        $site->shouldReceive('webserver->id')->andReturn(Nginx::id());
+
+        SSH::fake();
+
+        app(UpdateBasicAuth::class)->update($site, [
+            'enabled' => true,
+            'users' => [],
+        ]);
+
+        $site->refresh();
+        $this->assertFalse($site->type_data['basic_auth']['enabled']);
+        $this->assertSame([], $site->type_data['basic_auth']['users']);
+
+        SSH::assertExecutedContains('rm -f');
+    }
+
+    public function test_blank_password_preserves_existing_hashes(): void
+    {
+        $apr1 = '$apr1$abcdefgh$existinghash1234567890';
+        $bcrypt = password_hash('original', PASSWORD_BCRYPT);
+
+        $this->site->type_data = [
+            'basic_auth' => [
+                'enabled' => true,
+                'users' => [
+                    ['username' => 'alice', 'apr1' => $apr1, 'bcrypt' => $bcrypt],
+                ],
+            ],
+        ];
+        $this->site->save();
+
+        /** @var \App\Models\Site $site */
+        $site = \Mockery::mock($this->site)->makePartial();
+        $site->shouldReceive('webserver->updateVHost')->andReturn();
+        $site->shouldReceive('webserver->id')->andReturn(Nginx::id());
+
+        SSH::fake();
+
+        app(UpdateBasicAuth::class)->update($site, [
+            'enabled' => true,
+            'users' => [
+                ['username' => 'alice', 'password' => ''],
+            ],
+        ]);
+
+        $site->refresh();
+        $this->assertSame($apr1, $site->type_data['basic_auth']['users'][0]['apr1']);
+        $this->assertSame($bcrypt, $site->type_data['basic_auth']['users'][0]['bcrypt']);
+    }
+
+    public function test_validation_rejects_duplicate_usernames(): void
+    {
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-basic-auth', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'enabled' => true,
+            'users' => [
+                ['username' => 'alice', 'password' => 'p1'],
+                ['username' => 'alice', 'password' => 'p2'],
+            ],
+        ])->assertSessionHasErrors();
+    }
+
+    public function test_validation_rejects_new_user_without_password(): void
+    {
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-basic-auth', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'enabled' => true,
+            'users' => [
+                ['username' => 'newbie', 'password' => ''],
+            ],
+        ])->assertSessionHasErrors();
+    }
+
+    public function test_caddy_server_does_not_write_htpasswd_file(): void
+    {
+        $this->server->webserver()?->update([
+            'name' => Caddy::id(),
+        ]);
+
+        SSH::fake();
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-basic-auth', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'enabled' => true,
+            'users' => [
+                ['username' => 'alice', 'password' => 'secret123'],
+            ],
+        ])
+            ->assertRedirect()
+            ->assertSessionDoesntHaveErrors();
+
+        SSH::assertNotExecutedContains('/etc/nginx/auth/');
+    }
+
+    public function test_vhost_generation_includes_auth_basic_when_enabled(): void
+    {
+        HostedDomain::factory()->primary()->create([
+            'site_id' => $this->site->id,
+            'domain' => $this->site->domain,
+        ]);
+
+        $this->site->type_data = [
+            'basic_auth' => [
+                'enabled' => true,
+                'users' => [
+                    ['username' => 'alice', 'apr1' => '$apr1$saltxxxx$hashhashhashhashhashhh', 'bcrypt' => '$2y$10$bcrypthashhere'],
+                ],
+            ],
+        ];
+        $this->site->save();
+
+        $vhost = $this->site->webserver()->generateVhost($this->site);
+
+        $this->assertStringContainsString('auth_basic "'.$this->site->domain.'"', $vhost);
+        $this->assertStringContainsString('auth_basic_user_file /etc/nginx/auth/site-'.$this->site->id.'.htpasswd', $vhost);
+    }
+
+    public function test_vhost_generation_omits_auth_basic_when_disabled(): void
+    {
+        HostedDomain::factory()->primary()->create([
+            'site_id' => $this->site->id,
+            'domain' => $this->site->domain,
+        ]);
+
+        $this->site->type_data = [
+            'basic_auth' => [
+                'enabled' => false,
+                'users' => [],
+            ],
+        ];
+        $this->site->save();
+
+        $vhost = $this->site->webserver()->generateVhost($this->site);
+
+        $this->assertStringNotContainsString('auth_basic', $vhost);
+    }
+
+    public function test_site_resource_does_not_leak_hashes(): void
+    {
+        $this->site->type_data = [
+            'basic_auth' => [
+                'enabled' => true,
+                'users' => [
+                    ['username' => 'alice', 'apr1' => '$apr1$leakedapr1', 'bcrypt' => '$2y$10$leakedbcrypt'],
+                ],
+            ],
+        ];
+        $this->site->save();
+        $this->site->load('server');
+
+        $json = json_encode(SiteResource::make($this->site)->toArray(request()));
+
+        $this->assertIsString($json);
+        $this->assertStringNotContainsString('apr1', $json);
+        $this->assertStringNotContainsString('bcrypt', $json);
+        $this->assertStringNotContainsString('leakedapr1', $json);
+        $this->assertStringNotContainsString('leakedbcrypt', $json);
+        $this->assertStringContainsString('alice', $json);
+    }
+
+    public function test_disable_keeps_users_but_removes_htpasswd_and_strips_auth_basic(): void
+    {
+        HostedDomain::factory()->primary()->create([
+            'site_id' => $this->site->id,
+            'domain' => $this->site->domain,
+        ]);
+
+        $apr1 = '$apr1$abcdefgh$existinghash1234567890';
+        $bcrypt = password_hash('original', PASSWORD_BCRYPT);
+        $this->site->type_data = [
+            'basic_auth' => [
+                'enabled' => true,
+                'users' => [
+                    ['username' => 'alice', 'apr1' => $apr1, 'bcrypt' => $bcrypt],
+                ],
+            ],
+        ];
+        $this->site->save();
+
+        SSH::fake();
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-basic-auth', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'enabled' => false,
+            'users' => [
+                ['username' => 'alice', 'password' => ''],
+            ],
+        ])
+            ->assertRedirect()
+            ->assertSessionDoesntHaveErrors();
+
+        $this->site->refresh();
+        $this->assertFalse($this->site->type_data['basic_auth']['enabled']);
+        $this->assertCount(1, $this->site->type_data['basic_auth']['users']);
+        $this->assertSame($apr1, $this->site->type_data['basic_auth']['users'][0]['apr1']);
+        $this->assertSame($bcrypt, $this->site->type_data['basic_auth']['users'][0]['bcrypt']);
+
+        SSH::assertExecutedContains('rm -f');
+
+        $vhost = $this->site->webserver()->generateVhost($this->site);
+        $this->assertStringNotContainsString('auth_basic', $vhost);
+    }
+
+    public function test_authorization_requires_project_access(): void
+    {
+        $otherUser = \App\Models\User::factory()->create();
+        $otherUser->ensureHasDefaultProject();
+
+        $this->actingAs($otherUser);
+
+        $this->patch(route('site-settings.update-basic-auth', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'enabled' => true,
+            'users' => [
+                ['username' => 'alice', 'password' => 'secret123'],
+            ],
+        ])->assertForbidden();
+    }
+}

--- a/tests/Unit/Helpers/Apr1HasherTest.php
+++ b/tests/Unit/Helpers/Apr1HasherTest.php
@@ -119,5 +119,4 @@ class Apr1HasherTest extends TestCase
         $this->assertSame(8, strlen($matches[1]));
         $this->assertSame('abcdefgh', $matches[1]);
     }
-
 }

--- a/tests/Unit/Helpers/Apr1HasherTest.php
+++ b/tests/Unit/Helpers/Apr1HasherTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use App\Helpers\Apr1Hasher;
+use Tests\TestCase;
+
+class Apr1HasherTest extends TestCase
+{
+    /**
+     * Known-good vectors verified against Apache's htpasswd -vb.
+     *
+     * @var array<string, array{password: string, salt: string, expected: string}>
+     */
+    private array $knownVectors = [
+        'simple' => [
+            'password' => 'password',
+            'salt' => 'salt1234',
+            'expected' => '$apr1$salt1234$k3J5yKYW6TlGmTytnkXbQ0',
+        ],
+        'short_password' => [
+            'password' => 'a',
+            'salt' => 'abcdefgh',
+            'expected' => '$apr1$abcdefgh$G8IsPsylW5ROvIKsQMRG61',
+        ],
+        'long_password' => [
+            'password' => 'this-is-a-much-longer-password-with-many-characters',
+            'salt' => 'longsalt',
+            'expected' => '$apr1$longsalt$H18n0FnZ3fZTIJggqWyvU/',
+        ],
+        'special_chars' => [
+            'password' => 'p@ssw0rd!#$%',
+            'salt' => 'specials',
+            'expected' => '$apr1$specials$gvYEtzxoUQMAV.udPg/lH1',
+        ],
+        'empty_password' => [
+            'password' => '',
+            'salt' => 'salt1234',
+            'expected' => '$apr1$salt1234$5H34QiH40LY95k4Ru.Rsw0',
+        ],
+    ];
+
+    public function test_hash_produces_apr1_format(): void
+    {
+        $hash = Apr1Hasher::hash('password');
+
+        $this->assertMatchesRegularExpression(
+            '/^\$apr1\$[A-Za-z0-9.\/]{8}\$[A-Za-z0-9.\/]{22}$/',
+            $hash
+        );
+    }
+
+    public function test_hash_is_deterministic_for_same_salt(): void
+    {
+        $hash1 = Apr1Hasher::hash('password', 'salt1234');
+        $hash2 = Apr1Hasher::hash('password', 'salt1234');
+
+        $this->assertSame($hash1, $hash2);
+    }
+
+    public function test_hash_differs_with_different_salts(): void
+    {
+        $hash1 = Apr1Hasher::hash('password', 'salt1234');
+        $hash2 = Apr1Hasher::hash('password', 'differen');
+
+        $this->assertNotSame($hash1, $hash2);
+    }
+
+    public function test_hash_differs_with_different_passwords(): void
+    {
+        $hash1 = Apr1Hasher::hash('password1', 'salt1234');
+        $hash2 = Apr1Hasher::hash('password2', 'salt1234');
+
+        $this->assertNotSame($hash1, $hash2);
+    }
+
+    public function test_random_salt_is_used_when_not_provided(): void
+    {
+        $hash1 = Apr1Hasher::hash('password');
+        $hash2 = Apr1Hasher::hash('password');
+
+        $this->assertNotSame($hash1, $hash2);
+    }
+
+    public function test_hash_against_known_vectors(): void
+    {
+        foreach ($this->knownVectors as $name => $vector) {
+            $this->assertSame(
+                $vector['expected'],
+                Apr1Hasher::hash($vector['password'], $vector['salt']),
+                "Vector '{$name}' failed"
+            );
+        }
+    }
+
+    public function test_salt_is_sanitised_when_containing_invalid_characters(): void
+    {
+        $hash = Apr1Hasher::hash('password', 'bad!@#$%');
+
+        $this->assertMatchesRegularExpression(
+            '/^\$apr1\$[A-Za-z0-9.\/]{8}\$[A-Za-z0-9.\/]{22}$/',
+            $hash
+        );
+    }
+
+    public function test_short_salt_is_padded(): void
+    {
+        $hash = Apr1Hasher::hash('password', 'ab');
+
+        preg_match('/^\$apr1\$([^$]+)\$/', $hash, $matches);
+        $this->assertSame(8, strlen($matches[1]));
+    }
+
+    public function test_long_salt_is_truncated(): void
+    {
+        $hash = Apr1Hasher::hash('password', 'abcdefghijklmnop');
+
+        preg_match('/^\$apr1\$([^$]+)\$/', $hash, $matches);
+        $this->assertSame(8, strlen($matches[1]));
+        $this->assertSame('abcdefgh', $matches[1]);
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a comprehensive implementation of HTTP Basic Authentication management for sites, including backend logic, frontend UI, and integration with both Nginx and Caddy webservers. The changes allow users to enable/disable basic auth, manage users and passwords, and ensure secure handling of credentials throughout the stack.

This is often used for staging sites, or preview sites where the owner does not want them accessed yet, especially during development.   LetsEncrypt maintains a list of recently requested certificates, meaning potential abusers can find development sites even if they are not published anywhere else, this feature adds an extra layer of protection for sites that need to be publicly accessible, but not to everyone. 

| Basic Auth Interface |
|-|
| <img width="518" height="399" alt="CleanShot 2026-05-16 at 14 19 37" src="https://github.com/user-attachments/assets/25f3b0de-e36a-44cb-be54-4791f9f25fd8" /> |


**Key changes include:**

### Backend: Basic Auth Management

- Added `UpdateBasicAuth` action (`app/Actions/Site/UpdateBasicAuth.php`) to handle enabling/disabling basic auth, user management, password hashing (using both bcrypt and custom APR1 for Nginx), validation, and updating the relevant auth files on the server.
- Introduced `Apr1Hasher` helper (`app/Helpers/Apr1Hasher.php`) for generating Apache APR1 password hashes in pure PHP, removing the need for external dependencies.
- Added `htpasswdPath()` method to the `Site` model to standardize the auth file location.
- Ensured removal of the basic auth file when a site is deleted or basic auth is disabled.

### API & Resource Layer

- Updated `SiteResource` to expose basic auth status and usernames, while stripping password hashes from API responses for security. 
- Registered a new controller endpoint for updating basic auth settings via PATCH.

### Webserver Integration

- Extended config generation in `AbstractGenerateConfig` to inject basic auth parameters into site/server block data for both Nginx and Caddy. 
- Updated Nginx and Caddy vhost templates to conditionally include basic auth directives and reference the correct user/password data.

### Frontend: Site Settings UI

- Added a new React component (`basic-auth.tsx`) providing a modal UI for managing basic auth users and settings, including form validation and error handling.
- Integrated the new Basic Auth UI into the site settings page, showing current status and allowing user management for supported webservers.

These changes provide a secure, user-friendly way to manage HTTP Basic Authentication for sites, with robust backend validation, secure password handling, and seamless integration into the deployment pipeline.