### PR TITLE
[Fix] Console WS_URL fallback to APP_URL

### DIFF
--- a/app/Http/Controllers/ConsoleController.php
+++ b/app/Http/Controllers/ConsoleController.php
@@ -47,7 +47,7 @@ class ConsoleController extends Controller
             'ssh_user' => $request->input('user'),
         ]);
 
-        $appUrl = parse_url(config('app.url'));
+        $appUrl = parse_url(config('app.ws_url') ?: config('app.url'));
         $isSecure = ($appUrl['scheme'] ?? 'http') === 'https';
         $wsProtocol = $isSecure ? 'wss' : 'ws';
         $host = $appUrl['host'] ?? 'localhost';


### PR DESCRIPTION
Use ws_url with app_url fallback

fails pre-commit due to two errors.  These were existing, but have been resolved in https://github.com/vitodeploy/vito/pull/1096/changes/3f5853ea0c6fb57c6c2c509ac1280e54cd54bafa - to avoid a merge conflict, I left them. 