### PR TITLE
[Fix] Resolve Dropbox backup issue

### DIFF
--- a/resources/views/ssh/storage/dropbox/upload.blade.php
+++ b/resources/views/ssh/storage/dropbox/upload.blade.php
@@ -3,4 +3,4 @@ curl -sb --location --request POST 'https://content.dropboxapi.com/2/files/uploa
 --header 'Dropbox-API-Arg: {"path":"{{ $dest }}"}' \
 --header 'Content-Type: text/plain; charset=dropbox-cors-hack' \
 --header 'Authorization: Bearer {{ $token }}' \
---data-binary '@{{ $src }}'
+--data-binary '{{ "@" . $src }}'


### PR DESCRIPTION
This pull request makes a minor adjustment to the Dropbox upload view template to ensure the file upload path is correctly interpreted.

* Changed the `--data-binary` parameter in `resources/views/ssh/storage/dropbox/upload.blade.php` to properly concatenate the `@` symbol with the source file variable, improving the way the file is referenced for upload.