### PR TITLE
[Fix] Remove "Link" header

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -23,7 +23,6 @@ use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Foundation\Http\Middleware\ValidatePostSize;
-use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 use Illuminate\Http\Middleware\HandleCors;
 use Illuminate\Http\Middleware\SetCacheHeaders;
 use Illuminate\Routing\Middleware\SubstituteBindings;
@@ -68,7 +67,6 @@ class Kernel extends HttpKernel
             SubstituteBindings::class,
             HandleInertiaRequests::class,
             HandleAppearance::class,
-            AddLinkHeadersForPreloadedAssets::class,
         ],
 
         'api' => [


### PR DESCRIPTION
Removes the "Link" header to remove the need to set NGINX proxy_buffer_size/proxy_buffers/proxy_busy_buffers_size from reverse proxy configurations. 

Vite still injects preloads into the <HEAD> of the application, allowing the application to lazily load assets prior to the complete rendering of the application. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a middleware from the web middleware stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->