### PR TITLE
[Feat] More tooling + Blank (Reverse Proxy) site type

### DIFF
--- a/app/Actions/Site/Deploy.php
+++ b/app/Actions/Site/Deploy.php
@@ -4,6 +4,7 @@ namespace App\Actions\Site;
 
 use App\Enums\DeploymentStatus;
 use App\Exceptions\DeploymentScriptIsEmptyException;
+use App\Exceptions\ReverseProxyNotConfiguredException;
 use App\Jobs\Site\DeployJob;
 use App\Models\Deployment;
 use App\Models\ServerLog;
@@ -13,9 +14,12 @@ class Deploy
 {
     /**
      * @throws DeploymentScriptIsEmptyException
+     * @throws ReverseProxyNotConfiguredException
      */
     public function run(Site $site, bool $modern = true): Deployment
     {
+        $site->type()->assertReadyToDeploy();
+
         if ($site->sourceControl) {
             $site->sourceControl->getRepo($site->repository);
         }

--- a/app/Exceptions/ReverseProxyNotConfiguredException.php
+++ b/app/Exceptions/ReverseProxyNotConfiguredException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+
+class ReverseProxyNotConfiguredException extends Exception
+{
+    public function render(Request $request): RedirectResponse
+    {
+        $message = $this->getMessage() !== ''
+            ? $this->getMessage()
+            : 'Please set a port and a start command before deploying this site.';
+
+        if ($request->header('X-Inertia')) {
+            return back()->with('error', $message);
+        }
+
+        throw ValidationException::withMessages([
+            'deployment' => $message,
+        ]);
+    }
+}

--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -9,6 +9,7 @@ use App\Actions\Site\UpdateEnv;
 use App\Actions\Site\UpdateLoadBalancer;
 use App\Exceptions\DeploymentScriptIsEmptyException;
 use App\Exceptions\FailedToDestroyGitHook;
+use App\Exceptions\ReverseProxyNotConfiguredException;
 use App\Exceptions\SourceControlIsNotConnected;
 use App\Exceptions\SSHError;
 use App\Helpers\EnvParser;
@@ -73,6 +74,7 @@ class ApplicationController extends Controller
 
     /**
      * @throws DeploymentScriptIsEmptyException
+     * @throws ReverseProxyNotConfiguredException
      */
     #[Post('/deploy', name: 'application.deploy')]
     public function deploy(Server $server, Site $site): RedirectResponse

--- a/app/Jobs/Site/Tooling/InstallSiteToolingJob.php
+++ b/app/Jobs/Site/Tooling/InstallSiteToolingJob.php
@@ -11,6 +11,7 @@ use App\Traits\UniqueQueue;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use RuntimeException;
 use Throwable;
 
 class InstallSiteToolingJob implements ShouldBeUnique, ShouldQueue
@@ -39,7 +40,7 @@ class InstallSiteToolingJob implements ShouldBeUnique, ShouldQueue
             $tool = ToolingRegistry::find($this->toolId);
 
             if (! $tool) {
-                return;
+                throw new RuntimeException("Tooling '{$this->toolId}' is not registered; it may have been removed or the worker is out of sync.");
             }
 
             $tool->install($this->site, $this->version);

--- a/app/Jobs/Site/Tooling/UninstallSiteToolingJob.php
+++ b/app/Jobs/Site/Tooling/UninstallSiteToolingJob.php
@@ -11,6 +11,7 @@ use App\Traits\UniqueQueue;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use RuntimeException;
 use Throwable;
 
 class UninstallSiteToolingJob implements ShouldBeUnique, ShouldQueue
@@ -38,7 +39,7 @@ class UninstallSiteToolingJob implements ShouldBeUnique, ShouldQueue
             $tool = ToolingRegistry::find($this->toolId);
 
             if (! $tool) {
-                return;
+                throw new RuntimeException("Tooling '{$this->toolId}' is not registered; it may have been removed or the worker is out of sync.");
             }
 
             $tool->uninstall($this->site);

--- a/app/Providers/SiteTypeServiceProvider.php
+++ b/app/Providers/SiteTypeServiceProvider.php
@@ -11,6 +11,7 @@ use App\Plugins\RegisterSiteType;
 use App\SiteFeatures\ModernDeployment\Configuration;
 use App\SiteFeatures\ModernDeployment\Disable;
 use App\SiteFeatures\ModernDeployment\Enable;
+use App\SiteTypes\Blank;
 use App\SiteTypes\BunSite;
 use App\SiteTypes\Laravel;
 use App\SiteTypes\LoadBalancer;
@@ -37,6 +38,7 @@ class SiteTypeServiceProvider extends ServiceProvider
         $this->nodeJS();
         $this->nodeSite();
         $this->bunSite();
+        $this->blank();
         $this->loadBalancer();
         $this->phpMyAdmin();
         $this->wordpress();
@@ -192,6 +194,15 @@ class SiteTypeServiceProvider extends ServiceProvider
             ->label('Bun')
             ->handler(BunSite::class)
             ->form(DynamicForm::make(BunSite::formFields()))
+            ->register();
+    }
+
+    private function blank(): void
+    {
+        RegisterSiteType::make(Blank::id())
+            ->label('Blank')
+            ->handler(Blank::class)
+            ->form(DynamicForm::make(Blank::formFields()))
             ->register();
     }
 

--- a/app/Providers/SiteTypeServiceProvider.php
+++ b/app/Providers/SiteTypeServiceProvider.php
@@ -200,7 +200,7 @@ class SiteTypeServiceProvider extends ServiceProvider
     private function blank(): void
     {
         RegisterSiteType::make(Blank::id())
-            ->label('Blank')
+            ->label('Blank (Reverse Proxy)')
             ->handler(Blank::class)
             ->form(DynamicForm::make(Blank::formFields()))
             ->register();

--- a/app/Providers/ToolingServiceProvider.php
+++ b/app/Providers/ToolingServiceProvider.php
@@ -4,8 +4,10 @@ namespace App\Providers;
 
 use App\Tooling\BunTooling;
 use App\Tooling\ComposerTooling;
+use App\Tooling\DotnetTooling;
 use App\Tooling\NodeTooling;
 use App\Tooling\PnpmTooling;
+use App\Tooling\PythonTooling;
 use App\Tooling\YarnTooling;
 use Illuminate\Support\ServiceProvider;
 
@@ -19,6 +21,8 @@ class ToolingServiceProvider extends ServiceProvider
                 BunTooling::class,
                 PnpmTooling::class,
                 YarnTooling::class,
+                PythonTooling::class,
+                DotnetTooling::class,
                 ComposerTooling::class,
             ],
         ]);

--- a/app/SiteTypes/AbstractProxiedSiteType.php
+++ b/app/SiteTypes/AbstractProxiedSiteType.php
@@ -5,6 +5,7 @@ namespace App\SiteTypes;
 use App\Actions\Worker\CreateWorker;
 use App\DTOs\DynamicField;
 use App\Exceptions\FailedToDeployGitKey;
+use App\Exceptions\ReverseProxyNotConfiguredException;
 use App\Exceptions\SSHError;
 use App\Models\Deployment;
 use App\Models\SourceControl;
@@ -27,6 +28,25 @@ abstract class AbstractProxiedSiteType extends AbstractSiteType
         return [];
     }
 
+    public function assertReadyToDeploy(): void
+    {
+        $missing = [];
+
+        if (empty($this->site->port)) {
+            $missing[] = 'a port';
+        }
+
+        if ($this->startCommand() === '') {
+            $missing[] = 'a start command';
+        }
+
+        if ($missing !== []) {
+            throw new ReverseProxyNotConfiguredException(
+                'Please set '.implode(' and ', $missing).' before deploying this site.'
+            );
+        }
+    }
+
     public function vhostData(): array
     {
         return ['is_reverse_proxy' => true];
@@ -46,7 +66,7 @@ abstract class AbstractProxiedSiteType extends AbstractSiteType
     public function createFields(array $input): array
     {
         return [
-            'source_control_id' => $input['source_control'] ?? '',
+            'source_control_id' => ! empty($input['source_control']) ? $input['source_control'] : null,
             'repository' => $input['repository'] ?? '',
             'branch' => $input['branch'] ?? '',
             'port' => $input['port'] ?? '',
@@ -59,14 +79,14 @@ abstract class AbstractProxiedSiteType extends AbstractSiteType
     public static function sharedFormFields(): array
     {
         return [
-            DynamicField::make('source_control')
-                ->component()
-                ->label('Source Control'),
             DynamicField::make('port')
                 ->text()
                 ->label('Port')
                 ->placeholder('3000')
                 ->description('On which port your app will be running. Must be a non-privileged port (1024-65535).'),
+            DynamicField::make('source_control')
+                ->component()
+                ->label('Source Control'),
             DynamicField::make('repository')
                 ->text()
                 ->label('Repository')

--- a/app/SiteTypes/AbstractSiteType.php
+++ b/app/SiteTypes/AbstractSiteType.php
@@ -86,6 +86,11 @@ abstract class AbstractSiteType implements SiteType
         //
     }
 
+    public function assertReadyToDeploy(): void
+    {
+        //
+    }
+
     public function defaultDeploymentScript(): string
     {
         $path = resource_path('deployment-scripts/'.static::id().'.sh');
@@ -125,7 +130,11 @@ abstract class AbstractSiteType implements SiteType
      */
     protected function deployKey(): void
     {
-        if ($this->site->sourceControl?->isGithubApp()) {
+        if (! $this->site->sourceControl) {
+            return;
+        }
+
+        if ($this->site->sourceControl->isGithubApp()) {
             return;
         }
 
@@ -204,6 +213,10 @@ abstract class AbstractSiteType implements SiteType
      */
     protected function cloneRepository(): void
     {
+        if (! $this->site->repository) {
+            return;
+        }
+
         if ($this->repositoryAlreadyCloned()) {
             return;
         }

--- a/app/SiteTypes/Blank.php
+++ b/app/SiteTypes/Blank.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\SiteTypes;
+
+use App\DTOs\DynamicField;
+use App\Models\Deployment;
+use App\Models\Site;
+
+class Blank extends AbstractProxiedSiteType
+{
+    public static function id(): string
+    {
+        return 'blank';
+    }
+
+    public function language(): string
+    {
+        return 'blank';
+    }
+
+    public static function make(): self
+    {
+        return new self(new Site(['type' => self::id()]));
+    }
+
+    /**
+     * @return array<int, DynamicField>
+     */
+    public static function formFields(): array
+    {
+        return parent::sharedFormFields();
+    }
+
+    public function data(array $input): array
+    {
+        return [
+            'start_command' => ! empty($input['start_command']) ? $input['start_command'] : '',
+        ];
+    }
+
+    public function afterDeploy(Deployment $deployment): void
+    {
+        if ($this->startCommand() === '') {
+            return;
+        }
+
+        parent::afterDeploy($deployment);
+    }
+
+    protected function defaultStartCommand(): string
+    {
+        return '';
+    }
+}

--- a/app/SiteTypes/Blank.php
+++ b/app/SiteTypes/Blank.php
@@ -5,6 +5,7 @@ namespace App\SiteTypes;
 use App\DTOs\DynamicField;
 use App\Models\Deployment;
 use App\Models\Site;
+use App\Models\SourceControl;
 
 class Blank extends AbstractProxiedSiteType
 {
@@ -28,7 +29,42 @@ class Blank extends AbstractProxiedSiteType
      */
     public static function formFields(): array
     {
-        return parent::sharedFormFields();
+        $shared = parent::sharedFormFields();
+
+        return [
+            array_shift($shared),
+            DynamicField::make('use_source_control')
+                ->checkbox()
+                ->label('Add source control')
+                ->description('Deploy this site from a Git repository.')
+                ->default(false),
+            ...$shared,
+        ];
+    }
+
+    public function createRules(array $input): array
+    {
+        $rules = [
+            'port' => ['required', 'integer', 'between:1024,65535'],
+            'start_command' => ['nullable', 'string', 'max:255', 'not_regex:/[\r\n]/'],
+        ];
+
+        if (! empty($input['use_source_control'])) {
+            $rules['source_control'] = SourceControl::siteValidationRules($this->site->server);
+            $rules['repository'] = ['required'];
+            $rules['branch'] = ['required'];
+        }
+
+        return $rules;
+    }
+
+    public function defaultDeploymentScript(): string
+    {
+        if (! $this->site->repository) {
+            return '';
+        }
+
+        return parent::defaultDeploymentScript();
     }
 
     public function data(array $input): array

--- a/app/SiteTypes/SiteType.php
+++ b/app/SiteTypes/SiteType.php
@@ -36,6 +36,8 @@ interface SiteType
 
     public function install(): void;
 
+    public function assertReadyToDeploy(): void;
+
     /**
      * @return array<array<string, string>>
      */

--- a/app/Tooling/DotnetTooling.php
+++ b/app/Tooling/DotnetTooling.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Tooling;
+
+class DotnetTooling extends AbstractMiseTooling
+{
+    public static function id(): string
+    {
+        return 'dotnet';
+    }
+
+    public static function label(): string
+    {
+        return '.NET';
+    }
+
+    public static function description(): string
+    {
+        return '.NET SDK used to build and run ASP.NET applications during deployment.';
+    }
+
+    public static function supportedVersions(): array
+    {
+        return ['10', '9', '8'];
+    }
+
+    public static function commands(): array
+    {
+        return ['dotnet'];
+    }
+}

--- a/app/Tooling/PythonTooling.php
+++ b/app/Tooling/PythonTooling.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Tooling;
+
+class PythonTooling extends AbstractMiseTooling
+{
+    public static function id(): string
+    {
+        return 'python';
+    }
+
+    public static function label(): string
+    {
+        return 'Python';
+    }
+
+    public static function description(): string
+    {
+        return 'Python runtime used to run Python applications and tools during deployment.';
+    }
+
+    public static function supportedVersions(): array
+    {
+        return ['3.14', '3.13', '3.12', '3.11'];
+    }
+
+    public static function commands(): array
+    {
+        return ['python', 'python3', 'pip', 'pip3'];
+    }
+}

--- a/resources/js/pages/application/components/deploy.tsx
+++ b/resources/js/pages/application/components/deploy.tsx
@@ -26,6 +26,8 @@ export default function Deploy({ site, children }: { site: Site; children: React
   }>();
   const form = useForm();
 
+  const reverseProxyMisconfigured = site.is_proxied_site_type && (!site.port || !site.start_command);
+
   const submit = () => {
     form.post(route('application.deploy', { server: site.server_id, site: site.id }), {
       onSuccess: () => {
@@ -60,13 +62,23 @@ export default function Deploy({ site, children }: { site: Site; children: React
               <AlertDescription>Your pre flight script is empty!</AlertDescription>
             </Alert>
           )}
+          {reverseProxyMisconfigured && (
+            <Alert variant="destructive">
+              <TriangleAlert />
+              <AlertDescription>
+                Set {!site.port && 'a port'}
+                {!site.port && !site.start_command && ' and '}
+                {!site.start_command && 'a start command'} before deploying this site.
+              </AlertDescription>
+            </Alert>
+          )}
           <p>Are you sure you want to deploy this site?</p>
         </div>
         <DialogFooter>
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
           </DialogClose>
-          <Button disabled={form.processing} onClick={submit}>
+          <Button disabled={form.processing || reverseProxyMisconfigured} onClick={submit}>
             {form.processing && <LoaderCircleIcon className="animate-spin" />}
             <FormSuccessful successful={form.recentlySuccessful} />
             Deploy

--- a/resources/js/pages/sites/components/create-site.tsx
+++ b/resources/js/pages/sites/components/create-site.tsx
@@ -147,8 +147,14 @@ export default function CreateSite({
   useEffect(() => {
     const typeConfig = configs.site.types[form.data.type];
 
+    const sourceControlFields = ['source_control', 'repository', 'branch'];
+    const sourceControlOff = typeConfig?.form?.some((f) => f.name === 'use_source_control') && !form.data.use_source_control;
+
     if (typeConfig?.form) {
       typeConfig.form.forEach((field: DynamicFieldConfig) => {
+        if (sourceControlOff && sourceControlFields.includes(field.name)) {
+          return;
+        }
         if (field.default !== undefined) {
           if (form.data[field.name] === '' || form.data[field.name] === undefined) {
             form.setData(field.name, field.default);
@@ -156,7 +162,7 @@ export default function CreateSite({
         }
       });
     }
-  }, [form.data.type, form.setData, configs]);
+  }, [form.data.type, form.data.use_source_control, form.setData, configs]);
 
   const selectedIsolatedUser = useMemo<IsolatedUserOption | null>(
     () => (isolatedUsersQuery.data ?? []).find((u) => u.user === form.data.user) ?? null,
@@ -214,7 +220,25 @@ export default function CreateSite({
     });
   }, [activeTools, lockedVersions, form.data, form.setData, configs]);
 
+  const hasSourceControlToggle = useMemo<boolean>(
+    () => (configs.site.types[form.data.type]?.form ?? []).some((f) => f.name === 'use_source_control'),
+    [configs, form.data.type],
+  );
+  const sourceControlEnabled = !hasSourceControlToggle || !!form.data.use_source_control;
+
+  useEffect(() => {
+    if (hasSourceControlToggle && !form.data.use_source_control) {
+      if (form.data.source_control) form.setData('source_control', '');
+      if (form.data.repository) form.setData('repository', '');
+      if (form.data.branch) form.setData('branch', '');
+    }
+  }, [hasSourceControlToggle, form.data.use_source_control, form.data.source_control, form.data.repository, form.data.branch, form.setData]);
+
   const getFormField = (field: DynamicFieldConfig) => {
+    if (!sourceControlEnabled && (field.name === 'source_control' || field.name === 'repository' || field.name === 'branch')) {
+      return null;
+    }
+
     if (field.name === 'source_control') {
       return (
         <FormField key={`field-${field.name}`}>

--- a/tests/Feature/ApplicationTest.php
+++ b/tests/Feature/ApplicationTest.php
@@ -10,6 +10,7 @@ use App\Models\GitHook;
 use App\Models\Site;
 use App\Models\Worker;
 use App\Notifications\DeploymentCompleted;
+use App\SiteTypes\Blank;
 use App\SiteTypes\NodeSite;
 use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -146,6 +147,56 @@ class ApplicationTest extends TestCase
         SSH::assertExecutedContains('git pull');
 
         Notification::assertSentTo($this->notificationChannel, DeploymentCompleted::class);
+    }
+
+    public function test_deploy_reverse_proxy_without_port_and_start_command_shows_error(): void
+    {
+        SSH::fake();
+        $this->actingAs($this->user);
+
+        /** @var Site $proxied */
+        $proxied = Site::factory()->create([
+            'server_id' => $this->server->id,
+            'type' => Blank::id(),
+            'port' => null,
+            'type_data' => [],
+        ]);
+
+        $this->withHeader('X-Inertia', 'true')
+            ->post(route('application.deploy', [
+                'server' => $this->server,
+                'site' => $proxied,
+            ]))->assertSessionHas('error');
+
+        $this->assertDatabaseMissing('deployments', [
+            'site_id' => $proxied->id,
+        ]);
+    }
+
+    public function test_deploy_reverse_proxy_with_port_and_start_command_is_allowed(): void
+    {
+        SSH::fake('fake output');
+        Notification::fake();
+        $this->actingAs($this->user);
+
+        /** @var Site $proxied */
+        $proxied = Site::factory()->create([
+            'server_id' => $this->server->id,
+            'type' => Blank::id(),
+            'port' => 3000,
+            'type_data' => ['start_command' => 'node app.js'],
+        ]);
+
+        $proxied->deploymentScript->update(['content' => 'echo deploy']);
+
+        $this->post(route('application.deploy', [
+            'server' => $this->server,
+            'site' => $proxied,
+        ]))->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('deployments', [
+            'site_id' => $proxied->id,
+        ]);
     }
 
     public function test_deploy_modern(): void

--- a/tests/Feature/SiteToolingTest.php
+++ b/tests/Feature/SiteToolingTest.php
@@ -301,6 +301,31 @@ class SiteToolingTest extends TestCase
         $this->assertSame('uninstall_failed', $iuser->toolingStatus('node'));
     }
 
+    public function test_install_marks_failed_when_tool_missing_from_registry(): void
+    {
+        Event::fake([SocketEvent::class]);
+
+        $this->iuser()->setToolingStatus('ghost-tool', SiteToolingState::STATUS_INSTALLING);
+
+        dispatch_sync(new InstallSiteToolingJob($this->isolatedSite, 'ghost-tool', '1.0'));
+
+        $this->assertSame('install_failed', $this->iuser()->toolingStatus('ghost-tool'));
+
+        Event::assertDispatched(
+            SocketEvent::class,
+            fn (SocketEvent $event) => $event->data->type === 'isolated-user.tooling-updated',
+        );
+    }
+
+    public function test_uninstall_marks_failed_when_tool_missing_from_registry(): void
+    {
+        $this->iuser()->setToolingStatus('ghost-tool', SiteToolingState::STATUS_UNINSTALLING);
+
+        dispatch_sync(new UninstallSiteToolingJob($this->isolatedSite, 'ghost-tool'));
+
+        $this->assertSame('uninstall_failed', $this->iuser()->toolingStatus('ghost-tool'));
+    }
+
     public function test_complete_install_broadcasts_tooling_updated(): void
     {
         Event::fake([SocketEvent::class]);

--- a/tests/Feature/SiteToolingTest.php
+++ b/tests/Feature/SiteToolingTest.php
@@ -319,11 +319,18 @@ class SiteToolingTest extends TestCase
 
     public function test_uninstall_marks_failed_when_tool_missing_from_registry(): void
     {
+        Event::fake([SocketEvent::class]);
+
         $this->iuser()->setToolingStatus('ghost-tool', SiteToolingState::STATUS_UNINSTALLING);
 
         dispatch_sync(new UninstallSiteToolingJob($this->isolatedSite, 'ghost-tool'));
 
         $this->assertSame('uninstall_failed', $this->iuser()->toolingStatus('ghost-tool'));
+
+        Event::assertDispatched(
+            SocketEvent::class,
+            fn (SocketEvent $event) => $event->data->type === 'isolated-user.tooling-updated',
+        );
     }
 
     public function test_complete_install_broadcasts_tooling_updated(): void

--- a/tests/Feature/SitesTest.php
+++ b/tests/Feature/SitesTest.php
@@ -11,6 +11,7 @@ use App\Models\DatabaseUser;
 use App\Models\Service;
 use App\Models\Site;
 use App\Models\SourceControl;
+use App\SiteTypes\Blank;
 use App\SiteTypes\BunSite;
 use App\SiteTypes\Laravel;
 use App\SiteTypes\LoadBalancer;
@@ -340,6 +341,48 @@ class SitesTest extends TestCase
             'domain' => 'example.com',
             'status' => SiteStatus::READY,
         ]);
+    }
+
+    public function test_create_blank_site_without_source_control(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+
+        $this->post(route('sites.store', ['server' => $this->server]), [
+            'type' => Blank::id(),
+            'domain' => 'blank-example.com',
+            'port' => '3000',
+            'user' => 'blanktest',
+        ])->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('sites', [
+            'domain' => 'blank-example.com',
+            'status' => SiteStatus::READY->value,
+            'user' => 'blanktest',
+            'source_control_id' => null,
+        ]);
+    }
+
+    public function test_create_blank_site_with_source_control_requires_repository(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+        /** @var SourceControl $sourceControl */
+        $sourceControl = SourceControl::factory()->create([
+            'provider' => Github::id(),
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->post(route('sites.store', ['server' => $this->server]), [
+            'type' => Blank::id(),
+            'domain' => 'blank-sc.com',
+            'port' => '3000',
+            'user' => 'blanksc',
+            'use_source_control' => true,
+            'source_control' => $sourceControl->id,
+        ])->assertSessionHasErrors(['repository', 'branch']);
     }
 
     public function test_create_laravel_site_dispatches_ensure_env_script(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Blank (Reverse Proxy)" site type for reverse proxy deployments
  * Added Python and .NET tooling support
  * Introduced deployment readiness validation requiring port and start command configuration for proxied sites
  * Added UI alert warning when reverse proxy configuration is incomplete before deployment

* **Bug Fixes**
  * Improved error handling when tooling is missing from the registry during installation and uninstallation

* **Tests**
  * Added test coverage for reverse proxy deployment validation
  * Added test coverage for blank site creation with and without source control
  * Added test coverage for tooling failure scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->