### PR TITLE
[Feat] Github App Deployment

### DIFF
--- a/app/Actions/GithubApp/HandlePushWebhook.php
+++ b/app/Actions/GithubApp/HandlePushWebhook.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Actions\GithubApp;
+
+use App\Jobs\Site\TriggerDeployFromWebhookJob;
+use App\Models\Site;
+use App\Models\SourceControl;
+
+class HandlePushWebhook
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function handle(array $payload): void
+    {
+        $installationId = (int) ($payload['installation']['id'] ?? 0);
+        $repository = (string) ($payload['repository']['full_name'] ?? '');
+        $branch = str((string) ($payload['ref'] ?? ''))->after('refs/heads/')->toString();
+
+        if ($installationId === 0 || $repository === '' || $branch === '') {
+            return;
+        }
+
+        $sourceControl = SourceControl::query()
+            ->where('provider', SourceControl::PROVIDER_GITHUB_APP)
+            ->where('external_identifier', (string) $installationId)
+            ->first();
+
+        if (! $sourceControl instanceof SourceControl) {
+            return;
+        }
+
+        $sites = Site::query()
+            ->with('gitHook')
+            ->where('source_control_id', $sourceControl->id)
+            ->where('repository', $repository)
+            ->where('branch', $branch)
+            ->get();
+
+        foreach ($sites as $site) {
+            $gitHook = $site->gitHook;
+            if (! $gitHook) {
+                continue;
+            }
+            if (! in_array('deploy', (array) $gitHook->actions, true)) {
+                continue;
+            }
+
+            TriggerDeployFromWebhookJob::dispatch($site->id);
+        }
+    }
+}

--- a/app/Actions/Site/UpdateSourceControl.php
+++ b/app/Actions/Site/UpdateSourceControl.php
@@ -5,10 +5,15 @@ namespace App\Actions\Site;
 use App\Exceptions\RepositoryNotFound;
 use App\Exceptions\RepositoryPermissionDenied;
 use App\Exceptions\SourceControlIsNotConnected;
+use App\Exceptions\SSHError;
 use App\Models\Site;
 use App\Models\SourceControl;
+use App\SSH\OS\Git;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
+use Throwable;
 
 class UpdateSourceControl
 {
@@ -16,18 +21,29 @@ class UpdateSourceControl
      * @param  array<string, mixed>  $input
      *
      * @throws ValidationException
+     * @throws SSHError
      */
     public function update(Site $site, array $input): void
     {
         Validator::make($input, [
-            'source_control' => SourceControl::siteValidationRules(),
+            'source_control' => SourceControl::siteValidationRules($site->server),
         ])->validate();
 
-        $site->source_control_id = $input['source_control'];
+        $newSourceControlId = (int) $input['source_control'];
+
+        if ($site->source_control_id === $newSourceControlId) {
+            return;
+        }
+
+        $newSourceControl = SourceControl::find($newSourceControlId);
+        if (! $newSourceControl instanceof SourceControl) {
+            throw ValidationException::withMessages([
+                'source_control' => 'Source control not found',
+            ]);
+        }
+
         try {
-            if ($site->sourceControl) {
-                $site->sourceControl->getRepo($site->repository);
-            }
+            $newSourceControl->getRepo($site->repository);
         } catch (SourceControlIsNotConnected) {
             throw ValidationException::withMessages([
                 'source_control' => 'Source control is not connected',
@@ -41,6 +57,54 @@ class UpdateSourceControl
                 'repository' => 'Repository not found',
             ]);
         }
-        $site->save();
+
+        $oldSourceControl = $site->sourceControl;
+        $oldDeployKeyId = $site->type_data['deploy_key_id'] ?? null;
+        $oldGitHook = $site->gitHook;
+
+        DB::transaction(function () use ($site, $newSourceControl, $oldDeployKeyId): void {
+            $site->source_control_id = $newSourceControl->id;
+            $site->setRelation('sourceControl', $newSourceControl);
+            if ($oldDeployKeyId) {
+                $site->jsonUpdate('type_data', 'deploy_key_id', null);
+            }
+            $site->save();
+        });
+
+        if ($oldDeployKeyId && $oldSourceControl) {
+            try {
+                $oldSourceControl->provider()->deleteDeployKey((string) $oldDeployKeyId, $site->repository);
+            } catch (Throwable $e) {
+                Log::warning('Failed to delete old deploy key on source-control swap', [
+                    'site_id' => $site->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        if ($oldGitHook) {
+            try {
+                $oldGitHook->destroyHook();
+            } catch (Throwable $e) {
+                Log::warning('Failed to destroy old git hook on source-control swap', [
+                    'site_id' => $site->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        $newRepoUrl = $newSourceControl->provider()->fullRepoUrl(
+            $site->repository,
+            $site->getSshKeyName()
+        );
+
+        try {
+            app(Git::class)->setRemote($site, $newRepoUrl);
+        } catch (SSHError $e) {
+            Log::warning('Failed to rewrite remote URL after source-control swap', [
+                'site_id' => $site->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 }

--- a/app/Actions/Site/UpdateSourceControl.php
+++ b/app/Actions/Site/UpdateSourceControl.php
@@ -66,7 +66,7 @@ class UpdateSourceControl
             $site->source_control_id = $newSourceControl->id;
             $site->setRelation('sourceControl', $newSourceControl);
             if ($oldDeployKeyId) {
-                $site->jsonUpdate('type_data', 'deploy_key_id', null);
+                $site->jsonUpdate('type_data', 'deploy_key_id', null, save: false);
             }
             $site->save();
         });

--- a/app/Http/Controllers/API/GithubAppWebhookController.php
+++ b/app/Http/Controllers/API/GithubAppWebhookController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\API;
 
+use App\Actions\GithubApp\HandlePushWebhook;
 use App\Actions\GithubApp\ImportGithubAppInstallation;
 use App\Http\Controllers\Controller;
 use App\Models\GithubApp;
@@ -38,6 +39,7 @@ class GithubAppWebhookController extends Controller
             match ($event) {
                 'installation' => $this->handleInstallation($action, $payload),
                 'installation_repositories' => $this->bustRepoCache((int) ($payload['installation']['id'] ?? 0)),
+                'push' => app(HandlePushWebhook::class)->handle($payload),
                 default => null,
             };
         } catch (Throwable $e) {

--- a/app/Jobs/Site/DeployJob.php
+++ b/app/Jobs/Site/DeployJob.php
@@ -119,14 +119,16 @@ class DeployJob implements ShouldQueue
         );
 
         // link resources
-        $site->server->ssh($site->user)->exec(
-            view('ssh.modern-deployment.link-resources', [
-                'site' => $site,
-                'releasePath' => $this->deployment->path(),
-            ]),
-            'link-resources',
-            $site->id
-        );
+        $site->server->ssh($site->user)
+            ->variables($site->environmentVariables($this->deployment))
+            ->exec(
+                view('ssh.modern-deployment.link-resources', [
+                    'site' => $site,
+                    'releasePath' => $this->deployment->path(),
+                ]),
+                'link-resources',
+                $site->id
+            );
 
         // pre-flight
         $site->server->os()->runScript(

--- a/app/Jobs/Site/TriggerDeployFromWebhookJob.php
+++ b/app/Jobs/Site/TriggerDeployFromWebhookJob.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Jobs\Site;
+
+use App\Actions\Site\Deploy;
+use App\Models\ServerLog;
+use App\Models\Site;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class TriggerDeployFromWebhookJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(
+        protected int $siteId,
+    ) {
+        $this->onQueue('default');
+    }
+
+    public function handle(): void
+    {
+        $this->run("trigger-deploy-{$this->siteId}", function () {
+            $site = Site::find($this->siteId);
+            if (! $site instanceof Site) {
+                return;
+            }
+
+            try {
+                app(Deploy::class)->run($site);
+            } catch (Throwable $e) {
+                ServerLog::log($site->server, 'deploy-failed', $e->getMessage(), $site);
+                Log::error('webhook-deploy-failed', [
+                    'site_id' => $site->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        Log::error('webhook-deploy-job-failed', [
+            'site_id' => $this->siteId,
+            'error' => $e->getMessage(),
+        ]);
+    }
+}

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -414,7 +414,7 @@ class Site extends AbstractModel
      */
     public function environmentVariables(?Deployment $deployment = null): array
     {
-        return [
+        $variables = [
             'SITE_PATH' => $this->path,
             'DOMAIN' => $this->domain,
             'BRANCH' => $this->branch ?? '',
@@ -423,6 +423,14 @@ class Site extends AbstractModel
             'PHP_VERSION' => $this->php_version,
             'PHP_PATH' => '/usr/bin/php'.$this->php_version,
         ];
+
+        if ($this->sourceControl?->isGithubApp()) {
+            /** @var \App\SourceControlProviders\GithubApp $provider */
+            $provider = $this->sourceControl->provider();
+            $variables['GIT_HTTP_TOKEN'] = $provider->installationAccessToken();
+        }
+
+        return $variables;
     }
 
     /**

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -11,6 +11,7 @@ use App\Jobs\SSL\DeleteSiteSslJob;
 use App\Services\Webserver\Webserver;
 use App\SiteFeatures\ActionInterface;
 use App\SiteTypes\SiteType;
+use App\SourceControlProviders\GithubApp;
 use App\Traits\HasProjectThroughServer;
 use Database\Factories\SiteFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -425,7 +426,7 @@ class Site extends AbstractModel
         ];
 
         if ($this->sourceControl?->isGithubApp()) {
-            /** @var \App\SourceControlProviders\GithubApp $provider */
+            /** @var GithubApp $provider */
             $provider = $this->sourceControl->provider();
             $variables['GIT_HTTP_TOKEN'] = $provider->installationAccessToken();
         }

--- a/app/Models/SourceControl.php
+++ b/app/Models/SourceControl.php
@@ -56,12 +56,9 @@ class SourceControl extends AbstractModel
     }
 
     /**
-     * Validation rules for a `source_control` site input that must reference
-     * a source control whose provider is usable for sites.
-     *
      * @return array<int, mixed>
      */
-    public static function siteValidationRules(): array
+    public static function siteValidationRules(Server $server): array
     {
         /** @var array<string, array<string, mixed>> $providers */
         $providers = config('source-control.providers', []);
@@ -73,7 +70,14 @@ class SourceControl extends AbstractModel
 
         return [
             'required',
-            Rule::exists('source_controls', 'id')->whereIn('provider', $usableProviders),
+            Rule::exists('source_controls', 'id')
+                ->whereIn('provider', $usableProviders)
+                ->where(function ($query) use ($server): void {
+                    $query->where('user_id', $server->user_id)
+                        ->where(function ($q) use ($server): void {
+                            $q->where('project_id', $server->project_id)->orWhereNull('project_id');
+                        });
+                }),
         ];
     }
 

--- a/app/Providers/SourceControlServiceProvider.php
+++ b/app/Providers/SourceControlServiceProvider.php
@@ -33,7 +33,6 @@ class SourceControlServiceProvider extends ServiceProvider
             ->label('GitHub App')
             ->handler(GithubApp::class)
             ->connectable(false)
-            ->usableForSites(false)
             ->register();
     }
 

--- a/app/SSH/OS/Git.php
+++ b/app/SSH/OS/Git.php
@@ -12,14 +12,23 @@ class Git
      */
     public function clone(Site $site, ?string $path = null): void
     {
-        $site->server->ssh($site->user)->exec(
+        $usesToken = $site->sourceControl?->isGithubApp() ?? false;
+        $ssh = $site->server->ssh($site->user);
+
+        if ($usesToken) {
+            $ssh = $ssh->variables($site->environmentVariables());
+        }
+
+        $repoUrl = (string) $site->getFullRepositoryUrl();
+        $ssh->exec(
             view('ssh.git.clone', [
-                'host' => str($site->getFullRepositoryUrl())->after('@')->before('-'),
-                'repo' => $site->getFullRepositoryUrl(),
-                'path' => $path ?? $site->path,
-                'branch' => $site->branch,
+                'host' => $usesToken ? '' : str($repoUrl)->after('@')->before('-'),
+                'repo' => escapeshellarg($repoUrl),
+                'path' => escapeshellarg((string) ($path ?? $site->path)),
+                'branch' => escapeshellarg((string) $site->branch),
                 'key' => $site->getSshKeyName(),
                 'port' => $site->sourceControl?->provider()?->getSshPort() ?? 22,
+                'usesToken' => $usesToken,
             ]),
             'clone-repository',
             $site->id
@@ -33,8 +42,8 @@ class Git
     {
         $site->server->ssh($site->user)->exec(
             view('ssh.git.checkout', [
-                'path' => $site->path,
-                'branch' => $site->branch,
+                'path' => escapeshellarg((string) $site->path),
+                'branch' => escapeshellarg((string) $site->branch),
             ]),
             'checkout-branch',
             $site->id
@@ -46,11 +55,40 @@ class Git
      */
     public function fetchOrigin(Site $site): void
     {
-        $site->server->ssh($site->user)->exec(
+        $ssh = $site->server->ssh($site->user);
+
+        if ($site->sourceControl?->isGithubApp()) {
+            $ssh = $ssh->variables($site->environmentVariables());
+        }
+
+        $ssh->exec(
             view('ssh.git.fetch-origin', [
-                'path' => $site->path,
+                'path' => escapeshellarg((string) $site->path),
             ]),
             'fetch-origin',
+            $site->id
+        );
+    }
+
+    /**
+     * @throws SSHError
+     */
+    public function setRemote(Site $site, string $newRepoUrl): void
+    {
+        $usesToken = $site->sourceControl?->isGithubApp() ?? false;
+        $ssh = $site->server->ssh($site->user);
+
+        if ($usesToken) {
+            $ssh = $ssh->variables($site->environmentVariables());
+        }
+
+        $ssh->exec(
+            view('ssh.git.set-remote', [
+                'path' => escapeshellarg((string) $site->path),
+                'newRepoUrl' => escapeshellarg($newRepoUrl),
+                'usesToken' => $usesToken,
+            ]),
+            'set-remote',
             $site->id
         );
     }

--- a/app/SSH/OS/OS.php
+++ b/app/SSH/OS/OS.php
@@ -78,6 +78,7 @@ class OS
                 'user' => $user,
                 'serverUser' => $this->server->getSshUser(),
                 'password' => $password,
+                'key' => escapeshellarg(trim($this->server->sshKey()['public_key'])),
             ]),
             'create-isolated-user',
             $site_id
@@ -247,15 +248,13 @@ class OS
         }
         if ($variables !== null && $variables !== []) {
             foreach ($variables as $key => $variable) {
-                $command .= "export $key=$variable\n";
+                $command .= sprintf("export %s=%s\n", $key, escapeshellarg((string) $variable));
             }
         }
         $command .= view('ssh.os.run-script', [
             'path' => $path,
             'script' => $script,
         ]);
-
-        info($command);
 
         $ssh->exec($command, 'run-script');
 

--- a/app/SiteTypes/AbstractSiteType.php
+++ b/app/SiteTypes/AbstractSiteType.php
@@ -85,6 +85,10 @@ abstract class AbstractSiteType implements SiteType
      */
     protected function deployKey(): void
     {
+        if ($this->site->sourceControl?->isGithubApp()) {
+            return;
+        }
+
         $os = $this->site->server->os();
 
         if (! $this->site->ssh_key) {
@@ -121,13 +125,11 @@ abstract class AbstractSiteType implements SiteType
         }
 
         try {
-            if (! $this->site->userSharedWithSiblings() && ! $this->userExists($this->site->user)) {
-                $this->site->server->os()->createIsolatedUser(
-                    $this->site->user,
-                    Str::random(15),
-                    $this->site->id
-                );
-            }
+            $this->site->server->os()->createIsolatedUser(
+                $this->site->user,
+                Str::random(15),
+                $this->site->id
+            );
 
             if ($this->site->php_version) {
                 $service = $this->site->php();
@@ -157,22 +159,6 @@ abstract class AbstractSiteType implements SiteType
             return;
         }
         app(Git::class)->clone($this->site);
-    }
-
-    /**
-     * @throws SSHError
-     */
-    protected function userExists(string $user): bool
-    {
-        try {
-            $this->site->server->ssh()->exec(view('ssh.site.check-user-exists', [
-                'user' => $user,
-            ]));
-
-            return true;
-        } catch (SSHCommandError) {
-            return false;
-        }
     }
 
     /**

--- a/app/SiteTypes/MiseBun.php
+++ b/app/SiteTypes/MiseBun.php
@@ -55,7 +55,7 @@ class MiseBun extends MiseSiteType
     public function createRules(array $input): array
     {
         return [
-            'source_control' => SourceControl::siteValidationRules(),
+            'source_control' => SourceControl::siteValidationRules($this->site->server),
             'repository' => [
                 'required',
             ],

--- a/app/SiteTypes/MiseNodeJS.php
+++ b/app/SiteTypes/MiseNodeJS.php
@@ -57,7 +57,7 @@ class MiseNodeJS extends MiseSiteType
     public function createRules(array $input): array
     {
         return [
-            'source_control' => SourceControl::siteValidationRules(),
+            'source_control' => SourceControl::siteValidationRules($this->site->server),
             'repository' => [
                 'required',
             ],

--- a/app/SiteTypes/NodeJS.php
+++ b/app/SiteTypes/NodeJS.php
@@ -39,7 +39,7 @@ class NodeJS extends AbstractSiteType
     public function createRules(array $input): array
     {
         return [
-            'source_control' => SourceControl::siteValidationRules(),
+            'source_control' => SourceControl::siteValidationRules($this->site->server),
             'repository' => [
                 'required',
             ],

--- a/app/SiteTypes/PHPSite.php
+++ b/app/SiteTypes/PHPSite.php
@@ -44,7 +44,7 @@ class PHPSite extends AbstractSiteType
                 'required',
                 Rule::in($this->site->server->installedPHPVersions()),
             ],
-            'source_control' => SourceControl::siteValidationRules(),
+            'source_control' => SourceControl::siteValidationRules($this->site->server),
             'web_directory' => [
                 'nullable',
                 'string',

--- a/app/SourceControlProviders/GithubApp.php
+++ b/app/SourceControlProviders/GithubApp.php
@@ -2,10 +2,7 @@
 
 namespace App\SourceControlProviders;
 
-use App\Exceptions\FailedToDeployGitHook;
-use App\Exceptions\FailedToDestroyGitHook;
 use App\Models\GithubApp as GithubAppModel;
-use BadMethodCallException;
 use Exception;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
@@ -85,24 +82,24 @@ class GithubApp extends AbstractSourceControlProvider
 
     public function fullRepoUrl(string $repo, string $key): string
     {
-        throw new BadMethodCallException('fullRepoUrl is not yet implemented for the GitHub App provider.');
+        return sprintf('https://github.com/%s.git', $repo);
     }
 
     /**
-     * @throws FailedToDeployGitHook
+     * @param  array<int, string>  $events
+     * @return array{hook_id: string, hook_response: array<string, string>}
      */
     public function deployHook(string $repo, array $events, string $secret): array
     {
-        throw new BadMethodCallException('deployHook is not yet implemented for the GitHub App provider.');
+        return [
+            'hook_id' => 'app-installation',
+            'hook_response' => [
+                'source' => 'github-app-installation',
+            ],
+        ];
     }
 
-    /**
-     * @throws FailedToDestroyGitHook
-     */
-    public function destroyHook(string $repo, string $hookId): void
-    {
-        throw new BadMethodCallException('destroyHook is not yet implemented for the GitHub App provider.');
-    }
+    public function destroyHook(string $repo, string $hookId): void {}
 
     /**
      * @throws Exception
@@ -132,13 +129,10 @@ class GithubApp extends AbstractSourceControlProvider
 
     public function deployKey(string $title, string $repo, string $key): string
     {
-        throw new BadMethodCallException('deployKey is not yet implemented for the GitHub App provider.');
+        return '';
     }
 
-    public function deleteDeployKey(string $keyId, string $repo): void
-    {
-        throw new BadMethodCallException('deleteDeployKey is not yet implemented for the GitHub App provider.');
-    }
+    public function deleteDeployKey(string $keyId, string $repo): void {}
 
     public function getRepos(bool $useCache = true): array
     {

--- a/resources/views/ssh/git/checkout.blade.php
+++ b/resources/views/ssh/git/checkout.blade.php
@@ -1,7 +1,7 @@
-if ! cd {{ $path }}; then
+if ! cd {!! $path !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 
-if ! git checkout -f {{ $branch }}; then
+if ! git checkout -f {!! $branch !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi

--- a/resources/views/ssh/git/clone.blade.php
+++ b/resources/views/ssh/git/clone.blade.php
@@ -1,3 +1,34 @@
+@if (! empty($usesToken))
+rm -rf {!! $path !!}
+
+if ! git config --global core.fileMode false; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+if ! git -c credential.helper='!f() { test "$1" = get && printf "username=x-access-token\npassword=%s\n\n" "$GIT_HTTP_TOKEN"; }; f' clone -b {!! $branch !!} {!! $repo !!} {!! $path !!}; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+if ! cd {!! $path !!}; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+if ! git config credential.helper '!f() { test "$1" = get && printf "username=x-access-token\npassword=%s\n\n" "$GIT_HTTP_TOKEN"; }; f'; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+if ! git config core.fileMode false; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+if ! find {!! $path !!} -type d -exec chmod 755 {} \;; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+if ! find {!! $path !!} -type f -exec chmod 644 {} \;; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+@else
 if [ -f ~/.ssh/config ]; then
     if ! awk -v alias_name='{{ $host }}-{{ $key }}' '
         /^Host[[:space:]]/ { skip = ($2 == alias_name && NF == 2) ? 1 : 0 }
@@ -18,24 +49,25 @@ chmod 600 ~/.ssh/config
 
 ssh-keyscan -T 5 -p {{ $port }} -H {{ $host }} >> ~/.ssh/known_hosts
 
-rm -rf {{ $path }}
+rm -rf {!! $path !!}
 
 if ! git config --global core.fileMode false; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 
-if ! git clone -b {{ $branch }} {{ $repo }} {{ $path }}; then
+if ! git clone -b {!! $branch !!} {!! $repo !!} {!! $path !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 
-if ! find {{ $path }} -type d -exec chmod 755 {} \;; then
+if ! find {!! $path !!} -type d -exec chmod 755 {} \;; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 
-if ! find {{ $path }} -type f -exec chmod 644 {} \;; then
+if ! find {!! $path !!} -type f -exec chmod 644 {} \;; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 
-if ! cd {{ $path }} && git config core.fileMode false; then
+if ! cd {!! $path !!} && git config core.fileMode false; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
+@endif

--- a/resources/views/ssh/git/clone.blade.php
+++ b/resources/views/ssh/git/clone.blade.php
@@ -67,7 +67,11 @@ if ! find {!! $path !!} -type f -exec chmod 644 {} \;; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 
-if ! cd {!! $path !!} && git config core.fileMode false; then
+if ! cd {!! $path !!}; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+if ! git config core.fileMode false; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 @endif

--- a/resources/views/ssh/git/fetch-origin.blade.php
+++ b/resources/views/ssh/git/fetch-origin.blade.php
@@ -1,4 +1,4 @@
-if ! cd {{ $path }}; then
+if ! cd {!! $path !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/git/set-remote.blade.php
+++ b/resources/views/ssh/git/set-remote.blade.php
@@ -1,0 +1,19 @@
+if [ ! -d {!! $path !!}/.git ]; then
+    exit 0
+fi
+
+if ! cd {!! $path !!}; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+if ! git remote set-url origin {!! $newRepoUrl !!}; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+@if (! empty($usesToken))
+if ! git config credential.helper '!f() { test "$1" = get && printf "username=x-access-token\npassword=%s\n\n" "$GIT_HTTP_TOKEN"; }; f'; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+@else
+git config --unset credential.helper || true
+@endif

--- a/resources/views/ssh/os/create-isolated-user.blade.php
+++ b/resources/views/ssh/os/create-isolated-user.blade.php
@@ -1,10 +1,12 @@
 export DEBIAN_FRONTEND=noninteractive
 if id -u {{ $user }} >/dev/null 2>&1; then
     echo "User {{ $user }} already exists, reasserting directories and permissions."
+    VITO_USER_CREATED=0
 else
     if ! sudo useradd -p $(openssl passwd -1 {{ $password }}) {{ $user }}; then
         echo 'VITO_SSH_ERROR' && exit 1
     fi
+    VITO_USER_CREATED=1
 fi
 
 sudo mkdir -p /home/{{ $user }}
@@ -12,6 +14,12 @@ sudo mkdir -p /home/{{ $user }}/.logs
 sudo mkdir -p /home/{{ $user }}/tmp
 sudo mkdir -p /home/{{ $user }}/bin
 sudo mkdir -p /home/{{ $user }}/.ssh
+sudo touch /home/{{ $user }}/.ssh/authorized_keys
+VITO_PUBKEY={!! $key !!}
+if ! sudo grep -qxF "$VITO_PUBKEY" /home/{{ $user }}/.ssh/authorized_keys; then
+    printf '%s\n' "$VITO_PUBKEY" | sudo tee -a /home/{{ $user }}/.ssh/authorized_keys
+fi
+unset VITO_PUBKEY
 PATH_LINE='export PATH="/home/{{ $user }}/bin:$PATH"'
 sudo touch /home/{{ $user }}/.bashrc /home/{{ $user }}/.profile
 grep -qxF "$PATH_LINE" /home/{{ $user }}/.bashrc || echo "$PATH_LINE" | sudo tee -a /home/{{ $user }}/.bashrc
@@ -22,7 +30,11 @@ fi
 sudo chown -R {{ $user }}:{{ $user }} /home/{{ $user }}
 sudo chmod 750 /home/{{ $user }}
 sudo chmod 700 /home/{{ $user }}/.ssh
+sudo chmod 600 /home/{{ $user }}/.ssh/authorized_keys
 sudo chmod 700 /home/{{ $user }}/.logs
 sudo chmod 700 /home/{{ $user }}/tmp
 sudo chsh -s /bin/bash {{ $user }}
-echo "Created user {{ $user }}."
+if [ "$VITO_USER_CREATED" = "1" ]; then
+    echo "Created user {{ $user }}."
+fi
+unset VITO_USER_CREATED

--- a/resources/views/ssh/site/check-user-exists.blade.php
+++ b/resources/views/ssh/site/check-user-exists.blade.php
@@ -1,1 +1,0 @@
-id -u {{ $user }} >/dev/null 2>&1

--- a/tests/Feature/API/SitesTest.php
+++ b/tests/Feature/API/SitesTest.php
@@ -61,6 +61,7 @@ class SitesTest extends TestCase
         /** @var SourceControl $sourceControl */
         $sourceControl = SourceControl::factory()->create([
             'provider' => Github::id(),
+            'user_id' => $this->user->id,
         ]);
 
         $inputs['source_control'] = $sourceControl->id;

--- a/tests/Feature/GithubAppTest.php
+++ b/tests/Feature/GithubAppTest.php
@@ -2,12 +2,15 @@
 
 namespace Tests\Feature;
 
+use App\Facades\SSH;
+use App\Models\GitHook;
 use App\Models\GithubApp;
 use App\Models\SourceControl;
 use App\Models\User;
 use App\SiteTypes\Laravel;
 use App\SourceControlProviders\GithubApp as GithubAppProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
@@ -279,11 +282,18 @@ class GithubAppTest extends TestCase
         $this->assertNull($sc->project_id);
     }
 
-    public function test_cannot_create_site_with_github_app_source_control(): void
+    public function test_can_create_site_with_github_app_source_control(): void
     {
+        SSH::fake();
         GithubApp::factory()->create();
         $sc = SourceControl::factory()->githubApp()->create([
             'user_id' => $this->user->id,
+        ]);
+
+        Http::fake([
+            'api.github.com/repos/test/test' => Http::response(['full_name' => 'test/test'], 200),
+            'api.github.com/repos/test/test/commits/main' => Http::response([], 200),
+            'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'ghs_TESTTOKEN'], 201),
         ]);
 
         $this->actingAs($this->user)
@@ -298,21 +308,39 @@ class GithubAppTest extends TestCase
                 'user' => 'example',
                 'source_control' => $sc->id,
             ])
-            ->assertSessionHasErrors('source_control');
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('sites', [
+            'domain' => 'example.com',
+            'source_control_id' => $sc->id,
+        ]);
+
+        Http::assertNotSent(fn ($request) => str_contains($request->url(), '/keys'));
     }
 
-    public function test_cannot_update_site_to_use_github_app_source_control(): void
+    public function test_can_update_site_to_use_github_app_source_control(): void
     {
+        SSH::fake();
         GithubApp::factory()->create();
         $sc = SourceControl::factory()->githubApp()->create([
             'user_id' => $this->user->id,
+        ]);
+
+        Http::fake([
+            'api.github.com/repos/*' => Http::response(['full_name' => 'test/test'], 200),
+            'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'ghs_TESTTOKEN'], 201),
         ]);
 
         $this->actingAs($this->user)
             ->patch(route('site-settings.update-source-control', ['server' => $this->server, 'site' => $this->site]), [
                 'source_control' => $sc->id,
             ])
-            ->assertSessionHasErrors('source_control');
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('sites', [
+            'id' => $this->site->id,
+            'source_control_id' => $sc->id,
+        ]);
     }
 
     public function test_cannot_remove_github_app_when_trashed_source_control_still_has_sites(): void
@@ -413,15 +441,139 @@ class GithubAppTest extends TestCase
         ]);
     }
 
-    public function test_provider_throws_for_unimplemented_methods(): void
+    public function test_provider_implements_deployment_surface(): void
     {
         $sc = SourceControl::factory()->githubApp()->create([
             'user_id' => $this->admin->id,
         ]);
         $provider = new GithubAppProvider($sc);
 
-        $this->expectException(\BadMethodCallException::class);
-        $provider->deployKey('t', 'r', 'k');
+        $this->assertSame(
+            'https://github.com/owner/repo.git',
+            $provider->fullRepoUrl('owner/repo', 'irrelevant-key')
+        );
+
+        $this->assertSame('', $provider->deployKey('t', 'owner/repo', 'public-key'));
+        $provider->deleteDeployKey('deploy-key-id', 'owner/repo');
+
+        $hookResult = $provider->deployHook('owner/repo', ['push'], 'secret');
+        $this->assertSame('app-installation', $hookResult['hook_id']);
+        $this->assertSame('github-app-installation', $hookResult['hook_response']['source']);
+
+        $provider->destroyHook('owner/repo', 'app-installation');
+    }
+
+    public function test_environment_variables_include_git_http_token_for_github_app_sites(): void
+    {
+        GithubApp::factory()->create();
+        $sc = SourceControl::factory()->githubApp()->create([
+            'user_id' => $this->user->id,
+            'external_identifier' => '12345',
+        ]);
+        $this->site->update(['source_control_id' => $sc->id]);
+        $this->site->refresh();
+
+        Cache::put('github_app_token_12345', 'ghs_CACHEDTOKEN', 60);
+
+        $vars = $this->site->environmentVariables();
+
+        $this->assertArrayHasKey('GIT_HTTP_TOKEN', $vars);
+        $this->assertSame('ghs_CACHEDTOKEN', $vars['GIT_HTTP_TOKEN']);
+    }
+
+    public function test_environment_variables_omit_git_http_token_for_non_github_app_sites(): void
+    {
+        $vars = $this->site->environmentVariables();
+
+        $this->assertArrayNotHasKey('GIT_HTTP_TOKEN', $vars);
+    }
+
+    public function test_webhook_handles_push_event_triggers_deploy(): void
+    {
+        SSH::fake();
+        $app = GithubApp::factory()->create();
+        $sc = SourceControl::factory()->githubApp()->create([
+            'user_id' => $this->user->id,
+            'external_identifier' => '555',
+        ]);
+        $this->site->update([
+            'source_control_id' => $sc->id,
+            'repository' => 'acme/widgets',
+            'branch' => 'main',
+        ]);
+        $this->site->deploymentScript->update(['content' => 'echo deploying']);
+        GitHook::factory()->create([
+            'site_id' => $this->site->id,
+            'source_control_id' => $sc->id,
+            'events' => ['push'],
+            'actions' => ['deploy'],
+            'hook_id' => 'app-installation',
+        ]);
+
+        Http::fake([
+            'api.github.com/repos/acme/widgets' => Http::response(['full_name' => 'acme/widgets'], 200),
+            'api.github.com/repos/acme/widgets/commits/main' => Http::response([
+                'sha' => 'abc123',
+                'commit' => ['committer' => ['name' => 'a', 'email' => 'a@b'], 'message' => 'm'],
+                'html_url' => 'https://github.com/x',
+            ], 200),
+            'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'ghs_TESTTOKEN'], 201),
+        ]);
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/main',
+            'installation' => ['id' => 555],
+            'repository' => ['full_name' => 'acme/widgets'],
+        ]);
+        $sig = 'sha256='.hash_hmac('sha256', $payload, $app->webhook_secret);
+
+        $this->call('POST', '/api/webhooks/github-app', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_HUB_SIGNATURE_256' => $sig,
+            'HTTP_X_GITHUB_EVENT' => 'push',
+        ], $payload)->assertOk();
+
+        $this->assertDatabaseHas('deployments', [
+            'site_id' => $this->site->id,
+            'commit_id' => 'abc123',
+        ]);
+    }
+
+    public function test_webhook_push_event_for_unmatched_branch_does_not_deploy(): void
+    {
+        $app = GithubApp::factory()->create();
+        $sc = SourceControl::factory()->githubApp()->create([
+            'user_id' => $this->user->id,
+            'external_identifier' => '666',
+        ]);
+        $this->site->update([
+            'source_control_id' => $sc->id,
+            'repository' => 'acme/widgets',
+            'branch' => 'main',
+        ]);
+        GitHook::factory()->create([
+            'site_id' => $this->site->id,
+            'source_control_id' => $sc->id,
+            'events' => ['push'],
+            'actions' => ['deploy'],
+        ]);
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/develop',
+            'installation' => ['id' => 666],
+            'repository' => ['full_name' => 'acme/widgets'],
+        ]);
+        $sig = 'sha256='.hash_hmac('sha256', $payload, $app->webhook_secret);
+
+        $this->call('POST', '/api/webhooks/github-app', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_HUB_SIGNATURE_256' => $sig,
+            'HTTP_X_GITHUB_EVENT' => 'push',
+        ], $payload)->assertOk();
+
+        $this->assertDatabaseMissing('deployments', [
+            'site_id' => $this->site->id,
+        ]);
     }
 
     private function generatePrivateKey(): string

--- a/tests/Feature/SitesTest.php
+++ b/tests/Feature/SitesTest.php
@@ -60,6 +60,7 @@ class SitesTest extends TestCase
         /** @var SourceControl $sourceControl */
         $sourceControl = SourceControl::factory()->create([
             'provider' => Github::id(),
+            'user_id' => $this->user->id,
         ]);
 
         $inputs['source_control'] = $sourceControl->id;
@@ -122,7 +123,7 @@ class SitesTest extends TestCase
             'path' => '/home/shared/second.example.com',
         ]);
 
-        SSH::assertNotExecutedContains('useradd');
+        SSH::assertExecutedContains('User shared already exists');
     }
 
     public function test_isolated_users_endpoint_lists_users_with_counts(): void
@@ -328,6 +329,7 @@ class SitesTest extends TestCase
         /** @var SourceControl $sourceControl */
         $sourceControl = SourceControl::factory()->create([
             'provider' => Github::id(),
+            'user_id' => $this->user->id,
         ]);
 
         $inputs['source_control'] = $sourceControl->id;
@@ -352,6 +354,7 @@ class SitesTest extends TestCase
         /** @var SourceControl $sourceControl */
         $sourceControl = SourceControl::factory()->create([
             'provider' => Github::id(),
+            'user_id' => $this->user->id,
         ]);
 
         $this->post(route('sites.store', ['server' => $this->server]), [
@@ -457,6 +460,7 @@ class SitesTest extends TestCase
         /** @var SourceControl $sourceControl */
         $sourceControl = SourceControl::factory()->create([
             'provider' => Github::id(),
+            'user_id' => $this->user->id,
         ]);
 
         $this->patch(route('site-settings.update-source-control', [
@@ -486,6 +490,7 @@ class SitesTest extends TestCase
         /** @var SourceControl $sourceControl */
         $sourceControl = SourceControl::factory()->create([
             'provider' => Github::id(),
+            'user_id' => $this->user->id,
         ]);
 
         $this->patch(route('site-settings.update-source-control', [
@@ -545,7 +550,7 @@ class SitesTest extends TestCase
         $this->site->refresh();
         $this->assertEquals('master', $this->site->branch);
 
-        SSH::assertExecutedContains('git checkout -f master');
+        SSH::assertExecutedContains("git checkout -f 'master'");
     }
 
     public function test_update_web_directory(): void


### PR DESCRIPTION
Implements site deployments for GitHub App via short-lived installation tokens injected through a git credential helper, plus a handful of pre-existing-bug fixes uncovered along the way.

Implemented a git credential helper - clone and pull operations now run through a credential.helper for GitHub App deployments, token is per-repo and the token only ever lives in env at exec-time, never on disk.  Token is only valid for 1h.  Using a git credential helper here allows existing deployment scripts authenticate for any required commands during the deployment without changes. 

- Removed OS::runScript's info($command) call — it was writing the full deploy script (and now the token env var) to laravel.log at INFO
- AbstractSiteType::isolate() no longer guards createIsolatedUser on !userSharedWithSiblings() or !userExists() — the blade is fully idempotent and we need it to always run so existing isolated users (created before the auth-keys fix) get the server's public key installed into their authorized_keys.
- Removed userExists() and check-user-exists.blade.php — became zero-callers after the isolate() guard was dropped.
- SourceControl::siteValidationRules() now requires a Server — added user/project scoping to close a cross-tenant binding gap that became reachable once GitHub App was marked usableForSites(true).
- create-isolated-user.blade.php now writes the server's public key to the isolated user's authorized_keys — fixes a pre-existing bug where the terminal/live-console couldn't SSH into any isolated user.