### PR TITLE
[Fix] Resolve PHP8.5 deprecation warnings

### DIFF
--- a/tests/Feature/WorkflowInputResolutionTest.php
+++ b/tests/Feature/WorkflowInputResolutionTest.php
@@ -14,10 +14,8 @@ class WorkflowInputResolutionTest extends TestCase
     {
         $runWorkflow = new RunWorkflow;
 
-        // Use reflection to access the private resolveInputs method
         $reflection = new \ReflectionClass($runWorkflow);
         $method = $reflection->getMethod('resolveInputs');
-        $method->setAccessible(true);
 
         $previousOutputs = [
             'server_id' => 123,
@@ -50,7 +48,6 @@ class WorkflowInputResolutionTest extends TestCase
 
         $reflection = new \ReflectionClass($runWorkflow);
         $method = $reflection->getMethod('resolveInputs');
-        $method->setAccessible(true);
 
         $previousOutputs = [
             'server_id' => 123,
@@ -77,7 +74,6 @@ class WorkflowInputResolutionTest extends TestCase
 
         $reflection = new \ReflectionClass($runWorkflow);
         $method = $reflection->getMethod('resolveInputs');
-        $method->setAccessible(true);
 
         $previousOutputs = [
             'server_id' => 123,
@@ -106,7 +102,6 @@ class WorkflowInputResolutionTest extends TestCase
 
         $reflection = new \ReflectionClass($runWorkflow);
         $method = $reflection->getMethod('resolveInputs');
-        $method->setAccessible(true);
 
         $previousOutputs = [
             'server_id' => 123,
@@ -134,7 +129,6 @@ class WorkflowInputResolutionTest extends TestCase
 
         $reflection = new \ReflectionClass($runWorkflow);
         $method = $reflection->getMethod('resolveInputs');
-        $method->setAccessible(true);
 
         $previousOutputs = [
             'server_id' => 123,
@@ -166,7 +160,6 @@ class WorkflowInputResolutionTest extends TestCase
 
         $reflection = new \ReflectionClass($runWorkflow);
         $method = $reflection->getMethod('resolveInputs');
-        $method->setAccessible(true);
 
         $previousOutputs = [
             'server_id' => 123,
@@ -195,7 +188,6 @@ class WorkflowInputResolutionTest extends TestCase
 
         $reflection = new \ReflectionClass($runWorkflow);
         $method = $reflection->getMethod('resolveInputs');
-        $method->setAccessible(true);
 
         $previousOutputs = [
             'service_id' => 456,
@@ -223,7 +215,6 @@ class WorkflowInputResolutionTest extends TestCase
 
         $reflection = new \ReflectionClass($runWorkflow);
         $method = $reflection->getMethod('resolveInputs');
-        $method->setAccessible(true);
 
         $previousOutputs = [
             'server_id' => 123, // This should take priority

--- a/tests/Unit/Models/ServerModelTest.php
+++ b/tests/Unit/Models/ServerModelTest.php
@@ -87,7 +87,6 @@ class ServerModelTest extends TestCase
         $connection->method('disconnect');
 
         $reflection = new ReflectionProperty(SSHHelper::class, 'connection');
-        $reflection->setAccessible(true);
         $reflection->setValue($ssh, $connection);
 
         $command = <<<'BASH'

--- a/tests/Unit/Plugins/LegacyPluginsTest.php
+++ b/tests/Unit/Plugins/LegacyPluginsTest.php
@@ -344,7 +344,6 @@ class LegacyPluginsTest extends TestCase
 
         $reflection = new \ReflectionClass($this->plugins);
         $method = $reflection->getMethod('executeInstallPluginScripts');
-        $method->setAccessible(true);
 
         $result = $method->invoke($this->plugins, $composerJson);
 
@@ -366,7 +365,6 @@ class LegacyPluginsTest extends TestCase
 
         $reflection = new \ReflectionClass($this->plugins);
         $method = $reflection->getMethod('executeInstallPluginScripts');
-        $method->setAccessible(true);
 
         $result = $method->invoke($this->plugins, $composerJson);
 
@@ -389,7 +387,6 @@ class LegacyPluginsTest extends TestCase
 
         $reflection = new \ReflectionClass($this->plugins);
         $method = $reflection->getMethod('executeComposerScripts');
-        $method->setAccessible(true);
 
         $result = $method->invoke($this->plugins, $composerJson, 'post-package-install');
 


### PR DESCRIPTION
This pull request removes unnecessary calls to `setAccessible(true)` when using PHP's Reflection API in various test files. This method has been removed in 8.5 and has been deprecated since 8.1, so throws warnings when we run unit tests against 8.5. 