### PR TITLE
[Fix] Caddy force-ssl verification

### DIFF
--- a/app/Actions/Webserver/GenerateCaddyConfig.php
+++ b/app/Actions/Webserver/GenerateCaddyConfig.php
@@ -84,6 +84,39 @@ class GenerateCaddyConfig extends AbstractGenerateConfig
         return $block;
     }
 
+    protected function finalizeData(array $data, Site $site): array
+    {
+        $domains = $this->httpVerificationDomains($data['server_blocks'], $site);
+
+        $data['has_http_verification'] = $domains !== [];
+        $data['http_verification_domains'] = $domains;
+
+        return $data;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $serverBlocks
+     * @return array<int, array{address: string}>
+     */
+    private function httpVerificationDomains(array $serverBlocks, Site $site): array
+    {
+        if (! $site->verification_key) {
+            return [];
+        }
+
+        $domains = [];
+        foreach ($serverBlocks as $block) {
+            if ($block['http_only'] ?? false) {
+                continue;
+            }
+            foreach ($block['domains'] as $domain) {
+                $domains[$domain['name']] = ['address' => 'http://'.$domain['name']];
+            }
+        }
+
+        return array_values($domains);
+    }
+
     protected function buildRedirectBlock(HostedDomain $hd, string $primaryDomain, Site $site): array
     {
         $hasSsl = $hd->ssl_id && $hd->ssl;

--- a/resources/views/ssh/services/webserver/caddy/vhost.mustache
+++ b/resources/views/ssh/services/webserver/caddy/vhost.mustache
@@ -80,6 +80,20 @@
 
 {{/server_blocks}}
 
+{{#has_http_verification}}
+{{#http_verification_domains}}{{address}} {{/http_verification_domains}}{
+    handle_path /.well-known/vito/{{verification_key}}/* {
+        root * /var/lib/vito/verify/{{verification_key}}
+        header Cache-Control "no-store"
+        file_server
+    }
+
+    handle {
+        redir https://{host}{uri} permanent
+    }
+}
+
+{{/has_http_verification}}
 {{#redirect_blocks}}
 {{#domains}}{{address}} {{/domains}}{
     {{#has_tls}}

--- a/tests/Feature/Webserver/VerificationBlockTest.php
+++ b/tests/Feature/Webserver/VerificationBlockTest.php
@@ -88,4 +88,59 @@ class VerificationBlockTest extends TestCase
         $this->assertStringContainsString('handle_path /.well-known/vito/caddyKey99/*', $vhost);
         $this->assertStringContainsString('root * /var/lib/vito/verify/caddyKey99', $vhost);
     }
+
+    public function test_caddy_serves_verification_over_http_when_using_auto_https(): void
+    {
+        $this->switchToCaddy();
+
+        HostedDomain::factory()->primary()->create([
+            'site_id' => $this->site->id,
+            'domain' => $this->site->domain,
+        ]);
+
+        $this->site->update([
+            'ssl_enabled' => true,
+            'verification_key' => 'caddyForce42',
+        ]);
+        $this->site->refresh();
+
+        $vhost = $this->server->webserver()->handler()->generateVhost($this->site);
+
+        $this->assertStringContainsString('http://'.$this->site->domain.' {', $vhost);
+        $this->assertStringContainsString('handle_path /.well-known/vito/caddyForce42/*', $vhost);
+        $this->assertStringContainsString('redir https://{host}{uri} permanent', $vhost);
+    }
+
+    public function test_caddy_omits_http_verification_block_for_http_only_site(): void
+    {
+        $this->switchToCaddy();
+
+        HostedDomain::factory()->primary()->create([
+            'site_id' => $this->site->id,
+            'domain' => $this->site->domain,
+        ]);
+
+        $this->site->update([
+            'ssl_enabled' => false,
+            'verification_key' => 'caddyPlain1',
+        ]);
+        $this->site->refresh();
+
+        $vhost = $this->server->webserver()->handler()->generateVhost($this->site);
+
+        $this->assertStringContainsString('handle_path /.well-known/vito/caddyPlain1/*', $vhost);
+        $this->assertStringNotContainsString('redir https://{host}{uri} permanent', $vhost);
+    }
+
+    private function switchToCaddy(): void
+    {
+        $this->server->services()->where('type', 'webserver')->delete();
+        $this->server->services()->create([
+            'type' => Caddy::type(),
+            'name' => Caddy::id(),
+            'version' => 'latest',
+            'status' => ServiceStatus::READY,
+        ]);
+        $this->server->refresh();
+    }
 }


### PR DESCRIPTION
Like nginx, when caddy is in force-ssl mode, vito domain verification does not function, this PR allows us to support HTTP requests to the verify URL even when force-ssl is enabled.