### PR TITLE
[Feat] Gitea/GitLab Custom SSH Ports

### DIFF
--- a/app/Actions/SSL/GetMatchingSslCertificates.php
+++ b/app/Actions/SSL/GetMatchingSslCertificates.php
@@ -11,7 +11,7 @@ class GetMatchingSslCertificates
     /**
      * Get all server-level SSL certificates that match any of the site's hosted domains.
      *
-     * @return Collection<int, array{id: int, label: string, domains: array<int, string>}>
+     * @return Collection<int, array{id: int, label: non-falsy-string, domains: array<int, string>}>
      */
     public function get(Site $site): Collection
     {
@@ -23,7 +23,7 @@ class GetMatchingSslCertificates
     /**
      * Get all server-level SSL certificates that match a specific domain.
      *
-     * @return Collection<int, array{id: int, label: string, domains: array<int, string>}>
+     * @return Collection<int, array{id: int, label: non-falsy-string, domains: array<int, string>}>
      */
     public function forDomain(Site $site, string $domain): Collection
     {
@@ -32,7 +32,7 @@ class GetMatchingSslCertificates
 
     /**
      * @param  array<int, string>  $domains
-     * @return Collection<int, array{id: int, label: string, domains: array<int, string>}>
+     * @return Collection<int, array{id: int, label: non-falsy-string, domains: array<int, string>}>
      */
     private function filterSsls(Site $site, array $domains): Collection
     {
@@ -54,11 +54,15 @@ class GetMatchingSslCertificates
 
                 return false;
             })
-            ->map(fn (Ssl $ssl) => [
-                'id' => $ssl->id,
-                'label' => $ssl->type.' #'.$ssl->id.' ('.implode(', ', (array) ($ssl->domains ?? [])).')',
-                'domains' => (array) ($ssl->domains ?? []),
-            ])
+            ->map(function (Ssl $ssl): array {
+                $domains = (array) ($ssl->domains ?? []);
+
+                return [
+                    'id' => $ssl->id,
+                    'label' => sprintf('%s #%d (%s)', $ssl->type, $ssl->id, implode(', ', $domains)),
+                    'domains' => $domains,
+                ];
+            })
             ->values();
     }
 }

--- a/app/Actions/Site/GetIsolatedUsers.php
+++ b/app/Actions/Site/GetIsolatedUsers.php
@@ -16,10 +16,15 @@ class GetIsolatedUsers
             ->where('user', '!=', $server->getSshUser())
             ->get(['user'])
             ->groupBy('user')
-            ->map(fn ($group, $user) => [
-                'user' => (string) $user,
-                'sites_count' => $group->count(),
-            ])
+            ->map(function (Collection $group, string $user): array {
+                /** @var int $count */
+                $count = $group->count();
+
+                return [
+                    'user' => $user,
+                    'sites_count' => $count,
+                ];
+            })
             ->values();
     }
 }

--- a/app/Actions/SourceControl/EditSourceControl.php
+++ b/app/Actions/SourceControl/EditSourceControl.php
@@ -15,16 +15,16 @@ class EditSourceControl
      */
     public function edit(SourceControl $sourceControl, array $input): SourceControl
     {
-        Validator::make($input, [
-            'name' => [
-                'required',
-            ],
-        ])->validate();
+        Validator::make($input, array_merge(
+            ['name' => ['required']],
+            $sourceControl->provider()->editRules($input),
+        ))->validate();
 
         $sourceControl->profile = $input['name'];
         $sourceControl->project_id = isset($input['global']) && $input['global']
             ? null
             : $sourceControl->user->currentProject?->id;
+        $sourceControl->provider_data = $sourceControl->provider()->editData($input);
 
         $sourceControl->save();
 

--- a/app/Http/Resources/SourceControlResource.php
+++ b/app/Http/Resources/SourceControlResource.php
@@ -14,6 +14,9 @@ class SourceControlResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        $provider = $this->provider();
+        $supportsSshPort = in_array('ssh_port', $provider::editableFields(), true);
+
         $data = [
             'id' => $this->id,
             'project_id' => $this->project_id,
@@ -22,6 +25,7 @@ class SourceControlResource extends JsonResource
             'name' => $this->profile,
             'provider' => $this->provider,
             'external_identifier' => $this->external_identifier,
+            'ssh_port' => $this->when($supportsSshPort, fn () => $provider->getSshPort()),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Http/Resources/SourceControlResource.php
+++ b/app/Http/Resources/SourceControlResource.php
@@ -14,8 +14,10 @@ class SourceControlResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        $provider = $this->provider();
-        $supportsSshPort = in_array('ssh_port', $provider::editableFields(), true);
+        $handler = config('source-control.providers.'.$this->provider.'.handler');
+        $supportsSshPort = is_string($handler)
+            && is_a($handler, \App\SourceControlProviders\SourceControlProvider::class, true)
+            && in_array('ssh_port', $handler::editableFields(), true);
 
         $data = [
             'id' => $this->id,
@@ -25,7 +27,7 @@ class SourceControlResource extends JsonResource
             'name' => $this->profile,
             'provider' => $this->provider,
             'external_identifier' => $this->external_identifier,
-            'ssh_port' => $this->when($supportsSshPort, fn () => $provider->getSshPort()),
+            'ssh_port' => $this->when($supportsSshPort, fn () => $this->provider()->getSshPort()),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Http/Resources/SourceControlResource.php
+++ b/app/Http/Resources/SourceControlResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources;
 
 use App\Models\SourceControl;
+use App\SourceControlProviders\SourceControlProvider;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -16,7 +17,7 @@ class SourceControlResource extends JsonResource
     {
         $handler = config('source-control.providers.'.$this->provider.'.handler');
         $supportsSshPort = is_string($handler)
-            && is_a($handler, \App\SourceControlProviders\SourceControlProvider::class, true)
+            && is_a($handler, SourceControlProvider::class, true)
             && in_array('ssh_port', $handler::editableFields(), true);
 
         $data = [

--- a/app/Plugins/RegisterSourceControl.php
+++ b/app/Plugins/RegisterSourceControl.php
@@ -3,6 +3,7 @@
 namespace App\Plugins;
 
 use App\DTOs\DynamicForm;
+use App\SourceControlProviders\SourceControlProvider;
 
 class RegisterSourceControl
 {
@@ -66,12 +67,17 @@ class RegisterSourceControl
     {
         $providers = config('source-control.providers');
 
+        $editableFields = is_subclass_of($this->handler, SourceControlProvider::class)
+            ? $this->handler::editableFields()
+            : [];
+
         $providers[$this->name] = [
             'label' => $this->label,
             'handler' => $this->handler,
             'form' => $this->form ? $this->form->toArray() : [],
             'connectable' => $this->connectable,
             'usable_for_sites' => $this->usableForSites,
+            'editable_fields' => $editableFields,
         ];
 
         config(['source-control.providers' => $providers]);

--- a/app/Plugins/RegisterSourceControl.php
+++ b/app/Plugins/RegisterSourceControl.php
@@ -67,9 +67,10 @@ class RegisterSourceControl
     {
         $providers = config('source-control.providers');
 
-        $editableFields = is_subclass_of($this->handler, SourceControlProvider::class)
-            ? $this->handler::editableFields()
-            : [];
+        $editableFields = class_exists($this->handler)
+            && is_a($this->handler, SourceControlProvider::class, true)
+                ? $this->handler::editableFields()
+                : [];
 
         $providers[$this->name] = [
             'label' => $this->label,

--- a/app/Providers/SourceControlServiceProvider.php
+++ b/app/Providers/SourceControlServiceProvider.php
@@ -65,6 +65,11 @@ class SourceControlServiceProvider extends ServiceProvider
                     DynamicField::make('url')
                         ->text()
                         ->label('Self hosted URL'),
+                    DynamicField::make('ssh_port')
+                        ->text()
+                        ->label('SSH Port')
+                        ->default(22)
+                        ->description('SSH port used when cloning repositories (default: 22).'),
                 ])
             )
             ->register();
@@ -119,6 +124,11 @@ class SourceControlServiceProvider extends ServiceProvider
                     DynamicField::make('url')
                         ->text()
                         ->label('Self hosted URL'),
+                    DynamicField::make('ssh_port')
+                        ->text()
+                        ->label('SSH Port')
+                        ->default(22)
+                        ->description('SSH port used when cloning repositories (default: 22).'),
                 ])
             )
             ->register();

--- a/app/Providers/SourceControlServiceProvider.php
+++ b/app/Providers/SourceControlServiceProvider.php
@@ -69,7 +69,8 @@ class SourceControlServiceProvider extends ServiceProvider
                         ->text()
                         ->label('SSH Port')
                         ->default(22)
-                        ->description('SSH port used when cloning repositories (default: 22).'),
+                        ->placeholder('22')
+                        ->description('Numeric SSH port used when cloning repositories (default: 22).'),
                 ])
             )
             ->register();
@@ -128,7 +129,8 @@ class SourceControlServiceProvider extends ServiceProvider
                         ->text()
                         ->label('SSH Port')
                         ->default(22)
-                        ->description('SSH port used when cloning repositories (default: 22).'),
+                        ->placeholder('22')
+                        ->description('Numeric SSH port used when cloning repositories (default: 22).'),
                 ])
             )
             ->register();

--- a/app/SSH/OS/Git.php
+++ b/app/SSH/OS/Git.php
@@ -19,6 +19,7 @@ class Git
                 'path' => $path ?? $site->path,
                 'branch' => $site->branch,
                 'key' => $site->getSshKeyName(),
+                'port' => $site->sourceControl?->provider()?->getSshPort() ?? 22,
             ]),
             'clone-repository',
             $site->id

--- a/app/SourceControlProviders/AbstractSourceControlProvider.php
+++ b/app/SourceControlProviders/AbstractSourceControlProvider.php
@@ -61,6 +61,37 @@ abstract class AbstractSourceControlProvider implements SourceControlProvider
         return str($payload['ref'] ?? '')->after('refs/heads/')->toString();
     }
 
+    public function getSshPort(): int
+    {
+        return 22;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function editableFields(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @return array<string, array<int, string>>
+     */
+    public function editRules(array $input): array
+    {
+        return [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @return array<string, mixed>
+     */
+    public function editData(array $input): array
+    {
+        return $this->sourceControl->provider_data ?? [];
+    }
+
     public function getRepos(bool $useCache = true): array
     {
         return [];

--- a/app/SourceControlProviders/AbstractSourceControlProvider.php
+++ b/app/SourceControlProviders/AbstractSourceControlProvider.php
@@ -86,10 +86,32 @@ abstract class AbstractSourceControlProvider implements SourceControlProvider
     /**
      * @param  array<string, mixed>  $input
      * @return array<string, mixed>
+     *
+     * @note Subclasses that return a non-empty editableFields() MUST override
+     *       this method to whitelist exactly which keys are merged from $input.
+     *       Spreading $input here would let an attacker overwrite encrypted
+     *       fields like `token`.
      */
     public function editData(array $input): array
     {
         return $this->sourceControl->provider_data ?? [];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function sshPortRules(): array
+    {
+        return ['sometimes', 'nullable', 'integer', 'min:1', 'max:65535'];
+    }
+
+    protected function normalizeSshPort(mixed $value): int
+    {
+        if ($value === null || $value === '') {
+            return 22;
+        }
+
+        return (int) $value;
     }
 
     public function getRepos(bool $useCache = true): array

--- a/app/SourceControlProviders/Gitea.php
+++ b/app/SourceControlProviders/Gitea.php
@@ -38,7 +38,74 @@ class Gitea extends AbstractSourceControlProvider
                 'url:http,https',
                 'ends_with:/',
             ],
+            'ssh_port' => $this->sshPortRules(),
         ];
+    }
+
+    public function createData(array $input): array
+    {
+        return [
+            'token' => $input['token'] ?? '',
+            'ssh_port' => $this->normalizeSshPort($input['ssh_port'] ?? null),
+        ];
+    }
+
+    public function data(): array
+    {
+        $token = $this->sourceControl->access_token ?? '';
+
+        return [
+            'token' => $this->sourceControl->provider_data['token'] ?? $token,
+            'ssh_port' => (int) ($this->sourceControl->provider_data['ssh_port'] ?? 22),
+        ];
+    }
+
+    public function getSshPort(): int
+    {
+        return (int) ($this->data()['ssh_port'] ?? 22);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function editableFields(): array
+    {
+        return ['ssh_port'];
+    }
+
+    public function editRules(array $input): array
+    {
+        return [
+            'ssh_port' => $this->sshPortRules(),
+        ];
+    }
+
+    public function editData(array $input): array
+    {
+        $data = $this->sourceControl->provider_data ?? [];
+
+        if (array_key_exists('ssh_port', $input)) {
+            $data['ssh_port'] = $this->normalizeSshPort($input['ssh_port']);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function sshPortRules(): array
+    {
+        return ['nullable', 'integer', 'min:1', 'max:65535'];
+    }
+
+    private function normalizeSshPort(mixed $value): int
+    {
+        if ($value === null || $value === '') {
+            return 22;
+        }
+
+        return (int) $value;
     }
 
     public function connect(): bool

--- a/app/SourceControlProviders/Gitea.php
+++ b/app/SourceControlProviders/Gitea.php
@@ -62,7 +62,7 @@ class Gitea extends AbstractSourceControlProvider
 
     public function getSshPort(): int
     {
-        return (int) ($this->data()['ssh_port'] ?? 22);
+        return $this->data()['ssh_port'];
     }
 
     /**
@@ -89,23 +89,6 @@ class Gitea extends AbstractSourceControlProvider
         }
 
         return $data;
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private function sshPortRules(): array
-    {
-        return ['nullable', 'integer', 'min:1', 'max:65535'];
-    }
-
-    private function normalizeSshPort(mixed $value): int
-    {
-        if ($value === null || $value === '') {
-            return 22;
-        }
-
-        return (int) $value;
     }
 
     public function connect(): bool

--- a/app/SourceControlProviders/Gitlab.php
+++ b/app/SourceControlProviders/Gitlab.php
@@ -62,7 +62,7 @@ class Gitlab extends AbstractSourceControlProvider
 
     public function getSshPort(): int
     {
-        return (int) ($this->data()['ssh_port'] ?? 22);
+        return $this->data()['ssh_port'];
     }
 
     /**
@@ -89,23 +89,6 @@ class Gitlab extends AbstractSourceControlProvider
         }
 
         return $data;
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private function sshPortRules(): array
-    {
-        return ['nullable', 'integer', 'min:1', 'max:65535'];
-    }
-
-    private function normalizeSshPort(mixed $value): int
-    {
-        if ($value === null || $value === '') {
-            return 22;
-        }
-
-        return (int) $value;
     }
 
     public function connect(): bool

--- a/app/SourceControlProviders/Gitlab.php
+++ b/app/SourceControlProviders/Gitlab.php
@@ -38,7 +38,74 @@ class Gitlab extends AbstractSourceControlProvider
                 'url:http,https',
                 'ends_with:/',
             ],
+            'ssh_port' => $this->sshPortRules(),
         ];
+    }
+
+    public function createData(array $input): array
+    {
+        return [
+            'token' => $input['token'] ?? '',
+            'ssh_port' => $this->normalizeSshPort($input['ssh_port'] ?? null),
+        ];
+    }
+
+    public function data(): array
+    {
+        $token = $this->sourceControl->access_token ?? '';
+
+        return [
+            'token' => $this->sourceControl->provider_data['token'] ?? $token,
+            'ssh_port' => (int) ($this->sourceControl->provider_data['ssh_port'] ?? 22),
+        ];
+    }
+
+    public function getSshPort(): int
+    {
+        return (int) ($this->data()['ssh_port'] ?? 22);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function editableFields(): array
+    {
+        return ['ssh_port'];
+    }
+
+    public function editRules(array $input): array
+    {
+        return [
+            'ssh_port' => $this->sshPortRules(),
+        ];
+    }
+
+    public function editData(array $input): array
+    {
+        $data = $this->sourceControl->provider_data ?? [];
+
+        if (array_key_exists('ssh_port', $input)) {
+            $data['ssh_port'] = $this->normalizeSshPort($input['ssh_port']);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function sshPortRules(): array
+    {
+        return ['nullable', 'integer', 'min:1', 'max:65535'];
+    }
+
+    private function normalizeSshPort(mixed $value): int
+    {
+        if ($value === null || $value === '') {
+            return 22;
+        }
+
+        return (int) $value;
     }
 
     public function connect(): bool

--- a/app/SourceControlProviders/SourceControlProvider.php
+++ b/app/SourceControlProviders/SourceControlProvider.php
@@ -33,6 +33,25 @@ interface SourceControlProvider
 
     public function fullRepoUrl(string $repo, string $key): string;
 
+    public function getSshPort(): int;
+
+    /**
+     * @return array<int, string>
+     */
+    public static function editableFields(): array;
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @return array<string, array<int, string>>
+     */
+    public function editRules(array $input): array;
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @return array<string, mixed>
+     */
+    public function editData(array $input): array;
+
     /**
      * @param  array<int, mixed>  $events
      * @return array<string, mixed>

--- a/public/api-docs/openapi/schemas/SourceControl.yaml
+++ b/public/api-docs/openapi/schemas/SourceControl.yaml
@@ -44,6 +44,13 @@ properties:
         nullable: true
         format: uri
         example: 'https://github.com/organizations/acme-org/settings/installations/12345678'
+  ssh_port:
+    type: integer
+    nullable: true
+    minimum: 1
+    maximum: 65535
+    example: 22
+    description: 'SSH port used when cloning repositories. Only present for providers that support a custom port (Gitea, GitLab).'
   created_at:
     type: string
     format: date-time

--- a/public/api-docs/openapi/source-controls.yaml
+++ b/public/api-docs/openapi/source-controls.yaml
@@ -93,6 +93,13 @@ paths:
                   type: string
                   description: Custom URL for self-hosted instances (optional)
                   example: 'https://git.example.com'
+                ssh_port:
+                  type: integer
+                  nullable: true
+                  minimum: 1
+                  maximum: 65535
+                  description: 'SSH port used when cloning repositories. Only honoured by providers that support a custom port (Gitea, GitLab). Defaults to 22 when omitted.'
+                  example: 22
       responses:
         '201':
           description: Source control created successfully
@@ -209,6 +216,13 @@ paths:
                   type: string
                   description: Source control name
                   example: 'GitHub'
+                ssh_port:
+                  type: integer
+                  nullable: true
+                  minimum: 1
+                  maximum: 65535
+                  description: 'SSH port used when cloning repositories. Only honoured by providers that support a custom port (Gitea, GitLab).'
+                  example: 22
       responses:
         '200':
           description: Source control updated successfully

--- a/public/api-docs/openapi/user-source-controls.yaml
+++ b/public/api-docs/openapi/user-source-controls.yaml
@@ -69,6 +69,13 @@ paths:
                   type: string
                   description: Custom URL for self-hosted instances (optional)
                   example: 'https://git.example.com'
+                ssh_port:
+                  type: integer
+                  nullable: true
+                  minimum: 1
+                  maximum: 65535
+                  description: 'SSH port used when cloning repositories. Only honoured by providers that support a custom port (Gitea, GitLab). Defaults to 22 when omitted.'
+                  example: 22
                 global:
                   type: boolean
                   description: Whether this source control should be available globally (not tied to current project)
@@ -167,6 +174,13 @@ paths:
                   type: string
                   description: Source control name
                   example: 'GitHub'
+                ssh_port:
+                  type: integer
+                  nullable: true
+                  minimum: 1
+                  maximum: 65535
+                  description: 'SSH port used when cloning repositories. Only honoured by providers that support a custom port (Gitea, GitLab).'
+                  example: 22
                 global:
                   type: boolean
                   description: Whether this source control should be available globally (not tied to current project)

--- a/resources/js/pages/source-controls/components/columns.tsx
+++ b/resources/js/pages/source-controls/components/columns.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { useForm } from '@inertiajs/react';
+import { useForm, usePage } from '@inertiajs/react';
 import { LoaderCircleIcon, MoreVerticalIcon } from 'lucide-react';
 import FormSuccessful from '@/components/form-successful';
 import { FormEvent, useState } from 'react';
@@ -23,14 +23,27 @@ import { Form, FormField, FormFields } from '@/components/ui/form';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
+import { SharedData } from '@/types';
+import { DynamicFieldConfig } from '@/types/dynamic-field-config';
+import DynamicField from '@/components/ui/dynamic-field';
 
 function Edit({ sourceControl }: { sourceControl: SourceControl }) {
   const [open, setOpen] = useState(false);
   const isGithubApp = sourceControl.provider === 'github-app';
-  const form = useForm({
+  const page = usePage<SharedData>();
+  const providerConfig = page.props.configs.source_control.providers[sourceControl.provider];
+  const editableFields = providerConfig?.editable_fields ?? [];
+  const editableFormFields = (providerConfig?.form ?? []).filter((f: DynamicFieldConfig) => editableFields.includes(f.name));
+
+  const initialValues: Record<string, unknown> = {
     name: sourceControl.name,
     global: sourceControl.global,
-  });
+  };
+  for (const field of editableFormFields) {
+    initialValues[field.name] = sourceControl[field.name] ?? field.default ?? '';
+  }
+
+  const form = useForm<Record<string, unknown>>(initialValues);
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
@@ -58,20 +71,34 @@ function Edit({ sourceControl }: { sourceControl: SourceControl }) {
                 type="text"
                 id="name"
                 name="name"
-                value={form.data.name}
+                value={form.data.name as string}
                 onChange={(e) => form.setData('name', e.target.value)}
                 disabled={isGithubApp}
                 readOnly={isGithubApp}
               />
               {isGithubApp && <p className="text-muted-foreground text-xs">The name is the GitHub organization and cannot be changed.</p>}
-              <InputError message={form.errors.name} />
+              <InputError message={form.errors.name as string | undefined} />
             </FormField>
+            {editableFormFields.map((field: DynamicFieldConfig) => (
+              <DynamicField
+                key={`field-${field.name}`}
+                value={form.data[field.name] as string | number | boolean | string[] | undefined}
+                onChange={(value) => form.setData(field.name, value)}
+                config={field}
+                error={form.errors[field.name] as string | undefined}
+              />
+            ))}
             <FormField>
               <div className="flex items-center space-x-3">
-                <Checkbox id="global" name="global" checked={form.data.global} onClick={() => form.setData('global', !form.data.global)} />
+                <Checkbox
+                  id="global"
+                  name="global"
+                  checked={form.data.global as boolean}
+                  onClick={() => form.setData('global', !form.data.global)}
+                />
                 <Label htmlFor="global">Is global (accessible in all projects)</Label>
               </div>
-              <InputError message={form.errors.global} />
+              <InputError message={form.errors.global as string | undefined} />
             </FormField>
           </FormFields>
         </Form>

--- a/resources/js/pages/source-controls/components/columns.tsx
+++ b/resources/js/pages/source-controls/components/columns.tsx
@@ -17,7 +17,7 @@ import { Button } from '@/components/ui/button';
 import { useForm, usePage } from '@inertiajs/react';
 import { LoaderCircleIcon, MoreVerticalIcon } from 'lucide-react';
 import FormSuccessful from '@/components/form-successful';
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { FormEvent, useMemo, useState } from 'react';
 import InputError from '@/components/ui/input-error';
 import { Form, FormField, FormFields } from '@/components/ui/form';
 import { Label } from '@/components/ui/label';
@@ -27,8 +27,7 @@ import { SharedData } from '@/types';
 import { DynamicFieldConfig } from '@/types/dynamic-field-config';
 import DynamicField from '@/components/ui/dynamic-field';
 
-function Edit({ sourceControl }: { sourceControl: SourceControl }) {
-  const [open, setOpen] = useState(false);
+function EditForm({ sourceControl, onSuccess }: { sourceControl: SourceControl; onSuccess: () => void }) {
   const isGithubApp = sourceControl.provider === 'github-app';
   const page = usePage<SharedData>();
   const providerConfig = page.props.configs?.source_control?.providers?.[sourceControl.provider];
@@ -38,35 +37,76 @@ function Edit({ sourceControl }: { sourceControl: SourceControl }) {
     return (providerConfig?.form ?? []).filter((f) => editableFields.includes(f.name));
   }, [providerConfig]);
 
-  const initialValues = useMemo<Record<string, unknown>>(
-    () => ({
-      name: sourceControl.name,
-      global: sourceControl.global,
-      ...Object.fromEntries(editableFormFields.map((f) => [f.name, sourceControl[f.name] ?? f.default ?? null])),
-    }),
-    [sourceControl, editableFormFields],
-  );
-
-  const form = useForm<Record<string, unknown>>(initialValues);
-
-  useEffect(() => {
-    if (!open) {
-      form.setDefaults(initialValues);
-      form.reset();
-      form.clearErrors();
-    }
-    // form is a stable Inertia helper; tracking initialValues + open is sufficient
-     
-  }, [initialValues, open]);
+  const form = useForm<Record<string, unknown>>({
+    name: sourceControl.name,
+    global: sourceControl.global,
+    ...Object.fromEntries(editableFormFields.map((f) => [f.name, sourceControl[f.name] ?? f.default ?? null])),
+  });
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
     form.patch(route('source-controls.update', sourceControl.id), {
-      onSuccess: () => {
-        setOpen(false);
-      },
+      onSuccess,
     });
   };
+
+  return (
+    <>
+      <Form id="edit-source-control-form" className="p-4" onSubmit={submit}>
+        <FormFields>
+          <FormField>
+            <Label htmlFor="name">Name</Label>
+            <Input
+              type="text"
+              id="name"
+              name="name"
+              value={form.data.name as string}
+              onChange={(e) => form.setData('name', e.target.value)}
+              disabled={isGithubApp}
+              readOnly={isGithubApp}
+            />
+            {isGithubApp && <p className="text-muted-foreground text-xs">The name is the GitHub organization and cannot be changed.</p>}
+            <InputError message={form.errors.name as string | undefined} />
+          </FormField>
+          {editableFormFields.map((field) => (
+            <DynamicField
+              key={field.name}
+              value={form.data[field.name] as string | number | boolean | string[] | undefined}
+              onChange={(value) => form.setData(field.name, value)}
+              config={field}
+              error={form.errors[field.name] as string | undefined}
+            />
+          ))}
+          <FormField>
+            <div className="flex items-center space-x-3">
+              <Checkbox
+                id="global"
+                name="global"
+                checked={form.data.global as boolean}
+                onCheckedChange={(checked) => form.setData('global', checked === true)}
+              />
+              <Label htmlFor="global">Is global (accessible in all projects)</Label>
+            </div>
+            <InputError message={form.errors.global as string | undefined} />
+          </FormField>
+        </FormFields>
+      </Form>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button variant="outline">Cancel</Button>
+        </DialogClose>
+        <Button form="edit-source-control-form" disabled={form.processing} onClick={submit}>
+          {form.processing && <LoaderCircleIcon className="animate-spin" />}
+          <FormSuccessful successful={form.recentlySuccessful} />
+          Save
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function Edit({ sourceControl }: { sourceControl: SourceControl }) {
+  const [open, setOpen] = useState(false);
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
@@ -77,55 +117,7 @@ function Edit({ sourceControl }: { sourceControl: SourceControl }) {
           <DialogTitle>Edit {sourceControl.name}</DialogTitle>
           <DialogDescription className="sr-only">Edit source control</DialogDescription>
         </DialogHeader>
-        <Form id="edit-source-control-form" className="p-4" onSubmit={submit}>
-          <FormFields>
-            <FormField>
-              <Label htmlFor="name">Name</Label>
-              <Input
-                type="text"
-                id="name"
-                name="name"
-                value={form.data.name as string}
-                onChange={(e) => form.setData('name', e.target.value)}
-                disabled={isGithubApp}
-                readOnly={isGithubApp}
-              />
-              {isGithubApp && <p className="text-muted-foreground text-xs">The name is the GitHub organization and cannot be changed.</p>}
-              <InputError message={form.errors.name as string | undefined} />
-            </FormField>
-            {editableFormFields.map((field) => (
-              <DynamicField
-                key={field.name}
-                value={form.data[field.name] as string | number | boolean | string[] | undefined}
-                onChange={(value) => form.setData(field.name, value)}
-                config={field}
-                error={form.errors[field.name] as string | undefined}
-              />
-            ))}
-            <FormField>
-              <div className="flex items-center space-x-3">
-                <Checkbox
-                  id="global"
-                  name="global"
-                  checked={form.data.global as boolean}
-                  onCheckedChange={(checked) => form.setData('global', checked === true)}
-                />
-                <Label htmlFor="global">Is global (accessible in all projects)</Label>
-              </div>
-              <InputError message={form.errors.global as string | undefined} />
-            </FormField>
-          </FormFields>
-        </Form>
-        <DialogFooter>
-          <DialogClose asChild>
-            <Button variant="outline">Cancel</Button>
-          </DialogClose>
-          <Button form="edit-source-control-form" disabled={form.processing} onClick={submit}>
-            {form.processing && <LoaderCircleIcon className="animate-spin" />}
-            <FormSuccessful successful={form.recentlySuccessful} />
-            Save
-          </Button>
-        </DialogFooter>
+        {open && <EditForm sourceControl={sourceControl} onSuccess={() => setOpen(false)} />}
       </DialogContent>
     </Dialog>
   );

--- a/resources/js/pages/source-controls/components/columns.tsx
+++ b/resources/js/pages/source-controls/components/columns.tsx
@@ -56,7 +56,7 @@ function Edit({ sourceControl }: { sourceControl: SourceControl }) {
       form.clearErrors();
     }
     // form is a stable Inertia helper; tracking initialValues + open is sufficient
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+     
   }, [initialValues, open]);
 
   const submit = (e: FormEvent) => {

--- a/resources/js/pages/source-controls/components/columns.tsx
+++ b/resources/js/pages/source-controls/components/columns.tsx
@@ -17,7 +17,7 @@ import { Button } from '@/components/ui/button';
 import { useForm, usePage } from '@inertiajs/react';
 import { LoaderCircleIcon, MoreVerticalIcon } from 'lucide-react';
 import FormSuccessful from '@/components/form-successful';
-import { FormEvent, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
 import InputError from '@/components/ui/input-error';
 import { Form, FormField, FormFields } from '@/components/ui/form';
 import { Label } from '@/components/ui/label';
@@ -31,19 +31,33 @@ function Edit({ sourceControl }: { sourceControl: SourceControl }) {
   const [open, setOpen] = useState(false);
   const isGithubApp = sourceControl.provider === 'github-app';
   const page = usePage<SharedData>();
-  const providerConfig = page.props.configs.source_control.providers[sourceControl.provider];
-  const editableFields = providerConfig?.editable_fields ?? [];
-  const editableFormFields = (providerConfig?.form ?? []).filter((f: DynamicFieldConfig) => editableFields.includes(f.name));
+  const providerConfig = page.props.configs?.source_control?.providers?.[sourceControl.provider];
 
-  const initialValues: Record<string, unknown> = {
-    name: sourceControl.name,
-    global: sourceControl.global,
-  };
-  for (const field of editableFormFields) {
-    initialValues[field.name] = sourceControl[field.name] ?? field.default ?? '';
-  }
+  const editableFormFields = useMemo<DynamicFieldConfig[]>(() => {
+    const editableFields = providerConfig?.editable_fields ?? [];
+    return (providerConfig?.form ?? []).filter((f) => editableFields.includes(f.name));
+  }, [providerConfig]);
+
+  const initialValues = useMemo<Record<string, unknown>>(
+    () => ({
+      name: sourceControl.name,
+      global: sourceControl.global,
+      ...Object.fromEntries(editableFormFields.map((f) => [f.name, sourceControl[f.name] ?? f.default ?? null])),
+    }),
+    [sourceControl, editableFormFields],
+  );
 
   const form = useForm<Record<string, unknown>>(initialValues);
+
+  useEffect(() => {
+    if (!open) {
+      form.setDefaults(initialValues);
+      form.reset();
+      form.clearErrors();
+    }
+    // form is a stable Inertia helper; tracking initialValues + open is sufficient
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialValues, open]);
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
@@ -79,9 +93,9 @@ function Edit({ sourceControl }: { sourceControl: SourceControl }) {
               {isGithubApp && <p className="text-muted-foreground text-xs">The name is the GitHub organization and cannot be changed.</p>}
               <InputError message={form.errors.name as string | undefined} />
             </FormField>
-            {editableFormFields.map((field: DynamicFieldConfig) => (
+            {editableFormFields.map((field) => (
               <DynamicField
-                key={`field-${field.name}`}
+                key={field.name}
                 value={form.data[field.name] as string | number | boolean | string[] | undefined}
                 onChange={(value) => form.setData(field.name, value)}
                 config={field}
@@ -94,7 +108,7 @@ function Edit({ sourceControl }: { sourceControl: SourceControl }) {
                   id="global"
                   name="global"
                   checked={form.data.global as boolean}
-                  onClick={() => form.setData('global', !form.data.global)}
+                  onCheckedChange={(checked) => form.setData('global', checked === true)}
                 />
                 <Label htmlFor="global">Is global (accessible in all projects)</Label>
               </div>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -68,6 +68,7 @@ export interface Configs {
         form?: DynamicFieldConfig[];
         connectable?: boolean;
         usable_for_sites?: boolean;
+        editable_fields?: string[];
       };
     };
   };

--- a/resources/js/types/source-control.d.ts
+++ b/resources/js/types/source-control.d.ts
@@ -12,6 +12,7 @@ export interface SourceControl {
   provider: string;
   external_identifier?: string | null;
   github_app?: GithubAppDetails;
+  ssh_port?: number;
   created_at: string;
   updated_at: string;
 

--- a/resources/views/ssh/git/clone.blade.php
+++ b/resources/views/ssh/git/clone.blade.php
@@ -1,3 +1,14 @@
+if [ -f ~/.ssh/config ]; then
+    if ! awk -v alias_name='{{ $host }}-{{ $key }}' '
+        /^Host[[:space:]]/ { skip = ($2 == alias_name && NF == 2) ? 1 : 0 }
+        !skip { print }
+    ' ~/.ssh/config > ~/.ssh/config.vito.tmp; then
+        rm -f ~/.ssh/config.vito.tmp
+        echo 'VITO_SSH_ERROR' && exit 1
+    fi
+    mv ~/.ssh/config.vito.tmp ~/.ssh/config
+fi
+
 echo "Host {{ $host }}-{{ $key }}
         Hostname {{ $host }}
         Port {{ $port }}

--- a/resources/views/ssh/git/clone.blade.php
+++ b/resources/views/ssh/git/clone.blade.php
@@ -1,10 +1,11 @@
 echo "Host {{ $host }}-{{ $key }}
         Hostname {{ $host }}
+        Port {{ $port }}
         IdentityFile=~/.ssh/{{ $key }}" >> ~/.ssh/config
 
 chmod 600 ~/.ssh/config
 
-ssh-keyscan -H {{ $host }} >> ~/.ssh/known_hosts
+ssh-keyscan -T 5 -p {{ $port }} -H {{ $host }} >> ~/.ssh/known_hosts
 
 rm -rf {{ $path }}
 

--- a/tests/Feature/SourceControlsTest.php
+++ b/tests/Feature/SourceControlsTest.php
@@ -6,6 +6,7 @@ use App\Models\SourceControl;
 use App\Models\User;
 use App\SourceControlProviders\Bitbucket;
 use App\SourceControlProviders\BitbucketV2;
+use App\SourceControlProviders\Gitea;
 use App\SourceControlProviders\Github;
 use App\SourceControlProviders\Gitlab;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -278,6 +279,164 @@ class SourceControlsTest extends TestCase
         );
     }
 
+    public function test_connect_gitea_persists_ssh_port_in_provider_data(): void
+    {
+        Http::fake();
+        $this->actingAs($this->user);
+
+        $this->post(route('source-controls.store'), [
+            'name' => 'gitea-custom-port',
+            'provider' => Gitea::id(),
+            'token' => 'test-token',
+            'url' => 'https://gitea.example.com/',
+            'ssh_port' => 2222,
+        ])->assertSessionDoesntHaveErrors();
+
+        /** @var SourceControl $sourceControl */
+        $sourceControl = SourceControl::query()
+            ->where('provider', Gitea::id())
+            ->where('profile', 'gitea-custom-port')
+            ->firstOrFail();
+
+        $this->assertSame(2222, $sourceControl->provider_data['ssh_port']);
+        $this->assertSame('test-token', $sourceControl->provider_data['token']);
+        $this->assertSame(2222, $sourceControl->provider()->getSshPort());
+    }
+
+    public function test_connect_gitea_without_ssh_port_defaults_to_22(): void
+    {
+        Http::fake();
+        $this->actingAs($this->user);
+
+        $this->post(route('source-controls.store'), [
+            'name' => 'gitea-default',
+            'provider' => Gitea::id(),
+            'token' => 'test-token',
+        ])->assertSessionDoesntHaveErrors();
+
+        /** @var SourceControl $sourceControl */
+        $sourceControl = SourceControl::query()
+            ->where('provider', Gitea::id())
+            ->where('profile', 'gitea-default')
+            ->firstOrFail();
+
+        $this->assertSame(22, $sourceControl->provider_data['ssh_port']);
+        $this->assertSame(22, $sourceControl->provider()->getSshPort());
+    }
+
+    public function test_edit_gitea_updates_ssh_port(): void
+    {
+        Http::fake();
+        $this->actingAs($this->user);
+
+        /** @var SourceControl $sourceControl */
+        $sourceControl = SourceControl::factory()->create([
+            'provider' => Gitea::id(),
+            'user_id' => $this->user->id,
+            'profile' => 'gitea',
+            'provider_data' => ['token' => 'original-token', 'ssh_port' => 22],
+        ]);
+
+        $this->patch(route('source-controls.update', $sourceControl), [
+            'name' => 'gitea',
+            'ssh_port' => 2222,
+        ])->assertSessionDoesntHaveErrors();
+
+        $sourceControl->refresh();
+
+        $this->assertSame(2222, $sourceControl->provider_data['ssh_port']);
+        $this->assertSame('original-token', $sourceControl->provider_data['token']);
+    }
+
+    public function test_edit_cannot_clobber_token_via_extra_input(): void
+    {
+        Http::fake();
+        $this->actingAs($this->user);
+
+        /** @var SourceControl $sourceControl */
+        $sourceControl = SourceControl::factory()->create([
+            'provider' => Gitea::id(),
+            'user_id' => $this->user->id,
+            'profile' => 'gitea',
+            'provider_data' => ['token' => 'original-token', 'ssh_port' => 22],
+        ]);
+
+        $this->patch(route('source-controls.update', $sourceControl), [
+            'name' => 'gitea',
+            'ssh_port' => 2222,
+            'token' => 'stolen-token',
+        ])->assertSessionDoesntHaveErrors();
+
+        $sourceControl->refresh();
+
+        $this->assertSame('original-token', $sourceControl->provider_data['token']);
+        $this->assertSame(2222, $sourceControl->provider_data['ssh_port']);
+    }
+
+    public function test_edit_gitea_rejects_out_of_range_ssh_port(): void
+    {
+        Http::fake();
+        $this->actingAs($this->user);
+
+        /** @var SourceControl $sourceControl */
+        $sourceControl = SourceControl::factory()->create([
+            'provider' => Gitea::id(),
+            'user_id' => $this->user->id,
+            'provider_data' => ['token' => 'original-token', 'ssh_port' => 22],
+        ]);
+
+        $this->patch(route('source-controls.update', $sourceControl), [
+            'name' => 'gitea',
+            'ssh_port' => 70000,
+        ])->assertSessionHasErrors(['ssh_port']);
+
+        $sourceControl->refresh();
+        $this->assertSame(22, $sourceControl->provider_data['ssh_port']);
+    }
+
+    public function test_legacy_row_without_ssh_port_falls_back_to_22(): void
+    {
+        /** @var SourceControl $sourceControl */
+        $sourceControl = SourceControl::factory()->create([
+            'provider' => Gitea::id(),
+            'user_id' => $this->user->id,
+            'provider_data' => ['token' => 'legacy-token'],
+        ]);
+
+        $this->assertSame(22, $sourceControl->provider()->getSshPort());
+        $this->assertSame(22, $sourceControl->provider()->data()['ssh_port']);
+    }
+
+    public function test_clone_script_renders_custom_port(): void
+    {
+        $rendered = view('ssh.git.clone', [
+            'host' => 'gitea.example.com',
+            'repo' => 'git@gitea.example.com-site_1:owner/repo.git',
+            'path' => '/home/vito/test',
+            'branch' => 'main',
+            'key' => 'site_1',
+            'port' => 2222,
+        ])->render();
+
+        $this->assertStringContainsString('Port 2222', $rendered);
+        $this->assertStringContainsString('ssh-keyscan -T 5 -p 2222 -H gitea.example.com', $rendered);
+    }
+
+    public function test_clone_script_renders_default_port_22(): void
+    {
+        $rendered = view('ssh.git.clone', [
+            'host' => 'gitea.example.com',
+            'repo' => 'git@gitea.example.com-site_1:owner/repo.git',
+            'path' => '/home/vito/test',
+            'branch' => 'main',
+            'key' => 'site_1',
+            'port' => 22,
+        ])->render();
+
+        $this->assertStringContainsString('Port 22', $rendered);
+        $this->assertStringContainsString('ssh-keyscan -T 5 -p 22 -H gitea.example.com', $rendered);
+    }
+
     /**
      * @return array<int, mixed>
      */
@@ -288,6 +447,9 @@ class SourceControlsTest extends TestCase
             [Github::id(), null, ['token' => 'test', 'global' => true]],
             [Gitlab::id(), null, ['token' => 'test']],
             [Gitlab::id(), 'https://git.example.com/', ['token' => 'test']],
+            [Gitlab::id(), 'https://git.example.com/', ['token' => 'test', 'ssh_port' => 2222]],
+            [Gitea::id(), null, ['token' => 'test']],
+            [Gitea::id(), 'https://gitea.example.com/', ['token' => 'test', 'ssh_port' => 222]],
             [Bitbucket::id(), null, ['username' => 'test', 'password' => 'test']],
             [BitbucketV2::id(), null, ['key' => 'test', 'secret' => 'test']],
         ];

--- a/tests/Feature/SourceControlsTest.php
+++ b/tests/Feature/SourceControlsTest.php
@@ -373,6 +373,31 @@ class SourceControlsTest extends TestCase
         $this->assertSame(2222, $sourceControl->provider_data['ssh_port']);
     }
 
+    public function test_edit_gitlab_cannot_clobber_token_via_extra_input(): void
+    {
+        Http::fake();
+        $this->actingAs($this->user);
+
+        /** @var SourceControl $sourceControl */
+        $sourceControl = SourceControl::factory()->create([
+            'provider' => Gitlab::id(),
+            'user_id' => $this->user->id,
+            'profile' => 'gitlab',
+            'provider_data' => ['token' => 'original-token', 'ssh_port' => 22],
+        ]);
+
+        $this->patch(route('source-controls.update', $sourceControl), [
+            'name' => 'gitlab',
+            'ssh_port' => 2222,
+            'token' => 'stolen-token',
+        ])->assertSessionDoesntHaveErrors();
+
+        $sourceControl->refresh();
+
+        $this->assertSame('original-token', $sourceControl->provider_data['token']);
+        $this->assertSame(2222, $sourceControl->provider_data['ssh_port']);
+    }
+
     public function test_edit_gitea_rejects_out_of_range_ssh_port(): void
     {
         Http::fake();

--- a/tests/Feature/SourceControlsTest.php
+++ b/tests/Feature/SourceControlsTest.php
@@ -445,6 +445,7 @@ class SourceControlsTest extends TestCase
 
         $this->assertStringContainsString('Port 2222', $rendered);
         $this->assertStringContainsString('ssh-keyscan -T 5 -p 2222 -H gitea.example.com', $rendered);
+        $this->assertStringContainsString("alias_name='gitea.example.com-site_1'", $rendered);
     }
 
     public function test_clone_script_renders_default_port_22(): void


### PR DESCRIPTION
This pull request introduces support for configuring a custom SSH port for Gitea and GitLab source control providers, allowing users to specify which port should be used when cloning repositories. It also generalizes provider editability, so only safe, whitelisted fields can be edited, and ensures the UI and API reflect these changes. The most significant changes are grouped below.

| Gitlab UI |
|-|
| <img width="583" height="612" alt="CleanShot 2026-05-17 at 11 35 30" src="https://github.com/user-attachments/assets/52673e9c-730e-4237-866e-63d87e3fb748" /> |

| Gitea UI |
|-|
| <img width="579" height="610" alt="CleanShot 2026-05-17 at 11 36 23" src="https://github.com/user-attachments/assets/7c5dfd86-958d-43d6-88b8-cdda083ea2df" /> |

**Backend: SSH Port Support and Provider Editability**

* Added `ssh_port` as a configurable and editable field for Gitea and GitLab providers, including validation, normalization, and persistence logic in their respective provider classes (`Gitea.php`, `Gitlab.php`). The default is 22, but users can specify a different port if needed.
* Updated the abstract provider and interface to require implementation of `getSshPort`, `editableFields`, `editRules`, and `editData` methods, ensuring only whitelisted fields can be edited and preventing unsafe mass assignment.
* The edit action now merges provider-specific rules and data handling, so only allowed fields are validated and saved.

**UI/API: Dynamic Edit Forms and Schema Updates**

* The API resource and OpenAPI schema now conditionally include the `ssh_port` field for providers that support it, with proper typing and documentation.
* The frontend edit form dynamically renders only the editable fields for each provider, using provider config and dynamic field components, ensuring the UI matches backend validation and security.
* Registration and configuration of providers now include a list of editable fields, so the UI and backend remain in sync about what can be edited.

**Operational: SSH Clone Script and Usage**

* The SSH clone script and logic now use the configured port when cloning repositories, and update `ssh-keyscan` and SSH config generation accordingly.

**Provider Registration**

* When registering Gitea and GitLab providers, the SSH port field is included in their dynamic forms, with defaults and descriptions.

These changes make SSH port configuration safer, more flexible, and more user-friendly for self-hosted source control integrations. 

Resolves #1085 