### PR TITLE
[Fix] Remove react dupes

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
   resolve: {
     alias: {
       'ziggy-js': resolve(__dirname, 'vendor/tightenco/ziggy'),
+      react: resolve(__dirname, 'node_modules/react'),
+      'react-dom': resolve(__dirname, 'node_modules/react-dom'),
     },
+    dedupe: ['react', 'react-dom'],
   },
 });


### PR DESCRIPTION
Temporary fix for now until forjedio/inertia-table release an NPM package resolving the file: dependency issue for duplicate versions of react.   Issue has been caused by the update to react 19 from react 18, and file: deps from NPM assuming development builds, therefore automatically installing devDeps, etc. 