### PR TITLE
[Fix] Test failing when mailpit enabled

### DIFF
--- a/tests/Feature/NotificationChannelsTest.php
+++ b/tests/Feature/NotificationChannelsTest.php
@@ -45,7 +45,8 @@ class NotificationChannelsTest extends TestCase
     public function test_cannot_add_email_channel(): void
     {
         config()->set('mail.default', 'smtp');
-        config()->set('mail.mailers.smtp.host', '127.0.0.1'); // invalid host
+        config()->set('mail.mailers.smtp.host', '127.0.0.1');
+        config()->set('mail.mailers.smtp.port', 1); // closed port so the SMTP connection fails even if a local mail catcher (e.g. Mailpit) is listening
 
         $this->actingAs($this->user);
 


### PR DESCRIPTION
A test was failing locally when the user had mailpit configured, as a connection to 127.0.0.1 was using the ENVs mail port, which may have been directed towards a mailpit server accepting connections. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated email notification testing procedures to ensure proper handling of SMTP connection failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->