### PR TITLE
[Fix] Service Install Fixes

### DIFF
--- a/resources/views/ssh/services/database/postgresql/install-12.blade.php
+++ b/resources/views/ssh/services/database/postgresql/install-12.blade.php
@@ -18,7 +18,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wget lsb-release gnupg
 
 # Import PostgreSQL GPG key to modern keyring location
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
 
 # Add PostgreSQL repository with signed-by directive
 CODENAME=$(lsb_release -cs)

--- a/resources/views/ssh/services/database/postgresql/install-13.blade.php
+++ b/resources/views/ssh/services/database/postgresql/install-13.blade.php
@@ -18,7 +18,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wget lsb-release gnupg
 
 # Import PostgreSQL GPG key to modern keyring location
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
 
 # Add PostgreSQL repository with signed-by directive
 CODENAME=$(lsb_release -cs)

--- a/resources/views/ssh/services/database/postgresql/install-14.blade.php
+++ b/resources/views/ssh/services/database/postgresql/install-14.blade.php
@@ -18,7 +18,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wget lsb-release gnupg
 
 # Import PostgreSQL GPG key to modern keyring location
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
 
 # Add PostgreSQL repository with signed-by directive
 CODENAME=$(lsb_release -cs)

--- a/resources/views/ssh/services/database/postgresql/install-15.blade.php
+++ b/resources/views/ssh/services/database/postgresql/install-15.blade.php
@@ -18,7 +18,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wget lsb-release gnupg
 
 # Import PostgreSQL GPG key to modern keyring location
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
 
 # Add PostgreSQL repository with signed-by directive
 CODENAME=$(lsb_release -cs)

--- a/resources/views/ssh/services/database/postgresql/install-16.blade.php
+++ b/resources/views/ssh/services/database/postgresql/install-16.blade.php
@@ -18,7 +18,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wget lsb-release gnupg
 
 # Import PostgreSQL GPG key to modern keyring location
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
 
 # Add PostgreSQL repository with signed-by directive
 CODENAME=$(lsb_release -cs)

--- a/resources/views/ssh/services/database/postgresql/install-17.blade.php
+++ b/resources/views/ssh/services/database/postgresql/install-17.blade.php
@@ -18,7 +18,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wget lsb-release gnupg
 
 # Import PostgreSQL GPG key to modern keyring location
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
 
 # Add PostgreSQL repository with signed-by directive
 CODENAME=$(lsb_release -cs)

--- a/resources/views/ssh/services/database/postgresql/install-18.blade.php
+++ b/resources/views/ssh/services/database/postgresql/install-18.blade.php
@@ -18,7 +18,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wget lsb-release gnupg
 
 # Import PostgreSQL GPG key to modern keyring location
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
 
 # Add PostgreSQL repository with signed-by directive
 CODENAME=$(lsb_release -cs)

--- a/resources/views/ssh/services/webserver/caddy/caddy-systemd.blade.php
+++ b/resources/views/ssh/services/webserver/caddy/caddy-systemd.blade.php
@@ -11,7 +11,7 @@ ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile --adapter caddyfi
 TimeoutStopSec=5s
 LimitNOFILE=1048576
 LimitNPROC=512
-PrivateTmp=true
+PrivateTmp=false
 ProtectSystem=full
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 

--- a/resources/views/ssh/services/webserver/caddy/default-vhost.blade.php
+++ b/resources/views/ssh/services/webserver/caddy/default-vhost.blade.php
@@ -1,9 +1,7 @@
-:80, :443 {
+:80 {
     import access_log default
     import compression
     import security_headers
-
-    tls internal
 
     root * /var/www/vito-splash
     file_server

--- a/resources/views/ssh/services/webserver/caddy/install-caddy.blade.php
+++ b/resources/views/ssh/services/webserver/caddy/install-caddy.blade.php
@@ -1,5 +1,5 @@
 # Add Caddy's GPG key and repository
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
 
 curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | \
 

--- a/resources/views/ssh/services/webserver/nginx/default-vhost.blade.php
+++ b/resources/views/ssh/services/webserver/nginx/default-vhost.blade.php
@@ -1,12 +1,7 @@
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
-    listen 443 ssl default_server;
-    listen [::]:443 ssl default_server;
     server_name _;
-
-    ssl_certificate /etc/nginx/ssl/default.crt;
-    ssl_certificate_key /etc/nginx/ssl/default.key;
 
     root /var/www/vito-splash;
     index index.html;


### PR DESCRIPTION
- Resolves an issue with reinstalling services requiring gpg, which where override is needed falls back to an interactive shell causing the install the fail.  Set the default to yes running in batch mode (override yes) to avoid interactive shell and therefore stopped the service install from failing.
- Updated nginx default configuration from binding to SSL - as this was blocking reloads.
- Updated the caddy default configuration from binding to SSL - as this was blocking reloads.
- Updated caddy to have PrivateTmp=false - as having this as true was blocking reloads, forcing restarts each time SSL's changed for each site.   While there is a small loss in isolation from not having a dedicated tmp, this is low risk due to caddys use of tmp, and any potential attacks would require the attacker to already have shell access to the server. 