### PR TITLE
[Fix] Resolves issue with GitHub App Auto Creation

### DIFF
--- a/app/Actions/GithubApp/CreateGithubAppFromManifest.php
+++ b/app/Actions/GithubApp/CreateGithubAppFromManifest.php
@@ -5,6 +5,7 @@ namespace App\Actions\GithubApp;
 use App\Actions\Bootstrap\GetBootstrap;
 use App\Models\GithubApp;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\ValidationException;
 
 class CreateGithubAppFromManifest
@@ -20,12 +21,21 @@ class CreateGithubAppFromManifest
         $response = Http::withHeaders([
             'Accept' => 'application/vnd.github+json',
             'X-GitHub-Api-Version' => '2022-11-28',
-        ])->post("https://api.github.com/app-manifests/{$code}/conversions");
+            'User-Agent' => 'Vito',
+        ])->send('POST', "https://api.github.com/app-manifests/{$code}/conversions");
 
         if (! $response->successful()) {
+            Log::error('GitHub App manifest conversion failed', [
+                'status' => $response->status(),
+                'body' => $response->body(),
+            ]);
+
+            $message = (string) ($response->json('message') ?? '');
+
             throw ValidationException::withMessages([
-                'github_app' => __('Failed to convert manifest (HTTP :status).', [
+                'github_app' => __('Failed to convert manifest (HTTP :status):status_message.', [
                     'status' => $response->status(),
+                    'status_message' => $message !== '' ? ' '.$message : '',
                 ]),
             ]);
         }

--- a/tests/Feature/GithubAppTest.php
+++ b/tests/Feature/GithubAppTest.php
@@ -77,6 +77,11 @@ class GithubAppTest extends TestCase
             'app_id' => 12345,
             'app_slug' => 'vito-test',
         ]);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://api.github.com/app-manifests/test-code/conversions'
+                && $request->body() === '';
+        });
     }
 
     public function test_manifest_callback_rejects_missing_code(): void


### PR DESCRIPTION
Github App automatic creation currently fails with the error: `links/0/schema', [] is not a null or object.`

This was due to Laravel automatically sending and empty array on post, whereas Github expects a null or empty string.  This PR resolves this by moving to sending the post manually instead of using the ->post helper. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for GitHub app creation from manifest, with more informative error messages that include API response details.
  * Added detailed logging for failed manifest conversion requests to improve troubleshooting and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->