### PR TITLE
[Feat] Server Provider Deletion

### DIFF
--- a/app/Actions/Server/DeleteServer.php
+++ b/app/Actions/Server/DeleteServer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Actions\Server;
+
+use App\Models\Server;
+use App\ServerProviders\Custom;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+class DeleteServer
+{
+    /**
+     * @param  array<string, mixed>  $input
+     *
+     * @throws ValidationException
+     */
+    public function delete(Server $server, array $input): void
+    {
+        $this->validate($server, $input);
+
+        if (array_key_exists('delete_from_provider', $input)) {
+            $server->deleteFromProvider = filter_var($input['delete_from_provider'], FILTER_VALIDATE_BOOLEAN);
+        }
+
+        $server->delete();
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    private function validate(Server $server, array $input): void
+    {
+        $rules = [
+            'name' => [
+                'required',
+                Rule::in([$server->name]),
+            ],
+            'delete_from_provider' => [
+                Rule::requiredIf(fn (): bool => $server->provider !== Custom::id()),
+                'boolean',
+            ],
+        ];
+
+        Validator::make($input, $rules)->validate();
+    }
+}

--- a/app/Http/Controllers/API/ServerController.php
+++ b/app/Http/Controllers/API/ServerController.php
@@ -76,12 +76,13 @@ class ServerController extends Controller
     }
 
     #[Delete('{server}', name: 'api.projects.servers.delete', middleware: 'ability:write')]
-    public function delete(Project $project, Server $server): Response
+    public function delete(Project $project, Server $server, Request $request): Response
     {
         $this->authorize('delete', [$server, $project]);
 
         $this->validateRoute($project, $server);
 
+        $server->deleteFromProvider = $request->boolean('delete_from_provider', true);
         $server->delete();
 
         return response()->noContent();

--- a/app/Http/Controllers/API/ServerController.php
+++ b/app/Http/Controllers/API/ServerController.php
@@ -12,6 +12,7 @@ use App\Models\Server;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Validator;
 use Spatie\RouteAttributes\Attributes\Delete;
 use Spatie\RouteAttributes\Attributes\Get;
 use Spatie\RouteAttributes\Attributes\Middleware;
@@ -81,6 +82,10 @@ class ServerController extends Controller
         $this->authorize('delete', [$server, $project]);
 
         $this->validateRoute($project, $server);
+
+        Validator::make($request->all(), [
+            'delete_from_provider' => ['nullable', 'boolean'],
+        ])->validate();
 
         $server->deleteFromProvider = $request->boolean('delete_from_provider', true);
         $server->delete();

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Server\CreateServer;
+use App\Actions\Server\DeleteServer;
 use App\Actions\Server\GetServers;
 use App\Actions\Server\RebootServer;
 use App\Actions\Server\TransferServer;
@@ -17,7 +18,6 @@ use App\Tables\ServerTable;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\ResourceCollection;
-use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response;
 use Spatie\RouteAttributes\Attributes\Delete;
@@ -153,14 +153,7 @@ class ServerController extends Controller
     {
         $this->authorize('delete', $server);
 
-        $this->validate($request, [
-            'name' => [
-                'required',
-                Rule::in([$server->name]),
-            ],
-        ]);
-
-        $server->delete();
+        app(DeleteServer::class)->delete($server, $request->all());
 
         return redirect()->route('servers')
             ->with('success', __('Server deleted successfully.'));

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -113,6 +113,8 @@ class Server extends AbstractModel
         'authentication',
     ];
 
+    public bool $deleteFromProvider = true;
+
     public static function boot(): void
     {
         parent::boot();
@@ -146,7 +148,9 @@ class Server extends AbstractModel
                 if (File::exists($server->sshKey()['private_key_path'])) {
                     File::delete($server->sshKey()['private_key_path']);
                 }
-                $server->provider()->delete();
+                if ($server->deleteFromProvider) {
+                    $server->provider()->delete();
+                }
                 DB::commit();
             } catch (Throwable $e) {
                 DB::rollBack();

--- a/public/api-docs/openapi/servers.yaml
+++ b/public/api-docs/openapi/servers.yaml
@@ -226,7 +226,7 @@ paths:
 
     delete:
       summary: Delete server
-      description: Delete a server
+      description: Delete a server. By default the underlying VM at the provider is also destroyed (when the server was provisioned through an API provider). Set `delete_from_provider` to `false` to keep the VM running and only remove it from Vito.
       tags:
         - Servers
       security:
@@ -246,6 +246,18 @@ paths:
           schema:
             type: integer
             example: 1
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                delete_from_provider:
+                  type: boolean
+                  description: When true (default), also destroy the underlying VM at the provider. When false, only remove the server from Vito. Ignored for manually added (`custom`) servers.
+                  default: true
+                  example: false
       responses:
         '204':
           description: Server deleted successfully

--- a/resources/js/components/ui/radio-group.tsx
+++ b/resources/js/components/ui/radio-group.tsx
@@ -55,7 +55,7 @@ function RadioGroupItem({ className, value, disabled, ...props }: RadioGroupItem
       disabled={isDisabled}
       onClick={() => ctx.onValueChange(value)}
       className={cn(
-        'inline-flex size-4 shrink-0 items-center justify-center rounded-full border border-input bg-background text-primary shadow-xs outline-none transition-shadow focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40',
+        'border-input bg-background text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40 inline-flex size-4 shrink-0 items-center justify-center rounded-full border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       {...props}

--- a/resources/js/components/ui/radio-group.tsx
+++ b/resources/js/components/ui/radio-group.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { CircleIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+type RadioGroupContextValue = {
+  name: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  disabled?: boolean;
+};
+
+const RadioGroupContext = React.createContext<RadioGroupContextValue | null>(null);
+
+type RadioGroupProps = Omit<React.ComponentProps<'div'>, 'onChange'> & {
+  value: string;
+  onValueChange: (value: string) => void;
+  name?: string;
+  disabled?: boolean;
+};
+
+function RadioGroup({ className, value, onValueChange, name, disabled, children, ...props }: RadioGroupProps) {
+  const generatedName = React.useId();
+  const groupName = name ?? generatedName;
+
+  return (
+    <RadioGroupContext.Provider value={{ name: groupName, value, onValueChange, disabled }}>
+      <div role="radiogroup" data-slot="radio-group" className={cn('grid gap-3', className)} {...props}>
+        {children}
+      </div>
+    </RadioGroupContext.Provider>
+  );
+}
+
+type RadioGroupItemProps = Omit<React.ComponentProps<'button'>, 'type' | 'role' | 'value' | 'onClick'> & {
+  value: string;
+};
+
+function RadioGroupItem({ className, value, disabled, ...props }: RadioGroupItemProps) {
+  const ctx = React.useContext(RadioGroupContext);
+  if (!ctx) {
+    throw new Error('RadioGroupItem must be rendered inside a RadioGroup');
+  }
+
+  const checked = ctx.value === value;
+  const isDisabled = disabled ?? ctx.disabled;
+
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={checked}
+      data-state={checked ? 'checked' : 'unchecked'}
+      data-slot="radio-group-item"
+      disabled={isDisabled}
+      onClick={() => ctx.onValueChange(value)}
+      className={cn(
+        'inline-flex size-4 shrink-0 items-center justify-center rounded-full border border-input bg-background text-primary shadow-xs outline-none transition-shadow focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40',
+        className,
+      )}
+      {...props}
+    >
+      {checked && <CircleIcon className="size-2 fill-current" />}
+    </button>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/resources/js/pages/servers/components/delete-server.tsx
+++ b/resources/js/pages/servers/components/delete-server.tsx
@@ -54,8 +54,7 @@ export default function DeleteServer({ server, children }: { server: Server; chi
     });
   };
 
-  const submitDisabled =
-    form.processing || form.data.name !== server.name || (!isCustom && form.data.delete_from_provider === '');
+  const submitDisabled = form.processing || form.data.name !== server.name || (!isCustom && form.data.delete_from_provider === '');
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -126,14 +125,14 @@ function RadioCard({ value, selected, title, description }: { value: string; sel
   return (
     <label
       className={cn(
-        'flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors hover:bg-accent',
+        'hover:bg-accent flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors',
         selected && 'border-primary bg-accent',
       )}
     >
       <RadioGroupItem value={value} className="mt-0.5" />
       <span className="flex flex-col gap-1">
         <span className="text-sm font-medium">{title}</span>
-        <span className="text-sm text-muted-foreground">{description}</span>
+        <span className="text-muted-foreground text-sm">{description}</span>
       </span>
     </label>
   );

--- a/resources/js/pages/servers/components/delete-server.tsx
+++ b/resources/js/pages/servers/components/delete-server.tsx
@@ -43,8 +43,13 @@ export default function DeleteServer({ server, children }: { server: Server; chi
     }
   };
 
+  const choiceMissing = !isCustom && form.data.delete_from_provider === '';
+
   const submit = (e: FormEvent) => {
     e.preventDefault();
+    if (choiceMissing) {
+      return;
+    }
     form.transform((data) => ({
       name: data.name,
       ...(isCustom ? {} : { delete_from_provider: data.delete_from_provider === 'yes' }),
@@ -54,7 +59,7 @@ export default function DeleteServer({ server, children }: { server: Server; chi
     });
   };
 
-  const submitDisabled = form.processing || form.data.name !== server.name || (!isCustom && form.data.delete_from_provider === '');
+  const submitDisabled = form.processing || form.data.name !== server.name || choiceMissing;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>

--- a/resources/js/pages/servers/components/delete-server.tsx
+++ b/resources/js/pages/servers/components/delete-server.tsx
@@ -1,5 +1,5 @@
 import { Server } from '@/types/server';
-import { FormEvent, ReactNode } from 'react';
+import { FormEvent, ReactNode, useId, useState } from 'react';
 import {
   Dialog,
   DialogClose,
@@ -16,20 +16,49 @@ import { Form, FormField, FormFields } from '@/components/ui/form';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import InputError from '@/components/ui/input-error';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { useConfigs } from '@/stores/bootstrap-store';
 import { LoaderCircleIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type DeleteFromProviderChoice = '' | 'yes' | 'no';
 
 export default function DeleteServer({ server, children }: { server: Server; children: ReactNode }) {
-  const form = useForm({
+  const configs = useConfigs();
+  const isCustom = server.provider === 'custom';
+  const providerLabel = configs?.server_provider.providers[server.provider]?.label ?? server.provider;
+  const groupLabelId = useId();
+  const [open, setOpen] = useState(false);
+
+  const form = useForm<{ name: string; delete_from_provider: DeleteFromProviderChoice }>({
     name: '',
+    delete_from_provider: '',
   });
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) {
+      form.reset();
+      form.clearErrors();
+    }
+  };
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
-    form.delete(route('servers.destroy', server.id));
+    form.transform((data) => ({
+      name: data.name,
+      ...(isCustom ? {} : { delete_from_provider: data.delete_from_provider === 'yes' }),
+    }));
+    form.delete(route('servers.destroy', server.id), {
+      onSuccess: () => setOpen(false),
+    });
   };
 
+  const submitDisabled =
+    form.processing || form.data.name !== server.name || (!isCustom && form.data.delete_from_provider === '');
+
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent>
         <DialogHeader>
@@ -44,6 +73,32 @@ export default function DeleteServer({ server, children }: { server: Server; chi
 
         <Form id="delete-server-form" onSubmit={submit} className="p-4">
           <FormFields>
+            {!isCustom && (
+              <FormField>
+                <Label id={groupLabelId}>How should we handle the server at {providerLabel}?</Label>
+                <RadioGroup
+                  value={form.data.delete_from_provider}
+                  onValueChange={(value) => form.setData('delete_from_provider', value as DeleteFromProviderChoice)}
+                  aria-labelledby={groupLabelId}
+                  className="gap-2"
+                >
+                  <RadioCard
+                    value="no"
+                    selected={form.data.delete_from_provider === 'no'}
+                    title="Remove from Vito only"
+                    description={`Keep the server running at ${providerLabel}.`}
+                  />
+                  <RadioCard
+                    value="yes"
+                    selected={form.data.delete_from_provider === 'yes'}
+                    title={`Delete from Vito and ${providerLabel}`}
+                    description="Permanently destroy the server at the provider. This cannot be undone."
+                  />
+                </RadioGroup>
+                <InputError message={form.errors.delete_from_provider} />
+              </FormField>
+            )}
+
             <FormField>
               <Label htmlFor="server-name">Server name</Label>
               <Input id="server-name" value={form.data.name} onChange={(e) => form.setData('name', e.target.value)} />
@@ -57,12 +112,29 @@ export default function DeleteServer({ server, children }: { server: Server; chi
             <Button variant="outline">Cancel</Button>
           </DialogClose>
 
-          <Button form="delete-server-form" variant="destructive" disabled={form.processing}>
+          <Button form="delete-server-form" variant="destructive" disabled={submitDisabled}>
             {form.processing && <LoaderCircleIcon className="size-4 animate-spin" />}
             Delete server
           </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function RadioCard({ value, selected, title, description }: { value: string; selected: boolean; title: string; description: string }) {
+  return (
+    <label
+      className={cn(
+        'flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors hover:bg-accent',
+        selected && 'border-primary bg-accent',
+      )}
+    >
+      <RadioGroupItem value={value} className="mt-0.5" />
+      <span className="flex flex-col gap-1">
+        <span className="text-sm font-medium">{title}</span>
+        <span className="text-sm text-muted-foreground">{description}</span>
+      </span>
+    </label>
   );
 }

--- a/tests/Feature/ServerTest.php
+++ b/tests/Feature/ServerTest.php
@@ -18,6 +18,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
+use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
 class ServerTest extends TestCase
@@ -109,6 +110,7 @@ class ServerTest extends TestCase
 
         $this->delete(route('servers.destroy', $this->server), [
             'name' => $this->server->name,
+            'delete_from_provider' => true,
         ])
             ->assertSessionDoesntHaveErrors();
 
@@ -117,6 +119,183 @@ class ServerTest extends TestCase
         ]);
 
         Mail::assertSent(NotificationMail::class);
+    }
+
+    public function test_delete_server_destroys_provider_vm_when_opted_in(): void
+    {
+        Http::fake();
+
+        $this->actingAs($this->user);
+
+        $provider = ServerProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'provider' => Hetzner::id(),
+            'credentials' => [
+                'token' => 'token',
+            ],
+        ]);
+
+        $this->server->update([
+            'provider' => Hetzner::id(),
+            'provider_id' => $provider->id,
+            'provider_data' => [
+                'hetzner_id' => 42,
+                'ssh_key_id' => 1,
+            ],
+        ]);
+
+        $this->delete(route('servers.destroy', $this->server), [
+            'name' => $this->server->name,
+            'delete_from_provider' => true,
+        ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseMissing('servers', [
+            'id' => $this->server->id,
+        ]);
+
+        Http::assertSent(fn ($request): bool => $request->method() === 'DELETE'
+            && str_contains($request->url(), '/servers/42'));
+    }
+
+    public function test_delete_server_keeps_provider_vm_when_opted_out(): void
+    {
+        Http::fake();
+
+        $this->actingAs($this->user);
+
+        $provider = ServerProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'provider' => Hetzner::id(),
+            'credentials' => [
+                'token' => 'token',
+            ],
+        ]);
+
+        $this->server->update([
+            'provider' => Hetzner::id(),
+            'provider_id' => $provider->id,
+            'provider_data' => [
+                'hetzner_id' => 42,
+                'ssh_key_id' => 1,
+            ],
+        ]);
+
+        $this->delete(route('servers.destroy', $this->server), [
+            'name' => $this->server->name,
+            'delete_from_provider' => false,
+        ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseMissing('servers', [
+            'id' => $this->server->id,
+        ]);
+
+        Http::assertNothingSent();
+    }
+
+    public function test_delete_server_requires_delete_from_provider_for_non_custom(): void
+    {
+        $this->actingAs($this->user);
+
+        $provider = ServerProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'provider' => Hetzner::id(),
+            'credentials' => [
+                'token' => 'token',
+            ],
+        ]);
+
+        $this->server->update([
+            'provider' => Hetzner::id(),
+            'provider_id' => $provider->id,
+            'provider_data' => [
+                'hetzner_id' => 42,
+                'ssh_key_id' => 1,
+            ],
+        ]);
+
+        $this->delete(route('servers.destroy', $this->server), [
+            'name' => $this->server->name,
+        ])
+            ->assertSessionHasErrors('delete_from_provider');
+
+        $this->assertDatabaseHas('servers', [
+            'id' => $this->server->id,
+        ]);
+    }
+
+    public function test_api_delete_server_defaults_to_destroying_provider_vm(): void
+    {
+        Http::fake();
+
+        $provider = ServerProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'provider' => Hetzner::id(),
+            'credentials' => [
+                'token' => 'token',
+            ],
+        ]);
+
+        $this->server->update([
+            'provider' => Hetzner::id(),
+            'provider_id' => $provider->id,
+            'provider_data' => [
+                'hetzner_id' => 99,
+                'ssh_key_id' => 1,
+            ],
+        ]);
+
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        $this->deleteJson(route('api.projects.servers.delete', [
+            'project' => $this->server->project_id,
+            'server' => $this->server->id,
+        ]))
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('servers', [
+            'id' => $this->server->id,
+        ]);
+
+        Http::assertSent(fn ($request): bool => $request->method() === 'DELETE'
+            && str_contains($request->url(), '/servers/99'));
+    }
+
+    public function test_api_delete_server_can_opt_out_of_provider_destruction(): void
+    {
+        Http::fake();
+
+        $provider = ServerProvider::factory()->create([
+            'user_id' => $this->user->id,
+            'provider' => Hetzner::id(),
+            'credentials' => [
+                'token' => 'token',
+            ],
+        ]);
+
+        $this->server->update([
+            'provider' => Hetzner::id(),
+            'provider_id' => $provider->id,
+            'provider_data' => [
+                'hetzner_id' => 99,
+                'ssh_key_id' => 1,
+            ],
+        ]);
+
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        $this->deleteJson(route('api.projects.servers.delete', [
+            'project' => $this->server->project_id,
+            'server' => $this->server->id,
+        ]), ['delete_from_provider' => false])
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('servers', [
+            'id' => $this->server->id,
+        ]);
+
+        Http::assertNothingSent();
     }
 
     public function test_check_connection_is_ready(): void


### PR DESCRIPTION
This pull request introduces a major improvement to the server deletion workflow, allowing users to choose whether deleting a server should also destroy the underlying VM at the provider or only remove it from the application. This change is implemented across the backend, frontend, API documentation, and test suite to ensure a consistent and robust experience.

<img width="523" height="543" alt="CleanShot 2026-05-22 at 10 24 02" src="https://github.com/user-attachments/assets/06b6b338-0828-489f-b5a7-8c823b897f77" />

Not shown for custom servers

Closes #1106