### PR TITLE
[Feat] SSL/Domain Improvements

### DIFF
--- a/app/Actions/Site/CreateSite.php
+++ b/app/Actions/Site/CreateSite.php
@@ -8,7 +8,6 @@ use App\Enums\SiteStatus;
 use App\Exceptions\RepositoryNotFound;
 use App\Exceptions\RepositoryPermissionDenied;
 use App\Exceptions\SourceControlIsNotConnected;
-use App\Jobs\HostedDomain\CheckDomainJob;
 use App\Jobs\Site\CreateJob;
 use App\Models\Server;
 use App\Models\Service;
@@ -89,16 +88,15 @@ class CreateSite
 
             $defaultSslMethod = $webserverHandler->defaultSslMethod();
 
-            $primaryDomain = $site->hostedDomains()->create([
+            $site->hostedDomains()->create([
                 'domain' => $site->domain,
                 'type' => HostedDomainType::PRIMARY,
                 'status' => HostedDomainStatus::CREATING,
                 'ssl_method' => $defaultSslMethod,
             ]);
 
-            $aliasDomains = [];
             foreach ($input['aliases'] ?? [] as $alias) {
-                $aliasDomains[] = $site->hostedDomains()->create([
+                $site->hostedDomains()->create([
                     'domain' => $alias,
                     'type' => HostedDomainType::ALIAS,
                     'status' => HostedDomainStatus::CREATING,
@@ -111,13 +109,8 @@ class CreateSite
 
             DB::commit();
 
-            // install site
+            // install site; CheckDomainJob is dispatched from CreateJob after install succeeds
             dispatch(new CreateJob($site))->onQueue('ssh');
-
-            dispatch(new CheckDomainJob($primaryDomain))->onQueue('ssh');
-            foreach ($aliasDomains as $aliasDomain) {
-                dispatch(new CheckDomainJob($aliasDomain))->onQueue('ssh');
-            }
 
             return $site;
         } catch (Exception $e) {

--- a/app/Http/Resources/HostedDomainResource.php
+++ b/app/Http/Resources/HostedDomainResource.php
@@ -23,7 +23,7 @@ class HostedDomainResource extends JsonResource
             'type_color' => $this->type->getColor(),
             'status' => $this->status->getText(),
             'status_color' => $this->status->getColor(),
-            'ssl_method' => $this->ssl_method->getText(),
+            'ssl_method' => $this->ssl_method->value,
             'ssl_id' => $this->ssl_id,
             'error' => $this->error,
             'ssl_type' => $this->ssl?->type,

--- a/app/Jobs/Site/CreateJob.php
+++ b/app/Jobs/Site/CreateJob.php
@@ -7,6 +7,7 @@ use App\Enums\SiteStatus;
 use App\Events\SocketEvent;
 use App\Facades\Notifier;
 use App\Http\Resources\SiteResource;
+use App\Jobs\HostedDomain\CheckDomainJob;
 use App\Models\ServerLog;
 use App\Models\Site;
 use App\Notifications\SiteInstallationFailed;
@@ -33,6 +34,10 @@ class CreateJob implements ShouldQueue
             ]);
             $this->broadcastSiteUpdate();
             Notifier::send($this->site, new SiteInstallationSucceed($this->site));
+
+            foreach ($this->site->hostedDomains as $hostedDomain) {
+                dispatch(new CheckDomainJob($hostedDomain))->onQueue('ssh');
+            }
         });
     }
 

--- a/app/Services/Webserver/AbstractWebserver.php
+++ b/app/Services/Webserver/AbstractWebserver.php
@@ -48,7 +48,9 @@ abstract class AbstractWebserver extends AbstractService implements Webserver
 
     public function siteDefaults(): array
     {
-        return [];
+        return [
+            'ssl_enabled' => true,
+        ];
     }
 
     public function canConfigureSSL(): bool

--- a/app/Tables/HostedDomainTable.php
+++ b/app/Tables/HostedDomainTable.php
@@ -36,7 +36,12 @@ class HostedDomainTable extends Table
                     HostedDomainType::ALIAS => 'copy',
                     HostedDomainType::REDIRECT => 'signpost',
                 }),
-            EnumColumn::make('ssl_method', 'SSL')->uppercase(),
+            Column::make('ssl_method', 'SSL')
+                ->value(fn (HostedDomain $hd) => $hd->ssl_method->value)
+                ->badge(
+                    value: fn (HostedDomain $hd) => strtoupper($hd->ssl_method->getText()),
+                    variant: 'outline',
+                ),
             Column::make('certificate', 'Certificate'),
             BadgeColumn::make('ssl.expires_at', 'Expires In')
                 ->variant('outline')

--- a/resources/js/components/vito-table.tsx
+++ b/resources/js/components/vito-table.tsx
@@ -36,9 +36,12 @@ function resolveHref(display: CellRenderProps['displays'][number], row: CellRend
 
 function vitoCellRenderer({ row, value, displays, defaultRender }: CellRenderProps & { defaultRender: () => ReactNode }): ReactNode {
   if (displays.length === 1 && displays[0].type === 'badge') {
+    if (value == null || value === '') {
+      return <span className="text-muted-foreground">-</span>;
+    }
     const display = displays[0];
     const color = display.color_field ? (row[display.color_field] as string) : display.variant;
-    return <Badge variant={(color ?? 'default') as 'default'}>{String(value ?? '')}</Badge>;
+    return <Badge variant={(color ?? 'default') as 'default'}>{String(value)}</Badge>;
   }
 
   if (displays.some((d) => d.type === 'link')) {

--- a/resources/js/pages/hosted-domains/components/create-hosted-domain.tsx
+++ b/resources/js/pages/hosted-domains/components/create-hosted-domain.tsx
@@ -109,6 +109,10 @@ export default function CreateHostedDomain({ site, children }: { site: Site; chi
                   <SelectItem value="redirect">Redirect</SelectItem>
                 </SelectContent>
               </Select>
+              <p className="text-muted-foreground text-sm">
+                <strong>Alias</strong> serves the same site content under another domain.{' '}
+                <strong>Redirect</strong> sends visitors to the primary domain via an HTTP redirect.
+              </p>
               <InputError message={form.errors.type} />
             </FormField>
             <FormField>

--- a/resources/js/pages/hosted-domains/components/create-hosted-domain.tsx
+++ b/resources/js/pages/hosted-domains/components/create-hosted-domain.tsx
@@ -110,8 +110,8 @@ export default function CreateHostedDomain({ site, children }: { site: Site; chi
                 </SelectContent>
               </Select>
               <p className="text-muted-foreground text-sm">
-                <strong>Alias</strong> serves the same site content under another domain.{' '}
-                <strong>Redirect</strong> sends visitors to the primary domain via an HTTP redirect.
+                <strong>Alias</strong> serves the same site content under another domain. <strong>Redirect</strong> sends visitors to the primary
+                domain via an HTTP redirect.
               </p>
               <InputError message={form.errors.type} />
             </FormField>

--- a/resources/js/pages/hosted-domains/components/edit-hosted-domain.tsx
+++ b/resources/js/pages/hosted-domains/components/edit-hosted-domain.tsx
@@ -126,6 +126,12 @@ export default function EditHostedDomain({ hostedDomain, children }: { hostedDom
                   <SelectItem value="redirect">Redirect</SelectItem>
                 </SelectContent>
               </Select>
+              {!isPrimary && (
+                <p className="text-muted-foreground text-sm">
+                  <strong>Alias</strong> serves the same site content under another domain.{' '}
+                  <strong>Redirect</strong> sends visitors to the primary domain via an HTTP redirect.
+                </p>
+              )}
               <InputError message={form.errors.type} />
             </FormField>
             <FormField>

--- a/resources/js/pages/hosted-domains/components/edit-hosted-domain.tsx
+++ b/resources/js/pages/hosted-domains/components/edit-hosted-domain.tsx
@@ -128,8 +128,8 @@ export default function EditHostedDomain({ hostedDomain, children }: { hostedDom
               </Select>
               {!isPrimary && (
                 <p className="text-muted-foreground text-sm">
-                  <strong>Alias</strong> serves the same site content under another domain.{' '}
-                  <strong>Redirect</strong> sends visitors to the primary domain via an HTTP redirect.
+                  <strong>Alias</strong> serves the same site content under another domain. <strong>Redirect</strong> sends visitors to the primary
+                  domain via an HTTP redirect.
                 </p>
               )}
               <InputError message={form.errors.type} />

--- a/resources/js/pages/hosted-domains/index.tsx
+++ b/resources/js/pages/hosted-domains/index.tsx
@@ -249,12 +249,6 @@ export default function HostedDomains() {
                 <span className="hidden lg:block">Docs</span>
               </Button>
             </a>
-            <CreateHostedDomain site={page.props.site}>
-              <Button>
-                <PlusIcon />
-                <span className="hidden lg:block">Add Domain</span>
-              </Button>
-            </CreateHostedDomain>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="outline">
@@ -315,6 +309,12 @@ export default function HostedDomains() {
                 )}
               </DropdownMenuContent>
             </DropdownMenu>
+            <CreateHostedDomain site={page.props.site}>
+              <Button>
+                <PlusIcon />
+                <span className="hidden lg:block">Add Domain</span>
+              </Button>
+            </CreateHostedDomain>
           </div>
         </HeaderContainer>
 


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the handling of hosted domains and SSL methods in the site creation and management process. The most significant changes streamline domain checking after site installation, clarify UI elements for domain types, and improve consistency in how SSL methods are displayed.

**Backend logic improvements:**

* Moved the dispatching of `CheckDomainJob` for all hosted domains from the `CreateSite` action to the `CreateJob` job, ensuring domain checks only occur after a successful site installation. This also removes unnecessary intermediate variables and simplifies the domain creation logic.
* Updated the `siteDefaults` method in `AbstractWebserver` to explicitly enable SSL by default for new sites.

**UI and resource consistency:**

* Changed the `ssl_method` field in `HostedDomainResource` and `HostedDomainTable` to use the enum value instead of the display text, and updated the badge display logic for better clarity and consistency.

**User experience enhancements:**

* Added descriptive helper text in the create and edit hosted domain forms to clarify the difference between "Alias" and "Redirect" domain types for users.
* Moved the "Add Domain" button within the hosted domains page for improved layout and user interaction. 