### PR TITLE
[Fix] Available tooling using isolated user

### DIFF
--- a/app/Http/Resources/SiteResource.php
+++ b/app/Http/Resources/SiteResource.php
@@ -57,6 +57,7 @@ class SiteResource extends JsonResource
             'has_custom_vhost_template' => $this->vhost_template !== null,
             'modern_deployment' => $this->modernDeploymentEnabled(),
             'is_proxied_site_type' => $this->type() instanceof AbstractProxiedSiteType,
+            'available_tooling_commands' => $this->availableToolingCommands(),
             'start_command' => $this->type_data['start_command'] ?? null,
             'bootstrap_worker_id' => isset($this->type_data['bootstrap_worker_id'])
                 ? (int) $this->type_data['bootstrap_worker_id']

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -20,6 +20,7 @@ use App\SiteTypes\BunSite;
 use App\SiteTypes\NodeSite;
 use App\SiteTypes\SiteType;
 use App\SourceControlProviders\GithubApp;
+use App\Tooling\ToolingRegistry;
 use App\Traits\HasProjectThroughServer;
 use Database\Factories\SiteFactory;
 use Illuminate\Database\Eloquent\Builder;
@@ -583,6 +584,30 @@ class Site extends AbstractModel
         }
 
         return $query;
+    }
+
+    /**
+     * Shell commands available to this site's deployment scripts: the PHP binary
+     * when a PHP version is set, plus every command exposed by tooling installed
+     * for the isolated user.
+     *
+     * @return array<int, string>
+     */
+    public function availableToolingCommands(): array
+    {
+        $commands = [];
+
+        if ($this->php_version) {
+            $commands[] = 'php';
+        }
+
+        foreach (ToolingRegistry::all() as $id => $tool) {
+            if ($this->isolatedUser?->toolingVersion($id) !== null) {
+                $commands = array_merge($commands, $tool::commands());
+            }
+        }
+
+        return array_values(array_unique($commands));
     }
 
     public function fpmPoolSharedWithSiblings(?string $phpVersion = null): bool

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -587,10 +587,6 @@ class Site extends AbstractModel
     }
 
     /**
-     * Shell commands available to this site's deployment scripts: the PHP binary
-     * when a PHP version is set, plus every command exposed by tooling installed
-     * for the isolated user.
-     *
      * @return array<int, string>
      */
     public function availableToolingCommands(): array

--- a/resources/js/pages/application/components/deployment-script.tsx
+++ b/resources/js/pages/application/components/deployment-script.tsx
@@ -1,6 +1,5 @@
-import React, { FormEvent, Fragment, ReactNode, useMemo, useState } from 'react';
+import React, { FormEvent, Fragment, ReactNode, useState } from 'react';
 import { Link, useForm } from '@inertiajs/react';
-import { useConfigs } from '@/stores/bootstrap-store';
 import { Editor, useMonaco } from '@monaco-editor/react';
 import { Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { Form, FormField, FormFields } from '@/components/ui/form';
@@ -30,19 +29,8 @@ export default function DeploymentScript({
 }) {
   const { getActualAppearance } = useAppearance();
   const setFocused = useInputFocus((state) => state.setFocused);
-  const configs = useConfigs();
 
-  const availableCommands = useMemo<string[]>(() => {
-    const commands: string[] = [];
-    if (site.type === 'php') commands.push('php');
-    for (const tool of configs?.tooling ?? []) {
-      const version = site.type_data?.[`${tool.id}_version`];
-      if (typeof version === 'string' && version !== '' && version !== 'none') {
-        commands.push(...tool.commands);
-      }
-    }
-    return Array.from(new Set(commands));
-  }, [configs, site.type, site.type_data]);
+  const availableCommands = site.available_tooling_commands;
 
   const [open, setOpen] = useState(false);
   const form = useForm<{

--- a/resources/js/types/site.d.ts
+++ b/resources/js/types/site.d.ts
@@ -40,6 +40,7 @@ export interface Site {
   features: SiteFeature[];
   modern_deployment: boolean;
   is_proxied_site_type: boolean;
+  available_tooling_commands: string[];
   start_command: string | null;
   bootstrap_worker_id: number | null;
   basic_auth: {


### PR DESCRIPTION
Resolved an issue where available tooling was still using site_data and not the isolated user, and resolved an issue where it was only appearing on PHP site types. 