### PR TITLE
[Fix] Reload webservice on delete of site

### DIFF
--- a/app/Services/Webserver/Caddy.php
+++ b/app/Services/Webserver/Caddy.php
@@ -191,7 +191,7 @@ class Caddy extends AbstractWebserver implements HasLogs
             'delete-vhost',
             $site->id
         );
-        $this->service->restart();
+        $this->service->reload();
     }
 
     /**

--- a/app/Services/Webserver/Nginx.php
+++ b/app/Services/Webserver/Nginx.php
@@ -174,7 +174,7 @@ class Nginx extends AbstractWebserver implements HasLogs
             'delete-vhost',
             $site->id
         );
-        $this->service->restart();
+        $this->service->reload();
     }
 
     /**


### PR DESCRIPTION
At present, when a site is deleted, the webserver is restarted (both nginx and caddy), however, this is wasteful, as a restart will end any connections for ALL sites.  A reload will much more efficiently handle the removed config, and both nginx and caddy support reloading as an acceptable form of removal of config. 