### PR TITLE
[Feat] [4.x] Site Stats

### DIFF
--- a/app/Actions/CronJob/SyncCronJobs.php
+++ b/app/Actions/CronJob/SyncCronJobs.php
@@ -34,8 +34,6 @@ class SyncCronJobs
             ->where('user', $user)
             ->get();
 
-        // Hidden infra crons stay in $vitoCronJobs (so they match and are never recreated as
-        // duplicates) but are excluded from the disable sweeps below.
         $serverLevelCronJobs = $vitoCronJobs->where('site_id', null)->where('hidden', false);
 
         if (empty($crontabOutput)) {

--- a/app/Actions/CronJob/SyncCronJobs.php
+++ b/app/Actions/CronJob/SyncCronJobs.php
@@ -34,8 +34,9 @@ class SyncCronJobs
             ->where('user', $user)
             ->get();
 
-        // Filter only server-level cronjobs (site_id = null) for status updates
-        $serverLevelCronJobs = $vitoCronJobs->where('site_id', null);
+        // Hidden infra crons stay in $vitoCronJobs (so they match and are never recreated as
+        // duplicates) but are excluded from the disable sweeps below.
+        $serverLevelCronJobs = $vitoCronJobs->where('site_id', null)->where('hidden', false);
 
         if (empty($crontabOutput)) {
             // If crontab is empty, mark all server-level Vito cronjobs as disabled
@@ -106,7 +107,7 @@ class SyncCronJobs
                 $foundCronJobs[] = $matchingCronJob->id;
 
                 // Update status based on comment state (only for server-level cronjobs)
-                if ($matchingCronJob->site_id === null) {
+                if ($matchingCronJob->site_id === null && ! $matchingCronJob->hidden) {
                     if ($isCommented && $matchingCronJob->status === CronjobStatus::READY) {
                         $matchingCronJob->update(['status' => CronjobStatus::DISABLED]);
                     } elseif (! $isCommented && $matchingCronJob->status === CronjobStatus::DISABLED) {

--- a/app/Actions/CronJob/SyncCronJobs.php
+++ b/app/Actions/CronJob/SyncCronJobs.php
@@ -134,7 +134,6 @@ class SyncCronJobs
                     'user' => $user,
                     'command' => $cronJobData['command'],
                     'frequency' => $cronJobData['frequency'],
-                    'hidden' => false,
                     'status' => $cronJobData['commented'] ? CronjobStatus::DISABLED : CronjobStatus::READY,
                 ]);
             }

--- a/app/Actions/CronJob/SyncCronJobs.php
+++ b/app/Actions/CronJob/SyncCronJobs.php
@@ -34,7 +34,7 @@ class SyncCronJobs
             ->where('user', $user)
             ->get();
 
-        $serverLevelCronJobs = $vitoCronJobs->where('site_id', null)->where('hidden', false);
+        $serverLevelCronJobs = $vitoCronJobs->where('site_id', null);
 
         if (empty($crontabOutput)) {
             // If crontab is empty, mark all server-level Vito cronjobs as disabled
@@ -105,7 +105,7 @@ class SyncCronJobs
                 $foundCronJobs[] = $matchingCronJob->id;
 
                 // Update status based on comment state (only for server-level cronjobs)
-                if ($matchingCronJob->site_id === null && ! $matchingCronJob->hidden) {
+                if ($matchingCronJob->site_id === null) {
                     if ($isCommented && $matchingCronJob->status === CronjobStatus::READY) {
                         $matchingCronJob->update(['status' => CronjobStatus::DISABLED]);
                     } elseif (! $isCommented && $matchingCronJob->status === CronjobStatus::DISABLED) {

--- a/app/Actions/Service/Manage.php
+++ b/app/Actions/Service/Manage.php
@@ -59,9 +59,9 @@ class Manage
 
     private function validate(Service $service): void
     {
-        if (! $service->handler()->unit()) {
+        if (! $service->handler()->canBeManaged()) {
             throw ValidationException::withMessages([
-                'service' => __('This service does not have a systemd unit configured.'),
+                'service' => __('This service cannot be managed.'),
             ]);
         }
     }

--- a/app/Actions/Site/DeleteSite.php
+++ b/app/Actions/Site/DeleteSite.php
@@ -84,7 +84,7 @@ class DeleteSite
      */
     private function deleteRow(Site $site): void
     {
-        $serverId = $site->server_id;
+        $server = $site->server;
         $siteId = $site->id;
         $domain = $site->domain;
 
@@ -101,7 +101,7 @@ class DeleteSite
             throw $e;
         }
 
-        SiteDeletedEvent::dispatch($serverId, $siteId, $domain);
+        SiteDeletedEvent::dispatch($server, $siteId, $domain);
     }
 
     /**

--- a/app/Actions/Site/DeleteSite.php
+++ b/app/Actions/Site/DeleteSite.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Site;
 
+use App\Events\SiteDeletedEvent;
 use App\Exceptions\SSHError;
 use App\Models\Service;
 use App\Models\Site;
@@ -83,6 +84,10 @@ class DeleteSite
      */
     private function deleteRow(Site $site): void
     {
+        $serverId = $site->server_id;
+        $siteId = $site->id;
+        $domain = $site->domain;
+
         try {
             $site->delete();
         } catch (Throwable $e) {
@@ -95,6 +100,8 @@ class DeleteSite
 
             throw $e;
         }
+
+        SiteDeletedEvent::dispatch($serverId, $siteId, $domain);
     }
 
     /**

--- a/app/Actions/Site/UpdateSiteStats.php
+++ b/app/Actions/Site/UpdateSiteStats.php
@@ -19,10 +19,7 @@ class UpdateSiteStats
 
     public function enable(Site $site): void
     {
-        $typeData = $site->type_data ?? [];
-        unset($typeData['stats_disabled']);
-        $site->type_data = $typeData;
-        $site->save();
+        $site->jsonForget('type_data', 'stats_disabled');
 
         if ($site->server->service('log_analysis')) {
             dispatch(new WriteSiteStatsConfJob($site));

--- a/app/Actions/Site/UpdateSiteStats.php
+++ b/app/Actions/Site/UpdateSiteStats.php
@@ -16,7 +16,7 @@ class UpdateSiteStats
             dispatch(new CleanupSiteStatsJob($site->server, $site->id));
         }
     }
-    
+
     public function enable(Site $site): void
     {
         $typeData = $site->type_data ?? [];

--- a/app/Actions/Site/UpdateSiteStats.php
+++ b/app/Actions/Site/UpdateSiteStats.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Actions\Site;
+
+use App\Jobs\Site\CleanupSiteStatsJob;
+use App\Jobs\Site\WriteSiteStatsConfJob;
+use App\Models\Site;
+
+class UpdateSiteStats
+{
+    public function disable(Site $site): void
+    {
+        $site->jsonUpdate('type_data', 'stats_disabled', true);
+
+        if ($site->server->service('log_analysis')) {
+            dispatch(new CleanupSiteStatsJob($site->server, $site->id));
+        }
+    }
+    
+    public function enable(Site $site): void
+    {
+        $typeData = $site->type_data ?? [];
+        unset($typeData['stats_disabled']);
+        $site->type_data = $typeData;
+        $site->save();
+
+        if ($site->server->service('log_analysis')) {
+            dispatch(new WriteSiteStatsConfJob($site));
+        }
+    }
+}

--- a/app/Actions/SiteStats/GetSiteStats.php
+++ b/app/Actions/SiteStats/GetSiteStats.php
@@ -14,6 +14,7 @@ class GetSiteStats
 {
     /**
      * @return array{months: array<int, string>, month: string, summary: array<int, array<string, mixed>>, detail: ?array<string, mixed>}
+     *
      * @throws SSHError
      */
     public function get(Site $site, ?string $month = null): array
@@ -56,8 +57,9 @@ class GetSiteStats
     }
 
     /**
-     * @param  ?array<string, mixed> $status
+     * @param  ?array<string, mixed>  $status
      * @return ?array<string, mixed>
+     *
      * @throws SSHError
      */
     private function detail(SSH|SSHFake $ssh, Site $site, string $month, ?array $status): ?array
@@ -151,6 +153,7 @@ class GetSiteStats
 
     /**
      * @return ?array<string, mixed>
+     *
      * @throws SSHError
      */
     private function readJson(SSH|SSHFake $ssh, Site $site, string $file): ?array
@@ -160,6 +163,7 @@ class GetSiteStats
 
     /**
      * @return ?array<string, mixed>
+     *
      * @throws SSHError
      */
     private function readMonth(SSH|SSHFake $ssh, Site $site, string $month): ?array
@@ -175,6 +179,7 @@ class GetSiteStats
 
     /**
      * @return ?array<string, mixed>
+     *
      * @throws SSHError
      */
     private function cat(SSH|SSHFake $ssh, string $path): ?array

--- a/app/Actions/SiteStats/GetSiteStats.php
+++ b/app/Actions/SiteStats/GetSiteStats.php
@@ -21,7 +21,11 @@ class GetSiteStats
     {
         $ssh = $site->server->ssh();
 
-        $status = $this->readJson($ssh, $site, 'status.json');
+        $status = Cache::remember(
+            "site-stats-status:{$site->id}",
+            10,
+            fn (): ?array => $this->readJson($ssh, $site, 'status.json'),
+        );
         $token = (string) ($status['last_run_finished_at'] ?? 'none');
 
         return Cache::remember(
@@ -97,6 +101,10 @@ class GetSiteStats
                 'hits' => (int) ($row['hits']['count'] ?? 0),
                 'bandwidth' => (int) ($row['bytes']['count'] ?? 0),
             ];
+        }
+
+        if (preg_match('/^\d{4}-\d{2}$/', $month) !== 1) {
+            return [];
         }
 
         $start = Carbon::createFromFormat('Y-m', $month)->startOfMonth();

--- a/app/Actions/SiteStats/GetSiteStats.php
+++ b/app/Actions/SiteStats/GetSiteStats.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace App\Actions\SiteStats;
+
+use App\Exceptions\SSHError;
+use App\Helpers\SSH;
+use App\Models\Site;
+use App\Services\LogAnalysis\GoAccess\GoAccess;
+use App\Support\Testing\SSHFake;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
+
+class GetSiteStats
+{
+    /**
+     * @return array{months: array<int, string>, month: string, summary: array<int, array<string, mixed>>, detail: ?array<string, mixed>}
+     * @throws SSHError
+     */
+    public function get(Site $site, ?string $month = null): array
+    {
+        $ssh = $site->server->ssh();
+
+        $status = $this->readJson($ssh, $site, 'status.json');
+        $token = (string) ($status['last_run_finished_at'] ?? 'none');
+
+        return Cache::remember(
+            "site-stats:{$site->id}:".($month ?? 'current').":{$token}",
+            300,
+            function () use ($ssh, $site, $month, $status): array {
+                $summary = $this->readJson($ssh, $site, 'summary.json') ?? [];
+                $summary = collect($summary)
+                    ->filter(fn ($row): bool => is_array($row) && isset($row['month']))
+                    ->sortBy('month')
+                    ->values()
+                    ->all();
+
+                $months = collect($summary)->pluck('month')->sortDesc()->values()->all();
+                $selected = $month && in_array($month, $months, true)
+                    ? $month
+                    : ($months[0] ?? Carbon::now()->format('Y-m'));
+
+                return [
+                    'months' => $months,
+                    'month' => $selected,
+                    'summary' => $summary,
+                    'detail' => $this->detail($ssh, $site, $selected, $status),
+                    'status' => $status ? [
+                        'last_success_at' => $status['last_success_at'] ?? null,
+                        'last_run_finished_at' => $status['last_run_finished_at'] ?? null,
+                        'exit_code' => $status['exit_code'] ?? null,
+                        'error' => $status['error'] ?? null,
+                    ] : null,
+                ];
+            }
+        );
+    }
+
+    /**
+     * @param  ?array<string, mixed> $status
+     * @return ?array<string, mixed>
+     * @throws SSHError
+     */
+    private function detail(SSH|SSHFake $ssh, Site $site, string $month, ?array $status): ?array
+    {
+        $report = $this->readMonth($ssh, $site, $month);
+        if ($report === null) {
+            return null;
+        }
+
+        return [
+            'generated_at' => $status['last_success_at'] ?? null,
+            'totals' => [
+                'visitors' => (int) ($report['general']['unique_visitors'] ?? 0),
+                'hits' => (int) ($report['general']['total_requests'] ?? 0),
+                'bandwidth' => (int) ($report['general']['bandwidth'] ?? 0),
+            ],
+            'daily' => $this->daily($report, $month),
+            'top_pages' => $this->panel($report, 'requests', 12),
+            'referrers' => $this->panel($report, 'referrers', 20),
+            'status_codes' => $this->statusCodes($report),
+            'not_found' => $this->panel($report, 'not_found', 20),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     * @return array<int, array<string, mixed>>
+     */
+    private function daily(array $report, string $month): array
+    {
+        $byDate = [];
+        foreach ($report['visitors']['data'] ?? [] as $row) {
+            $byDate[$this->formatDate((string) ($row['data'] ?? ''))] = [
+                'visitors' => (int) ($row['visitors']['count'] ?? 0),
+                'hits' => (int) ($row['hits']['count'] ?? 0),
+                'bandwidth' => (int) ($row['bytes']['count'] ?? 0),
+            ];
+        }
+
+        $start = Carbon::createFromFormat('Y-m', $month)->startOfMonth();
+
+        $days = [];
+        for ($day = 1; $day <= $start->daysInMonth; $day++) {
+            $date = $start->copy()->day($day)->format('Y-m-d');
+            $days[] = array_merge(
+                ['date' => $date],
+                $byDate[$date] ?? ['visitors' => 0, 'hits' => 0, 'bandwidth' => 0]
+            );
+        }
+
+        return $days;
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     * @return array<int, array<string, mixed>>
+     */
+    private function panel(array $report, string $key, int $limit): array
+    {
+        return collect($report[$key]['data'] ?? [])
+            ->take($limit)
+            ->map(fn (array $row): array => [
+                'name' => (string) ($row['data'] ?? ''),
+                'hits' => (int) ($row['hits']['count'] ?? 0),
+                'visitors' => (int) ($row['visitors']['count'] ?? 0),
+                'bandwidth' => (int) ($row['bytes']['count'] ?? 0),
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     * @return array<int, array<string, mixed>>
+     */
+    private function statusCodes(array $report): array
+    {
+        $codes = [];
+        foreach ($report['status_codes']['data'] ?? [] as $row) {
+            $children = $row['items'] ?? [$row];
+            foreach ($children as $child) {
+                $codes[] = [
+                    'name' => (string) ($child['data'] ?? ''),
+                    'hits' => (int) ($child['hits']['count'] ?? 0),
+                ];
+            }
+        }
+
+        return $codes;
+    }
+
+    /**
+     * @return ?array<string, mixed>
+     * @throws SSHError
+     */
+    private function readJson(SSH|SSHFake $ssh, Site $site, string $file): ?array
+    {
+        return $this->cat($ssh, GoAccess::BASE_DIR."/data/{$site->id}/{$file}");
+    }
+
+    /**
+     * @return ?array<string, mixed>
+     * @throws SSHError
+     */
+    private function readMonth(SSH|SSHFake $ssh, Site $site, string $month): ?array
+    {
+        if (preg_match('/^\d{4}-\d{2}$/', $month) !== 1) {
+            return null;
+        }
+
+        $report = $this->cat($ssh, GoAccess::BASE_DIR."/data/{$site->id}/{$month}/report.json");
+
+        return ($report !== null && isset($report['general'])) ? $report : null;
+    }
+
+    /**
+     * @return ?array<string, mixed>
+     * @throws SSHError
+     */
+    private function cat(SSH|SSHFake $ssh, string $path): ?array
+    {
+        $out = trim($ssh->exec('cat '.escapeshellarg($path).' 2>/dev/null || echo ""'));
+        if ($out === '') {
+            return null;
+        }
+
+        $decoded = json_decode($out, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private function formatDate(string $value): string
+    {
+        if (preg_match('/^\d{8}$/', $value) === 1) {
+            return Carbon::createFromFormat('Ymd', $value)->format('Y-m-d');
+        }
+
+        return $value;
+    }
+}

--- a/app/Actions/SiteStats/GetSiteStats.php
+++ b/app/Actions/SiteStats/GetSiteStats.php
@@ -208,7 +208,7 @@ class GetSiteStats
             return null;
         }
 
-        $decoded = json_decode($out, true);
+        $decoded = json_decode($out, true, 512, JSON_INVALID_UTF8_SUBSTITUTE);
 
         return is_array($decoded) ? $decoded : null;
     }

--- a/app/Actions/SiteStats/GetSiteStats.php
+++ b/app/Actions/SiteStats/GetSiteStats.php
@@ -53,11 +53,22 @@ class GetSiteStats
                         'last_success_at' => $status['last_success_at'] ?? null,
                         'last_run_finished_at' => $status['last_run_finished_at'] ?? null,
                         'exit_code' => $status['exit_code'] ?? null,
-                        'error' => $status['error'] ?? null,
+                        'error' => $this->sanitizeError($status['error'] ?? null),
                     ] : null,
                 ];
             }
         );
+    }
+
+    private function sanitizeError(mixed $error): ?string
+    {
+        if (! is_string($error) || $error === '') {
+            return null;
+        }
+
+        $clean = trim((string) preg_replace('/[[:cntrl:]]+/', ' ', $error));
+
+        return $clean === '' ? null : mb_substr($clean, 0, 200);
     }
 
     /**

--- a/app/Actions/SiteStats/RenderSiteStatsConf.php
+++ b/app/Actions/SiteStats/RenderSiteStatsConf.php
@@ -7,10 +7,14 @@ use Exception;
 
 class RenderSiteStatsConf
 {
-    public function render(Site $site): string
+    /**
+     * @throws Exception
+     */
+    public function render(Site $site, ?string $webserverId = null, ?int $retentionMonths = null): string
     {
         $domain = $this->safeDomain($site);
-        $caddy = $site->webserver()::id() === 'caddy';
+        $caddy = ($webserverId ?? $site->webserver()::id()) === 'caddy';
+        $retention = $retentionMonths ?? (int) ($site->server->service('log_analysis')?->type_data['data_retention'] ?? 12);
 
         $vars = [
             'SITE_ID' => (string) $site->id,
@@ -18,7 +22,7 @@ class RenderSiteStatsConf
             'LOG_FORMAT' => $caddy ? 'CADDY' : 'COMBINED',
             'LIVE_LOG' => $caddy ? "/var/log/caddy/{$domain}-access.log" : "/var/log/nginx/{$domain}-access.log",
             'LOG_GLOB' => $caddy ? "/var/log/caddy/{$domain}-access*.log*" : "/var/log/nginx/{$domain}-access.log*",
-            'RETENTION_MONTHS' => (string) (int) ($site->server->service('log_analysis')?->type_data['data_retention'] ?? 12),
+            'RETENTION_MONTHS' => (string) $retention,
             'SSH_USER' => $site->server->getSshUser(),
         ];
 

--- a/app/Actions/SiteStats/RenderSiteStatsConf.php
+++ b/app/Actions/SiteStats/RenderSiteStatsConf.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Actions\SiteStats;
+
+use App\Models\Site;
+use Exception;
+
+class RenderSiteStatsConf
+{
+    public function render(Site $site): string
+    {
+        $domain = $this->safeDomain($site);
+        $caddy = $site->webserver()::id() === 'caddy';
+
+        $vars = [
+            'SITE_ID' => (string) $site->id,
+            'DOMAIN' => $domain,
+            'LOG_FORMAT' => $caddy ? 'CADDY' : 'COMBINED',
+            'LIVE_LOG' => $caddy ? "/var/log/caddy/{$domain}-access.log" : "/var/log/nginx/{$domain}-access.log",
+            'LOG_GLOB' => $caddy ? "/var/log/caddy/{$domain}-access*.log*" : "/var/log/nginx/{$domain}-access.log*",
+            'RETENTION_MONTHS' => (string) (int) ($site->server->service('log_analysis')?->type_data['data_retention'] ?? 12),
+            'SSH_USER' => $site->server->getSshUser(),
+        ];
+
+        $lines = [];
+        foreach ($vars as $key => $value) {
+            $lines[] = $key."='".$value."'";
+        }
+
+        return implode("\n", $lines)."\n";
+    }
+
+    private function safeDomain(Site $site): string
+    {
+        $domain = (string) $site->domain;
+
+        if (! preg_match('/^[A-Za-z0-9.\-]+$/', $domain)) {
+            throw new Exception('Unsafe site domain for stats processing.');
+        }
+
+        return $domain;
+    }
+}

--- a/app/Actions/SiteStats/RenderSiteStatsConf.php
+++ b/app/Actions/SiteStats/RenderSiteStatsConf.php
@@ -13,7 +13,7 @@ class RenderSiteStatsConf
     public function render(Site $site, ?string $webserverId = null, ?int $retentionMonths = null): string
     {
         $domain = $this->safeDomain($site);
-        $caddy = ($webserverId ?? $site->webserver()::id()) === 'caddy';
+        $caddy = ($webserverId ?? $this->resolveWebserverId($site)) === 'caddy';
         $retention = $retentionMonths ?? (int) ($site->server->service('log_analysis')?->type_data['data_retention'] ?? 12);
 
         $vars = [
@@ -23,7 +23,7 @@ class RenderSiteStatsConf
             'LIVE_LOG' => $caddy ? "/var/log/caddy/{$domain}-access.log" : "/var/log/nginx/{$domain}-access.log",
             'LOG_GLOB' => $caddy ? "/var/log/caddy/{$domain}-access*.log*" : "/var/log/nginx/{$domain}-access.log*",
             'RETENTION_MONTHS' => (string) $retention,
-            'SSH_USER' => $site->server->getSshUser(),
+            'SSH_USER' => $this->safeSshUser($site),
         ];
 
         $lines = [];
@@ -32,6 +32,13 @@ class RenderSiteStatsConf
         }
 
         return implode("\n", $lines)."\n";
+    }
+
+    private function resolveWebserverId(Site $site): string
+    {
+        $webserver = $site->server->webserver();
+
+        return $webserver ? $webserver->handler()::id() : 'nginx';
     }
 
     private function safeDomain(Site $site): string
@@ -43,5 +50,16 @@ class RenderSiteStatsConf
         }
 
         return $domain;
+    }
+
+    private function safeSshUser(Site $site): string
+    {
+        $user = (string) $site->server->getSshUser();
+
+        if (! preg_match('/^[A-Za-z0-9_.\-]+$/', $user)) {
+            throw new Exception('Unsafe SSH user for stats processing.');
+        }
+
+        return $user;
     }
 }

--- a/app/Actions/SiteStats/ResyncGoAccess.php
+++ b/app/Actions/SiteStats/ResyncGoAccess.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Actions\SiteStats;
+
+use App\Jobs\Site\ResyncGoAccessJob;
+use App\Models\Server;
+
+class ResyncGoAccess
+{
+    public function handle(Server $server): void
+    {
+        dispatch(new ResyncGoAccessJob($server));
+    }
+}

--- a/app/Actions/SiteStats/SyncGoAccessServer.php
+++ b/app/Actions/SiteStats/SyncGoAccessServer.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Actions\SiteStats;
+
+use App\Enums\CronjobStatus;
+use App\Models\CronJob;
+use App\Models\Server;
+use App\Services\LogAnalysis\GoAccess\GoAccess;
+
+class SyncGoAccessServer
+{
+    public function sync(Server $server): void
+    {
+        $service = $server->service('log_analysis');
+        if (! $service) {
+            return;
+        }
+
+        $base = GoAccess::BASE_DIR;
+        $ssh = $server->ssh();
+
+        $ssh->exec("sudo mkdir -p {$base}/bin {$base}/sites {$base}/data", 'goaccess-mkdir');
+
+        $ssh->write("{$base}/bin/run.sh", view('ssh.services.log_analysis.goaccess.bin.run', [
+            'baseDir' => $base,
+        ]), 'root');
+        $ssh->write("{$base}/bin/process.sh", view('ssh.services.log_analysis.goaccess.bin.process', [
+            'baseDir' => $base,
+            'scriptVersion' => GoAccess::SCRIPT_VERSION,
+        ]), 'root');
+
+        $renderer = app(RenderSiteStatsConf::class);
+        foreach ($server->sites()->with('server.services')->get() as $site) {
+            $site->setRelation('server', $server);
+            $ssh->write("{$base}/sites/{$site->id}.conf", $renderer->render($site), 'root');
+        }
+
+        $this->ensureCron($server);
+
+        $service->type_data = array_merge($service->type_data ?? [], [
+            'script_version' => GoAccess::SCRIPT_VERSION,
+            'conf_version' => GoAccess::CONF_VERSION,
+        ]);
+        $service->save();
+    }
+
+    private function ensureCron(Server $server): void
+    {
+        $cron = $server->cronJobs()
+            ->where('user', 'root')
+            ->where('hidden', true)
+            ->where('command', GoAccess::CRON_COMMAND)
+            ->first();
+
+        if (! $cron) {
+            $server->cronJobs()->create([
+                'site_id' => null,
+                'user' => 'root',
+                'command' => GoAccess::CRON_COMMAND,
+                'frequency' => GoAccess::CRON_FREQUENCY,
+                'hidden' => true,
+                'status' => CronjobStatus::READY,
+            ]);
+        } elseif ($cron->status !== CronjobStatus::READY) {
+            $cron->update(['status' => CronjobStatus::READY]);
+        }
+
+        $server->cron()->update('root', CronJob::crontab($server, 'root'));
+    }
+}

--- a/app/Actions/SiteStats/SyncGoAccessServer.php
+++ b/app/Actions/SiteStats/SyncGoAccessServer.php
@@ -73,20 +73,18 @@ class SyncGoAccessServer
     {
         $cron = $server->cronJobs()
             ->where('user', 'root')
-            ->where('hidden', true)
             ->where('command', GoAccess::CRON_COMMAND)
             ->first();
 
         if (! $cron) {
-            $cron = $server->cronJobs()->make([
+            $cron = $server->cronJobs()->create([
                 'site_id' => null,
+                'name' => GoAccess::CRON_NAME,
                 'user' => 'root',
                 'command' => GoAccess::CRON_COMMAND,
                 'frequency' => GoAccess::CRON_FREQUENCY,
                 'status' => CronjobStatus::READY,
             ]);
-            $cron->hidden = true;
-            $cron->save();
         } elseif (! in_array($cron->status, [CronjobStatus::READY, CronjobStatus::DISABLED], true)) {
             $cron->update(['status' => CronjobStatus::READY]);
         }

--- a/app/Actions/SiteStats/SyncGoAccessServer.php
+++ b/app/Actions/SiteStats/SyncGoAccessServer.php
@@ -27,7 +27,13 @@ class SyncGoAccessServer
             $ssh->setLog($log);
         }
 
-        $ssh->exec("sudo mkdir -p {$base}/bin {$base}/sites {$base}/data", 'goaccess-mkdir');
+        $ssh->exec(
+            'sudo mkdir -p '
+            .escapeshellarg("{$base}/bin").' '
+            .escapeshellarg("{$base}/sites").' '
+            .escapeshellarg("{$base}/data"),
+            'goaccess-mkdir'
+        );
 
         $ssh->write("{$base}/bin/run.sh", view('ssh.services.log_analysis.goaccess.bin.run', [
             'baseDir' => $base,
@@ -81,7 +87,7 @@ class SyncGoAccessServer
             ]);
             $cron->hidden = true;
             $cron->save();
-        } elseif ($cron->status !== CronjobStatus::READY) {
+        } elseif (! in_array($cron->status, [CronjobStatus::READY, CronjobStatus::DISABLED], true)) {
             $cron->update(['status' => CronjobStatus::READY]);
         }
 

--- a/app/Actions/SiteStats/SyncGoAccessServer.php
+++ b/app/Actions/SiteStats/SyncGoAccessServer.php
@@ -6,6 +6,7 @@ use App\Enums\CronjobStatus;
 use App\Exceptions\SSHError;
 use App\Models\CronJob;
 use App\Models\Server;
+use App\Models\ServerLog;
 use App\Services\LogAnalysis\GoAccess\GoAccess;
 
 class SyncGoAccessServer
@@ -13,7 +14,7 @@ class SyncGoAccessServer
     /**
      * @throws SSHError
      */
-    public function sync(Server $server): void
+    public function sync(Server $server, ?ServerLog $log = null): void
     {
         $service = $server->service('log_analysis');
         if (! $service) {
@@ -22,6 +23,9 @@ class SyncGoAccessServer
 
         $base = GoAccess::BASE_DIR;
         $ssh = $server->ssh();
+        if ($log) {
+            $ssh->setLog($log);
+        }
 
         $ssh->exec("sudo mkdir -p {$base}/bin {$base}/sites {$base}/data", 'goaccess-mkdir');
 
@@ -35,7 +39,7 @@ class SyncGoAccessServer
 
         $renderer = app(RenderSiteStatsConf::class);
         $webserver = $server->webserver();
-        $webserverId = $webserver ? $webserver->name : 'nginx';
+        $webserverId = $webserver ? $webserver->handler()::id() : 'nginx';
         $retention = (int) ($service->type_data['data_retention'] ?? 12);
 
         foreach ($server->sites as $site) {
@@ -68,14 +72,15 @@ class SyncGoAccessServer
             ->first();
 
         if (! $cron) {
-            $server->cronJobs()->create([
+            $cron = $server->cronJobs()->make([
                 'site_id' => null,
                 'user' => 'root',
                 'command' => GoAccess::CRON_COMMAND,
                 'frequency' => GoAccess::CRON_FREQUENCY,
-                'hidden' => true,
                 'status' => CronjobStatus::READY,
             ]);
+            $cron->hidden = true;
+            $cron->save();
         } elseif ($cron->status !== CronjobStatus::READY) {
             $cron->update(['status' => CronjobStatus::READY]);
         }

--- a/app/Actions/SiteStats/SyncGoAccessServer.php
+++ b/app/Actions/SiteStats/SyncGoAccessServer.php
@@ -34,7 +34,11 @@ class SyncGoAccessServer
         ]), 'root');
 
         $renderer = app(RenderSiteStatsConf::class);
-        foreach ($server->sites()->with('server.services')->get() as $site) {
+        $webserver = $server->webserver();
+        $webserverId = $webserver ? $webserver->name : 'nginx';
+        $retention = (int) ($service->type_data['data_retention'] ?? 12);
+
+        foreach ($server->sites as $site) {
             $site->setRelation('server', $server);
 
             if (! $site->statsEnabled()) {
@@ -43,7 +47,7 @@ class SyncGoAccessServer
                 continue;
             }
 
-            $ssh->write("{$base}/sites/{$site->id}.conf", $renderer->render($site), 'root');
+            $ssh->write("{$base}/sites/{$site->id}.conf", $renderer->render($site, $webserverId, $retention), 'root');
         }
 
         $this->ensureCron($server);

--- a/app/Actions/SiteStats/SyncGoAccessServer.php
+++ b/app/Actions/SiteStats/SyncGoAccessServer.php
@@ -3,12 +3,16 @@
 namespace App\Actions\SiteStats;
 
 use App\Enums\CronjobStatus;
+use App\Exceptions\SSHError;
 use App\Models\CronJob;
 use App\Models\Server;
 use App\Services\LogAnalysis\GoAccess\GoAccess;
 
 class SyncGoAccessServer
 {
+    /**
+     * @throws SSHError
+     */
     public function sync(Server $server): void
     {
         $service = $server->service('log_analysis');
@@ -32,6 +36,13 @@ class SyncGoAccessServer
         $renderer = app(RenderSiteStatsConf::class);
         foreach ($server->sites()->with('server.services')->get() as $site) {
             $site->setRelation('server', $server);
+
+            if (! $site->statsEnabled()) {
+                $ssh->exec('sudo rm -f '.escapeshellarg("{$base}/sites/{$site->id}.conf"), 'goaccess-skip-disabled');
+
+                continue;
+            }
+
             $ssh->write("{$base}/sites/{$site->id}.conf", $renderer->render($site), 'root');
         }
 

--- a/app/Events/SiteCreatedEvent.php
+++ b/app/Events/SiteCreatedEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Site;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class SiteCreatedEvent
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Site $site,
+    ) {}
+}

--- a/app/Events/SiteDeletedEvent.php
+++ b/app/Events/SiteDeletedEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class SiteDeletedEvent
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly int $serverId,
+        public readonly int $siteId,
+        public readonly string $domain,
+    ) {}
+}

--- a/app/Events/SiteDeletedEvent.php
+++ b/app/Events/SiteDeletedEvent.php
@@ -2,6 +2,7 @@
 
 namespace App\Events;
 
+use App\Models\Server;
 use Illuminate\Foundation\Events\Dispatchable;
 
 class SiteDeletedEvent
@@ -9,7 +10,7 @@ class SiteDeletedEvent
     use Dispatchable;
 
     public function __construct(
-        public readonly int $serverId,
+        public readonly Server $server,
         public readonly int $siteId,
         public readonly string $domain,
     ) {}

--- a/app/Http/Controllers/API/CronJobController.php
+++ b/app/Http/Controllers/API/CronJobController.php
@@ -81,7 +81,7 @@ class CronJobController extends Controller
 
         $this->validateRoute($project, $server, site: $site);
 
-        return CronJobResource::collection($site->cronJobs()->simplePaginate(25));
+        return CronJobResource::collection($site->cronJobs()->where('hidden', false)->simplePaginate(25));
     }
 
     /**

--- a/app/Http/Controllers/API/CronJobController.php
+++ b/app/Http/Controllers/API/CronJobController.php
@@ -31,7 +31,7 @@ class CronJobController extends Controller
 
         $this->validateRoute($project, $server);
 
-        return CronJobResource::collection($server->cronJobs()->simplePaginate(25));
+        return CronJobResource::collection($server->cronJobs()->where('hidden', false)->simplePaginate(25));
     }
 
     /**

--- a/app/Http/Controllers/API/CronJobController.php
+++ b/app/Http/Controllers/API/CronJobController.php
@@ -31,7 +31,7 @@ class CronJobController extends Controller
 
         $this->validateRoute($project, $server);
 
-        return CronJobResource::collection($server->cronJobs()->where('hidden', false)->simplePaginate(25));
+        return CronJobResource::collection($server->cronJobs()->simplePaginate(25));
     }
 
     /**
@@ -81,7 +81,7 @@ class CronJobController extends Controller
 
         $this->validateRoute($project, $server, site: $site);
 
-        return CronJobResource::collection($site->cronJobs()->where('hidden', false)->simplePaginate(25));
+        return CronJobResource::collection($site->cronJobs()->simplePaginate(25));
     }
 
     /**

--- a/app/Http/Controllers/CronJobController.php
+++ b/app/Http/Controllers/CronJobController.php
@@ -34,7 +34,7 @@ class CronJobController extends Controller
         $this->authorize('viewAny', [CronJob::class, $server]);
 
         return Inertia::render('cronjobs/index', [
-            'cronjobs' => CronJobResource::collection($server->cronJobs()->latest()->simplePaginate(config('web.pagination_size'))),
+            'cronjobs' => CronJobResource::collection($server->cronJobs()->where('hidden', false)->latest()->simplePaginate(config('web.pagination_size'))),
             'sites' => $server->sites()->select('id', 'domain')->get(),
         ]);
     }

--- a/app/Http/Controllers/LogAnalysisController.php
+++ b/app/Http/Controllers/LogAnalysisController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Jobs\Site\ResyncGoAccessJob;
+use App\Actions\SiteStats\ResyncGoAccess;
 use App\Models\Server;
 use App\Models\Service;
 use Illuminate\Http\RedirectResponse;
@@ -23,7 +23,7 @@ class LogAnalysisController extends Controller
 
         $this->authorize('update', $service);
 
-        dispatch(new ResyncGoAccessJob($server));
+        app(ResyncGoAccess::class)->handle($server);
 
         return back()->with('success', 'Re-syncing site statistics scripts...');
     }

--- a/app/Http/Controllers/LogAnalysisController.php
+++ b/app/Http/Controllers/LogAnalysisController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Jobs\Site\ResyncGoAccessJob;
+use App\Models\Server;
+use App\Models\Service;
+use Illuminate\Http\RedirectResponse;
+use Spatie\RouteAttributes\Attributes\Middleware;
+use Spatie\RouteAttributes\Attributes\Post;
+use Spatie\RouteAttributes\Attributes\Prefix;
+
+#[Prefix('/servers/{server}/log-analysis')]
+#[Middleware(['auth', 'has-project'])]
+class LogAnalysisController extends Controller
+{
+    #[Post('/resync', name: 'log-analysis.resync')]
+    public function resync(Server $server): RedirectResponse
+    {
+        /** @var ?Service $service */
+        $service = $server->service('log_analysis');
+        abort_if($service === null, 404);
+
+        $this->authorize('update', $service);
+
+        dispatch(new ResyncGoAccessJob($server));
+
+        return back()->with('success', 'Re-syncing site statistics scripts...');
+    }
+}

--- a/app/Http/Controllers/SiteSettingController.php
+++ b/app/Http/Controllers/SiteSettingController.php
@@ -8,6 +8,7 @@ use App\Actions\Site\UpdateBasicAuth;
 use App\Actions\Site\UpdateBranch;
 use App\Actions\Site\UpdatePHPVersion;
 use App\Actions\Site\UpdatePort;
+use App\Actions\Site\UpdateSiteStats;
 use App\Actions\Site\UpdateSourceControl;
 use App\Actions\Site\UpdateStartCommand;
 use App\Actions\Site\UpdateVhost;
@@ -259,6 +260,26 @@ class SiteSettingController extends Controller
         $site->webserver()->updateVHost($site);
 
         return back()->with('success', 'Force SSL disabled successfully.');
+    }
+
+    #[Post('/stats/enable', name: 'site-settings.enable-stats')]
+    public function enableStats(Server $server, Site $site): RedirectResponse
+    {
+        $this->authorize('update', [$site, $server]);
+
+        app(UpdateSiteStats::class)->enable($site);
+
+        return back()->with('success', 'Statistics enabled for this site.');
+    }
+
+    #[Post('/stats/disable', name: 'site-settings.disable-stats')]
+    public function disableStats(Server $server, Site $site): RedirectResponse
+    {
+        $this->authorize('update', [$site, $server]);
+
+        app(UpdateSiteStats::class)->disable($site);
+
+        return back()->with('success', 'Statistics disabled and historical data erased.');
     }
 
     /**

--- a/app/Http/Controllers/SiteStatsController.php
+++ b/app/Http/Controllers/SiteStatsController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\SiteStats\GetSiteStats;
+use App\Jobs\Site\RefreshSiteStatsJob;
+use App\Models\Server;
+use App\Models\Site;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+use Spatie\RouteAttributes\Attributes\Get;
+use Spatie\RouteAttributes\Attributes\Middleware;
+use Spatie\RouteAttributes\Attributes\Post;
+use Spatie\RouteAttributes\Attributes\Prefix;
+
+#[Prefix('/servers/{server}/sites/{site}/stats')]
+#[Middleware(['auth', 'has-project'])]
+class SiteStatsController extends Controller
+{
+    #[Get('/', name: 'site-stats')]
+    public function index(Server $server, Site $site): Response
+    {
+        $this->authorize('view', [$site, $server]);
+
+        return Inertia::render('sites/stats', [
+            'hasStatsService' => (bool) $server->service('log_analysis'),
+        ]);
+    }
+
+    #[Get('/json', name: 'site-stats.json')]
+    public function json(Request $request, Server $server, Site $site): JsonResponse
+    {
+        $this->authorize('view', [$site, $server]);
+
+        $month = $request->string('month')->toString();
+        $month = preg_match('/^\d{4}-\d{2}$/', $month) === 1 ? $month : null;
+
+        return response()->json(app(GetSiteStats::class)->get($site, $month));
+    }
+
+    #[Post('/refresh', name: 'site-stats.refresh')]
+    public function refresh(Server $server, Site $site): RedirectResponse
+    {
+        $this->authorize('update', [$site, $server]);
+
+        abort_unless((bool) $server->service('log_analysis'), 404);
+
+        dispatch(new RefreshSiteStatsJob($site));
+
+        return back()->with('success', 'Refreshing site statistics...');
+    }
+}

--- a/app/Http/Controllers/SiteStatsController.php
+++ b/app/Http/Controllers/SiteStatsController.php
@@ -27,6 +27,7 @@ class SiteStatsController extends Controller
 
         return Inertia::render('sites/stats', [
             'hasStatsService' => (bool) $server->service('log_analysis'),
+            'statsEnabled' => $site->statsEnabled(),
         ]);
     }
 
@@ -34,6 +35,8 @@ class SiteStatsController extends Controller
     public function json(Request $request, Server $server, Site $site): JsonResponse
     {
         $this->authorize('view', [$site, $server]);
+
+        abort_unless((bool) $server->service('log_analysis') && $site->statsEnabled(), 404);
 
         $month = $request->string('month')->toString();
         $month = preg_match('/^\d{4}-\d{2}$/', $month) === 1 ? $month : null;
@@ -46,7 +49,7 @@ class SiteStatsController extends Controller
     {
         $this->authorize('update', [$site, $server]);
 
-        abort_unless((bool) $server->service('log_analysis'), 404);
+        abort_unless((bool) $server->service('log_analysis') && $site->statsEnabled(), 404);
 
         dispatch(new RefreshSiteStatsJob($site));
 

--- a/app/Http/Resources/SiteResource.php
+++ b/app/Http/Resources/SiteResource.php
@@ -56,6 +56,7 @@ class SiteResource extends JsonResource
             'vhost_generation_enabled' => $this->vhost_generation_enabled,
             'has_custom_vhost_template' => $this->vhost_template !== null,
             'modern_deployment' => $this->modernDeploymentEnabled(),
+            'stats_enabled' => $this->statsEnabled(),
             'is_proxied_site_type' => $this->type() instanceof AbstractProxiedSiteType,
             'available_tooling_commands' => $this->availableToolingCommands(),
             'start_command' => $this->type_data['start_command'] ?? null,

--- a/app/Jobs/Service/ManageJob.php
+++ b/app/Jobs/Service/ManageJob.php
@@ -27,12 +27,8 @@ class ManageJob implements ShouldQueue
     public function handle(): void
     {
         $this->run("server-{$this->service->server_id}", function () {
-            $status = $this->service->server->systemd()->{$this->action}($this->service->handler()->unit());
-            if (str($status)->contains($this->getExpectedActiveState())) {
-                $this->service->status = $this->successStatus;
-            } else {
-                $this->service->status = ServiceStatus::FAILED;
-            }
+            $succeeded = $this->service->handler()->manage($this->action);
+            $this->service->status = $succeeded ? $this->successStatus : ServiceStatus::FAILED;
             $this->service->save();
             $this->broadcastServiceUpdate();
         });
@@ -55,10 +51,5 @@ class ManageJob implements ShouldQueue
             type: 'service.updated',
             data: new ServiceResource($this->service),
         ));
-    }
-
-    private function getExpectedActiveState(): string
-    {
-        return in_array($this->action, ['stop', 'disable']) ? 'Active: inactive' : 'Active: active';
     }
 }

--- a/app/Jobs/Site/CleanupSiteStatsJob.php
+++ b/app/Jobs/Site/CleanupSiteStatsJob.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Jobs\Site;
+
+use App\Models\Server;
+use App\Models\ServerLog;
+use App\Services\LogAnalysis\GoAccess\GoAccess;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class CleanupSiteStatsJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public int $timeout = 120;
+
+    public function __construct(protected Server $server, protected int $siteId)
+    {
+        $this->onQueue('ssh');
+    }
+
+    public function handle(): void
+    {
+        if ($this->siteId <= 0) {
+            return;
+        }
+
+        $this->run("server-{$this->server->id}-site-stats", function (): void {
+            $base = GoAccess::BASE_DIR;
+            $this->server->ssh()->exec(
+                'sudo rm -rf '.escapeshellarg("{$base}/data/{$this->siteId}").' '.escapeshellarg("{$base}/sites/{$this->siteId}.conf"),
+                'cleanup-site-stats'
+            );
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        ServerLog::log(
+            $this->server,
+            'cleanup-site-stats-failed',
+            $e->getMessage()
+        );
+    }
+}

--- a/app/Jobs/Site/CleanupSiteStatsJob.php
+++ b/app/Jobs/Site/CleanupSiteStatsJob.php
@@ -28,7 +28,7 @@ class CleanupSiteStatsJob implements ShouldQueue
             return;
         }
 
-        $this->run("server-{$this->server->id}-site-stats", function (): void {
+        $this->run("server-{$this->server->id}-site-{$this->siteId}-stats", function (): void {
             $base = GoAccess::BASE_DIR;
             $this->server->ssh()->exec(
                 'sudo rm -rf '.escapeshellarg("{$base}/data/{$this->siteId}").' '.escapeshellarg("{$base}/sites/{$this->siteId}.conf"),

--- a/app/Jobs/Site/CreateJob.php
+++ b/app/Jobs/Site/CreateJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs\Site;
 
 use App\DTOs\SocketEventDTO;
 use App\Enums\SiteStatus;
+use App\Events\SiteCreatedEvent;
 use App\Events\SocketEvent;
 use App\Exceptions\FailedToDeployGitKey;
 use App\Exceptions\RepositoryNotFound;
@@ -44,6 +45,7 @@ class CreateJob implements ShouldQueue
             $this->site->save();
             $this->broadcastSiteUpdate();
             Notifier::send($this->site, new SiteInstallationSucceed($this->site));
+            SiteCreatedEvent::dispatch($this->site);
 
             foreach ($this->site->hostedDomains as $hostedDomain) {
                 dispatch(new CheckDomainJob($hostedDomain))->onQueue('ssh');

--- a/app/Jobs/Site/RefreshSiteStatsJob.php
+++ b/app/Jobs/Site/RefreshSiteStatsJob.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Jobs\Site;
+
+use App\DTOs\SocketEventDTO;
+use App\Events\SocketEvent;
+use App\Models\ServerLog;
+use App\Models\Site;
+use App\Services\LogAnalysis\GoAccess\GoAccess;
+use App\Traits\UniqueQueue;
+use Carbon\Carbon;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Str;
+
+class RefreshSiteStatsJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public int $timeout = 600;
+
+    public function __construct(protected Site $site)
+    {
+        $this->onQueue('ssh');
+    }
+
+    public function handle(): void
+    {
+        $this->run("server-{$this->site->server_id}-site-stats", function (): void {
+            $base = GoAccess::BASE_DIR;
+            $output = $this->site->server->ssh('root')->exec(
+                'bash '.escapeshellarg("{$base}/bin/process.sh").' '.escapeshellarg("{$base}/sites/{$this->site->id}.conf"),
+                'refresh-site-stats',
+                $this->site->id
+            );
+
+            if (Str::contains($output, 'VITO_STATS_BUSY')) {
+                return;
+            }
+
+            $now = Carbon::now();
+            $months = [$now->format('Y-m'), $now->copy()->subMonthNoOverflow()->format('Y-m')];
+
+            SocketEvent::dispatch(new SocketEventDTO(
+                projectId: $this->site->server->project_id,
+                type: 'site-stats.updated',
+                data: [
+                    'id' => $this->site->id,
+                    'months' => $months,
+                ],
+            ));
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        ServerLog::log(
+            $this->site->server,
+            'refresh-site-stats-failed',
+            $e->getMessage(),
+            $this->site
+        );
+    }
+}

--- a/app/Jobs/Site/RefreshSiteStatsJob.php
+++ b/app/Jobs/Site/RefreshSiteStatsJob.php
@@ -28,7 +28,7 @@ class RefreshSiteStatsJob implements ShouldQueue
 
     public function handle(): void
     {
-        $this->run("server-{$this->site->server_id}-site-stats", function (): void {
+        $this->run("server-{$this->site->server_id}-site-{$this->site->id}-stats", function (): void {
             $base = GoAccess::BASE_DIR;
             $output = $this->site->server->ssh('root')->exec(
                 'bash '.escapeshellarg("{$base}/bin/process.sh").' '.escapeshellarg("{$base}/sites/{$this->site->id}.conf"),

--- a/app/Jobs/Site/ResyncGoAccessJob.php
+++ b/app/Jobs/Site/ResyncGoAccessJob.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Jobs\Site;
+
+use App\Actions\SiteStats\SyncGoAccessServer;
+use App\Models\Server;
+use App\Models\ServerLog;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class ResyncGoAccessJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public int $timeout = 300;
+
+    public function __construct(protected Server $server)
+    {
+        $this->onQueue('ssh');
+    }
+
+    public function handle(): void
+    {
+        $this->run("server-{$this->server->id}-site-stats", function (): void {
+            app(SyncGoAccessServer::class)->sync($this->server);
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        ServerLog::log($this->server, 'resync-goaccess-failed', $e->getMessage());
+    }
+}

--- a/app/Jobs/Site/WriteSiteStatsConfJob.php
+++ b/app/Jobs/Site/WriteSiteStatsConfJob.php
@@ -25,6 +25,10 @@ class WriteSiteStatsConfJob implements ShouldQueue
 
     public function handle(): void
     {
+        if (! $this->site->statsEnabled()) {
+            return;
+        }
+
         $this->run("server-{$this->site->server_id}-site-stats", function (): void {
             $base = GoAccess::BASE_DIR;
             $ssh = $this->site->server->ssh();

--- a/app/Jobs/Site/WriteSiteStatsConfJob.php
+++ b/app/Jobs/Site/WriteSiteStatsConfJob.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Jobs\Site;
+
+use App\Actions\SiteStats\RenderSiteStatsConf;
+use App\Models\ServerLog;
+use App\Models\Site;
+use App\Services\LogAnalysis\GoAccess\GoAccess;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class WriteSiteStatsConfJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public int $timeout = 120;
+
+    public function __construct(protected Site $site)
+    {
+        $this->onQueue('ssh');
+    }
+
+    public function handle(): void
+    {
+        $this->run("server-{$this->site->server_id}-site-stats", function (): void {
+            $base = GoAccess::BASE_DIR;
+            $ssh = $this->site->server->ssh();
+            $ssh->exec("sudo mkdir -p {$base}/sites {$base}/data", 'goaccess-mkdir');
+            $ssh->write(
+                "{$base}/sites/{$this->site->id}.conf",
+                app(RenderSiteStatsConf::class)->render($this->site),
+                'root'
+            );
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        ServerLog::log(
+            $this->site->server,
+            'write-site-stats-conf-failed',
+            $e->getMessage(),
+            $this->site
+        );
+    }
+}

--- a/app/Listeners/HandleSiteCreatedStats.php
+++ b/app/Listeners/HandleSiteCreatedStats.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\SiteCreatedEvent;
+use App\Jobs\Site\WriteSiteStatsConfJob;
+
+class HandleSiteCreatedStats
+{
+    public function handle(SiteCreatedEvent $event): void
+    {
+        if ($event->site->server->service('log_analysis')) {
+            dispatch(new WriteSiteStatsConfJob($event->site));
+        }
+    }
+}

--- a/app/Listeners/HandleSiteDeletedStats.php
+++ b/app/Listeners/HandleSiteDeletedStats.php
@@ -4,16 +4,13 @@ namespace App\Listeners;
 
 use App\Events\SiteDeletedEvent;
 use App\Jobs\Site\CleanupSiteStatsJob;
-use App\Models\Server;
 
 class HandleSiteDeletedStats
 {
     public function handle(SiteDeletedEvent $event): void
     {
-        $server = Server::find($event->serverId);
-
-        if ($server && $server->service('log_analysis')) {
-            dispatch(new CleanupSiteStatsJob($server, $event->siteId));
+        if ($event->server->service('log_analysis')) {
+            dispatch(new CleanupSiteStatsJob($event->server, $event->siteId));
         }
     }
 }

--- a/app/Listeners/HandleSiteDeletedStats.php
+++ b/app/Listeners/HandleSiteDeletedStats.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\SiteDeletedEvent;
+use App\Jobs\Site\CleanupSiteStatsJob;
+use App\Models\Server;
+
+class HandleSiteDeletedStats
+{
+    public function handle(SiteDeletedEvent $event): void
+    {
+        $server = Server::find($event->serverId);
+
+        if ($server && $server->service('log_analysis')) {
+            dispatch(new CleanupSiteStatsJob($server, $event->siteId));
+        }
+    }
+}

--- a/app/Models/AbstractModel.php
+++ b/app/Models/AbstractModel.php
@@ -24,4 +24,14 @@ abstract class AbstractModel extends Model
             $this->save();
         }
     }
+
+    public function jsonForget(string $field, string $key, bool $save = true): void
+    {
+        $current = $this->{$field} ?? [];
+        unset($current[$key]);
+        $this->{$field} = $current;
+        if ($save) {
+            $this->save();
+        }
+    }
 }

--- a/app/Models/CronJob.php
+++ b/app/Models/CronJob.php
@@ -31,7 +31,6 @@ class CronJob extends AbstractModel
         'command',
         'user',
         'frequency',
-        'hidden',
         'status',
         'name',
     ];

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -348,6 +348,11 @@ class Site extends AbstractModel
         return (bool) ($this->type_data['modern_deployment'] ?? false);
     }
 
+    public function statsEnabled(): bool
+    {
+        return ! (bool) ($this->type_data['stats_disabled'] ?? false);
+    }
+
     /**
      * @return HasMany<Worker, covariant $this>
      */

--- a/app/Policies/CronJobPolicy.php
+++ b/app/Policies/CronJobPolicy.php
@@ -23,7 +23,8 @@ class CronJobPolicy
     {
         $cronJobServer = $cronjob->server;
 
-        return $this->hasReadAccess($user, $cronJobServer->project) &&
+        return ! $cronjob->hidden &&
+            $this->hasReadAccess($user, $cronJobServer->project) &&
             $cronJobServer->isReady() &&
             $cronjob->server_id === $server->id;
     }
@@ -37,7 +38,8 @@ class CronJobPolicy
     {
         $cronJobServer = $cronjob->server;
 
-        return $this->hasWriteAccess($user, $cronJobServer->project) &&
+        return ! $cronjob->hidden &&
+            $this->hasWriteAccess($user, $cronJobServer->project) &&
             $cronJobServer->isReady() &&
             $cronjob->server_id === $server->id;
     }
@@ -46,7 +48,8 @@ class CronJobPolicy
     {
         $cronJobServer = $cronjob->server;
 
-        return $this->hasWriteAccess($user, $cronJobServer->project) &&
+        return ! $cronjob->hidden &&
+            $this->hasWriteAccess($user, $cronJobServer->project) &&
             $cronJobServer->isReady() &&
             $cronjob->server_id === $server->id;
     }

--- a/app/Policies/CronJobPolicy.php
+++ b/app/Policies/CronJobPolicy.php
@@ -23,8 +23,7 @@ class CronJobPolicy
     {
         $cronJobServer = $cronjob->server;
 
-        return ! $cronjob->hidden &&
-            $this->hasReadAccess($user, $cronJobServer->project) &&
+        return $this->hasReadAccess($user, $cronJobServer->project) &&
             $cronJobServer->isReady() &&
             $cronjob->server_id === $server->id;
     }
@@ -38,8 +37,7 @@ class CronJobPolicy
     {
         $cronJobServer = $cronjob->server;
 
-        return ! $cronjob->hidden &&
-            $this->hasWriteAccess($user, $cronJobServer->project) &&
+        return $this->hasWriteAccess($user, $cronJobServer->project) &&
             $cronJobServer->isReady() &&
             $cronjob->server_id === $server->id;
     }
@@ -48,8 +46,7 @@ class CronJobPolicy
     {
         $cronJobServer = $cronjob->server;
 
-        return ! $cronjob->hidden &&
-            $this->hasWriteAccess($user, $cronJobServer->project) &&
+        return $this->hasWriteAccess($user, $cronJobServer->project) &&
             $cronJobServer->isReady() &&
             $cronjob->server_id === $server->id;
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,11 +2,15 @@
 
 namespace App\Providers;
 
+use App\Events\SiteCreatedEvent;
+use App\Events\SiteDeletedEvent;
 use App\Events\SocketEvent;
 use App\Helpers\FTP;
 use App\Helpers\Notifier;
 use App\Helpers\SFTP;
 use App\Helpers\SSH;
+use App\Listeners\HandleSiteCreatedStats;
+use App\Listeners\HandleSiteDeletedStats;
 use App\Listeners\SocketEventListener;
 use App\Models\PersonalAccessToken;
 use Illuminate\Http\Resources\Json\ResourceCollection;
@@ -39,5 +43,7 @@ class AppServiceProvider extends ServiceProvider
         }
 
         Event::listen(SocketEvent::class, SocketEventListener::class);
+        Event::listen(SiteCreatedEvent::class, HandleSiteCreatedStats::class);
+        Event::listen(SiteDeletedEvent::class, HandleSiteDeletedStats::class);
     }
 }

--- a/app/Providers/ServiceTypeServiceProvider.php
+++ b/app/Providers/ServiceTypeServiceProvider.php
@@ -7,6 +7,7 @@ use App\Services\Database\Mariadb;
 use App\Services\Database\Mysql;
 use App\Services\Database\Postgresql;
 use App\Services\Firewall\Ufw;
+use App\Services\LogAnalysis\GoAccess\GoAccess;
 use App\Services\Monitoring\RemoteMonitor\RemoteMonitor;
 use App\Services\Monitoring\VitoAgent\VitoAgent;
 use App\Services\NodeJS\NodeJS;
@@ -30,6 +31,7 @@ class ServiceTypeServiceProvider extends ServiceProvider
         $this->firewalls();
         $this->processManagers();
         $this->monitoring();
+        $this->logAnalysis();
         $this->php();
         $this->node();
     }
@@ -184,6 +186,15 @@ class ServiceTypeServiceProvider extends ServiceProvider
             ->type(RemoteMonitor::type())
             ->label('RemoteMonitor')
             ->handler(RemoteMonitor::class)
+            ->register();
+    }
+
+    private function logAnalysis(): void
+    {
+        RegisterServiceType::make(GoAccess::id())
+            ->type(GoAccess::type())
+            ->label('GoAccess')
+            ->handler(GoAccess::class)
             ->register();
     }
 

--- a/app/Services/AbstractService.php
+++ b/app/Services/AbstractService.php
@@ -42,4 +42,18 @@ abstract class AbstractService implements ServiceInterface
     {
         return $this->service->version;
     }
+
+    public function canBeManaged(): bool
+    {
+        return (bool) $this->unit();
+    }
+
+    public function manage(string $action): bool
+    {
+        $expectedState = in_array($action, ['stop', 'disable'], true) ? 'Active: inactive' : 'Active: active';
+
+        $status = $this->service->server->systemd()->{$action}($this->unit());
+
+        return str($status)->contains($expectedState);
+    }
 }

--- a/app/Services/LogAnalysis/GoAccess/GoAccess.php
+++ b/app/Services/LogAnalysis/GoAccess/GoAccess.php
@@ -15,6 +15,8 @@ class GoAccess extends AbstractService
 {
     public const BASE_DIR = '/var/lib/goaccess';
 
+    public const CRON_NAME = 'Site statistics';
+
     public const CRON_COMMAND = 'bash /var/lib/goaccess/bin/run.sh';
 
     public const CRON_FREQUENCY = '0 * * * *';
@@ -101,7 +103,6 @@ class GoAccess extends AbstractService
     {
         $cron = $this->service->server->cronJobs()
             ->where('user', 'root')
-            ->where('hidden', true)
             ->where('command', self::CRON_COMMAND)
             ->first();
         if ($cron) {
@@ -189,7 +190,6 @@ class GoAccess extends AbstractService
     {
         return $this->service->server->cronJobs()
             ->where('user', 'root')
-            ->where('hidden', true)
             ->where('command', self::CRON_COMMAND)
             ->first();
     }

--- a/app/Services/LogAnalysis/GoAccess/GoAccess.php
+++ b/app/Services/LogAnalysis/GoAccess/GoAccess.php
@@ -35,7 +35,7 @@ class GoAccess extends AbstractService
 
     /**
      * GoAccess has no systemd unit — work runs from a cron job (see {@see self::CRON_COMMAND}).
-     * Returning `''` here means the default {@see \App\Services\AbstractService::canBeManaged()}
+     * Returning `''` here means the default {@see AbstractService::canBeManaged()}
      * resolves to false, so {@see self::canBeManaged()} must stay overridden to `true`.
      */
     public function unit(): string

--- a/app/Services/LogAnalysis/GoAccess/GoAccess.php
+++ b/app/Services/LogAnalysis/GoAccess/GoAccess.php
@@ -33,6 +33,11 @@ class GoAccess extends AbstractService
         return 'log_analysis';
     }
 
+    /**
+     * GoAccess has no systemd unit — work runs from a cron job (see {@see self::CRON_COMMAND}).
+     * Returning `''` here means the default {@see \App\Services\AbstractService::canBeManaged()}
+     * resolves to false, so {@see self::canBeManaged()} must stay overridden to `true`.
+     */
     public function unit(): string
     {
         return '';
@@ -83,7 +88,7 @@ class GoAccess extends AbstractService
                 'install-goaccess'
             );
 
-        app(SyncGoAccessServer::class)->sync($this->service->server);
+        app(SyncGoAccessServer::class)->sync($this->service->server, $this->service->log);
 
         event('service.installed', $this->service);
         $this->service->server->os()->cleanup();

--- a/app/Services/LogAnalysis/GoAccess/GoAccess.php
+++ b/app/Services/LogAnalysis/GoAccess/GoAccess.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Services\LogAnalysis\GoAccess;
+
+use App\Actions\CronJob\DeleteCronJob;
+use App\Actions\SiteStats\SyncGoAccessServer;
+use App\Enums\CronjobStatus;
+use App\Exceptions\SSHError;
+use App\Models\CronJob;
+use App\Services\AbstractService;
+use Closure;
+use Illuminate\Validation\Rule;
+
+class GoAccess extends AbstractService
+{
+    public const BASE_DIR = '/var/lib/goaccess';
+
+    public const CRON_COMMAND = 'bash /var/lib/goaccess/bin/run.sh';
+
+    public const CRON_FREQUENCY = '0 * * * *';
+
+    public const SCRIPT_VERSION = 1;
+
+    public const CONF_VERSION = 1;
+
+    public static function id(): string
+    {
+        return 'goaccess';
+    }
+
+    public static function type(): string
+    {
+        return 'log_analysis';
+    }
+
+    public function unit(): string
+    {
+        return '';
+    }
+
+    public function creationRules(array $input): array
+    {
+        return [
+            'type' => [
+                function (string $attribute, mixed $value, Closure $fail): void {
+                    if ($this->service->server->service('log_analysis')) {
+                        $fail('You already have a log analysis service on the server.');
+                    }
+                },
+            ],
+            'version' => [
+                'required',
+                Rule::in(['latest']),
+            ],
+        ];
+    }
+
+    public function creationData(array $input): array
+    {
+        return [
+            'data_retention' => 12,
+        ];
+    }
+
+    public function data(): array
+    {
+        return [
+            'data_retention' => $this->service->type_data['data_retention'] ?? 12,
+        ];
+    }
+
+    /**
+     * @throws SSHError
+     */
+    public function install(): void
+    {
+        $this->service->server->ssh()
+            ->setLog($this->service->log)
+            ->exec(
+                view('ssh.services.log_analysis.goaccess.install', [
+                    'user' => $this->service->server->getSshUser(),
+                ]),
+                'install-goaccess'
+            );
+
+        app(SyncGoAccessServer::class)->sync($this->service->server);
+
+        event('service.installed', $this->service);
+        $this->service->server->os()->cleanup();
+    }
+
+    /**
+     * @throws SSHError
+     */
+    public function uninstall(): void
+    {
+        $cron = $this->service->server->cronJobs()
+            ->where('user', 'root')
+            ->where('hidden', true)
+            ->where('command', self::CRON_COMMAND)
+            ->first();
+        if ($cron) {
+            app(DeleteCronJob::class)->delete($this->service->server, $cron);
+        }
+
+        $this->service->server->ssh()
+            ->setLog($this->service->log)
+            ->exec(
+                view('ssh.services.log_analysis.goaccess.uninstall'),
+                'uninstall-goaccess'
+            );
+
+        event('service.uninstalled', $this->service);
+        $this->service->server->os()->cleanup();
+    }
+
+    /**
+     * @throws SSHError
+     */
+    public function version(): string
+    {
+        $version = $this->service->server->ssh()->exec(
+            "goaccess --version | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1"
+        );
+
+        return trim($version);
+    }
+
+    public function canBeManaged(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @throws SSHError
+     */
+    public function manage(string $action): bool
+    {
+        $enabled = ! in_array($action, ['stop', 'disable'], true);
+
+        return $this->toggleCron($enabled);
+    }
+
+    /**
+     * @throws SSHError
+     */
+    private function toggleCron(bool $enabled): bool
+    {
+        $server = $this->service->server;
+
+        $cron = $server->cronJobs()
+            ->where('user', 'root')
+            ->where('hidden', true)
+            ->where('command', self::CRON_COMMAND)
+            ->first();
+
+        if (! $cron) {
+            if ($enabled) {
+                app(SyncGoAccessServer::class)->sync($server);
+            }
+
+            return true;
+        }
+
+        $cron->status = $enabled ? CronjobStatus::READY : CronjobStatus::DISABLED;
+        $cron->save();
+
+        $server->cron()->update('root', CronJob::crontab($server, 'root'));
+
+        return true;
+    }
+}

--- a/app/Services/LogAnalysis/GoAccess/GoAccess.php
+++ b/app/Services/LogAnalysis/GoAccess/GoAccess.php
@@ -136,37 +136,56 @@ class GoAccess extends AbstractService
      */
     public function manage(string $action): bool
     {
-        $enabled = ! in_array($action, ['stop', 'disable'], true);
-
-        return $this->toggleCron($enabled);
+        return match ($action) {
+            'start', 'enable' => $this->setCronStatus(CronjobStatus::READY),
+            'stop', 'disable' => $this->setCronStatus(CronjobStatus::DISABLED),
+            default => $this->rebuildCrontab(),
+        };
     }
 
     /**
      * @throws SSHError
      */
-    private function toggleCron(bool $enabled): bool
+    private function setCronStatus(CronjobStatus $status): bool
     {
         $server = $this->service->server;
-
-        $cron = $server->cronJobs()
-            ->where('user', 'root')
-            ->where('hidden', true)
-            ->where('command', self::CRON_COMMAND)
-            ->first();
+        $cron = $this->statsCron();
 
         if (! $cron) {
-            if ($enabled) {
+            if ($status === CronjobStatus::READY) {
                 app(SyncGoAccessServer::class)->sync($server);
             }
 
             return true;
         }
 
-        $cron->status = $enabled ? CronjobStatus::READY : CronjobStatus::DISABLED;
+        $cron->status = $status;
         $cron->save();
 
         $server->cron()->update('root', CronJob::crontab($server, 'root'));
 
         return true;
+    }
+
+    /**
+     * @throws SSHError
+     */
+    private function rebuildCrontab(): bool
+    {
+        if ($this->statsCron()) {
+            $server = $this->service->server;
+            $server->cron()->update('root', CronJob::crontab($server, 'root'));
+        }
+
+        return true;
+    }
+
+    private function statsCron(): ?CronJob
+    {
+        return $this->service->server->cronJobs()
+            ->where('user', 'root')
+            ->where('hidden', true)
+            ->where('command', self::CRON_COMMAND)
+            ->first();
     }
 }

--- a/app/Services/ServiceInterface.php
+++ b/app/Services/ServiceInterface.php
@@ -39,6 +39,6 @@ interface ServiceInterface
     public function version(): string;
 
     public function canBeManaged(): bool;
-    
+
     public function manage(string $action): bool;
 }

--- a/app/Services/ServiceInterface.php
+++ b/app/Services/ServiceInterface.php
@@ -37,4 +37,8 @@ interface ServiceInterface
     public function uninstall(): void;
 
     public function version(): string;
+
+    public function canBeManaged(): bool;
+    
+    public function manage(string $action): bool;
 }

--- a/resources/js/components/site-switch.tsx
+++ b/resources/js/components/site-switch.tsx
@@ -27,8 +27,7 @@ export function SiteSwitch() {
   }, [page.props.site?.id, page.props.server?.id]);
 
   useEffect(() => {
-    const currentStoredSite = siteHelper.getStoredSite();
-    if (currentStoredSite && page.props.site && currentStoredSite.id !== page.props.site.id) {
+    if (page.props.site) {
       siteHelper.storeSite(page.props.site);
     }
   }, [page.props.site]);

--- a/resources/js/layouts/server/layout.tsx
+++ b/resources/js/layouts/server/layout.tsx
@@ -155,6 +155,7 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
                 title: 'Stats',
                 href: route('site-stats', { server: page.props.server.id, site: site.id }),
                 icon: ChartLineIcon,
+                isDisabled: isMenuDisabled,
                 hidden: !page.props.server.services['log_analysis'] || !site.stats_enabled,
               },
               {

--- a/resources/js/layouts/server/layout.tsx
+++ b/resources/js/layouts/server/layout.tsx
@@ -155,7 +155,7 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
                 title: 'Stats',
                 href: route('site-stats', { server: page.props.server.id, site: site.id }),
                 icon: ChartLineIcon,
-                hidden: !page.props.server.services['log_analysis'],
+                hidden: !page.props.server.services['log_analysis'] || !site.stats_enabled,
               },
               {
                 title: 'Settings',

--- a/resources/js/layouts/server/layout.tsx
+++ b/resources/js/layouts/server/layout.tsx
@@ -152,6 +152,12 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
                 icon: LogsIcon,
               },
               {
+                title: 'Stats',
+                href: route('site-stats', { server: page.props.server.id, site: site.id }),
+                icon: ChartLineIcon,
+                hidden: !page.props.server.services['log_analysis'],
+              },
+              {
                 title: 'Settings',
                 href: route('site-settings', { server: page.props.server.id, site: site.id }),
                 icon: Settings2Icon,

--- a/resources/js/pages/monitoring/components/resource-usage-chart.tsx
+++ b/resources/js/pages/monitoring/components/resource-usage-chart.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useId } from 'react';
 import { Area, AreaChart, XAxis, YAxis } from 'recharts';
 
 import { Card, CardContent } from '@/components/ui/card';
@@ -23,6 +24,7 @@ interface Props {
 }
 
 export function ResourceUsageChart({ title, color, dataKey, label, chartData, link, formatter, single, height, showXAxis, valueFormatter }: Props) {
+  const gradientId = useId();
   const resolvedHeight = height ?? (single ? 'large' : 'small');
   const heightClass = resolvedHeight === 'large' ? 'h-[400px]' : resolvedHeight === 'medium' ? 'h-[200px]' : 'h-[100px]';
   const xAxisVisible = showXAxis ?? single ?? false;
@@ -60,13 +62,13 @@ export function ResourceUsageChart({ title, color, dataKey, label, chartData, li
         </div>
         {validData.length === 0 ? (
           <div className={cn('text-muted-foreground flex aspect-auto w-full items-center justify-center rounded-b-xl border-t text-sm', heightClass)}>
-            No data in selected period
+            No data
           </div>
         ) : (
           <ChartContainer config={chartConfig} className={cn('aspect-auto w-full overflow-hidden rounded-b-xl', heightClass)}>
             <AreaChart accessibilityLayer data={validData} margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
               <defs>
-                <linearGradient id={`fill-${dataKey}`} x1="0" y1="0" x2="0" y2="1">
+                <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
                   <stop offset="5%" stopColor={color} stopOpacity={0.8} />
                   <stop offset="95%" stopColor={color} stopOpacity={0.1} />
                 </linearGradient>
@@ -106,7 +108,7 @@ export function ResourceUsageChart({ title, color, dataKey, label, chartData, li
                   />
                 }
               />
-              <Area dataKey={dataKey} type="monotone" fill={`url(#fill-${dataKey})`} stroke={color} />
+              <Area dataKey={dataKey} type="monotone" fill={`url(#${gradientId})`} stroke={color} />
             </AreaChart>
           </ChartContainer>
         )}

--- a/resources/js/pages/services/components/columns.tsx
+++ b/resources/js/pages/services/components/columns.tsx
@@ -71,7 +71,7 @@ export const columns: ColumnDef<Service>[] = [
               <Action type="reload" service={row.original} />
               <Action type="enable" service={row.original} />
               <Action type="disable" service={row.original} />
-              {row.original.name === 'goaccess' && (
+              {row.original.type === 'log_analysis' && (
                 <>
                   <DropdownMenuSeparator />
                   <ResyncStats service={row.original} />

--- a/resources/js/pages/services/components/columns.tsx
+++ b/resources/js/pages/services/components/columns.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import DateTime from '@/components/date-time';
 import Uninstall from '@/pages/services/components/uninstall';
 import { Action } from '@/pages/services/components/action';
+import { ResyncStats } from '@/pages/services/components/resync-stats';
 import Version from './version';
 import ConfigFile from './config-file';
 import InstallationLog from './installation-log';
@@ -70,6 +71,12 @@ export const columns: ColumnDef<Service>[] = [
               <Action type="reload" service={row.original} />
               <Action type="enable" service={row.original} />
               <Action type="disable" service={row.original} />
+              {row.original.name === 'goaccess' && (
+                <>
+                  <DropdownMenuSeparator />
+                  <ResyncStats service={row.original} />
+                </>
+              )}
               {row.original.config_paths && row.original.config_paths.length > 0 && (
                 <>
                   <DropdownMenuSeparator />

--- a/resources/js/pages/services/components/resync-stats.tsx
+++ b/resources/js/pages/services/components/resync-stats.tsx
@@ -1,0 +1,59 @@
+import { Service } from '@/types/service';
+import { useState } from 'react';
+import { useForm } from '@inertiajs/react';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+import { LoaderCircleIcon } from 'lucide-react';
+import FormSuccessful from '@/components/form-successful';
+import InputError from '@/components/ui/input-error';
+
+export function ResyncStats({ service }: { service: Service }) {
+  const [open, setOpen] = useState(false);
+  const form = useForm();
+
+  const submit = () => {
+    form.post(route('log-analysis.resync', { server: service.server_id }), {
+      onSuccess: () => setOpen(false),
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <DropdownMenuItem onSelect={(e) => e.preventDefault()}>Re-sync stats scripts</DropdownMenuItem>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Re-sync stats scripts</DialogTitle>
+          <DialogDescription className="sr-only">Re-sync GoAccess scripts and cron on the server</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2 p-4">
+          <p>This re-writes the GoAccess processing scripts and per-site configs on the server and ensures the cron is in place. Run this after a Vito update.</p>
+          {Object.entries(form.errors).map(([key, value]) => (
+            <InputError key={key} message={value as string | undefined} />
+          ))}
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button disabled={form.processing} onClick={submit}>
+            {form.processing && <LoaderCircleIcon className="animate-spin" />}
+            <FormSuccessful successful={form.recentlySuccessful} />
+            Re-sync
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/pages/services/components/resync-stats.tsx
+++ b/resources/js/pages/services/components/resync-stats.tsx
@@ -38,7 +38,10 @@ export function ResyncStats({ service }: { service: Service }) {
           <DialogDescription className="sr-only">Re-sync GoAccess scripts and cron on the server</DialogDescription>
         </DialogHeader>
         <div className="space-y-2 p-4">
-          <p>This re-writes the GoAccess processing scripts and per-site configs on the server and ensures the cron is in place. Run this after a Vito update.</p>
+          <p>
+            This re-writes the GoAccess processing scripts and per-site configs on the server and ensures the cron is in place. Run this after a Vito
+            update.
+          </p>
           {Object.entries(form.errors).map(([key, value]) => (
             <InputError key={key} message={value as string | undefined} />
           ))}

--- a/resources/js/pages/site-settings/components/stats-toggle.tsx
+++ b/resources/js/pages/site-settings/components/stats-toggle.tsx
@@ -1,0 +1,64 @@
+import { Site } from '@/types/site';
+import { ReactNode, useState } from 'react';
+import { useForm } from '@inertiajs/react';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { LoaderCircleIcon } from 'lucide-react';
+import FormSuccessful from '@/components/form-successful';
+
+export default function StatsToggle({ site, children }: { site: Site; children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const form = useForm();
+  const enabled = site.stats_enabled;
+
+  const submit = () => {
+    const routeName = enabled ? 'site-settings.disable-stats' : 'site-settings.enable-stats';
+    form.post(route(routeName, { server: site.server_id, site: site.id }), {
+      preserveScroll: true,
+      onSuccess: () => setOpen(false),
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{enabled ? 'Disable statistics' : 'Enable statistics'}</DialogTitle>
+          <DialogDescription className="sr-only">{enabled ? 'Disable' : 'Enable'} site statistics</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2 p-4 text-sm">
+          {enabled ? (
+            <p>
+              This stops processing logs for <span className="font-medium">{site.domain}</span> and{' '}
+              <span className="font-medium">permanently erases all historical statistics</span> for this site. This cannot be undone.
+            </p>
+          ) : (
+            <p>
+              Statistics collection will resume for <span className="font-medium">{site.domain}</span> from now on. Previous history is not recovered.
+            </p>
+          )}
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button variant={enabled ? 'destructive' : 'default'} disabled={form.processing} onClick={submit}>
+            {form.processing && <LoaderCircleIcon className="animate-spin" />}
+            <FormSuccessful successful={form.recentlySuccessful} />
+            {enabled ? 'Disable' : 'Enable'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/pages/site-settings/index.tsx
+++ b/resources/js/pages/site-settings/index.tsx
@@ -23,6 +23,7 @@ import VHost from '@/pages/site-settings/components/vhost';
 import VHostPreview from '@/pages/site-settings/components/vhost-preview';
 import ChangeSourceControl from '@/pages/site-settings/components/source-control';
 import BasicAuth from '@/pages/site-settings/components/basic-auth';
+import StatsToggle from '@/pages/site-settings/components/stats-toggle';
 import WebDirectory from './components/web-directory';
 
 export default function Databases() {
@@ -146,6 +147,19 @@ export default function Databases() {
                       {page.props.site.basic_auth?.enabled ? `Enabled (${page.props.site.basic_auth.users.length})` : 'Disabled'}
                     </Button>
                   </BasicAuth>
+                </div>
+              </>
+            )}
+            {page.props.server.services['log_analysis'] && (
+              <>
+                <Separator />
+                <div className="flex items-center justify-between p-4">
+                  <span>Statistics</span>
+                  <StatsToggle site={page.props.site}>
+                    <Button variant="outline" className="h-6">
+                      {page.props.site.stats_enabled ? 'Enabled' : 'Disabled'}
+                    </Button>
+                  </StatsToggle>
                 </div>
               </>
             )}

--- a/resources/js/pages/sites/components/stats-chart.tsx
+++ b/resources/js/pages/sites/components/stats-chart.tsx
@@ -1,0 +1,68 @@
+import { Area, AreaChart, XAxis, YAxis } from 'recharts';
+
+import { Card, CardContent } from '@/components/ui/card';
+import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  title: string;
+  value?: string;
+  color: string;
+  dataKey: string;
+  labelKey: string;
+  data: Array<Record<string, string | number>>;
+  formatLabel?: (value: string) => string;
+  formatValue?: (value: unknown) => string | number;
+  height?: 'sm' | 'md';
+}
+
+export function StatsChart({ title, value, color, dataKey, labelKey, data, formatLabel, formatValue, height = 'md' }: Props) {
+  const chartConfig = {
+    [dataKey]: { label: title, color },
+  } satisfies ChartConfig;
+
+  const heightClass = height === 'sm' ? 'h-[120px]' : 'h-[200px]';
+
+  return (
+    <Card>
+      <CardContent className="overflow-hidden p-0">
+        <div className="flex items-start justify-between p-4">
+          <div className="space-y-2 py-[7px]">
+            <h2 className="text-muted-foreground text-sm">{title}</h2>
+            {value !== undefined && <span className="text-3xl font-bold">{value}</span>}
+          </div>
+        </div>
+        {data.length === 0 ? (
+          <div className={cn('text-muted-foreground flex w-full items-center justify-center rounded-b-xl border-t text-sm', heightClass)}>No data</div>
+        ) : (
+          <ChartContainer config={chartConfig} className={cn('aspect-auto w-full overflow-hidden rounded-b-xl', heightClass)}>
+            <AreaChart accessibilityLayer data={data} margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
+              <defs>
+                <linearGradient id={`fill-${dataKey}`} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={color} stopOpacity={0.8} />
+                  <stop offset="95%" stopColor={color} stopOpacity={0.1} />
+                </linearGradient>
+              </defs>
+              <YAxis hide />
+              <XAxis
+                dataKey={labelKey}
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={32}
+                tickFormatter={(v) => (formatLabel ? formatLabel(String(v)) : String(v))}
+              />
+              <ChartTooltip
+                cursor={true}
+                content={
+                  <ChartTooltipContent labelFormatter={(v) => (formatLabel ? formatLabel(String(v)) : String(v))} formatter={formatValue} indicator="dot" />
+                }
+              />
+              <Area dataKey={dataKey} type="monotone" fill={`url(#fill-${dataKey})`} stroke={color} />
+            </AreaChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/resources/js/pages/sites/components/stats-chart.tsx
+++ b/resources/js/pages/sites/components/stats-chart.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import { Area, AreaChart, XAxis, YAxis } from 'recharts';
 
 import { Card, CardContent } from '@/components/ui/card';
@@ -12,16 +13,17 @@ interface Props {
   labelKey: string;
   data: Array<Record<string, string | number>>;
   formatLabel?: (value: string) => string;
-  formatValue?: (value: unknown) => string | number;
-  height?: 'sm' | 'md';
+  valueFormatter?: (value: unknown) => string | number;
+  height?: 'small' | 'medium';
 }
 
-export function StatsChart({ title, value, color, dataKey, labelKey, data, formatLabel, formatValue, height = 'md' }: Props) {
+export function StatsChart({ title, value, color, dataKey, labelKey, data, formatLabel, valueFormatter, height = 'medium' }: Props) {
+  const gradientId = useId();
   const chartConfig = {
     [dataKey]: { label: title, color },
   } satisfies ChartConfig;
 
-  const heightClass = height === 'sm' ? 'h-[120px]' : 'h-[200px]';
+  const heightClass = height === 'small' ? 'h-[100px]' : 'h-[200px]';
 
   return (
     <Card>
@@ -40,7 +42,7 @@ export function StatsChart({ title, value, color, dataKey, labelKey, data, forma
           <ChartContainer config={chartConfig} className={cn('aspect-auto w-full overflow-hidden rounded-b-xl', heightClass)}>
             <AreaChart accessibilityLayer data={data} margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
               <defs>
-                <linearGradient id={`fill-${dataKey}`} x1="0" y1="0" x2="0" y2="1">
+                <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
                   <stop offset="5%" stopColor={color} stopOpacity={0.8} />
                   <stop offset="95%" stopColor={color} stopOpacity={0.1} />
                 </linearGradient>
@@ -59,12 +61,12 @@ export function StatsChart({ title, value, color, dataKey, labelKey, data, forma
                 content={
                   <ChartTooltipContent
                     labelFormatter={(v) => (formatLabel ? formatLabel(String(v)) : String(v))}
-                    formatter={formatValue}
+                    formatter={valueFormatter}
                     indicator="dot"
                   />
                 }
               />
-              <Area dataKey={dataKey} type="monotone" fill={`url(#fill-${dataKey})`} stroke={color} />
+              <Area dataKey={dataKey} type="monotone" fill={`url(#${gradientId})`} stroke={color} />
             </AreaChart>
           </ChartContainer>
         )}

--- a/resources/js/pages/sites/components/stats-chart.tsx
+++ b/resources/js/pages/sites/components/stats-chart.tsx
@@ -33,7 +33,9 @@ export function StatsChart({ title, value, color, dataKey, labelKey, data, forma
           </div>
         </div>
         {data.length === 0 ? (
-          <div className={cn('text-muted-foreground flex w-full items-center justify-center rounded-b-xl border-t text-sm', heightClass)}>No data</div>
+          <div className={cn('text-muted-foreground flex w-full items-center justify-center rounded-b-xl border-t text-sm', heightClass)}>
+            No data
+          </div>
         ) : (
           <ChartContainer config={chartConfig} className={cn('aspect-auto w-full overflow-hidden rounded-b-xl', heightClass)}>
             <AreaChart accessibilityLayer data={data} margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
@@ -55,7 +57,11 @@ export function StatsChart({ title, value, color, dataKey, labelKey, data, forma
               <ChartTooltip
                 cursor={true}
                 content={
-                  <ChartTooltipContent labelFormatter={(v) => (formatLabel ? formatLabel(String(v)) : String(v))} formatter={formatValue} indicator="dot" />
+                  <ChartTooltipContent
+                    labelFormatter={(v) => (formatLabel ? formatLabel(String(v)) : String(v))}
+                    formatter={formatValue}
+                    indicator="dot"
+                  />
                 }
               />
               <Area dataKey={dataKey} type="monotone" fill={`url(#fill-${dataKey})`} stroke={color} />

--- a/resources/js/pages/sites/components/use-site-stats.ts
+++ b/resources/js/pages/sites/components/use-site-stats.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import { SiteStatsResponse } from '@/types/site-stats';
+import { Server } from '@/types/server';
+import { Site } from '@/types/site';
+
+export function useSiteStats(server: Server, site: Site, month?: string) {
+  return useQuery<SiteStatsResponse>({
+    queryKey: ['site-stats', site.id, month ?? 'current'],
+    queryFn: async () => {
+      const response = await fetch(route('site-stats.json', { server: server.id, site: site.id, month }));
+      if (!response.ok) {
+        throw new Error('Failed to fetch site statistics');
+      }
+      return response.json();
+    },
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/resources/js/pages/sites/stats.tsx
+++ b/resources/js/pages/sites/stats.tsx
@@ -25,6 +25,7 @@ type Page = {
   server: Server;
   site: Site;
   hasStatsService: boolean;
+  statsEnabled: boolean;
 };
 
 function formatNumber(value: number): string {
@@ -65,13 +66,13 @@ function formatDay(value: string): string {
 
 export default function SiteStats() {
   const page = usePage<Page>();
-  const { server, site, hasStatsService } = page.props;
+  const { server, site, hasStatsService, statsEnabled } = page.props;
 
   return (
     <ServerLayout>
       <Head title={`Stats - ${site.domain} - ${server.name}`} />
       <Container className="max-w-5xl">
-        {hasStatsService ? (
+        {statsEnabled && hasStatsService ? (
           <StatsView server={server} site={site} />
         ) : (
           <>
@@ -81,7 +82,16 @@ export default function SiteStats() {
             <SiteBanners site={site} />
             <Card>
               <CardContent className="text-muted-foreground p-6 text-sm">
-                Install the <span className="text-foreground font-medium">GoAccess</span> service on this server to enable site statistics.
+                {!statsEnabled ? (
+                  <>
+                    Statistics are <span className="text-foreground font-medium">disabled</span> for this site. Enable them from the site's Settings
+                    page.
+                  </>
+                ) : (
+                  <>
+                    Install the <span className="text-foreground font-medium">GoAccess</span> service on this server to enable site statistics.
+                  </>
+                )}
               </CardContent>
             </Card>
           </>
@@ -131,157 +141,155 @@ function StatsView({ server, site }: { server: Server; site: Site }) {
   return (
     <>
       <HeaderContainer>
-          <Heading title="Stats" description="Web statistics for this site" />
-          <div className="flex items-center gap-2">
-            {data && data.months.length > 0 && (
-              <Select value={selectedMonth} onValueChange={setMonth}>
-                <SelectTrigger className="w-[160px]">
-                  <SelectValue placeholder="Select month" />
-                </SelectTrigger>
-                <SelectContent>
-                  {data.months.map((m) => (
-                    <SelectItem key={m} value={m}>
-                      {formatMonth(m)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-            <Button variant="outline" onClick={refresh} disabled={refreshing} aria-label="Refresh">
-              <RefreshCwIcon className={refreshing ? 'animate-spin' : ''} />
-              <span className="hidden lg:block">Refresh</span>
-            </Button>
-          </div>
-        </HeaderContainer>
+        <Heading title="Stats" description="Web statistics for this site" />
+        <div className="flex items-center gap-2">
+          {data && data.months.length > 0 && (
+            <Select value={selectedMonth} onValueChange={setMonth}>
+              <SelectTrigger className="w-[160px]">
+                <SelectValue placeholder="Select month" />
+              </SelectTrigger>
+              <SelectContent>
+                {data.months.map((m) => (
+                  <SelectItem key={m} value={m}>
+                    {formatMonth(m)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          <Button variant="outline" onClick={refresh} disabled={refreshing} aria-label="Refresh">
+            <RefreshCwIcon className={refreshing ? 'animate-spin' : ''} />
+            <span className="hidden lg:block">Refresh</span>
+          </Button>
+        </div>
+      </HeaderContainer>
 
-        <SiteBanners site={site} />
+      <SiteBanners site={site} />
 
-        {data?.status && data.status.exit_code !== null && data.status.exit_code !== 0 && (
-          <Card className="border-destructive/50">
-            <CardContent className="text-destructive p-4 text-sm">
-              The last statistics run failed{data.status.error ? `: ${data.status.error}` : ''}. Try Refresh, or Re-sync the GoAccess service.
-            </CardContent>
-          </Card>
-        )}
+      {data?.status && data.status.exit_code !== null && data.status.exit_code !== 0 && (
+        <Card className="border-destructive/50">
+          <CardContent className="text-destructive p-4 text-sm">
+            The last statistics run failed{data.status.error ? `: ${data.status.error}` : ''}. Try Refresh, or Re-sync the GoAccess service.
+          </CardContent>
+        </Card>
+      )}
 
-        {isLoading && (
+      {isLoading && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <Skeleton className="h-[200px]" />
+          <Skeleton className="h-[200px]" />
+          <Skeleton className="h-[200px]" />
+        </div>
+      )}
+
+      {isError && (
+        <Card>
+          <CardContent className="text-muted-foreground p-6 text-sm">Failed to load site statistics. Try refreshing.</CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !isError && data && data.summary.length === 0 && !detail && (
+        <Card>
+          <CardContent className="text-muted-foreground p-6 text-sm">
+            No statistics yet. Data is collected hourly — use Refresh to generate it now.
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && data && data.summary.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <h3 className="text-foreground text-base font-medium">Growth (monthly)</h3>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-            <Skeleton className="h-[200px]" />
-            <Skeleton className="h-[200px]" />
-            <Skeleton className="h-[200px]" />
+            <StatsChart
+              title="Visitors"
+              value={formatNumber(data.summary.reduce((t, m) => t + m.visitors, 0))}
+              color="var(--color-chart-1)"
+              dataKey="visitors"
+              labelKey="month"
+              data={data.summary}
+              formatLabel={formatMonth}
+              formatValue={(v) => formatNumber(Number(v))}
+            />
+            <StatsChart
+              title="Hits"
+              value={formatNumber(data.summary.reduce((t, m) => t + m.hits, 0))}
+              color="var(--color-chart-2)"
+              dataKey="hits"
+              labelKey="month"
+              data={data.summary}
+              formatLabel={formatMonth}
+              formatValue={(v) => formatNumber(Number(v))}
+            />
+            <StatsChart
+              title="Bandwidth"
+              value={formatBytes(data.summary.reduce((t, m) => t + m.bandwidth, 0))}
+              color="var(--color-chart-3)"
+              dataKey="bandwidth"
+              labelKey="month"
+              data={data.summary}
+              formatLabel={formatMonth}
+              formatValue={(v) => formatBytes(Number(v))}
+            />
           </div>
-        )}
+        </div>
+      )}
 
-        {isError && (
-          <Card>
-            <CardContent className="text-muted-foreground p-6 text-sm">Failed to load site statistics. Try refreshing.</CardContent>
-          </Card>
-        )}
-
-        {!isLoading && !isError && data && data.summary.length === 0 && !detail && (
-          <Card>
-            <CardContent className="text-muted-foreground p-6 text-sm">
-              No statistics yet. Data is collected hourly — use Refresh to generate it now.
-            </CardContent>
-          </Card>
-        )}
-
-        {!isLoading && data && data.summary.length > 0 && (
+      {!isLoading && detail && (
+        <>
           <div className="flex flex-col gap-2">
-            <h3 className="text-foreground text-base font-medium">Growth (monthly)</h3>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-foreground text-base font-medium">{selectedMonth ? formatMonth(selectedMonth) : ''} detail</h3>
+              {detail.generated_at && <span className="text-muted-foreground text-xs">Updated {new Date(detail.generated_at).toLocaleString()}</span>}
+            </div>
+            <div className="flex flex-col gap-4">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                <StatCard title="Visitors" value={formatNumber(detail.totals.visitors)} />
+                <StatCard title="Hits" value={formatNumber(detail.totals.hits)} />
+                <StatCard title="Bandwidth" value={formatBytes(detail.totals.bandwidth)} />
+              </div>
               <StatsChart
-                title="Visitors"
-                value={formatNumber(data.summary.reduce((t, m) => t + m.visitors, 0))}
+                title="Visitors per day"
                 color="var(--color-chart-1)"
                 dataKey="visitors"
-                labelKey="month"
-                data={data.summary}
-                formatLabel={formatMonth}
+                labelKey="date"
+                data={detail.daily}
+                formatLabel={formatDay}
                 formatValue={(v) => formatNumber(Number(v))}
+                height="sm"
               />
               <StatsChart
-                title="Hits"
-                value={formatNumber(data.summary.reduce((t, m) => t + m.hits, 0))}
+                title="Hits per day"
                 color="var(--color-chart-2)"
                 dataKey="hits"
-                labelKey="month"
-                data={data.summary}
-                formatLabel={formatMonth}
+                labelKey="date"
+                data={detail.daily}
+                formatLabel={formatDay}
                 formatValue={(v) => formatNumber(Number(v))}
+                height="sm"
               />
               <StatsChart
-                title="Bandwidth"
-                value={formatBytes(data.summary.reduce((t, m) => t + m.bandwidth, 0))}
+                title="Bandwidth per day"
                 color="var(--color-chart-3)"
                 dataKey="bandwidth"
-                labelKey="month"
-                data={data.summary}
-                formatLabel={formatMonth}
+                labelKey="date"
+                data={detail.daily}
+                formatLabel={formatDay}
                 formatValue={(v) => formatBytes(Number(v))}
+                height="sm"
               />
             </div>
           </div>
-        )}
 
-        {!isLoading && detail && (
-          <>
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center justify-between">
-                <h3 className="text-foreground text-base font-medium">{selectedMonth ? formatMonth(selectedMonth) : ''} detail</h3>
-                {detail.generated_at && (
-                  <span className="text-muted-foreground text-xs">Updated {new Date(detail.generated_at).toLocaleString()}</span>
-                )}
-              </div>
-              <div className="flex flex-col gap-4">
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-                  <StatCard title="Visitors" value={formatNumber(detail.totals.visitors)} />
-                  <StatCard title="Hits" value={formatNumber(detail.totals.hits)} />
-                  <StatCard title="Bandwidth" value={formatBytes(detail.totals.bandwidth)} />
-                </div>
-                <StatsChart
-                  title="Visitors per day"
-                  color="var(--color-chart-1)"
-                  dataKey="visitors"
-                  labelKey="date"
-                  data={detail.daily}
-                  formatLabel={formatDay}
-                  formatValue={(v) => formatNumber(Number(v))}
-                  height="sm"
-                />
-                <StatsChart
-                  title="Hits per day"
-                  color="var(--color-chart-2)"
-                  dataKey="hits"
-                  labelKey="date"
-                  data={detail.daily}
-                  formatLabel={formatDay}
-                  formatValue={(v) => formatNumber(Number(v))}
-                  height="sm"
-                />
-                <StatsChart
-                  title="Bandwidth per day"
-                  color="var(--color-chart-3)"
-                  dataKey="bandwidth"
-                  labelKey="date"
-                  data={detail.daily}
-                  formatLabel={formatDay}
-                  formatValue={(v) => formatBytes(Number(v))}
-                  height="sm"
-                />
-              </div>
-            </div>
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <PanelCard title="Top pages" rows={detail.top_pages} />
+            <PanelCard title="Referrers" rows={detail.referrers} />
+          </div>
 
-            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-              <PanelCard title="Top pages" rows={detail.top_pages} />
-              <PanelCard title="Referrers" rows={detail.referrers} />
-            </div>
+          <StatusCodesCard rows={detail.status_codes} />
 
-            <StatusCodesCard rows={detail.status_codes} />
-
-            <PanelCard title="404 pages" rows={detail.not_found} />
-          </>
-        )}
+          <PanelCard title="404 pages" rows={detail.not_found} />
+        </>
+      )}
     </>
   );
 }

--- a/resources/js/pages/sites/stats.tsx
+++ b/resources/js/pages/sites/stats.tsx
@@ -130,7 +130,10 @@ function StatsView({ server, site }: { server: Server; site: Site }) {
       {},
       {
         preserveScroll: true,
-        onError: () => toast.error('Failed to refresh site statistics'),
+        onError: (errors) => {
+          const first = Object.values(errors)[0];
+          toast.error(typeof first === 'string' && first.length > 0 ? first : 'Failed to refresh site statistics');
+        },
         onFinish: () => setRefreshing(false),
       },
     );
@@ -208,7 +211,7 @@ function StatsView({ server, site }: { server: Server; site: Site }) {
               labelKey="month"
               data={data.summary}
               formatLabel={formatMonth}
-              formatValue={(v) => formatNumber(Number(v))}
+              valueFormatter={(v) => formatNumber(Number(v))}
             />
             <StatsChart
               title="Hits"
@@ -218,7 +221,7 @@ function StatsView({ server, site }: { server: Server; site: Site }) {
               labelKey="month"
               data={data.summary}
               formatLabel={formatMonth}
-              formatValue={(v) => formatNumber(Number(v))}
+              valueFormatter={(v) => formatNumber(Number(v))}
             />
             <StatsChart
               title="Bandwidth"
@@ -228,7 +231,7 @@ function StatsView({ server, site }: { server: Server; site: Site }) {
               labelKey="month"
               data={data.summary}
               formatLabel={formatMonth}
-              formatValue={(v) => formatBytes(Number(v))}
+              valueFormatter={(v) => formatBytes(Number(v))}
             />
           </div>
         </div>
@@ -254,8 +257,8 @@ function StatsView({ server, site }: { server: Server; site: Site }) {
                 labelKey="date"
                 data={detail.daily}
                 formatLabel={formatDay}
-                formatValue={(v) => formatNumber(Number(v))}
-                height="sm"
+                valueFormatter={(v) => formatNumber(Number(v))}
+                height="small"
               />
               <StatsChart
                 title="Hits per day"
@@ -264,8 +267,8 @@ function StatsView({ server, site }: { server: Server; site: Site }) {
                 labelKey="date"
                 data={detail.daily}
                 formatLabel={formatDay}
-                formatValue={(v) => formatNumber(Number(v))}
-                height="sm"
+                valueFormatter={(v) => formatNumber(Number(v))}
+                height="small"
               />
               <StatsChart
                 title="Bandwidth per day"
@@ -274,8 +277,8 @@ function StatsView({ server, site }: { server: Server; site: Site }) {
                 labelKey="date"
                 data={detail.daily}
                 formatLabel={formatDay}
-                formatValue={(v) => formatBytes(Number(v))}
-                height="sm"
+                valueFormatter={(v) => formatBytes(Number(v))}
+                height="small"
               />
             </div>
           </div>
@@ -325,8 +328,8 @@ function PanelCard({ title, rows }: { title: string; rows: SiteStatsPanelRow[] }
                 </TableCell>
               </TableRow>
             ) : (
-              rows.map((row, index) => (
-                <TableRow key={`${row.name}-${index}`}>
+              rows.map((row) => (
+                <TableRow key={row.name}>
                   <TableCell className="max-w-[280px] truncate">{row.name}</TableCell>
                   <TableCell className="text-right">{row.hits.toLocaleString()}</TableCell>
                   <TableCell className="text-right">{row.visitors.toLocaleString()}</TableCell>
@@ -359,8 +362,8 @@ function StatusCodesCard({ rows }: { rows: SiteStatsStatusCode[] }) {
                 </TableCell>
               </TableRow>
             ) : (
-              rows.map((row, index) => (
-                <TableRow key={`${row.name}-${index}`}>
+              rows.map((row) => (
+                <TableRow key={row.name}>
                   <TableCell>{row.name}</TableCell>
                   <TableCell className="text-right">{row.hits.toLocaleString()}</TableCell>
                 </TableRow>

--- a/resources/js/pages/sites/stats.tsx
+++ b/resources/js/pages/sites/stats.tsx
@@ -1,0 +1,356 @@
+import { Head, router, usePage } from '@inertiajs/react';
+import { useCallback, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { RefreshCwIcon } from 'lucide-react';
+import { toast } from 'sonner';
+import { useSocketListener } from '@/hooks/use-socket-events';
+
+import { Site } from '@/types/site';
+import { Server } from '@/types/server';
+import ServerLayout from '@/layouts/server/layout';
+import SiteBanners from '@/components/site-banners';
+import Container from '@/components/container';
+import HeaderContainer from '@/components/header-container';
+import Heading from '@/components/heading';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useSiteStats } from '@/pages/sites/components/use-site-stats';
+import { StatsChart } from '@/pages/sites/components/stats-chart';
+import { SiteStatsPanelRow, SiteStatsStatusCode } from '@/types/site-stats';
+
+type Page = {
+  server: Server;
+  site: Site;
+  hasStatsService: boolean;
+};
+
+function formatNumber(value: number): string {
+  return value.toLocaleString();
+}
+
+function formatBytes(bytes: number): string {
+  if (!bytes) {
+    return '0 B';
+  }
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / Math.pow(1024, i)).toFixed(i ? 1 : 0)} ${units[i]}`;
+}
+
+function formatMonth(value: string): string {
+  const [year, month] = value.split('-').map(Number);
+  if (!year || !month) {
+    return value;
+  }
+  return new Date(year, month - 1, 1).toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
+}
+
+function formatDay(value: string): string {
+  const parts = value.split('-');
+  if (parts.length !== 3) {
+    return value;
+  }
+  const day = parseInt(parts[2], 10);
+  if (Number.isNaN(day)) {
+    return value;
+  }
+  const j = day % 10;
+  const k = day % 100;
+  const suffix = j === 1 && k !== 11 ? 'st' : j === 2 && k !== 12 ? 'nd' : j === 3 && k !== 13 ? 'rd' : 'th';
+  return `${day}${suffix}`;
+}
+
+export default function SiteStats() {
+  const page = usePage<Page>();
+  const { server, site, hasStatsService } = page.props;
+
+  return (
+    <ServerLayout>
+      <Head title={`Stats - ${site.domain} - ${server.name}`} />
+      <Container className="max-w-5xl">
+        {hasStatsService ? (
+          <StatsView server={server} site={site} />
+        ) : (
+          <>
+            <HeaderContainer>
+              <Heading title="Stats" description="Web statistics for this site" />
+            </HeaderContainer>
+            <SiteBanners site={site} />
+            <Card>
+              <CardContent className="text-muted-foreground p-6 text-sm">
+                Install the <span className="text-foreground font-medium">GoAccess</span> service on this server to enable site statistics.
+              </CardContent>
+            </Card>
+          </>
+        )}
+      </Container>
+    </ServerLayout>
+  );
+}
+
+function StatsView({ server, site }: { server: Server; site: Site }) {
+  const [month, setMonth] = useState<string | undefined>(undefined);
+  const [refreshing, setRefreshing] = useState(false);
+  const { data, isLoading, isError } = useSiteStats(server, site, month);
+  const queryClient = useQueryClient();
+
+  const selectedMonth = month ?? data?.month;
+
+  useSocketListener(
+    useCallback(
+      (event) => {
+        if (event.type !== 'site-stats.updated') return;
+        const payload = event.data as { id?: number; months?: string[] } | undefined;
+        if (!payload || payload.id !== site.id) return;
+        if (!selectedMonth || payload.months?.includes(selectedMonth)) {
+          queryClient.invalidateQueries({ queryKey: ['site-stats', site.id] });
+        }
+      },
+      [site.id, selectedMonth, queryClient],
+    ),
+  );
+
+  const refresh = () => {
+    setRefreshing(true);
+    router.post(
+      route('site-stats.refresh', { server: server.id, site: site.id }),
+      {},
+      {
+        preserveScroll: true,
+        onError: () => toast.error('Failed to refresh site statistics'),
+        onFinish: () => setRefreshing(false),
+      },
+    );
+  };
+
+  const detail = data?.detail;
+
+  return (
+    <>
+      <HeaderContainer>
+          <Heading title="Stats" description="Web statistics for this site" />
+          <div className="flex items-center gap-2">
+            {data && data.months.length > 0 && (
+              <Select value={selectedMonth} onValueChange={setMonth}>
+                <SelectTrigger className="w-[160px]">
+                  <SelectValue placeholder="Select month" />
+                </SelectTrigger>
+                <SelectContent>
+                  {data.months.map((m) => (
+                    <SelectItem key={m} value={m}>
+                      {formatMonth(m)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            <Button variant="outline" onClick={refresh} disabled={refreshing} aria-label="Refresh">
+              <RefreshCwIcon className={refreshing ? 'animate-spin' : ''} />
+              <span className="hidden lg:block">Refresh</span>
+            </Button>
+          </div>
+        </HeaderContainer>
+
+        <SiteBanners site={site} />
+
+        {data?.status && data.status.exit_code !== null && data.status.exit_code !== 0 && (
+          <Card className="border-destructive/50">
+            <CardContent className="text-destructive p-4 text-sm">
+              The last statistics run failed{data.status.error ? `: ${data.status.error}` : ''}. Try Refresh, or Re-sync the GoAccess service.
+            </CardContent>
+          </Card>
+        )}
+
+        {isLoading && (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <Skeleton className="h-[200px]" />
+            <Skeleton className="h-[200px]" />
+            <Skeleton className="h-[200px]" />
+          </div>
+        )}
+
+        {isError && (
+          <Card>
+            <CardContent className="text-muted-foreground p-6 text-sm">Failed to load site statistics. Try refreshing.</CardContent>
+          </Card>
+        )}
+
+        {!isLoading && !isError && data && data.summary.length === 0 && !detail && (
+          <Card>
+            <CardContent className="text-muted-foreground p-6 text-sm">
+              No statistics yet. Data is collected hourly — use Refresh to generate it now.
+            </CardContent>
+          </Card>
+        )}
+
+        {!isLoading && data && data.summary.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <h3 className="text-foreground text-base font-medium">Growth (monthly)</h3>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              <StatsChart
+                title="Visitors"
+                value={formatNumber(data.summary.reduce((t, m) => t + m.visitors, 0))}
+                color="var(--color-chart-1)"
+                dataKey="visitors"
+                labelKey="month"
+                data={data.summary}
+                formatLabel={formatMonth}
+                formatValue={(v) => formatNumber(Number(v))}
+              />
+              <StatsChart
+                title="Hits"
+                value={formatNumber(data.summary.reduce((t, m) => t + m.hits, 0))}
+                color="var(--color-chart-2)"
+                dataKey="hits"
+                labelKey="month"
+                data={data.summary}
+                formatLabel={formatMonth}
+                formatValue={(v) => formatNumber(Number(v))}
+              />
+              <StatsChart
+                title="Bandwidth"
+                value={formatBytes(data.summary.reduce((t, m) => t + m.bandwidth, 0))}
+                color="var(--color-chart-3)"
+                dataKey="bandwidth"
+                labelKey="month"
+                data={data.summary}
+                formatLabel={formatMonth}
+                formatValue={(v) => formatBytes(Number(v))}
+              />
+            </div>
+          </div>
+        )}
+
+        {!isLoading && detail && (
+          <>
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <h3 className="text-foreground text-base font-medium">{selectedMonth ? formatMonth(selectedMonth) : ''} detail</h3>
+                {detail.generated_at && (
+                  <span className="text-muted-foreground text-xs">Updated {new Date(detail.generated_at).toLocaleString()}</span>
+                )}
+              </div>
+              <div className="flex flex-col gap-4">
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                  <StatCard title="Visitors" value={formatNumber(detail.totals.visitors)} />
+                  <StatCard title="Hits" value={formatNumber(detail.totals.hits)} />
+                  <StatCard title="Bandwidth" value={formatBytes(detail.totals.bandwidth)} />
+                </div>
+                <StatsChart
+                  title="Visitors per day"
+                  color="var(--color-chart-1)"
+                  dataKey="visitors"
+                  labelKey="date"
+                  data={detail.daily}
+                  formatLabel={formatDay}
+                  formatValue={(v) => formatNumber(Number(v))}
+                  height="sm"
+                />
+                <StatsChart
+                  title="Hits per day"
+                  color="var(--color-chart-2)"
+                  dataKey="hits"
+                  labelKey="date"
+                  data={detail.daily}
+                  formatLabel={formatDay}
+                  formatValue={(v) => formatNumber(Number(v))}
+                  height="sm"
+                />
+                <StatsChart
+                  title="Bandwidth per day"
+                  color="var(--color-chart-3)"
+                  dataKey="bandwidth"
+                  labelKey="date"
+                  data={detail.daily}
+                  formatLabel={formatDay}
+                  formatValue={(v) => formatBytes(Number(v))}
+                  height="sm"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+              <PanelCard title="Top pages" rows={detail.top_pages} />
+              <PanelCard title="Referrers" rows={detail.referrers} />
+            </div>
+
+            <StatusCodesCard rows={detail.status_codes} />
+
+            <PanelCard title="404 pages" rows={detail.not_found} />
+          </>
+        )}
+    </>
+  );
+}
+
+function StatCard({ title, value }: { title: string; value: string }) {
+  return (
+    <Card>
+      <CardContent className="space-y-2 p-4">
+        <h2 className="text-muted-foreground text-sm">{title}</h2>
+        <span className="text-3xl font-bold">{value}</span>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PanelCard({ title, rows }: { title: string; rows: SiteStatsPanelRow[] }) {
+  return (
+    <Card className="overflow-hidden">
+      <CardContent className="flex flex-1 flex-col p-0">
+        <Table className="[&_tr]:hover:bg-transparent">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="font-semibold">{title}</TableHead>
+              <TableHead className="text-right font-semibold">Hits</TableHead>
+              <TableHead className="text-right font-semibold">Visitors</TableHead>
+            </TableRow>
+          </TableHeader>
+          {rows.length > 0 && (
+            <TableBody>
+              {rows.map((row, index) => (
+                <TableRow key={`${row.name}-${index}`}>
+                  <TableCell className="max-w-[280px] truncate">{row.name}</TableCell>
+                  <TableCell className="text-right">{row.hits.toLocaleString()}</TableCell>
+                  <TableCell className="text-right">{row.visitors.toLocaleString()}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          )}
+        </Table>
+        {rows.length === 0 && <div className="text-muted-foreground flex flex-1 items-center justify-center py-12 text-sm">No data</div>}
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatusCodesCard({ rows }: { rows: SiteStatsStatusCode[] }) {
+  return (
+    <Card className="overflow-hidden">
+      <CardContent className="flex flex-1 flex-col p-0">
+        <Table className="[&_tr]:hover:bg-transparent">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="font-semibold">Status code</TableHead>
+              <TableHead className="text-right font-semibold">Hits</TableHead>
+            </TableRow>
+          </TableHeader>
+          {rows.length > 0 && (
+            <TableBody>
+              {rows.map((row, index) => (
+                <TableRow key={`${row.name}-${index}`}>
+                  <TableCell>{row.name}</TableCell>
+                  <TableCell className="text-right">{row.hits.toLocaleString()}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          )}
+        </Table>
+        {rows.length === 0 && <div className="text-muted-foreground flex flex-1 items-center justify-center py-12 text-sm">No data</div>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/resources/js/pages/sites/stats.tsx
+++ b/resources/js/pages/sites/stats.tsx
@@ -280,7 +280,7 @@ function StatsView({ server, site }: { server: Server; site: Site }) {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <div className="grid grid-cols-1 items-start gap-4 lg:grid-cols-2">
             <PanelCard title="Top pages" rows={detail.top_pages} />
             <PanelCard title="Referrers" rows={detail.referrers} />
           </div>
@@ -308,7 +308,7 @@ function StatCard({ title, value }: { title: string; value: string }) {
 function PanelCard({ title, rows }: { title: string; rows: SiteStatsPanelRow[] }) {
   return (
     <Card className="overflow-hidden">
-      <CardContent className="flex flex-1 flex-col p-0">
+      <CardContent className="p-0">
         <Table className="[&_tr]:hover:bg-transparent">
           <TableHeader>
             <TableRow>
@@ -317,19 +317,24 @@ function PanelCard({ title, rows }: { title: string; rows: SiteStatsPanelRow[] }
               <TableHead className="text-right font-semibold">Visitors</TableHead>
             </TableRow>
           </TableHeader>
-          {rows.length > 0 && (
-            <TableBody>
-              {rows.map((row, index) => (
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={3} className="text-muted-foreground h-32 text-center text-sm">
+                  No data
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((row, index) => (
                 <TableRow key={`${row.name}-${index}`}>
                   <TableCell className="max-w-[280px] truncate">{row.name}</TableCell>
                   <TableCell className="text-right">{row.hits.toLocaleString()}</TableCell>
                   <TableCell className="text-right">{row.visitors.toLocaleString()}</TableCell>
                 </TableRow>
-              ))}
-            </TableBody>
-          )}
+              ))
+            )}
+          </TableBody>
         </Table>
-        {rows.length === 0 && <div className="text-muted-foreground flex flex-1 items-center justify-center py-12 text-sm">No data</div>}
       </CardContent>
     </Card>
   );
@@ -338,7 +343,7 @@ function PanelCard({ title, rows }: { title: string; rows: SiteStatsPanelRow[] }
 function StatusCodesCard({ rows }: { rows: SiteStatsStatusCode[] }) {
   return (
     <Card className="overflow-hidden">
-      <CardContent className="flex flex-1 flex-col p-0">
+      <CardContent className="p-0">
         <Table className="[&_tr]:hover:bg-transparent">
           <TableHeader>
             <TableRow>
@@ -346,18 +351,23 @@ function StatusCodesCard({ rows }: { rows: SiteStatsStatusCode[] }) {
               <TableHead className="text-right font-semibold">Hits</TableHead>
             </TableRow>
           </TableHeader>
-          {rows.length > 0 && (
-            <TableBody>
-              {rows.map((row, index) => (
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={2} className="text-muted-foreground h-32 text-center text-sm">
+                  No data
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((row, index) => (
                 <TableRow key={`${row.name}-${index}`}>
                   <TableCell>{row.name}</TableCell>
                   <TableCell className="text-right">{row.hits.toLocaleString()}</TableCell>
                 </TableRow>
-              ))}
-            </TableBody>
-          )}
+              ))
+            )}
+          </TableBody>
         </Table>
-        {rows.length === 0 && <div className="text-muted-foreground flex flex-1 items-center justify-center py-12 text-sm">No data</div>}
       </CardContent>
     </Card>
   );

--- a/resources/js/types/site-stats.d.ts
+++ b/resources/js/types/site-stats.d.ts
@@ -1,0 +1,56 @@
+export interface SiteStatsMonthSummary {
+  month: string;
+  visitors: number;
+  hits: number;
+  bandwidth: number;
+  [key: string]: string | number;
+}
+
+export interface SiteStatsDaily {
+  date: string;
+  visitors: number;
+  hits: number;
+  bandwidth: number;
+  [key: string]: string | number;
+}
+
+export interface SiteStatsPanelRow {
+  name: string;
+  hits: number;
+  visitors: number;
+  bandwidth: number;
+}
+
+export interface SiteStatsStatusCode {
+  name: string;
+  hits: number;
+}
+
+export interface SiteStatsDetail {
+  generated_at: string | null;
+  totals: {
+    visitors: number;
+    hits: number;
+    bandwidth: number;
+  };
+  daily: SiteStatsDaily[];
+  top_pages: SiteStatsPanelRow[];
+  referrers: SiteStatsPanelRow[];
+  status_codes: SiteStatsStatusCode[];
+  not_found: SiteStatsPanelRow[];
+}
+
+export interface SiteStatsStatus {
+  last_success_at: string | null;
+  last_run_finished_at: string | null;
+  exit_code: number | null;
+  error: string | null;
+}
+
+export interface SiteStatsResponse {
+  months: string[];
+  month: string;
+  summary: SiteStatsMonthSummary[];
+  detail: SiteStatsDetail | null;
+  status: SiteStatsStatus | null;
+}

--- a/resources/js/types/site.d.ts
+++ b/resources/js/types/site.d.ts
@@ -39,6 +39,7 @@ export interface Site {
   has_custom_vhost_template: boolean;
   features: SiteFeature[];
   modern_deployment: boolean;
+  stats_enabled: boolean;
   is_proxied_site_type: boolean;
   available_tooling_commands: string[];
   start_command: string | null;

--- a/resources/views/ssh/services/log_analysis/goaccess/bin/process.blade.php
+++ b/resources/views/ssh/services/log_analysis/goaccess/bin/process.blade.php
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# vito-goaccess-script-version: {{ $scriptVersion }}
+set -euo pipefail
+
+CONF="${1:-}"
+[ -n "$CONF" ] && [ -f "$CONF" ] || exit 0
+
+# shellcheck disable=SC1090
+source "$CONF"
+
+BASE_DIR="{{ $baseDir }}"
+SITE_DATA="$BASE_DIR/data/$SITE_ID"
+mkdir -p "$SITE_DATA"
+
+# Per-site lock shared by the hourly runner AND the manual-refresh path.
+# Non-blocking: if a run is already in progress, report busy and exit cleanly
+# (exit 0 so the SSH `set -e` wrapper does not treat it as a failure).
+exec 9>"$SITE_DATA/.lock"
+if ! flock -n 9; then
+    echo "VITO_STATS_BUSY"
+    exit 0
+fi
+
+STARTED_AT="$(date -u +%FT%TZ)"
+THIS_MONTH="$(date +%Y-%m)"
+DAY="$((10#$(date +%d)))"
+
+MONTHS=("$THIS_MONTH")
+BOUNDARY=0
+if [ "$DAY" -le 2 ]; then
+    BOUNDARY=1
+    MONTHS+=("$(date -d "$THIS_MONTH-01 -1 day" +%Y-%m)")
+fi
+
+process_month() {
+    local key="$1"
+    local db="$SITE_DATA/$key"
+    local out="$db/report.json"
+    mkdir -p "$db"
+
+    if [ ! -e "$LIVE_LOG" ]; then
+        echo '{}' > "$out"
+        return 0
+    fi
+
+    if [ "$BOUNDARY" = "1" ]; then
+        # Boundary window (days 1–2): date-filter live+rotated into the right month db.
+        if [ "$LOG_FORMAT" = "CADDY" ]; then
+            # shellcheck disable=SC2086
+            zcat -f $LOG_GLOB 2>/dev/null \
+                | jq -c "select(.ts | startswith(\"$key\"))" \
+                | goaccess - --log-format=CADDY --persist --restore --db-path="$db" -o "$out" --date-spec=date --no-progress
+        else
+            local mon year
+            mon="$(date -d "$key-01" +%b)"
+            year="$(date -d "$key-01" +%Y)"
+            # shellcheck disable=SC2086
+            zcat -f $LOG_GLOB 2>/dev/null \
+                | grep -- "/$mon/$year:" \
+                | goaccess - --log-format=COMBINED --persist --restore --db-path="$db" -o "$out" --date-spec=date --no-progress
+        fi
+    else
+        # Normal path: direct-file incremental (GoAccess tracks inode/offset).
+        # shellcheck disable=SC2086
+        goaccess $LOG_GLOB --log-format="$LOG_FORMAT" --persist --restore --db-path="$db" -o "$out" --date-spec=date --no-progress
+    fi
+}
+
+build_summary() {
+    local summary="$SITE_DATA/summary.json"
+    local entries=""
+    for d in "$SITE_DATA"/*/; do
+        local key
+        key="$(basename "$d")"
+        [[ "$key" =~ ^[0-9]{4}-[0-9]{2}$ ]] || continue
+        [ -f "$d/report.json" ] || continue
+        local v h b
+        v="$(jq -r '(.general.unique_visitors // 0) | tonumber? // 0' "$d/report.json" 2>/dev/null || echo 0)"
+        h="$(jq -r '(.general.total_requests // 0) | tonumber? // 0' "$d/report.json" 2>/dev/null || echo 0)"
+        b="$(jq -r '(.general.bandwidth // 0) | tonumber? // 0' "$d/report.json" 2>/dev/null || echo 0)"
+        [ -n "$entries" ] && entries="$entries,"
+        entries="$entries{\"month\":\"$key\",\"visitors\":$v,\"hits\":$h,\"bandwidth\":$b}"
+    done
+    printf '[%s]\n' "$entries" > "$summary"
+}
+
+prune() {
+    local cutoff
+    cutoff="$(date -d "$THIS_MONTH-01 -$((RETENTION_MONTHS - 1)) month" +%Y-%m 2>/dev/null || true)"
+    [ -n "$cutoff" ] || return 0
+    for d in "$SITE_DATA"/*/; do
+        local key
+        key="$(basename "$d")"
+        [[ "$key" =~ ^[0-9]{4}-[0-9]{2}$ ]] || continue
+        if [[ "$key" < "$cutoff" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+
+write_status() {
+    local exit_code="$1"
+    local error_json="$2"
+    local success_at="$3"
+    local months_json="$4"
+    cat > "$SITE_DATA/status.json" <<JSON
+{"schema":1,"site_id":$SITE_ID,"last_run_started_at":"$STARTED_AT","last_run_finished_at":"$(date -u +%FT%TZ)","last_success_at":$success_at,"exit_code":$exit_code,"error":$error_json,"months_processed":[$months_json]}
+JSON
+}
+
+trap 'rc=$?; write_status "$rc" "\"processing failed\"" "null" ""; chown -R "$SSH_USER:$SSH_USER" "$SITE_DATA" 2>/dev/null || true' ERR
+
+processed=""
+for m in "${MONTHS[@]}"; do
+    process_month "$m"
+    [ -n "$processed" ] && processed="$processed,"
+    processed="$processed\"$m\""
+done
+
+build_summary
+prune
+write_status 0 "null" "\"$(date -u +%FT%TZ)\"" "$processed"
+chown -R "$SSH_USER:$SSH_USER" "$SITE_DATA" 2>/dev/null || true

--- a/resources/views/ssh/services/log_analysis/goaccess/bin/run.blade.php
+++ b/resources/views/ssh/services/log_analysis/goaccess/bin/run.blade.php
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="{{ $baseDir }}"
+SITES_DIR="$BASE_DIR/sites"
+
+[ -d "$SITES_DIR" ] || exit 0
+
+for conf in "$SITES_DIR"/*.conf; do
+    [ -e "$conf" ] || continue
+    # Isolate each site: a slow/hung/failed site must not starve the rest.
+    timeout 300 bash "$BASE_DIR/bin/process.sh" "$conf" >/dev/null 2>&1 || true
+done

--- a/resources/views/ssh/services/log_analysis/goaccess/install.blade.php
+++ b/resources/views/ssh/services/log_analysis/goaccess/install.blade.php
@@ -1,0 +1,11 @@
+wget -qO - https://deb.goaccess.io/gnugpg.key | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/goaccess.gpg
+
+echo "deb [signed-by=/usr/share/keyrings/goaccess.gpg arch=$(dpkg --print-architecture)] https://deb.goaccess.io/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/goaccess.list
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get install goaccess jq -y
+
+sudo mkdir -p /var/lib/goaccess
+
+sudo chown {{ $user }}:{{ $user }} /var/lib/goaccess

--- a/resources/views/ssh/services/log_analysis/goaccess/uninstall.blade.php
+++ b/resources/views/ssh/services/log_analysis/goaccess/uninstall.blade.php
@@ -1,0 +1,5 @@
+sudo DEBIAN_FRONTEND=noninteractive apt-get purge goaccess -y
+
+sudo rm -rf /var/lib/goaccess
+
+sudo rm -f /etc/apt/sources.list.d/goaccess.list /usr/share/keyrings/goaccess.gpg

--- a/resources/views/ssh/services/webserver/nginx/vhost.mustache
+++ b/resources/views/ssh/services/webserver/nginx/vhost.mustache
@@ -54,7 +54,7 @@ server {
     add_header X-Content-Type-Options "nosniff";
 
     charset utf-8;
-    access_log off;
+    access_log /var/log/nginx/{{primary_domain}}-access.log;
     error_log  /var/log/nginx/{{primary_domain}}-error.log error;
 
     {{#basic_auth_enabled}}

--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -428,6 +428,11 @@ class ServicesTest extends TestCase
                 'latest',
             ],
             [
+                'goaccess',
+                'log_analysis',
+                'latest',
+            ],
+            [
                 'redis',
                 'memory_database',
                 'latest',

--- a/tests/Feature/SiteStatsTest.php
+++ b/tests/Feature/SiteStatsTest.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Actions\SiteStats\RenderSiteStatsConf;
+use App\Actions\SiteStats\SyncGoAccessServer;
+use App\Enums\CronjobStatus;
+use App\Enums\ServiceStatus;
+use App\Events\SiteCreatedEvent;
+use App\Events\SiteDeletedEvent;
+use App\Facades\SSH;
+use App\Jobs\Service\ManageJob;
+use App\Jobs\Site\CleanupSiteStatsJob;
+use App\Jobs\Site\RefreshSiteStatsJob;
+use App\Jobs\Site\ResyncGoAccessJob;
+use App\Jobs\Site\WriteSiteStatsConfJob;
+use App\Listeners\HandleSiteCreatedStats;
+use App\Listeners\HandleSiteDeletedStats;
+use App\Models\Service;
+use App\Services\LogAnalysis\GoAccess\GoAccess;
+use App\Actions\SiteStats\GetSiteStats;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class SiteStatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function installGoAccess(): Service
+    {
+        return Service::factory()->create([
+            'server_id' => $this->server->id,
+            'type' => 'log_analysis',
+            'name' => 'goaccess',
+            'version' => 'latest',
+            'status' => ServiceStatus::READY,
+            'is_default' => true,
+            'type_data' => ['data_retention' => 12],
+        ]);
+    }
+
+    private function sampleReport(): string
+    {
+        return json_encode([
+            'general' => ['total_requests' => 1000, 'unique_visitors' => 200, 'bandwidth' => 50000],
+            'visitors' => ['data' => [
+                ['data' => '20260501', 'hits' => ['count' => 100], 'visitors' => ['count' => 20], 'bytes' => ['count' => 5000]],
+            ]],
+            'requests' => ['data' => [
+                ['data' => '/home', 'hits' => ['count' => 50], 'visitors' => ['count' => 10], 'bytes' => ['count' => 2500]],
+            ]],
+            'referrers' => ['data' => [
+                ['data' => 'google.com', 'hits' => ['count' => 30], 'visitors' => ['count' => 8], 'bytes' => ['count' => 0]],
+            ]],
+            'status_codes' => ['data' => [
+                ['data' => '2xx Success', 'items' => [['data' => '200', 'hits' => ['count' => 900]]]],
+            ]],
+            'not_found' => ['data' => [
+                ['data' => '/missing', 'hits' => ['count' => 7], 'visitors' => ['count' => 5], 'bytes' => ['count' => 0]],
+            ]],
+        ]);
+    }
+
+    public function test_stats_page_renders_without_service(): void
+    {
+        $this->actingAs($this->user);
+
+        $this->get(route('site-stats', ['server' => $this->server, 'site' => $this->site]))
+            ->assertSuccessful()
+            ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/stats')->where('hasStatsService', false));
+    }
+
+    public function test_stats_page_reports_service_installed(): void
+    {
+        $this->actingAs($this->user);
+        $this->installGoAccess();
+
+        $this->get(route('site-stats', ['server' => $this->server, 'site' => $this->site]))
+            ->assertSuccessful()
+            ->assertInertia(fn (AssertableInertia $page) => $page->where('hasStatsService', true));
+    }
+
+    public function test_conf_renderer_emits_expected_vars(): void
+    {
+        $conf = app(RenderSiteStatsConf::class)->render($this->site);
+
+        $this->assertStringContainsString("SITE_ID='{$this->site->id}'", $conf);
+        $this->assertStringContainsString("DOMAIN='{$this->site->domain}'", $conf);
+        $this->assertStringContainsString("LOG_FORMAT='COMBINED'", $conf);
+        $this->assertStringContainsString('RETENTION_MONTHS=', $conf);
+        $this->assertStringContainsString("SSH_USER='{$this->server->getSshUser()}'", $conf);
+    }
+
+    public function test_conf_renderer_rejects_unsafe_domain(): void
+    {
+        $this->site->domain = 'bad domain; rm -rf /';
+        $this->site->save();
+
+        $this->expectException(\Exception::class);
+        app(RenderSiteStatsConf::class)->render($this->site->refresh());
+    }
+
+    public function test_get_site_stats_parses_report_over_ssh(): void
+    {
+        SSH::fake($this->sampleReport());
+
+        $stats = app(GetSiteStats::class)->get($this->site, '2026-05');
+
+        $this->assertSame(200, $stats['detail']['totals']['visitors']);
+        $this->assertSame(1000, $stats['detail']['totals']['hits']);
+        $this->assertSame('/home', $stats['detail']['top_pages'][0]['name']);
+        $this->assertSame('200', $stats['detail']['status_codes'][0]['name']);
+        $this->assertSame(900, $stats['detail']['status_codes'][0]['hits']);
+        $this->assertSame('/missing', $stats['detail']['not_found'][0]['name']);
+        $this->assertSame(7, $stats['detail']['not_found'][0]['hits']);
+    }
+
+    public function test_json_endpoint_returns_detail(): void
+    {
+        SSH::fake($this->sampleReport());
+        $this->actingAs($this->user);
+
+        $this->get(route('site-stats.json', ['server' => $this->server, 'site' => $this->site, 'month' => '2026-05']))
+            ->assertSuccessful()
+            ->assertJsonPath('detail.totals.visitors', 200)
+            ->assertJsonPath('detail.top_pages.0.name', '/home');
+    }
+
+    public function test_refresh_requires_service(): void
+    {
+        $this->actingAs($this->user);
+
+        $this->post(route('site-stats.refresh', ['server' => $this->server, 'site' => $this->site]))
+            ->assertNotFound();
+    }
+
+    public function test_refresh_dispatches_job_when_installed(): void
+    {
+        Queue::fake();
+        $this->actingAs($this->user);
+        $this->installGoAccess();
+
+        $this->post(route('site-stats.refresh', ['server' => $this->server, 'site' => $this->site]))
+            ->assertSessionDoesntHaveErrors();
+
+        Queue::assertPushed(RefreshSiteStatsJob::class);
+    }
+
+    public function test_resync_requires_service_and_dispatches_job(): void
+    {
+        $this->actingAs($this->user);
+
+        $this->post(route('log-analysis.resync', ['server' => $this->server]))->assertNotFound();
+
+        Queue::fake();
+        $this->installGoAccess();
+
+        $this->post(route('log-analysis.resync', ['server' => $this->server]))->assertSessionDoesntHaveErrors();
+        Queue::assertPushed(ResyncGoAccessJob::class);
+    }
+
+    public function test_site_created_listener_writes_conf_when_installed(): void
+    {
+        Queue::fake();
+        $this->installGoAccess();
+
+        (new HandleSiteCreatedStats)->handle(new SiteCreatedEvent($this->site));
+
+        Queue::assertPushed(WriteSiteStatsConfJob::class);
+    }
+
+    public function test_site_created_listener_noop_without_service(): void
+    {
+        Queue::fake();
+
+        (new HandleSiteCreatedStats)->handle(new SiteCreatedEvent($this->site));
+
+        Queue::assertNotPushed(WriteSiteStatsConfJob::class);
+    }
+
+    public function test_site_deleted_listener_dispatches_cleanup_when_installed(): void
+    {
+        Queue::fake();
+        $this->installGoAccess();
+
+        (new HandleSiteDeletedStats)->handle(new SiteDeletedEvent($this->server->id, $this->site->id, $this->site->domain));
+
+        Queue::assertPushed(CleanupSiteStatsJob::class);
+    }
+
+    public function test_sync_creates_hidden_root_cron(): void
+    {
+        SSH::fake('');
+        $this->installGoAccess();
+
+        app(SyncGoAccessServer::class)->sync($this->server);
+
+        $this->assertDatabaseHas('cron_jobs', [
+            'server_id' => $this->server->id,
+            'user' => 'root',
+            'hidden' => true,
+            'command' => GoAccess::CRON_COMMAND,
+            'status' => CronjobStatus::READY->value,
+        ]);
+    }
+
+    public function test_goaccess_can_be_managed(): void
+    {
+        $service = $this->installGoAccess();
+
+        $this->assertTrue($service->handler()->canBeManaged());
+    }
+
+    public function test_stop_disables_cron_and_start_reenables(): void
+    {
+        SSH::fake('');
+        $service = $this->installGoAccess();
+        app(SyncGoAccessServer::class)->sync($this->server);
+
+        $cron = $this->server->cronJobs()->where('hidden', true)->where('command', GoAccess::CRON_COMMAND)->firstOrFail();
+
+        $service->handler()->manage('stop');
+        $this->assertSame(CronjobStatus::DISABLED, $cron->refresh()->status);
+
+        $service->handler()->manage('start');
+        $this->assertSame(CronjobStatus::READY, $cron->refresh()->status);
+    }
+
+    public function test_service_stop_route_works_for_goaccess(): void
+    {
+        Queue::fake();
+        $this->actingAs($this->user);
+        $service = $this->installGoAccess();
+
+        $this->post(route('services.stop', ['server' => $this->server, 'service' => $service->id]))
+            ->assertSessionDoesntHaveErrors();
+
+        Queue::assertPushed(ManageJob::class);
+    }
+
+    public function test_hidden_cron_survives_empty_crontab_sync(): void
+    {
+        SSH::fake(''); // getUserCrontab returns empty for every user
+
+        $cron = $this->server->cronJobs()->create([
+            'site_id' => null,
+            'user' => 'root',
+            'command' => GoAccess::CRON_COMMAND,
+            'frequency' => GoAccess::CRON_FREQUENCY,
+            'hidden' => true,
+            'status' => CronjobStatus::READY,
+        ]);
+
+        app(\App\Actions\CronJob\SyncCronJobs::class)->sync($this->server);
+
+        $this->assertSame(CronjobStatus::READY, $cron->refresh()->status);
+    }
+}

--- a/tests/Feature/SiteStatsTest.php
+++ b/tests/Feature/SiteStatsTest.php
@@ -193,7 +193,7 @@ class SiteStatsTest extends TestCase
         Queue::assertPushed(CleanupSiteStatsJob::class);
     }
 
-    public function test_sync_creates_hidden_root_cron(): void
+    public function test_sync_creates_named_root_cron(): void
     {
         SSH::fake('');
         $this->installGoAccess();
@@ -203,26 +203,26 @@ class SiteStatsTest extends TestCase
         $this->assertDatabaseHas('cron_jobs', [
             'server_id' => $this->server->id,
             'user' => 'root',
-            'hidden' => true,
+            'hidden' => false,
+            'name' => GoAccess::CRON_NAME,
             'command' => GoAccess::CRON_COMMAND,
             'status' => CronjobStatus::READY->value,
         ]);
     }
 
-    public function test_resync_preserves_disabled_hidden_cron(): void
+    public function test_resync_preserves_disabled_cron(): void
     {
         SSH::fake('');
         $this->installGoAccess();
 
-        $cron = $this->server->cronJobs()->make([
+        $cron = $this->server->cronJobs()->create([
             'site_id' => null,
+            'name' => GoAccess::CRON_NAME,
             'user' => 'root',
             'command' => GoAccess::CRON_COMMAND,
             'frequency' => GoAccess::CRON_FREQUENCY,
             'status' => CronjobStatus::DISABLED,
         ]);
-        $cron->hidden = true;
-        $cron->save();
 
         app(SyncGoAccessServer::class)->sync($this->server);
 
@@ -242,7 +242,7 @@ class SiteStatsTest extends TestCase
         $service = $this->installGoAccess();
         app(SyncGoAccessServer::class)->sync($this->server);
 
-        $cron = $this->server->cronJobs()->where('hidden', true)->where('command', GoAccess::CRON_COMMAND)->firstOrFail();
+        $cron = $this->server->cronJobs()->where('command', GoAccess::CRON_COMMAND)->firstOrFail();
 
         $service->handler()->manage('stop');
         $this->assertSame(CronjobStatus::DISABLED, $cron->refresh()->status);
@@ -338,22 +338,21 @@ class SiteStatsTest extends TestCase
         $this->assertFalse($this->site->statsEnabled());
     }
 
-    public function test_hidden_cron_survives_empty_crontab_sync(): void
+    public function test_stats_cron_is_subject_to_crontab_sync(): void
     {
         SSH::fake(''); // getUserCrontab returns empty for every user
 
-        $cron = $this->server->cronJobs()->make([
+        $cron = $this->server->cronJobs()->create([
             'site_id' => null,
+            'name' => GoAccess::CRON_NAME,
             'user' => 'root',
             'command' => GoAccess::CRON_COMMAND,
             'frequency' => GoAccess::CRON_FREQUENCY,
             'status' => CronjobStatus::READY,
         ]);
-        $cron->hidden = true;
-        $cron->save();
 
         app(SyncCronJobs::class)->sync($this->server);
 
-        $this->assertSame(CronjobStatus::READY, $cron->refresh()->status);
+        $this->assertSame(CronjobStatus::DISABLED, $cron->refresh()->status);
     }
 }

--- a/tests/Feature/SiteStatsTest.php
+++ b/tests/Feature/SiteStatsTest.php
@@ -188,7 +188,7 @@ class SiteStatsTest extends TestCase
         Queue::fake();
         $this->installGoAccess();
 
-        (new HandleSiteDeletedStats)->handle(new SiteDeletedEvent($this->server->id, $this->site->id, $this->site->domain));
+        (new HandleSiteDeletedStats)->handle(new SiteDeletedEvent($this->server, $this->site->id, $this->site->domain));
 
         Queue::assertPushed(CleanupSiteStatsJob::class);
     }
@@ -322,14 +322,15 @@ class SiteStatsTest extends TestCase
     {
         SSH::fake(''); // getUserCrontab returns empty for every user
 
-        $cron = $this->server->cronJobs()->create([
+        $cron = $this->server->cronJobs()->make([
             'site_id' => null,
             'user' => 'root',
             'command' => GoAccess::CRON_COMMAND,
             'frequency' => GoAccess::CRON_FREQUENCY,
-            'hidden' => true,
             'status' => CronjobStatus::READY,
         ]);
+        $cron->hidden = true;
+        $cron->save();
 
         app(SyncCronJobs::class)->sync($this->server);
 

--- a/tests/Feature/SiteStatsTest.php
+++ b/tests/Feature/SiteStatsTest.php
@@ -209,6 +209,26 @@ class SiteStatsTest extends TestCase
         ]);
     }
 
+    public function test_resync_preserves_disabled_hidden_cron(): void
+    {
+        SSH::fake('');
+        $this->installGoAccess();
+
+        $cron = $this->server->cronJobs()->make([
+            'site_id' => null,
+            'user' => 'root',
+            'command' => GoAccess::CRON_COMMAND,
+            'frequency' => GoAccess::CRON_FREQUENCY,
+            'status' => CronjobStatus::DISABLED,
+        ]);
+        $cron->hidden = true;
+        $cron->save();
+
+        app(SyncGoAccessServer::class)->sync($this->server);
+
+        $this->assertSame(CronjobStatus::DISABLED, $cron->refresh()->status);
+    }
+
     public function test_goaccess_can_be_managed(): void
     {
         $service = $this->installGoAccess();

--- a/tests/Feature/SiteStatsTest.php
+++ b/tests/Feature/SiteStatsTest.php
@@ -22,6 +22,7 @@ use App\Listeners\HandleSiteDeletedStats;
 use App\Models\Service;
 use App\Services\LogAnalysis\GoAccess\GoAccess;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Queue;
 use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
@@ -129,6 +130,20 @@ class SiteStatsTest extends TestCase
             ->assertSuccessful()
             ->assertJsonPath('detail.totals.visitors', 200)
             ->assertJsonPath('detail.top_pages.0.name', '/home');
+    }
+
+    public function test_get_site_stats_tolerates_invalid_utf8_in_report(): void
+    {
+        Cache::flush();
+        $report = str_replace('/home', "/home\x80\x81", $this->sampleReport());
+        $this->assertFalse(mb_check_encoding($report, 'UTF-8'));
+        SSH::fake($report);
+
+        $stats = app(GetSiteStats::class)->get($this->site, '2026-05');
+
+        $this->assertNotNull($stats['detail']);
+        $this->assertSame(1000, $stats['detail']['totals']['hits']);
+        $this->assertStringStartsWith('/home', $stats['detail']['top_pages'][0]['name']);
     }
 
     public function test_refresh_requires_service(): void

--- a/tests/Feature/SiteStatsTest.php
+++ b/tests/Feature/SiteStatsTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Actions\CronJob\SyncCronJobs;
+use App\Actions\Site\UpdateSiteStats;
+use App\Actions\SiteStats\GetSiteStats;
 use App\Actions\SiteStats\RenderSiteStatsConf;
 use App\Actions\SiteStats\SyncGoAccessServer;
 use App\Enums\CronjobStatus;
@@ -18,7 +21,6 @@ use App\Listeners\HandleSiteCreatedStats;
 use App\Listeners\HandleSiteDeletedStats;
 use App\Models\Service;
 use App\Services\LogAnalysis\GoAccess\GoAccess;
-use App\Actions\SiteStats\GetSiteStats;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
 use Inertia\Testing\AssertableInertia;
@@ -121,6 +123,7 @@ class SiteStatsTest extends TestCase
     {
         SSH::fake($this->sampleReport());
         $this->actingAs($this->user);
+        $this->installGoAccess();
 
         $this->get(route('site-stats.json', ['server' => $this->server, 'site' => $this->site, 'month' => '2026-05']))
             ->assertSuccessful()
@@ -240,6 +243,81 @@ class SiteStatsTest extends TestCase
         Queue::assertPushed(ManageJob::class);
     }
 
+    public function test_stats_enabled_defaults_true(): void
+    {
+        $this->assertTrue($this->site->statsEnabled());
+    }
+
+    public function test_disable_sets_flag_and_dispatches_cleanup_when_installed(): void
+    {
+        Queue::fake();
+        $this->installGoAccess();
+
+        app(UpdateSiteStats::class)->disable($this->site);
+
+        $this->assertFalse($this->site->refresh()->statsEnabled());
+        $this->assertTrue($this->site->type_data['stats_disabled']);
+        Queue::assertPushed(CleanupSiteStatsJob::class);
+    }
+
+    public function test_disable_without_service_does_not_dispatch(): void
+    {
+        Queue::fake();
+
+        app(UpdateSiteStats::class)->disable($this->site);
+
+        $this->assertFalse($this->site->refresh()->statsEnabled());
+        Queue::assertNotPushed(CleanupSiteStatsJob::class);
+    }
+
+    public function test_enable_unsets_flag_and_dispatches_write_when_installed(): void
+    {
+        Queue::fake();
+        $this->installGoAccess();
+        $this->site->jsonUpdate('type_data', 'stats_disabled', true);
+
+        app(UpdateSiteStats::class)->enable($this->site);
+
+        $this->site->refresh();
+        $this->assertTrue($this->site->statsEnabled());
+        $this->assertArrayNotHasKey('stats_disabled', $this->site->type_data ?? []);
+        Queue::assertPushed(WriteSiteStatsConfJob::class);
+    }
+
+    public function test_disable_route_disables_stats(): void
+    {
+        Queue::fake();
+        $this->actingAs($this->user);
+        $this->installGoAccess();
+
+        $this->post(route('site-settings.disable-stats', ['server' => $this->server, 'site' => $this->site]))
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertFalse($this->site->refresh()->statsEnabled());
+    }
+
+    public function test_json_returns_404_when_stats_disabled(): void
+    {
+        SSH::fake($this->sampleReport());
+        $this->actingAs($this->user);
+        $this->installGoAccess();
+        $this->site->jsonUpdate('type_data', 'stats_disabled', true);
+
+        $this->get(route('site-stats.json', ['server' => $this->server, 'site' => $this->site, 'month' => '2026-05']))
+            ->assertNotFound();
+    }
+
+    public function test_write_conf_job_noop_when_disabled(): void
+    {
+        SSH::fake('');
+        $this->site->jsonUpdate('type_data', 'stats_disabled', true);
+
+        (new WriteSiteStatsConfJob($this->site->refresh()))->handle();
+
+        SSH::assertNotExecutedContains('sites/'.$this->site->id.'.conf');
+        $this->assertFalse($this->site->statsEnabled());
+    }
+
     public function test_hidden_cron_survives_empty_crontab_sync(): void
     {
         SSH::fake(''); // getUserCrontab returns empty for every user
@@ -253,7 +331,7 @@ class SiteStatsTest extends TestCase
             'status' => CronjobStatus::READY,
         ]);
 
-        app(\App\Actions\CronJob\SyncCronJobs::class)->sync($this->server);
+        app(SyncCronJobs::class)->sync($this->server);
 
         $this->assertSame(CronjobStatus::READY, $cron->refresh()->status);
     }


### PR DESCRIPTION
Introduces a new "Service" -> GoAccess.
When installed, "Stats" appear per site.

<img width="1136" height="1201" alt="CleanShot 2026-05-26 at 08 46 51" src="https://github.com/user-attachments/assets/bcd7c931-4ec9-45d6-9cde-fe901b3aa14a" />

Server -> Services -> Install (GoAccess)
Site -> Site Stats -> Refresh
Site -> Settings -> Statistics -> Enable/Disable

Stats updated every hour using GoAccess.  Manual refresh via the stats page.  Disabling stats on a site stops the logs from being analysed. 