### PR TITLE
[Fix] Basic-auth command order

### DIFF
--- a/app/Actions/Site/UpdateBasicAuth.php
+++ b/app/Actions/Site/UpdateBasicAuth.php
@@ -62,8 +62,15 @@ class UpdateBasicAuth
             $site->update(['type_data' => $typeData]);
         });
 
-        $this->writeAuthFile($site, $enabled ? $users : []);
+        if ($enabled) {
+            $this->writeAuthFile($site, $users);
+            $site->webserver()->updateVHost($site);
+
+            return;
+        }
+
         $site->webserver()->updateVHost($site);
+        $this->writeAuthFile($site, []);
     }
 
     /**


### PR DESCRIPTION
Removing basic auth deleted the auth file first, then reloaded the webserver, however, for a period of time between the two, the website throws a 500 as it cannot load the auth file.    This PR resolves this issue by only deleting the file AFTER nginx has been reloaded.