### PR TITLE
[Fix] Required tooling

### DIFF
--- a/app/Actions/Site/Tooling/GetSiteTooling.php
+++ b/app/Actions/Site/Tooling/GetSiteTooling.php
@@ -14,6 +14,7 @@ class GetSiteTooling
      *     sibling_sites: array<int, array{id: int, domain: string, url: string}>,
      *     installed_versions: array<string, string|null>,
      *     tool_statuses: array<string, string|null>,
+     *     required_tooling: array<string, string>,
      *     watch_site_ids: array<int, int>,
      * }
      */
@@ -43,6 +44,7 @@ class GetSiteTooling
             'sibling_sites' => $siblings,
             'installed_versions' => $installed,
             'tool_statuses' => $statuses,
+            'required_tooling' => $site->requiredToolingMap(),
             'watch_site_ids' => array_merge([$site->id], array_column($siblings, 'id')),
         ];
     }

--- a/app/Actions/Site/Tooling/UninstallSiteTooling.php
+++ b/app/Actions/Site/Tooling/UninstallSiteTooling.php
@@ -33,6 +33,13 @@ class UninstallSiteTooling
             ]);
         }
 
+        $required = $site->requiredToolingMap();
+        if (isset($required[$toolId])) {
+            throw ValidationException::withMessages([
+                'tool' => "{$tool::label()} is required by the {$required[$toolId]} site type and cannot be uninstalled.",
+            ]);
+        }
+
         $current = $iuser->toolingStatus($toolId);
         if ($current === SiteToolingState::STATUS_INSTALLING || $current === SiteToolingState::STATUS_UNINSTALLING) {
             throw ValidationException::withMessages([

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -16,6 +16,7 @@ use App\Jobs\SSL\DeleteSiteSslJob;
 use App\Services\Webserver\Webserver;
 use App\SiteFeatures\ActionInterface;
 use App\SiteTypes\AbstractProxiedSiteType;
+use App\SiteTypes\AbstractSiteType;
 use App\SiteTypes\BunSite;
 use App\SiteTypes\NodeSite;
 use App\SiteTypes\SiteType;
@@ -593,10 +594,15 @@ class Site extends AbstractModel
         $required = [];
 
         foreach ($this->siblingsSharingUser(includeSelf: true)->get() as $site) {
-            $typeId = $site->type()::id();
+            $type = $site->type();
+            if (! $type instanceof AbstractSiteType) {
+                continue;
+            }
+
+            $typeId = $type::id();
             $label = config('site.types.'.$typeId.'.label') ?? $typeId;
 
-            foreach ($site->type()::requiredTooling() as $toolId) {
+            foreach ($type::requiredTooling() as $toolId) {
                 $required[$toolId] = $label;
             }
         }

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -585,6 +585,25 @@ class Site extends AbstractModel
         return $query;
     }
 
+    /**
+     * @return array<string, string>
+     */
+    public function requiredToolingMap(): array
+    {
+        $required = [];
+
+        foreach ($this->siblingsSharingUser(includeSelf: true)->get() as $site) {
+            $typeId = $site->type()::id();
+            $label = config('site.types.'.$typeId.'.label') ?? $typeId;
+
+            foreach ($site->type()::requiredTooling() as $toolId) {
+                $required[$toolId] = $label;
+            }
+        }
+
+        return $required;
+    }
+
     public function fpmPoolSharedWithSiblings(?string $phpVersion = null): bool
     {
         if (! $this->isolated_user_id) {

--- a/app/SiteTypes/AbstractSiteType.php
+++ b/app/SiteTypes/AbstractSiteType.php
@@ -35,6 +35,14 @@ abstract class AbstractSiteType implements SiteType
         return [];
     }
 
+    /**
+     * @return array<int, string>
+     */
+    public static function requiredTooling(): array
+    {
+        return [];
+    }
+
     public static function supportsTooling(): bool
     {
         return false;

--- a/app/SiteTypes/BunSite.php
+++ b/app/SiteTypes/BunSite.php
@@ -29,6 +29,11 @@ class BunSite extends AbstractProxiedSiteType
         return ['bun'];
     }
 
+    public static function requiredTooling(): array
+    {
+        return ['bun'];
+    }
+
     /**
      * @return array<int, DynamicField>
      */

--- a/app/SiteTypes/NodeSite.php
+++ b/app/SiteTypes/NodeSite.php
@@ -34,6 +34,11 @@ class NodeSite extends AbstractProxiedSiteType
         return ['node', 'pnpm', 'yarn'];
     }
 
+    public static function requiredTooling(): array
+    {
+        return ['node'];
+    }
+
     /**
      * @return array<int, DynamicField>
      */

--- a/resources/js/pages/site-tooling/components/tooling-table.tsx
+++ b/resources/js/pages/site-tooling/components/tooling-table.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Card } from '@/components/ui/card';
 import { CircleCheckIcon, CircleIcon, LoaderCircleIcon, SearchIcon, TrashIcon, TriangleAlertIcon } from 'lucide-react';
 import { Site } from '@/types/site';
@@ -16,11 +17,12 @@ type Props = {
   tools: ToolingDescriptor[];
   installedVersions: Record<string, string | null>;
   statuses: Record<string, SiteToolingStatus>;
+  requiredTooling: Record<string, string>;
   siblingCount: number;
   onSubmit?: () => void;
 };
 
-export default function ToolingTable({ site, tools, installedVersions, statuses, siblingCount, onSubmit }: Props) {
+export default function ToolingTable({ site, tools, installedVersions, statuses, requiredTooling, siblingCount, onSubmit }: Props) {
   const [query, setQuery] = useState('');
 
   const filtered = useMemo(() => {
@@ -68,6 +70,7 @@ export default function ToolingTable({ site, tools, installedVersions, statuses,
                   tool={tool}
                   installedVersion={installedVersions[tool.id] ?? null}
                   status={statuses[tool.id] ?? null}
+                  requiredBy={requiredTooling[tool.id] ?? null}
                   siblingCount={siblingCount}
                   onSubmit={onSubmit}
                 />
@@ -85,6 +88,7 @@ function ToolingRow({
   tool,
   installedVersion,
   status,
+  requiredBy,
   siblingCount,
   onSubmit,
 }: {
@@ -92,6 +96,7 @@ function ToolingRow({
   tool: ToolingDescriptor;
   installedVersion: string | null;
   status: SiteToolingStatus;
+  requiredBy: string | null;
   siblingCount: number;
   onSubmit?: () => void;
 }) {
@@ -112,8 +117,9 @@ function ToolingRow({
   const uninstallFailed = status === 'uninstall_failed';
 
   const installed = installedVersion !== null;
+  const required = requiredBy !== null;
   const primaryDisabled = submitting || busy || selected === '' || selected === installedVersion;
-  const uninstallDisabled = submitting || busy || !installed;
+  const uninstallDisabled = submitting || busy || !installed || required;
 
   const submitInstall = (e: FormEvent) => {
     e.preventDefault();
@@ -189,21 +195,34 @@ function ToolingRow({
           >
             {installing || submittingInstall ? <LoaderCircleIcon className="size-4 animate-spin" /> : 'Install'}
           </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            disabled={uninstallDisabled}
-            onClick={() => setConfirmOpen(true)}
-            aria-busy={uninstalling}
-            aria-label={uninstalling ? `Uninstalling ${tool.label}` : `Uninstall ${tool.label}`}
-          >
-            {uninstalling || submittingUninstall ? (
-              <LoaderCircleIcon className="text-destructive size-4 animate-spin" />
-            ) : (
-              <TrashIcon className="text-destructive size-4" />
-            )}
-          </Button>
+          {required ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span tabIndex={0}>
+                  <Button type="button" variant="outline" size="icon" disabled aria-label={`Uninstall ${tool.label}`}>
+                    <TrashIcon className="text-destructive size-4" />
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>Required by {requiredBy} site type</TooltipContent>
+            </Tooltip>
+          ) : (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              disabled={uninstallDisabled}
+              onClick={() => setConfirmOpen(true)}
+              aria-busy={uninstalling}
+              aria-label={uninstalling ? `Uninstalling ${tool.label}` : `Uninstall ${tool.label}`}
+            >
+              {uninstalling || submittingUninstall ? (
+                <LoaderCircleIcon className="text-destructive size-4 animate-spin" />
+              ) : (
+                <TrashIcon className="text-destructive size-4" />
+              )}
+            </Button>
+          )}
         </form>
 
         <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
@@ -213,13 +232,11 @@ function ToolingRow({
               <DialogDescription>This will remove {tool.label} from the isolated user.</DialogDescription>
             </DialogHeader>
             <div className="space-y-2 p-4 text-sm">
-              {siblingCount > 0 ? (
+              {siblingCount > 0 && (
                 <p>
                   This isolated user is shared with <strong>{siblingCount}</strong> other site{siblingCount === 1 ? '' : 's'}. Uninstalling will
                   affect them all.
                 </p>
-              ) : (
-                <p>No other sites share this isolated user.</p>
               )}
               <p>Are you sure you want to uninstall {tool.label}?</p>
             </div>

--- a/resources/js/pages/site-tooling/index.tsx
+++ b/resources/js/pages/site-tooling/index.tsx
@@ -23,7 +23,7 @@ export default function SiteTooling() {
 
   const configs = useConfigs();
   const tools = configs?.tooling ?? [];
-  const { isolated_user, sibling_sites, installed_versions, tool_statuses } = page.props;
+  const { isolated_user, sibling_sites, installed_versions, tool_statuses, required_tooling } = page.props;
 
   useStatusTransitionToasts(tool_statuses, tools);
 
@@ -91,6 +91,7 @@ export default function SiteTooling() {
           tools={tools}
           installedVersions={installed_versions}
           statuses={tool_statuses}
+          requiredTooling={required_tooling}
           siblingCount={sibling_sites.length}
           onSubmit={() => {
             ownSubmitAt.current = Date.now();

--- a/resources/js/types/site-tooling.d.ts
+++ b/resources/js/types/site-tooling.d.ts
@@ -5,5 +5,6 @@ export type SiteToolingProps = {
   sibling_sites: { id: number; domain: string; url: string }[];
   installed_versions: Record<string, string | null>;
   tool_statuses: Record<string, SiteToolingStatus>;
+  required_tooling: Record<string, string>;
   watch_site_ids: number[];
 };

--- a/tests/Feature/SiteToolingTest.php
+++ b/tests/Feature/SiteToolingTest.php
@@ -14,6 +14,7 @@ use App\Models\User;
 use App\SiteTypes\AbstractSiteType;
 use App\SiteTypes\Laravel;
 use App\SiteTypes\LoadBalancer;
+use App\SiteTypes\NodeSite;
 use App\SourceControlProviders\Github;
 use App\Tooling\SiteToolingState;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -398,6 +399,53 @@ class SiteToolingTest extends TestCase
         $site->refresh();
         $this->assertArrayNotHasKey('node_version', $site->type_data);
         $this->assertArrayNotHasKey('pnpm_version', $site->type_data);
+    }
+
+    public function test_index_exposes_required_tooling_from_sibling_site_types(): void
+    {
+        Site::factory()->create([
+            'server_id' => $this->server->id,
+            'domain' => 'iso-node.test',
+            'user' => 'isolated-foo',
+            'path' => '/home/isolated-foo/iso-node.test',
+            'type' => NodeSite::id(),
+            'status' => SiteStatus::READY,
+            'type_data' => [],
+        ]);
+
+        $this->actingAs($this->user);
+
+        $this->get(route('site-tooling', ['server' => $this->server, 'site' => $this->isolatedSite]))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $assert) => $assert
+                ->where('required_tooling.node', 'Node.js')
+                ->missing('required_tooling.bun')
+            );
+    }
+
+    public function test_uninstall_rejected_for_required_tooling(): void
+    {
+        SSH::fake();
+
+        Site::factory()->create([
+            'server_id' => $this->server->id,
+            'domain' => 'iso-node.test',
+            'user' => 'isolated-foo',
+            'path' => '/home/isolated-foo/iso-node.test',
+            'type' => NodeSite::id(),
+            'status' => SiteStatus::READY,
+            'type_data' => [],
+        ]);
+
+        $this->iuser()->setToolingVersion('node', '22');
+
+        $this->actingAs($this->user);
+
+        $this->delete(route('site-tooling.uninstall', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']))
+            ->assertSessionHasErrors('tool');
+
+        SSH::assertNotExecutedContains('mise unuse -g node');
+        $this->assertSame('22', $this->iuser()->toolingVersion('node'));
     }
 
     public function test_other_user_sites_are_not_touched(): void


### PR DESCRIPTION
Allows site types to define optional required tooling, such as the bun site type requiring bun.  Uses wont be able to uninstall bun from an isolated user that contains a bun site type, same for node.   Resolved an issue with the delete interface when user is shared with no other sites.