### PR TITLE
[Fix] Ensure .env for Laravel Sites

### DIFF
--- a/app/SiteTypes/Laravel.php
+++ b/app/SiteTypes/Laravel.php
@@ -2,6 +2,8 @@
 
 namespace App\SiteTypes;
 
+use App\Exceptions\FailedToDeployGitKey;
+use App\Exceptions\SSHError;
 use App\Models\Site;
 
 class Laravel extends PHPSite
@@ -14,6 +16,27 @@ class Laravel extends PHPSite
     public static function make(): self
     {
         return new self(new Site(['type' => self::id()]));
+    }
+
+    /**
+     * @throws FailedToDeployGitKey
+     * @throws SSHError
+     */
+    public function install(): void
+    {
+        parent::install();
+
+        $envPath = $this->site->type_data['env_path'] ?? $this->site->path.'/.env';
+        $examplePath = $this->site->path.'/.env.example';
+
+        $this->site->server->ssh($this->site->user)->exec(
+            view('ssh.laravel.ensure-env', [
+                'envPath' => $envPath,
+                'examplePath' => $examplePath,
+            ]),
+            'ensure-env',
+            $this->site->id,
+        );
     }
 
     public function baseCommands(): array

--- a/resources/views/ssh/laravel/ensure-env.blade.php
+++ b/resources/views/ssh/laravel/ensure-env.blade.php
@@ -3,15 +3,15 @@ if [ -f '{{ $envPath }}' ]; then
 fi
 
 if [ -f '{{ $examplePath }}' ]; then
-    if ! cp '{{ $examplePath }}' '{{ $envPath }}'; then
+    if ! cp -- '{{ $examplePath }}' '{{ $envPath }}'; then
         echo 'VITO_SSH_ERROR' && exit 1
     fi
 else
-    if ! touch '{{ $envPath }}'; then
+    if ! touch -- '{{ $envPath }}'; then
         echo 'VITO_SSH_ERROR' && exit 1
     fi
 fi
 
-if ! chmod 640 '{{ $envPath }}'; then
+if ! chmod 640 -- '{{ $envPath }}'; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi

--- a/resources/views/ssh/laravel/ensure-env.blade.php
+++ b/resources/views/ssh/laravel/ensure-env.blade.php
@@ -1,0 +1,17 @@
+if [ -f '{{ $envPath }}' ]; then
+    exit 0
+fi
+
+if [ -f '{{ $examplePath }}' ]; then
+    if ! cp '{{ $examplePath }}' '{{ $envPath }}'; then
+        echo 'VITO_SSH_ERROR' && exit 1
+    fi
+else
+    if ! touch '{{ $envPath }}'; then
+        echo 'VITO_SSH_ERROR' && exit 1
+    fi
+fi
+
+if ! chmod 640 '{{ $envPath }}'; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi

--- a/tests/Feature/SitesTest.php
+++ b/tests/Feature/SitesTest.php
@@ -377,9 +377,9 @@ class SitesTest extends TestCase
         $examplePath = '/home/envtest/env-example.com/.env.example';
 
         SSH::assertExecutedContains("[ -f '{$envPath}' ]");
-        SSH::assertExecutedContains("cp '{$examplePath}' '{$envPath}'");
-        SSH::assertExecutedContains("touch '{$envPath}'");
-        SSH::assertExecutedContains("chmod 640 '{$envPath}'");
+        SSH::assertExecutedContains("cp -- '{$examplePath}' '{$envPath}'");
+        SSH::assertExecutedContains("touch -- '{$envPath}'");
+        SSH::assertExecutedContains("chmod 640 -- '{$envPath}'");
     }
 
     public function test_see_sites_list(): void

--- a/tests/Feature/SitesTest.php
+++ b/tests/Feature/SitesTest.php
@@ -341,6 +341,47 @@ class SitesTest extends TestCase
         ]);
     }
 
+    public function test_create_laravel_site_dispatches_ensure_env_script(): void
+    {
+        SSH::fake();
+        Http::fake([
+            'https://api.github.com/repos/*' => Http::response([], 201),
+        ]);
+
+        $this->actingAs($this->user);
+        /** @var SourceControl $sourceControl */
+        $sourceControl = SourceControl::factory()->create([
+            'provider' => Github::id(),
+        ]);
+
+        $this->post(route('sites.store', ['server' => $this->server]), [
+            'type' => Laravel::id(),
+            'domain' => 'env-example.com',
+            'php_version' => '8.2',
+            'web_directory' => 'public',
+            'repository' => 'test/test',
+            'branch' => 'main',
+            'composer' => false,
+            'user' => 'envtest',
+            'source_control' => $sourceControl->id,
+        ])->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('sites', [
+            'domain' => 'env-example.com',
+            'status' => SiteStatus::READY->value,
+            'user' => 'envtest',
+            'path' => '/home/envtest/env-example.com',
+        ]);
+
+        $envPath = '/home/envtest/env-example.com/.env';
+        $examplePath = '/home/envtest/env-example.com/.env.example';
+
+        SSH::assertExecutedContains("[ -f '{$envPath}' ]");
+        SSH::assertExecutedContains("cp '{$examplePath}' '{$envPath}'");
+        SSH::assertExecutedContains("touch '{$envPath}'");
+        SSH::assertExecutedContains("chmod 640 '{$envPath}'");
+    }
+
     public function test_see_sites_list(): void
     {
         $this->actingAs($this->user);


### PR DESCRIPTION
This pull request adds support for automatically ensuring a `.env` file exists when deploying a Laravel site. If a `.env` file is missing, it will be created from `.env.example` if available, or as an empty file otherwise, and permissions will be set securely. The changes also include a new test to verify this behavior.