### PR TITLE
Fix env secrets being lost after pulling from server and saving

### DIFF
--- a/app/Actions/Site/GetEnv.php
+++ b/app/Actions/Site/GetEnv.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Actions\Site;
+
+use App\Helpers\EnvParser;
+use App\Models\Site;
+
+class GetEnv
+{
+    /**
+     * Read the live .env file and return it alongside its variables classified
+     * against the persisted secret keys, with secret values masked for display.
+     *
+     * @return array{env: string, variables: array<int, array{key: string, value: string, is_secret: bool}>}
+     */
+    public function get(Site $site): array
+    {
+        $env = $site->getEnv();
+
+        $variables = EnvParser::maskSecrets(
+            EnvParser::classify(EnvParser::parse($env), $site->env_variables)
+        );
+
+        return [
+            'env' => $env,
+            'variables' => $variables,
+        ];
+    }
+}

--- a/app/Actions/Site/UpdateEnv.php
+++ b/app/Actions/Site/UpdateEnv.php
@@ -39,76 +39,125 @@ class UpdateEnv
             ]);
         }
 
-        $variables = $this->processVariables($site, $input);
-
-        $envContent = EnvParser::stringify($variables);
+        $variables = $this->resolveVariables($site, $input, $path);
 
         $site->server->os()->write(
             $path,
-            $envContent,
+            EnvParser::stringify($variables),
             $site->user,
         );
 
-        $site->env_variables = $variables;
+        $site->env_variables = $this->secretKeys($variables);
         $site->save();
 
         $site->jsonUpdate('type_data', 'env_path', $path);
     }
 
     /**
-     * Process incoming variables, merging with stored secrets
+     * Build the variables to write to the .env file. Values are taken from the
+     * incoming request, restoring masked secrets from the live server file so a
+     * secret left empty in the form is never wiped.
+     *
+     * A key already stored as secret cannot be wiped by submitting it as a
+     * non-secret with an empty value: while the submitted value is empty it
+     * stays secret so its live value is restored rather than blanked. To make a
+     * secret key non-secret the user drops it and re-adds it with a fresh value,
+     * which is honoured because a real value is supplied.
+     *
+     * The raw-text path has no per-field secret toggle, so existing secret
+     * classifications are carried over and newly introduced keys fall back to
+     * pattern auto-detection. It writes the submitted content verbatim — no
+     * secret restoration is performed, so callers must supply real values.
      *
      * @param  array<string, mixed>  $input
      * @return array<int, array{key: string, value: string, is_secret: bool}>
+     *
+     * @throws SSHError
      */
-    private function processVariables(Site $site, array $input): array
+    private function resolveVariables(Site $site, array $input, string $path): array
     {
-        $existing = $this->existingVariables($site);
+        $secretKeys = array_flip(EnvParser::secretKeys($site->env_variables));
 
         if (isset($input['variables']) && is_array($input['variables'])) {
-            $incoming = array_map(function ($var) {
+            $live = EnvParser::parse($site->getEnv($path));
+
+            $this->guardAgainstWipingSecrets($input['variables'], $live, $secretKeys);
+
+            $incoming = array_map(function ($var) use ($secretKeys): array {
+                $key = $var['key'] ?? '';
+                $value = $var['value'] ?? '';
+                $isSecret = (bool) ($var['is_secret'] ?? false);
+
+                if ($value === '' && isset($secretKeys[$key])) {
+                    $isSecret = true;
+                }
+
                 return [
-                    'key' => $var['key'] ?? '',
-                    'value' => $var['value'] ?? '',
-                    'is_secret' => (bool) ($var['is_secret'] ?? false),
+                    'key' => $key,
+                    'value' => $value,
+                    'is_secret' => $isSecret,
                 ];
             }, $input['variables']);
 
-            return EnvParser::mergeWithStored($incoming, $existing);
+            return EnvParser::mergeWithLive($incoming, $live);
         }
 
-        $parsed = EnvParser::parse(trim((string) $input['env']));
+        return array_map(function ($variable) use ($secretKeys) {
+            $variable['is_secret'] = $variable['is_secret'] || isset($secretKeys[$variable['key']]);
 
-        return EnvParser::reconcileWithStored($parsed, $existing);
+            return $variable;
+        }, EnvParser::parse(trim((string) $input['env'])));
     }
 
     /**
-     * Build the existing variables used to restore masked secrets and classify
-     * keys: values come from the live .env file on the server (the source of
-     * truth), falling back to the database copy so a transient read failure can
-     * never wipe a secret. The user-defined `is_secret` flag stored in the
-     * database always wins over auto-detection on the live file.
+     * Guard against silently wiping a previously stored secret. Such a secret
+     * submitted with an empty value relies on its value being restored from the
+     * live server file; if the file could not be read (an SSH failure is
+     * swallowed by getEnv() and yields an empty parse) we would write it out
+     * blank. Abort instead so the user can retry rather than lose the value.
      *
-     * @return array<int, array{key: string, value: string, is_secret: bool}>
+     * Only keys already stored as secret are guarded — a brand-new key submitted
+     * empty has no value to lose, so an empty live file is treated as legitimate.
+     *
+     * @param  array<int, array<string, mixed>>  $incoming
+     * @param  array<int, array{key: string, value: string, is_secret: bool}>  $live
+     * @param  array<string, int>  $secretKeys
      */
-    private function existingVariables(Site $site): array
+    private function guardAgainstWipingSecrets(array $incoming, array $live, array $secretKeys): void
     {
-        $map = [];
-
-        foreach ($site->env_variables ?? [] as $variable) {
-            $map[$variable['key']] = $variable;
+        if ($live !== []) {
+            return;
         }
 
-        foreach (EnvParser::parse($site->getEnv()) as $variable) {
-            $key = $variable['key'];
+        foreach ($incoming as $var) {
+            $key = $var['key'] ?? '';
+            $isEmpty = ($var['value'] ?? '') === '';
 
-            if (isset($map[$key])) {
-                $variable['is_secret'] = $map[$key]['is_secret'];
+            if ($isEmpty && isset($secretKeys[$key])) {
+                throw ValidationException::withMessages([
+                    'variables' => __('Could not read the current .env file from the server to preserve secret values. Please try again.'),
+                ]);
             }
+        }
+    }
 
-            $map[$key] = $variable;
+    /**
+     * Collect the list of keys marked as secret. Only this list is persisted to
+     * the database — env values themselves always live on the server.
+     *
+     * @param  array<int, array{key: string, value: string, is_secret: bool}>  $variables
+     * @return array<int, string>
+     */
+    private function secretKeys(array $variables): array
+    {
+        $keys = [];
+
+        foreach ($variables as $variable) {
+            if ($variable['is_secret'] && $variable['key'] !== '') {
+                $keys[] = $variable['key'];
+            }
         }
 
-        return array_values($map);
+        return array_values(array_unique($keys));
     }
 }

--- a/app/Actions/Site/UpdateEnv.php
+++ b/app/Actions/Site/UpdateEnv.php
@@ -63,6 +63,8 @@ class UpdateEnv
      */
     private function processVariables(Site $site, array $input): array
     {
+        $existing = $this->existingVariables($site);
+
         if (isset($input['variables']) && is_array($input['variables'])) {
             $incoming = array_map(function ($var) {
                 return [
@@ -72,26 +74,41 @@ class UpdateEnv
                 ];
             }, $input['variables']);
 
-            return EnvParser::mergeWithStored($incoming, $site->env_variables);
+            return EnvParser::mergeWithStored($incoming, $existing);
         }
 
         $parsed = EnvParser::parse(trim((string) $input['env']));
 
-        if ($site->env_variables) {
-            $storedMap = [];
-            foreach ($site->env_variables as $var) {
-                $storedMap[$var['key']] = $var;
-            }
+        return EnvParser::reconcileWithStored($parsed, $existing);
+    }
 
-            return array_map(function ($var) use ($storedMap) {
-                if (isset($storedMap[$var['key']])) {
-                    $var['is_secret'] = $storedMap[$var['key']]['is_secret'];
-                }
+    /**
+     * Build the existing variables used to restore masked secrets and classify
+     * keys: values come from the live .env file on the server (the source of
+     * truth), falling back to the database copy so a transient read failure can
+     * never wipe a secret. The user-defined `is_secret` flag stored in the
+     * database always wins over auto-detection on the live file.
+     *
+     * @return array<int, array{key: string, value: string, is_secret: bool}>
+     */
+    private function existingVariables(Site $site): array
+    {
+        $map = [];
 
-                return $var;
-            }, $parsed);
+        foreach ($site->env_variables ?? [] as $variable) {
+            $map[$variable['key']] = $variable;
         }
 
-        return $parsed;
+        foreach (EnvParser::parse($site->getEnv()) as $variable) {
+            $key = $variable['key'];
+
+            if (isset($map[$key])) {
+                $variable['is_secret'] = $map[$key]['is_secret'];
+            }
+
+            $map[$key] = $variable;
+        }
+
+        return array_values($map);
     }
 }

--- a/app/Actions/Site/UpdateEnv.php
+++ b/app/Actions/Site/UpdateEnv.php
@@ -41,9 +41,11 @@ class UpdateEnv
 
         $variables = $this->resolveVariables($site, $input, $path);
 
+        $rawSubmission = ! isset($input['variables']) || ! is_array($input['variables']);
+
         $site->server->os()->write(
             $path,
-            EnvParser::stringify($variables),
+            $rawSubmission ? trim((string) $input['env']) : EnvParser::stringify($variables),
             $site->user,
         );
 

--- a/app/Actions/Worker/UpdateWorkerEnvironment.php
+++ b/app/Actions/Worker/UpdateWorkerEnvironment.php
@@ -82,7 +82,7 @@ class UpdateWorkerEnvironment
         $storedSecrets = [];
         foreach ($stored ?? [] as $variable) {
             $storedMap[$variable['key']] = $variable['value'];
-            if ($variable['is_secret'] ?? false) {
+            if ($variable['is_secret']) {
                 $storedSecrets[$variable['key']] = true;
             }
         }

--- a/app/Actions/Worker/UpdateWorkerEnvironment.php
+++ b/app/Actions/Worker/UpdateWorkerEnvironment.php
@@ -3,7 +3,6 @@
 namespace App\Actions\Worker;
 
 use App\Exceptions\SSHError;
-use App\Helpers\EnvParser;
 use App\Models\Worker;
 use App\Services\ProcessManager\ProcessManager;
 use Illuminate\Support\Facades\Validator;
@@ -64,19 +63,49 @@ class UpdateWorkerEnvironment
     }
 
     /**
+     * Worker environment values live only in the database (the supervisor
+     * config is generated from them and never read back), so masked secrets
+     * are restored from the stored copy rather than from a server file.
+     *
+     * A key already stored as secret cannot be wiped by submitting it as a
+     * non-secret with an empty value: while the value is empty it stays secret
+     * and its stored value is restored. Re-adding the key with a real value is
+     * the only way to make it non-secret, which is honoured.
+     *
      * @param  array<int, array<string, mixed>>  $incoming
      * @param  ?array<int, array{key: string, value: string, is_secret: bool}>  $stored
      * @return array<int, array{key: string, value: string, is_secret: bool}>
      */
     public static function processVariables(array $incoming, ?array $stored): array
     {
-        $normalized = array_map(fn (array $variable): array => [
-            'key' => (string) $variable['key'],
-            'value' => (string) ($variable['value'] ?? ''),
-            'is_secret' => (bool) ($variable['is_secret'] ?? false),
-        ], $incoming);
+        $storedMap = [];
+        $storedSecrets = [];
+        foreach ($stored ?? [] as $variable) {
+            $storedMap[$variable['key']] = $variable['value'];
+            if ($variable['is_secret'] ?? false) {
+                $storedSecrets[$variable['key']] = true;
+            }
+        }
 
-        return EnvParser::mergeWithStored($normalized, $stored);
+        return array_map(function (array $variable) use ($storedMap, $storedSecrets): array {
+            $key = (string) $variable['key'];
+            $value = (string) ($variable['value'] ?? '');
+            $isSecret = (bool) ($variable['is_secret'] ?? false);
+
+            if ($value === '' && isset($storedSecrets[$key])) {
+                $isSecret = true;
+            }
+
+            if ($isSecret && $value === '' && isset($storedMap[$key])) {
+                $value = (string) $storedMap[$key];
+            }
+
+            return [
+                'key' => $key,
+                'value' => $value,
+                'is_secret' => $isSecret,
+            ];
+        }, $incoming);
     }
 }
 

--- a/app/Helpers/EnvParser.php
+++ b/app/Helpers/EnvParser.php
@@ -112,34 +112,66 @@ class EnvParser
     }
 
     /**
-     * Reconcile the variables parsed from the live server .env file with the
-     * stored variables, carrying over the user-defined `is_secret` flags.
+     * Normalise the stored secret marker into a flat list of secret keys.
      *
-     * The live file is always the source of truth for values. The stored array
-     * only contributes the `is_secret` classification so manual secret/normal
-     * toggles survive a reload.
+     * Values are NEVER stored in the database; only the list of keys the user
+     * marked as secret is persisted (e.g. ['APP_KEY', 'JWT_SECRET']). Existing
+     * servers from before this change stored the full variable array
+     * ([{key, value, is_secret}]); this normaliser reads that legacy shape too
+     * so secret classifications survive the upgrade without a data migration.
+     *
+     * @param  array<int, mixed>|null  $stored
+     * @return array<int, string>
+     */
+    public static function secretKeys(?array $stored): array
+    {
+        if ($stored === null) {
+            return [];
+        }
+
+        $keys = [];
+
+        foreach ($stored as $entry) {
+            if (is_string($entry)) {
+                $keys[] = $entry;
+
+                continue;
+            }
+
+            if (is_array($entry) && ($entry['is_secret'] ?? false) && isset($entry['key'])) {
+                $keys[] = (string) $entry['key'];
+            }
+        }
+
+        return array_values(array_unique($keys));
+    }
+
+    /**
+     * Classify variables parsed from the live server .env file using the stored
+     * secret-key list. The live file is always the source of truth for values;
+     * the stored list only contributes the `is_secret` classification so manual
+     * secret toggles survive a reload.
+     *
+     * When no list has ever been stored (`null` — e.g. a site that has never
+     * been saved through Vito), there is no authoritative classification, so we
+     * fall back to pattern auto-detection from `parse()` to avoid exposing
+     * obvious secrets unmasked. Once a list exists (even empty), it is
+     * authoritative so deliberately un-secreted keys are not re-masked.
      *
      * @param  array<int, array{key: string, value: string, is_secret: bool}>  $parsed
-     * @param  array<int, array{key: string, value: string, is_secret: bool}>|null  $stored
+     * @param  array<int, mixed>|null  $stored
      * @return array<int, array{key: string, value: string, is_secret: bool}>
      */
-    public static function reconcileWithStored(array $parsed, ?array $stored): array
+    public static function classify(array $parsed, ?array $stored): array
     {
         if ($stored === null) {
             return $parsed;
         }
 
-        $storedMap = [];
-        foreach ($stored as $variable) {
-            $storedMap[$variable['key']] = $variable;
-        }
+        $secretKeys = array_flip(self::secretKeys($stored));
 
-        return array_map(function ($variable) use ($storedMap) {
-            $key = $variable['key'];
-
-            if (isset($storedMap[$key])) {
-                $variable['is_secret'] = $storedMap[$key]['is_secret'];
-            }
+        return array_map(function ($variable) use ($secretKeys) {
+            $variable['is_secret'] = isset($secretKeys[$variable['key']]);
 
             return $variable;
         }, $parsed);
@@ -164,35 +196,29 @@ class EnvParser
     }
 
     /**
-     * Merge incoming variables with the existing variables.
+     * Merge incoming variables with the live .env file on the server.
      *
      * A masked secret arrives with an empty value; its real value is restored
-     * from the existing set. The existing set should be parsed from the live
-     * .env file so the restored value reflects what is actually on the server,
-     * never a stale copy.
+     * from the live file so the secret is never lost when the form is saved
+     * without re-typing it. Non-secret variables and secrets with a new value
+     * are taken as-is from the incoming set.
      *
      * @param  array<int, array{key: string, value: string, is_secret: bool}>  $incoming
-     * @param  array<int, array{key: string, value: string, is_secret: bool}>|null  $existing
+     * @param  array<int, array{key: string, value: string, is_secret: bool}>  $live
      * @return array<int, array{key: string, value: string, is_secret: bool}>
      */
-    public static function mergeWithStored(array $incoming, ?array $existing): array
+    public static function mergeWithLive(array $incoming, array $live): array
     {
-        if ($existing === null) {
-            return $incoming;
+        $liveMap = [];
+        foreach ($live as $variable) {
+            $liveMap[$variable['key']] = $variable['value'];
         }
 
-        $existingMap = [];
-        foreach ($existing as $variable) {
-            $existingMap[$variable['key']] = $variable;
-        }
-
-        return array_map(function ($variable) use ($existingMap) {
+        return array_map(function ($variable) use ($liveMap) {
             $key = $variable['key'];
-            $isSecret = $variable['is_secret'];
-            $value = $variable['value'];
 
-            if ($isSecret && $value === '' && isset($existingMap[$key])) {
-                $variable['value'] = $existingMap[$key]['value'];
+            if ($variable['is_secret'] && $variable['value'] === '' && isset($liveMap[$key])) {
+                $variable['value'] = $liveMap[$key];
             }
 
             return $variable;

--- a/app/Helpers/EnvParser.php
+++ b/app/Helpers/EnvParser.php
@@ -112,6 +112,40 @@ class EnvParser
     }
 
     /**
+     * Reconcile the variables parsed from the live server .env file with the
+     * stored variables, carrying over the user-defined `is_secret` flags.
+     *
+     * The live file is always the source of truth for values. The stored array
+     * only contributes the `is_secret` classification so manual secret/normal
+     * toggles survive a reload.
+     *
+     * @param  array<int, array{key: string, value: string, is_secret: bool}>  $parsed
+     * @param  array<int, array{key: string, value: string, is_secret: bool}>|null  $stored
+     * @return array<int, array{key: string, value: string, is_secret: bool}>
+     */
+    public static function reconcileWithStored(array $parsed, ?array $stored): array
+    {
+        if ($stored === null) {
+            return $parsed;
+        }
+
+        $storedMap = [];
+        foreach ($stored as $variable) {
+            $storedMap[$variable['key']] = $variable;
+        }
+
+        return array_map(function ($variable) use ($storedMap) {
+            $key = $variable['key'];
+
+            if (isset($storedMap[$key])) {
+                $variable['is_secret'] = $storedMap[$key]['is_secret'];
+            }
+
+            return $variable;
+        }, $parsed);
+    }
+
+    /**
      * Mask secret values for frontend display
      * Secret values are completely hidden (not sent to frontend)
      *
@@ -130,31 +164,35 @@ class EnvParser
     }
 
     /**
-     * Merge incoming variables with stored variables
-     * For secrets with empty values, keep the stored value
+     * Merge incoming variables with the existing variables.
+     *
+     * A masked secret arrives with an empty value; its real value is restored
+     * from the existing set. The existing set should be parsed from the live
+     * .env file so the restored value reflects what is actually on the server,
+     * never a stale copy.
      *
      * @param  array<int, array{key: string, value: string, is_secret: bool}>  $incoming
-     * @param  array<int, array{key: string, value: string, is_secret: bool}>|null  $stored
+     * @param  array<int, array{key: string, value: string, is_secret: bool}>|null  $existing
      * @return array<int, array{key: string, value: string, is_secret: bool}>
      */
-    public static function mergeWithStored(array $incoming, ?array $stored): array
+    public static function mergeWithStored(array $incoming, ?array $existing): array
     {
-        if ($stored === null) {
+        if ($existing === null) {
             return $incoming;
         }
 
-        $storedMap = [];
-        foreach ($stored as $variable) {
-            $storedMap[$variable['key']] = $variable;
+        $existingMap = [];
+        foreach ($existing as $variable) {
+            $existingMap[$variable['key']] = $variable;
         }
 
-        return array_map(function ($variable) use ($storedMap) {
+        return array_map(function ($variable) use ($existingMap) {
             $key = $variable['key'];
             $isSecret = $variable['is_secret'];
             $value = $variable['value'];
 
-            if ($isSecret && $value === '' && isset($storedMap[$key])) {
-                $variable['value'] = $storedMap[$key]['value'];
+            if ($isSecret && $value === '' && isset($existingMap[$key])) {
+                $variable['value'] = $existingMap[$key]['value'];
             }
 
             return $variable;

--- a/app/Http/Controllers/API/SiteController.php
+++ b/app/Http/Controllers/API/SiteController.php
@@ -158,7 +158,7 @@ class SiteController extends Controller
         $env = $site->getEnv();
 
         $variables = EnvParser::maskSecrets(
-            EnvParser::reconcileWithStored(EnvParser::parse($env), $site->env_variables)
+            EnvParser::classify(EnvParser::parse($env), $site->env_variables)
         );
 
         return response()->json([

--- a/app/Http/Controllers/API/SiteController.php
+++ b/app/Http/Controllers/API/SiteController.php
@@ -157,11 +157,9 @@ class SiteController extends Controller
 
         $env = $site->getEnv();
 
-        if ($site->env_variables !== null) {
-            $variables = EnvParser::maskSecrets($site->env_variables);
-        } else {
-            $variables = EnvParser::parse($env);
-        }
+        $variables = EnvParser::maskSecrets(
+            EnvParser::reconcileWithStored(EnvParser::parse($env), $site->env_variables)
+        );
 
         return response()->json([
             'data' => [

--- a/app/Http/Controllers/API/SiteController.php
+++ b/app/Http/Controllers/API/SiteController.php
@@ -6,6 +6,7 @@ use App\Actions\Site\CreateSite;
 use App\Actions\Site\Deploy;
 use App\Actions\Site\DisableSsl;
 use App\Actions\Site\EnableSsl;
+use App\Actions\Site\GetEnv;
 use App\Actions\Site\RetrySite;
 use App\Actions\Site\UpdateDeploymentScript;
 use App\Actions\Site\UpdateEnv;
@@ -13,7 +14,6 @@ use App\Actions\Site\UpdateLoadBalancer;
 use App\Actions\Site\UpdateVhostGeneration;
 use App\Actions\Site\UpdateWebDirectory;
 use App\Exceptions\DeploymentScriptIsEmptyException;
-use App\Helpers\EnvParser;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\DeploymentResource;
 use App\Http\Resources\SiteResource;
@@ -155,17 +155,8 @@ class SiteController extends Controller
 
         $this->validateRoute($project, $server, $site);
 
-        $env = $site->getEnv();
-
-        $variables = EnvParser::maskSecrets(
-            EnvParser::classify(EnvParser::parse($env), $site->env_variables)
-        );
-
         return response()->json([
-            'data' => [
-                'env' => $env,
-                'variables' => $variables,
-            ],
+            'data' => app(GetEnv::class)->get($site),
         ]);
     }
 

--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Site\Deploy;
+use App\Actions\Site\GetEnv;
 use App\Actions\Site\Rollback;
 use App\Actions\Site\UpdateDeploymentScript;
 use App\Actions\Site\UpdateEnv;
@@ -123,16 +124,7 @@ class ApplicationController extends Controller
             $site->jsonUpdate('type_data', 'env_path', $request->input('env'), false);
         }
 
-        $env = $site->getEnv();
-
-        $variables = EnvParser::maskSecrets(
-            EnvParser::classify(EnvParser::parse($env), $site->env_variables)
-        );
-
-        return response()->json([
-            'env' => $env,
-            'variables' => $variables,
-        ]);
+        return response()->json(app(GetEnv::class)->get($site));
     }
 
     #[Post('/env/parse', name: 'application.parse-env')]

--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -126,7 +126,7 @@ class ApplicationController extends Controller
         $env = $site->getEnv();
 
         $variables = EnvParser::maskSecrets(
-            EnvParser::reconcileWithStored(EnvParser::parse($env), $site->env_variables)
+            EnvParser::classify(EnvParser::parse($env), $site->env_variables)
         );
 
         return response()->json([

--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -125,11 +125,9 @@ class ApplicationController extends Controller
 
         $env = $site->getEnv();
 
-        if ($site->env_variables !== null) {
-            $variables = EnvParser::maskSecrets($site->env_variables);
-        } else {
-            $variables = EnvParser::parse($env);
-        }
+        $variables = EnvParser::maskSecrets(
+            EnvParser::reconcileWithStored(EnvParser::parse($env), $site->env_variables)
+        );
 
         return response()->json([
             'env' => $env,

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -39,7 +39,7 @@ use RuntimeException;
  * @property int $server_id
  * @property string $type
  * @property array<string, mixed> $type_data
- * @property ?array<int, array{key: string, value: string, is_secret: bool}> $env_variables
+ * @property ?array<int, string> $env_variables List of keys marked as secret; values live on the server, never in the database.
  * @property ?array<int, array{key: string, value: string, is_secret: bool}> $worker_environment
  * @property string $domain
  * @property array<int, string> $aliases
@@ -576,10 +576,10 @@ class Site extends AbstractModel
             : 'site_'.$this->id;
     }
 
-    public function getEnv(): string
+    public function getEnv(?string $path = null): string
     {
         try {
-            $envPath = $this->type_data['env_path'] ?? $this->path.'/.env';
+            $envPath = $path ?? $this->type_data['env_path'] ?? $this->path.'/.env';
 
             return $this->server->os()->readFile($envPath);
         } catch (SSHError) {

--- a/public/api-docs/openapi/sites.yaml
+++ b/public/api-docs/openapi/sites.yaml
@@ -695,15 +695,15 @@ paths:
                               example: 'APP_NAME'
                             value:
                               type: string
-                              description: Variable value
+                              description: Variable value. Empty for variables marked as secret — secret values are never returned.
                               example: 'MyApp'
                             is_secret:
                               type: boolean
-                              description: Whether the variable contains sensitive data (PASSWORD, SECRET, TOKEN, KEY, PRIVATE)
+                              description: Whether the variable is marked as secret. Secret values are masked (returned empty) and must be re-entered to change them.
                               example: false
               example:
                 data:
-                  env: "APP_NAME=MyApp\nAPP_ENV=production\nDB_PASSWORD=secret123"
+                  env: "APP_NAME=MyApp\nAPP_ENV=production\nDB_PASSWORD=<the-actual-value>"
                   variables:
                     - key: 'APP_NAME'
                       value: 'MyApp'
@@ -712,7 +712,7 @@ paths:
                       value: 'production'
                       is_secret: false
                     - key: 'DB_PASSWORD'
-                      value: 'secret123'
+                      value: ''
                       is_secret: true
         '401':
           description: Unauthorized
@@ -787,8 +787,12 @@ paths:
                         example: 'APP_NAME'
                       value:
                         type: string
-                        description: Variable value
+                        description: Variable value. For a variable marked as secret, send an empty value to keep the current value on the server unchanged.
                         example: 'MyApp'
+                      is_secret:
+                        type: boolean
+                        description: Mark the variable as secret. Secret values are stored only on the server (never in the database) and are masked when read back.
+                        example: false
                 path:
                   type: string
                   description: Custom path to the .env file
@@ -800,12 +804,20 @@ paths:
                   env: "APP_NAME=MyApp\nAPP_ENV=production"
               structured:
                 summary: Using structured variables
+                description: >-
+                  Set a new secret value by sending it with is_secret true. To
+                  keep an existing secret unchanged, send it with an empty value.
                 value:
                   variables:
                     - key: 'APP_NAME'
                       value: 'MyApp'
-                    - key: 'APP_ENV'
-                      value: 'production'
+                      is_secret: false
+                    - key: 'APP_KEY'
+                      value: 'base64:newly-generated-key'
+                      is_secret: true
+                    - key: 'DB_PASSWORD'
+                      value: ''
+                      is_secret: true
       responses:
         '200':
           description: Environment variables updated successfully

--- a/tests/Feature/ApplicationTest.php
+++ b/tests/Feature/ApplicationTest.php
@@ -554,13 +554,12 @@ class ApplicationTest extends TestCase
         ]);
     }
 
-    public function test_secret_values_are_masked_when_stored_in_db(): void
+    public function test_only_secret_keys_are_stored_in_db(): void
     {
-        SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=supersecret123');
+        SSH::fake();
 
         $this->actingAs($this->user);
 
-        // First, save some variables with secrets
         $this->put(route('application.update-env', [
             'server' => $this->server,
             'site' => $this->site,
@@ -573,11 +572,17 @@ class ApplicationTest extends TestCase
 
         $this->site->refresh();
 
-        // Verify stored in DB
-        $this->assertNotNull($this->site->env_variables);
-        $this->assertCount(2, $this->site->env_variables);
+        $this->assertEquals(['DB_PASSWORD'], $this->site->env_variables);
+    }
 
-        // Now fetch the variables - secrets should be masked
+    public function test_secret_values_are_masked_on_read(): void
+    {
+        SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=supersecret123');
+
+        $this->actingAs($this->user);
+
+        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
+
         $response = $this->get(route('application.env', [
             'server' => $this->server,
             'site' => $this->site,
@@ -586,34 +591,47 @@ class ApplicationTest extends TestCase
         $response->assertOk();
         $data = $response->json('variables');
 
-        // Find the secret variable
         $secretVar = collect($data)->firstWhere('key', 'DB_PASSWORD');
         $this->assertTrue($secretVar['is_secret']);
-        $this->assertEquals('', $secretVar['value']); // Value should be empty/masked
+        $this->assertEquals('', $secretVar['value']);
 
-        // Non-secret should have value
         $normalVar = collect($data)->firstWhere('key', 'APP_NAME');
         $this->assertFalse($normalVar['is_secret']);
         $this->assertEquals('TestApp', $normalVar['value']);
     }
 
-    public function test_secret_values_preserved_when_updating_with_empty_value(): void
+    public function test_secret_classification_survives_legacy_db_shape(): void
     {
-        SSH::fake('DB_PASSWORD=original_secret');
+        SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=supersecret123');
 
         $this->actingAs($this->user);
 
-        // First, save variables with secrets
-        $this->put(route('application.update-env', [
+        $this->site->update([
+            'env_variables' => [
+                ['key' => 'APP_NAME', 'value' => 'TestApp', 'is_secret' => false],
+                ['key' => 'DB_PASSWORD', 'value' => 'supersecret123', 'is_secret' => true],
+            ],
+        ]);
+
+        $response = $this->get(route('application.env', [
             'server' => $this->server,
             'site' => $this->site,
-        ]), [
-            'variables' => [
-                ['key' => 'DB_PASSWORD', 'value' => 'original_secret', 'is_secret' => true],
-            ],
-        ])->assertSessionDoesntHaveErrors();
+        ]));
 
-        // Now update with empty value for the secret (simulating frontend behavior)
+        $response->assertOk();
+        $secretVar = collect($response->json('variables'))->firstWhere('key', 'DB_PASSWORD');
+        $this->assertTrue($secretVar['is_secret']);
+        $this->assertEquals('', $secretVar['value']);
+    }
+
+    public function test_secret_value_preserved_on_server_when_submitted_empty(): void
+    {
+        $ssh = SSH::fake('DB_PASSWORD=original_secret');
+
+        $this->actingAs($this->user);
+
+        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
+
         $this->put(route('application.update-env', [
             'server' => $this->server,
             'site' => $this->site,
@@ -623,35 +641,17 @@ class ApplicationTest extends TestCase
             ],
         ])->assertSessionDoesntHaveErrors();
 
-        $this->site->refresh();
-
-        // The original secret value should be preserved
-        $storedVar = collect($this->site->env_variables)->firstWhere('key', 'DB_PASSWORD');
-        $this->assertEquals('original_secret', $storedVar['value']);
+        $this->assertStringContainsString('DB_PASSWORD=original_secret', $ssh->getUploadedContent());
     }
 
-    public function test_secret_values_reflect_live_server_file_when_changed_out_of_band(): void
+    public function test_secret_value_reflects_live_server_file_when_changed_out_of_band(): void
     {
+        $ssh = SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=rotated_secret');
+
         $this->actingAs($this->user);
 
-        // Save a secret through Vito so it is also stored in the DB.
-        SSH::fake('DB_PASSWORD=original_secret');
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'variables' => [
-                ['key' => 'APP_NAME', 'value' => 'TestApp', 'is_secret' => false],
-                ['key' => 'DB_PASSWORD', 'value' => 'original_secret', 'is_secret' => true],
-            ],
-        ])->assertSessionDoesntHaveErrors();
+        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
 
-        // The secret is rotated directly on the server, out of band.
-        SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=rotated_secret');
-
-        // User pulls the env, changes a non-secret field and saves. The masked
-        // secret comes back empty and must be restored from the live file, not
-        // from the stale value stored in the database.
         $this->put(route('application.update-env', [
             'server' => $this->server,
             'site' => $this->site,
@@ -662,10 +662,112 @@ class ApplicationTest extends TestCase
             ],
         ])->assertSessionDoesntHaveErrors();
 
-        $this->site->refresh();
+        $uploaded = $ssh->getUploadedContent();
+        $this->assertStringContainsString('DB_PASSWORD=rotated_secret', $uploaded);
+        $this->assertStringContainsString('APP_NAME=ChangedApp', $uploaded);
+    }
 
-        $storedVar = collect($this->site->env_variables)->firstWhere('key', 'DB_PASSWORD');
-        $this->assertEquals('rotated_secret', $storedVar['value']);
+    public function test_stored_secret_cannot_be_wiped_by_marking_it_non_secret(): void
+    {
+        $ssh = SSH::fake('DB_PASSWORD=original_secret');
+
+        $this->actingAs($this->user);
+
+        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
+
+        $this->put(route('application.update-env', [
+            'server' => $this->server,
+            'site' => $this->site,
+        ]), [
+            'variables' => [
+                ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => false],
+            ],
+        ])->assertSessionDoesntHaveErrors();
+
+        $this->assertStringContainsString('DB_PASSWORD=original_secret', $ssh->getUploadedContent());
+
+        $this->site->refresh();
+        $this->assertEquals(['DB_PASSWORD'], $this->site->env_variables);
+    }
+
+    public function test_secret_can_be_dropped_to_non_secret_with_new_value(): void
+    {
+        $ssh = SSH::fake('DB_PASSWORD=original_secret');
+
+        $this->actingAs($this->user);
+
+        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
+
+        $this->put(route('application.update-env', [
+            'server' => $this->server,
+            'site' => $this->site,
+        ]), [
+            'variables' => [
+                ['key' => 'DB_PASSWORD', 'value' => 'now_plain', 'is_secret' => false],
+            ],
+        ])->assertSessionDoesntHaveErrors();
+
+        $this->assertStringContainsString('DB_PASSWORD=now_plain', $ssh->getUploadedContent());
+
+        $this->site->refresh();
+        $this->assertEquals([], $this->site->env_variables);
+    }
+
+    public function test_pattern_secrets_masked_for_site_never_saved_through_vito(): void
+    {
+        SSH::fake('APP_NAME=TestApp'.PHP_EOL.'APP_KEY=base64:supersecret');
+
+        $this->actingAs($this->user);
+
+        $this->assertNull($this->site->env_variables);
+
+        $response = $this->get(route('application.env', [
+            'server' => $this->server,
+            'site' => $this->site,
+        ]));
+
+        $response->assertOk();
+        $secretVar = collect($response->json('variables'))->firstWhere('key', 'APP_KEY');
+        $this->assertTrue($secretVar['is_secret']);
+        $this->assertEquals('', $secretVar['value']);
+    }
+
+    public function test_raw_env_path_writes_content_verbatim_without_restoring_secrets(): void
+    {
+        $ssh = SSH::fake('DB_PASSWORD=original_secret');
+
+        $this->actingAs($this->user);
+
+        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
+
+        $this->put(route('application.update-env', [
+            'server' => $this->server,
+            'site' => $this->site,
+        ]), [
+            'env' => 'APP_NAME=Raw'.PHP_EOL.'DB_PASSWORD=',
+        ])->assertSessionDoesntHaveErrors();
+
+        $uploaded = $ssh->getUploadedContent();
+        $this->assertStringContainsString('APP_NAME=Raw', $uploaded);
+        $this->assertStringNotContainsString('DB_PASSWORD=original_secret', $uploaded);
+    }
+
+    public function test_update_env_aborts_when_live_file_cannot_be_read(): void
+    {
+        SSH::fake('');
+
+        $this->actingAs($this->user);
+
+        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
+
+        $this->put(route('application.update-env', [
+            'server' => $this->server,
+            'site' => $this->site,
+        ]), [
+            'variables' => [
+                ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
+            ],
+        ])->assertSessionHasErrors('variables');
     }
 
     public function test_parse_env_endpoint(): void

--- a/tests/Feature/ApplicationTest.php
+++ b/tests/Feature/ApplicationTest.php
@@ -556,7 +556,7 @@ class ApplicationTest extends TestCase
 
     public function test_secret_values_are_masked_when_stored_in_db(): void
     {
-        SSH::fake();
+        SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=supersecret123');
 
         $this->actingAs($this->user);
 
@@ -599,7 +599,7 @@ class ApplicationTest extends TestCase
 
     public function test_secret_values_preserved_when_updating_with_empty_value(): void
     {
-        SSH::fake();
+        SSH::fake('DB_PASSWORD=original_secret');
 
         $this->actingAs($this->user);
 
@@ -628,6 +628,44 @@ class ApplicationTest extends TestCase
         // The original secret value should be preserved
         $storedVar = collect($this->site->env_variables)->firstWhere('key', 'DB_PASSWORD');
         $this->assertEquals('original_secret', $storedVar['value']);
+    }
+
+    public function test_secret_values_reflect_live_server_file_when_changed_out_of_band(): void
+    {
+        $this->actingAs($this->user);
+
+        // Save a secret through Vito so it is also stored in the DB.
+        SSH::fake('DB_PASSWORD=original_secret');
+        $this->put(route('application.update-env', [
+            'server' => $this->server,
+            'site' => $this->site,
+        ]), [
+            'variables' => [
+                ['key' => 'APP_NAME', 'value' => 'TestApp', 'is_secret' => false],
+                ['key' => 'DB_PASSWORD', 'value' => 'original_secret', 'is_secret' => true],
+            ],
+        ])->assertSessionDoesntHaveErrors();
+
+        // The secret is rotated directly on the server, out of band.
+        SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=rotated_secret');
+
+        // User pulls the env, changes a non-secret field and saves. The masked
+        // secret comes back empty and must be restored from the live file, not
+        // from the stale value stored in the database.
+        $this->put(route('application.update-env', [
+            'server' => $this->server,
+            'site' => $this->site,
+        ]), [
+            'variables' => [
+                ['key' => 'APP_NAME', 'value' => 'ChangedApp', 'is_secret' => false],
+                ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
+            ],
+        ])->assertSessionDoesntHaveErrors();
+
+        $this->site->refresh();
+
+        $storedVar = collect($this->site->env_variables)->firstWhere('key', 'DB_PASSWORD');
+        $this->assertEquals('rotated_secret', $storedVar['value']);
     }
 
     public function test_parse_env_endpoint(): void

--- a/tests/Feature/ApplicationTest.php
+++ b/tests/Feature/ApplicationTest.php
@@ -740,15 +740,17 @@ class ApplicationTest extends TestCase
 
         $this->site->update(['env_variables' => ['DB_PASSWORD']]);
 
+        $raw = '# leading comment'.PHP_EOL.'APP_NAME=Raw'.PHP_EOL.PHP_EOL.'DB_PASSWORD=';
+
         $this->put(route('application.update-env', [
             'server' => $this->server,
             'site' => $this->site,
         ]), [
-            'env' => 'APP_NAME=Raw'.PHP_EOL.'DB_PASSWORD=',
+            'env' => $raw,
         ])->assertSessionDoesntHaveErrors();
 
         $uploaded = $ssh->getUploadedContent();
-        $this->assertStringContainsString('APP_NAME=Raw', $uploaded);
+        $this->assertSame($raw, $uploaded);
         $this->assertStringNotContainsString('DB_PASSWORD=original_secret', $uploaded);
     }
 

--- a/tests/Feature/WorkerEnvironmentTest.php
+++ b/tests/Feature/WorkerEnvironmentTest.php
@@ -137,6 +137,29 @@ class WorkerEnvironmentTest extends TestCase
         ], $worker->refresh()->environment);
     }
 
+    public function test_update_env_stored_secret_cannot_be_wiped_by_marking_it_non_secret(): void
+    {
+        SSH::fake();
+        $this->actingAs($this->user);
+
+        $worker = Worker::factory()->create([
+            'server_id' => $this->server->id,
+            'environment' => [
+                ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
+            ],
+        ]);
+
+        $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
+            'variables' => [
+                ['key' => 'API_KEY', 'value' => '', 'is_secret' => false],
+            ],
+        ])->assertSessionDoesntHaveErrors();
+
+        $this->assertEquals([
+            ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
+        ], $worker->refresh()->environment);
+    }
+
     public function test_update_env_validates_input(): void
     {
         SSH::fake();

--- a/tests/Unit/EnvParserTest.php
+++ b/tests/Unit/EnvParserTest.php
@@ -218,4 +218,47 @@ class EnvParserTest extends TestCase
 
         $this->assertEquals($incoming, $merged);
     }
+
+    public function test_merge_restores_secret_from_live_file_value(): void
+    {
+        $live = [
+            ['key' => 'DB_PASSWORD', 'value' => 'rotated_secret', 'is_secret' => true],
+        ];
+
+        $incoming = [
+            ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
+        ];
+
+        $merged = EnvParser::mergeWithStored($incoming, $live);
+
+        $this->assertEquals('rotated_secret', $merged[0]['value']);
+    }
+
+    public function test_reconcile_carries_over_is_secret_flag(): void
+    {
+        $parsed = [
+            ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
+            ['key' => 'CUSTOM_VALUE', 'value' => 'plain', 'is_secret' => false],
+        ];
+
+        $stored = [
+            ['key' => 'CUSTOM_VALUE', 'value' => 'old', 'is_secret' => true],
+        ];
+
+        $reconciled = EnvParser::reconcileWithStored($parsed, $stored);
+
+        $this->assertEquals('Laravel', $reconciled[0]['value']);
+        $this->assertFalse($reconciled[0]['is_secret']);
+        $this->assertEquals('plain', $reconciled[1]['value']);
+        $this->assertTrue($reconciled[1]['is_secret']);
+    }
+
+    public function test_reconcile_with_null_stored_returns_parsed(): void
+    {
+        $parsed = [
+            ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
+        ];
+
+        $this->assertEquals($parsed, EnvParser::reconcileWithStored($parsed, null));
+    }
 }

--- a/tests/Unit/EnvParserTest.php
+++ b/tests/Unit/EnvParserTest.php
@@ -175,48 +175,46 @@ class EnvParserTest extends TestCase
         $this->assertEquals('', $masked[2]['value']);
     }
 
-    public function test_merge_with_stored_preserves_empty_secret_values(): void
+    public function test_merge_with_live_preserves_empty_secret_values(): void
     {
-        $stored = [
+        $live = [
             ['key' => 'DB_PASSWORD', 'value' => 'original_secret', 'is_secret' => true],
             ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
         ];
 
         $incoming = [
-            ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true], // Empty = keep stored
+            ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
             ['key' => 'APP_NAME', 'value' => 'NewName', 'is_secret' => false],
         ];
 
-        $merged = EnvParser::mergeWithStored($incoming, $stored);
+        $merged = EnvParser::mergeWithLive($incoming, $live);
 
         $this->assertEquals('original_secret', $merged[0]['value']);
         $this->assertEquals('NewName', $merged[1]['value']);
     }
 
-    public function test_merge_with_stored_allows_updating_secret_values(): void
+    public function test_merge_with_live_allows_updating_secret_values(): void
     {
-        $stored = [
+        $live = [
             ['key' => 'DB_PASSWORD', 'value' => 'original_secret', 'is_secret' => true],
         ];
 
         $incoming = [
-            ['key' => 'DB_PASSWORD', 'value' => 'new_secret', 'is_secret' => true], // New value provided
+            ['key' => 'DB_PASSWORD', 'value' => 'new_secret', 'is_secret' => true],
         ];
 
-        $merged = EnvParser::mergeWithStored($incoming, $stored);
+        $merged = EnvParser::mergeWithLive($incoming, $live);
 
         $this->assertEquals('new_secret', $merged[0]['value']);
     }
 
-    public function test_merge_with_null_stored_returns_incoming(): void
+    public function test_merge_with_empty_live_returns_incoming(): void
     {
         $incoming = [
             ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
         ];
 
-        $merged = EnvParser::mergeWithStored($incoming, null);
-
-        $this->assertEquals($incoming, $merged);
+        $this->assertEquals($incoming, EnvParser::mergeWithLive($incoming, []));
     }
 
     public function test_merge_restores_secret_from_live_file_value(): void
@@ -229,36 +227,104 @@ class EnvParserTest extends TestCase
             ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
         ];
 
-        $merged = EnvParser::mergeWithStored($incoming, $live);
+        $merged = EnvParser::mergeWithLive($incoming, $live);
 
         $this->assertEquals('rotated_secret', $merged[0]['value']);
     }
 
-    public function test_reconcile_carries_over_is_secret_flag(): void
+    public function test_merge_does_not_restore_non_secret_empty_values(): void
     {
-        $parsed = [
+        $live = [
             ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
-            ['key' => 'CUSTOM_VALUE', 'value' => 'plain', 'is_secret' => false],
         ];
 
-        $stored = [
-            ['key' => 'CUSTOM_VALUE', 'value' => 'old', 'is_secret' => true],
+        $incoming = [
+            ['key' => 'APP_NAME', 'value' => '', 'is_secret' => false],
         ];
 
-        $reconciled = EnvParser::reconcileWithStored($parsed, $stored);
+        $merged = EnvParser::mergeWithLive($incoming, $live);
 
-        $this->assertEquals('Laravel', $reconciled[0]['value']);
-        $this->assertFalse($reconciled[0]['is_secret']);
-        $this->assertEquals('plain', $reconciled[1]['value']);
-        $this->assertTrue($reconciled[1]['is_secret']);
+        $this->assertEquals('', $merged[0]['value']);
     }
 
-    public function test_reconcile_with_null_stored_returns_parsed(): void
+    public function test_secret_keys_from_flat_list(): void
+    {
+        $this->assertEquals(['APP_KEY', 'JWT_SECRET'], EnvParser::secretKeys(['APP_KEY', 'JWT_SECRET']));
+    }
+
+    public function test_secret_keys_from_legacy_variable_array(): void
+    {
+        $legacy = [
+            ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
+            ['key' => 'DB_PASSWORD', 'value' => 'secret', 'is_secret' => true],
+            ['key' => 'APP_KEY', 'value' => 'base64:abc', 'is_secret' => true],
+        ];
+
+        $this->assertEquals(['DB_PASSWORD', 'APP_KEY'], EnvParser::secretKeys($legacy));
+    }
+
+    public function test_secret_keys_deduplicates(): void
+    {
+        $this->assertEquals(['APP_KEY'], EnvParser::secretKeys(['APP_KEY', 'APP_KEY']));
+    }
+
+    public function test_secret_keys_from_null_returns_empty(): void
+    {
+        $this->assertEquals([], EnvParser::secretKeys(null));
+    }
+
+    public function test_classify_marks_only_stored_secret_keys(): void
     {
         $parsed = [
             ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
+            ['key' => 'DB_PASSWORD', 'value' => 'plain', 'is_secret' => true],
         ];
 
-        $this->assertEquals($parsed, EnvParser::reconcileWithStored($parsed, null));
+        $classified = EnvParser::classify($parsed, ['APP_NAME']);
+
+        $this->assertTrue($classified[0]['is_secret']);
+        $this->assertFalse($classified[1]['is_secret']);
+    }
+
+    public function test_classify_reads_legacy_stored_shape(): void
+    {
+        $parsed = [
+            ['key' => 'DB_PASSWORD', 'value' => 'plain', 'is_secret' => false],
+            ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
+        ];
+
+        $legacy = [
+            ['key' => 'DB_PASSWORD', 'value' => 'old', 'is_secret' => true],
+            ['key' => 'APP_NAME', 'value' => 'old', 'is_secret' => false],
+        ];
+
+        $classified = EnvParser::classify($parsed, $legacy);
+
+        $this->assertTrue($classified[0]['is_secret']);
+        $this->assertFalse($classified[1]['is_secret']);
+    }
+
+    public function test_classify_with_null_stored_falls_back_to_auto_detection(): void
+    {
+        $parsed = [
+            ['key' => 'DB_PASSWORD', 'value' => 'plain', 'is_secret' => true],
+            ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
+        ];
+
+        $classified = EnvParser::classify($parsed, null);
+
+        $this->assertTrue($classified[0]['is_secret']);
+        $this->assertFalse($classified[1]['is_secret']);
+    }
+
+    public function test_classify_with_empty_stored_list_is_authoritative(): void
+    {
+        $parsed = [
+            ['key' => 'DB_PASSWORD', 'value' => 'plain', 'is_secret' => true],
+        ];
+
+        $classified = EnvParser::classify($parsed, []);
+
+        $this->assertFalse($classified[0]['is_secret']);
     }
 }


### PR DESCRIPTION
Make the live server .env file the source of truth when restoring masked secrets on save and pull, so
  secrets that drifted out of band are no longer silently overwritten with a stale DB copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved environment variable processing to preserve secret values from the live server when secret fields are submitted empty, and to keep secret status consistent.
  * Updated worker environment updates to follow the same secret-preservation rules.

* **Tests**
  * Added/updated integration tests to verify only secret keys are stored, secret values are masked on read, and out-of-band secret rotations are respected during updates.
  * Expanded unit tests to cover live-based secret merge behaviour, including preservation vs non-preservation for empty values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->