### PR TITLE
[Feat] Check for updates automatically

### DIFF
--- a/app/Console/Commands/CheckServerUpdatesCommand.php
+++ b/app/Console/Commands/CheckServerUpdatesCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\ServerStatus;
+use App\Jobs\Server\CheckForUpdatesJob;
+use App\Models\Server;
+use Illuminate\Console\Command;
+
+class CheckServerUpdatesCommand extends Command
+{
+    protected $signature = 'servers:check-updates';
+
+    protected $description = 'Check each server for available package updates';
+
+    public function handle(): void
+    {
+        Server::query()
+            ->where('status', ServerStatus::READY)
+            ->chunk(50, function ($servers) {
+                /** @var Server $server */
+                foreach ($servers as $server) {
+                    CheckForUpdatesJob::dispatch($server)->onQueue('ssh');
+                }
+            });
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -19,6 +19,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('metrics:delete-older-metrics')->daily();
         $schedule->command('metrics:get')->everyMinute();
         $schedule->command('servers:check')->everyFiveMinutes();
+        $schedule->command('servers:check-updates')->dailyAt('02:00');
         $schedule->command('domains:check-pending')->everyFiveMinutes();
         $schedule->command('ssl:renew-wildcards')->daily();
         $schedule->command('ssl:check-expiry')->daily();

--- a/app/Jobs/Server/CheckForUpdatesJob.php
+++ b/app/Jobs/Server/CheckForUpdatesJob.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Jobs\Server;
+
+use App\DTOs\SocketEventDTO;
+use App\Events\SocketEvent;
+use App\Http\Resources\ServerResource;
+use App\Models\Server;
+use App\Traits\UniqueQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class CheckForUpdatesJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public int $timeout = 30;
+
+    public $tries = 1;
+
+    public function __construct(protected Server $server) {}
+
+    public function handle(): void
+    {
+        $this->run("server-{$this->server->id}-check-updates", function () {
+            $this->server->checkForUpdates();
+
+            SocketEvent::dispatch(new SocketEventDTO(
+                projectId: $this->server->project_id,
+                type: 'server.updated',
+                data: new ServerResource($this->server->refresh()),
+            ));
+        });
+    }
+}

--- a/app/Jobs/Server/CheckForUpdatesJob.php
+++ b/app/Jobs/Server/CheckForUpdatesJob.php
@@ -15,9 +15,7 @@ class CheckForUpdatesJob implements ShouldQueue
     use Queueable;
     use UniqueQueue;
 
-    public int $timeout = 30;
-
-    public $tries = 1;
+    public int $timeout = 90;
 
     public function __construct(protected Server $server) {}
 

--- a/app/SSH/OS/OS.php
+++ b/app/SSH/OS/OS.php
@@ -56,10 +56,7 @@ class OS
             'check-available-updates'
         );
 
-        // -1 because the first line is not a package
-        $availableUpdates = str($result)->after('Available updates:')->trim()->toInteger() - 1;
-
-        return max($availableUpdates, 0);
+        return max(str($result)->after('Available updates:')->trim()->toInteger(), 0);
     }
 
     /**

--- a/resources/views/ssh/os/available-updates.blade.php
+++ b/resources/views/ssh/os/available-updates.blade.php
@@ -1,5 +1,5 @@
 sudo DEBIAN_FRONTEND=noninteractive apt-get update
 
-AVAILABLE_UPDATES=$(sudo DEBIAN_FRONTEND=noninteractive apt list --upgradable | wc -l)
+AVAILABLE_UPDATES=$(sudo DEBIAN_FRONTEND=noninteractive apt list --upgradable 2>/dev/null | tail -n +2 | wc -l)
 
 echo "Available updates:$AVAILABLE_UPDATES"

--- a/tests/Feature/CheckServerUpdatesCommandTest.php
+++ b/tests/Feature/CheckServerUpdatesCommandTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ServerStatus;
+use App\Jobs\Server\CheckForUpdatesJob;
+use App\Models\Server;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+class CheckServerUpdatesCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dispatches_job_for_ready_servers(): void
+    {
+        Bus::fake();
+
+        $this->artisan('servers:check-updates')->assertSuccessful();
+
+        Bus::assertDispatched(CheckForUpdatesJob::class, function (CheckForUpdatesJob $job) {
+            return $job->queue === 'ssh';
+        });
+    }
+
+    public function test_does_not_dispatch_for_disconnected_servers(): void
+    {
+        Bus::fake();
+
+        $this->server->update(['status' => ServerStatus::DISCONNECTED]);
+
+        $this->artisan('servers:check-updates')->assertSuccessful();
+
+        Bus::assertNotDispatched(CheckForUpdatesJob::class);
+    }
+
+    public function test_dispatches_for_each_ready_server(): void
+    {
+        Bus::fake();
+
+        Server::factory()->count(2)->create([
+            'user_id' => $this->user->id,
+            'project_id' => $this->user->current_project_id,
+            'status' => ServerStatus::READY,
+        ]);
+
+        Server::factory()->create([
+            'user_id' => $this->user->id,
+            'project_id' => $this->user->current_project_id,
+            'status' => ServerStatus::DISCONNECTED,
+        ]);
+
+        $this->artisan('servers:check-updates')->assertSuccessful();
+
+        Bus::assertDispatchedTimes(CheckForUpdatesJob::class, 3);
+    }
+}

--- a/tests/Feature/ServerTest.php
+++ b/tests/Feature/ServerTest.php
@@ -417,7 +417,7 @@ class ServerTest extends TestCase
             ->assertSessionDoesntHaveErrors();
 
         $this->server->refresh();
-        $this->assertEquals(9, $this->server->updates);
+        $this->assertEquals(10, $this->server->updates);
     }
 
     public function test_update_server(): void


### PR DESCRIPTION
This pull request introduces a new scheduled process to check for package updates on all servers and improves the accuracy of update counting. The main changes include adding a new Artisan command and job for checking updates, scheduling this check to run daily, and refining the logic for determining the number of available updates.

* Modified the logic in `OS.php` to accurately count available updates by removing an unnecessary subtraction, ensuring the number does not go below zero.
* Updated the shell command in `available-updates.blade.php` to filter out the header line and suppress error output, providing a more accurate count of upgradable packages.