### PR TITLE
[Fix] Default WS_URL

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -19,7 +19,7 @@ class EventsController extends Controller
             'project_id' => $request->user()->current_project_id,
         ]);
 
-        $appUrl = parse_url(config('app.ws_url', config('app.url')));
+        $appUrl = parse_url(config('app.ws_url') ?: config('app.url'));
         $isSecure = ($appUrl['scheme'] ?? 'http') === 'https';
         $wsProtocol = $isSecure ? 'wss' : 'ws';
         $host = $appUrl['host'] ?? 'localhost';


### PR DESCRIPTION
This pull request makes a minor change to how the WebSocket URL is determined in the `EventsController`. It ensures that if `app.ws_url` is not set, the application will correctly fall back to `app.url`.