### PR TITLE
[Fix] GoAccess ignore historical compressed files

### DIFF
--- a/app/Services/LogAnalysis/GoAccess/GoAccess.php
+++ b/app/Services/LogAnalysis/GoAccess/GoAccess.php
@@ -21,7 +21,7 @@ class GoAccess extends AbstractService
 
     public const CRON_FREQUENCY = '0 * * * *';
 
-    public const SCRIPT_VERSION = 1;
+    public const SCRIPT_VERSION = 2;
 
     public const CONF_VERSION = 1;
 

--- a/resources/views/ssh/services/log_analysis/goaccess/bin/process.blade.php
+++ b/resources/views/ssh/services/log_analysis/goaccess/bin/process.blade.php
@@ -61,8 +61,19 @@ process_month() {
         fi
     else
         # Normal path: direct-file incremental (GoAccess tracks inode/offset).
+        # Feed only uncompressed logs — GoAccess reads rotated *.gz files as
+        # binary and aborts the run. Compressed rotations were already ingested
+        # by earlier runs, and the boundary window above re-reads them via
+        # `zcat -f` when crossing months.
+        local files=() f
         # shellcheck disable=SC2086
-        goaccess $LOG_GLOB --log-format="$LOG_FORMAT" --persist --restore --db-path="$db" -o "$out" --date-spec=date --no-progress
+        for f in $LOG_GLOB; do
+            [ -e "$f" ] || continue
+            case "$f" in *.gz) continue ;; esac
+            files+=("$f")
+        done
+        [ "${#files[@]}" -gt 0 ] || return 0
+        goaccess "${files[@]}" --log-format="$LOG_FORMAT" --persist --restore --db-path="$db" -o "$out" --date-spec=date --no-progress
     fi
 }
 


### PR DESCRIPTION
This pull request makes a minor update to the `GoAccess` log analysis service, ignoring compressed log files, as these will have already been read, but during boundary crossing are read via zcat -f.   Fixes a critical failure on log file ingestion over multiple months. 

To apply the fix to an existing server, navigate to Server -> Services -> GoAccess -> ... -> Re-sync stats scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log analysis processing to filter and handle compressed log files separately, now processing only uncompressed files.
  * Updated log analysis service version identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->