### PR TITLE
[FIX] 4.x: Identify Vito's own server by install marker, not by 'vito' user alone

### DIFF
--- a/app/ServerProviders/Custom.php
+++ b/app/ServerProviders/Custom.php
@@ -83,8 +83,8 @@ class Custom extends AbstractProvider
             throw new ServerProviderError('Cannot connect to server, make sure you have copied the public key.');
         }
 
-        $output = $this->server->ssh('root')->exec('id -u vito 2>/dev/null || echo "user_not_found"');
-        if (! str_contains($output, 'user_not_found')) {
+        $output = $this->server->ssh('root')->exec('id -u vito >/dev/null 2>&1 && test -f /home/vito/vito/artisan && echo "vito_managed_host" || echo "ok"');
+        if (str_contains($output, 'vito_managed_host')) {
             throw new ServerProviderError('You cannot perform this action on Vito\'s server itself.');
         }
     }

--- a/tests/Feature/ServerTest.php
+++ b/tests/Feature/ServerTest.php
@@ -699,7 +699,7 @@ class ServerTest extends TestCase
         $this->actingAs($this->user);
 
         Storage::fake();
-        SSH::fake('1000'); // Simulates vito user exists (returns user ID)
+        SSH::fake('vito_managed_host');
 
         $this->post(route('servers.store'), [
             'provider' => Custom::id(),
@@ -713,6 +713,29 @@ class ServerTest extends TestCase
 
         $this->assertDatabaseMissing('servers', [
             'name' => 'test-vito-server',
+        ]);
+    }
+
+    public function test_can_create_server_when_host_has_unrelated_vito_user(): void
+    {
+        $this->actingAs($this->user);
+
+        Storage::fake();
+        SSH::fake('ok');
+
+        $this->post(route('servers.store'), [
+            'provider' => Custom::id(),
+            'name' => 'unrelated-vito-user',
+            'ip' => '7.7.7.7',
+            'port' => '22',
+            'os' => OperatingSystem::UBUNTU22->value,
+            'services' => [],
+        ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('servers', [
+            'name' => 'unrelated-vito-user',
+            'ip' => '7.7.7.7',
         ]);
     }
 }


### PR DESCRIPTION
Closes #1103

`Custom::create` rejects a server whenever `id -u vito` succeeds (`app/ServerProviders/Custom.php` ~line 86). That guard was added in #942 for the 3.x bare-metal installer which creates a `vito` system user (`scripts/install.sh:50`). In 4.x Vito ships as a Docker container and the installer no longer writes to the host, so any unrelated machine that has a `vito` Linux user (old bare-metal leftovers, unrelated tooling) is rejected.

Combining the user check with `test -f /home/vito/vito/artisan` (the path `scripts/install.sh:197` clones into) keeps the original root-only bar and removes the false positive.

`vendor/bin/phpunit --filter "vito" tests/Feature/ServerTest.php` green. The existing "cannot create server on Vito server" test is updated to fake the new output token, and a sibling test covers the non-Vito host branch.

No migration. Open to a different marker if you prefer.
