### PR TITLE
[Feat] Per-site PHP runtime settings

### DIFF
--- a/app/Actions/Site/UpdatePHPSettings.php
+++ b/app/Actions/Site/UpdatePHPSettings.php
@@ -4,7 +4,6 @@ namespace App\Actions\Site;
 
 use App\Exceptions\SSHError;
 use App\Models\Site;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 
 class UpdatePHPSettings
@@ -18,11 +17,9 @@ class UpdatePHPSettings
     {
         $validated = $this->validate($input);
 
-        DB::transaction(function () use ($site, $validated): void {
-            $typeData = $site->type_data ?? [];
-            $typeData['php'] = $validated;
-            $site->update(['type_data' => $typeData]);
-        });
+        $typeData = $site->type_data ?? [];
+        $typeData['php'] = $validated;
+        $site->update(['type_data' => $typeData]);
 
         $site->webserver()->updateVHost($site);
 

--- a/app/Actions/Site/UpdatePHPSettings.php
+++ b/app/Actions/Site/UpdatePHPSettings.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Actions\Site;
+
+use App\Exceptions\SSHError;
+use App\Models\Site;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class UpdatePHPSettings
+{
+    /**
+     * @param  array<string, mixed>  $input
+     *
+     * @throws SSHError
+     */
+    public function update(Site $site, array $input): void
+    {
+        $validated = $this->validate($input);
+
+        DB::transaction(function () use ($site, $validated): void {
+            $typeData = $site->type_data ?? [];
+            $typeData['php'] = $validated;
+            $site->update(['type_data' => $typeData]);
+        });
+
+        $site->webserver()->updateVHost($site);
+
+        app(BroadcastSiteUpdate::class)->broadcast($site);
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @return array{max_upload_size: int|null, max_execution_time: int|null, memory_limit: int|null, max_input_vars: int|null}
+     */
+    private function validate(array $input): array
+    {
+        $validator = Validator::make($input, [
+            'max_upload_size' => ['nullable', 'integer', 'min:1', 'max:10240'],
+            'max_execution_time' => ['nullable', 'integer', 'min:1', 'max:3600'],
+            'memory_limit' => ['nullable', 'integer', 'min:16', 'max:8192'],
+            'max_input_vars' => ['nullable', 'integer', 'min:100', 'max:100000'],
+        ]);
+
+        $validator->after(function ($validator) use ($input): void {
+            if ($validator->errors()->hasAny(['max_upload_size', 'memory_limit'])) {
+                return;
+            }
+
+            $upload = $input['max_upload_size'] ?? null;
+            $memory = $input['memory_limit'] ?? null;
+
+            if (is_numeric($upload) && is_numeric($memory) && (int) $memory < (int) $upload) {
+                $validator->errors()->add(
+                    'memory_limit',
+                    'The memory limit must be greater than or equal to the max upload size.'
+                );
+            }
+        });
+
+        $validated = $validator->validate();
+
+        return [
+            'max_upload_size' => $this->intOrNull($validated['max_upload_size'] ?? null),
+            'max_execution_time' => $this->intOrNull($validated['max_execution_time'] ?? null),
+            'memory_limit' => $this->intOrNull($validated['memory_limit'] ?? null),
+            'max_input_vars' => $this->intOrNull($validated['max_input_vars'] ?? null),
+        ];
+    }
+
+    private function intOrNull(mixed $value): ?int
+    {
+        return is_numeric($value) ? (int) $value : null;
+    }
+}

--- a/app/Actions/Webserver/AbstractGenerateConfig.php
+++ b/app/Actions/Webserver/AbstractGenerateConfig.php
@@ -12,6 +12,8 @@ use Mustache\Engine;
 
 abstract class AbstractGenerateConfig
 {
+    protected const PHP_VALUE_TOKEN = '@@VITO_PHP_VALUE@@';
+
     /**
      * Generate the full vhost config for a site.
      */
@@ -26,7 +28,9 @@ abstract class AbstractGenerateConfig
             'escape' => fn ($value) => $value,
         ]);
 
-        return format_webserver_config($engine->render($template, $data));
+        $rendered = format_webserver_config($engine->render($template, $data));
+
+        return str_replace(self::PHP_VALUE_TOKEN, $data['php_value_string'] ?? '', $rendered);
     }
 
     /**
@@ -197,6 +201,9 @@ abstract class AbstractGenerateConfig
         $isOctane = (bool) data_get($site->type_data, 'octane', false);
         $isPhp = ($siteTypeData['is_php'] ?? false) && ! $isOctane;
 
+        $phpEnabled = $isPhp && $site->vhost_template === null;
+        $phpValueString = $phpEnabled ? $this->phpValueDirectives($site) : '';
+
         $basicAuth = data_get($site->type_data, 'basic_auth', []);
         $basicAuthEnabled = ! empty($basicAuth['enabled']) && ! empty($basicAuth['users']);
 
@@ -211,6 +218,10 @@ abstract class AbstractGenerateConfig
             'is_octane' => $isOctane,
             'octane_port' => data_get($site->type_data, 'octane_port', 8000),
             'php_socket' => $isPhp ? $this->buildPhpSocket($site) : '',
+            'php_value' => $phpValueString !== '',
+            'php_value_string' => $phpValueString,
+            'php_max_upload_size' => $phpEnabled ? $this->phpSetting($site, 'max_upload_size') : null,
+            'php_max_execution_time' => $phpEnabled ? $this->phpSetting($site, 'max_execution_time') : null,
             'port' => $site->port,
             'redirects' => $this->buildRedirects($site),
             'type_data' => $site->type_data ?? [],
@@ -240,6 +251,7 @@ abstract class AbstractGenerateConfig
             $block['is_octane'] = $data['is_octane'];
             $block['octane_port'] = $data['octane_port'];
             $block['php_socket'] = $data['php_socket'];
+            $block['php_value'] = $data['php_value'];
             $block['port'] = $data['port'];
             $block['redirects'] = $data['redirects'];
             $block['basic_auth_enabled'] = $data['basic_auth_enabled'];
@@ -265,5 +277,45 @@ abstract class AbstractGenerateConfig
         }
 
         return $redirects;
+    }
+
+    /**
+     * Build the multi-line PHP_VALUE directive string from the site's
+     * per-site PHP settings (type_data['php']). Empty when nothing is set.
+     */
+    protected function phpValueDirectives(Site $site): string
+    {
+        $directives = [];
+
+        $upload = $this->phpSetting($site, 'max_upload_size');
+        if ($upload !== null) {
+            $directives[] = "upload_max_filesize={$upload}M";
+            $directives[] = "post_max_size={$upload}M";
+        }
+
+        $execution = $this->phpSetting($site, 'max_execution_time');
+        if ($execution !== null) {
+            $directives[] = "max_execution_time={$execution}";
+            $directives[] = "max_input_time={$execution}";
+        }
+
+        $memory = $this->phpSetting($site, 'memory_limit');
+        if ($memory !== null) {
+            $directives[] = "memory_limit={$memory}M";
+        }
+
+        $inputVars = $this->phpSetting($site, 'max_input_vars');
+        if ($inputVars !== null) {
+            $directives[] = "max_input_vars={$inputVars}";
+        }
+
+        return implode("\n", $directives);
+    }
+
+    protected function phpSetting(Site $site, string $key): ?int
+    {
+        $value = data_get($site->type_data, "php.{$key}");
+
+        return is_numeric($value) ? (int) $value : null;
     }
 }

--- a/app/Actions/Webserver/AbstractGenerateConfig.php
+++ b/app/Actions/Webserver/AbstractGenerateConfig.php
@@ -30,7 +30,7 @@ abstract class AbstractGenerateConfig
 
         $rendered = format_webserver_config($engine->render($template, $data));
 
-        return str_replace(self::PHP_VALUE_TOKEN, $data['php_value_string'] ?? '', $rendered);
+        return str_replace(self::PHP_VALUE_TOKEN, $data['php_value_string'], $rendered);
     }
 
     /**

--- a/app/Actions/Webserver/GenerateCaddyConfig.php
+++ b/app/Actions/Webserver/GenerateCaddyConfig.php
@@ -80,6 +80,9 @@ class GenerateCaddyConfig extends AbstractGenerateConfig
     {
         $block['lb_servers'] = $data['lb_servers'];
         $block['lb_policy'] = $data['lb_policy'];
+        $block['request_body_max_size'] = $data['php_max_upload_size'] !== null
+            ? $data['php_max_upload_size'].'MB'
+            : false;
 
         return $block;
     }

--- a/app/Actions/Webserver/GenerateNginxConfig.php
+++ b/app/Actions/Webserver/GenerateNginxConfig.php
@@ -84,6 +84,12 @@ class GenerateNginxConfig extends AbstractGenerateConfig
     protected function enrichServerBlock(array $block, array $data): array
     {
         $block['upstream_name'] = $data['upstream_name'];
+        $block['client_max_body_size'] = $data['php_max_upload_size'] !== null
+            ? $data['php_max_upload_size'].'M'
+            : false;
+        $block['fastcgi_read_timeout'] = $data['php_max_execution_time'] !== null
+            ? $data['php_max_execution_time'].'s'
+            : false;
 
         return $block;
     }

--- a/app/Http/Controllers/SiteSettingController.php
+++ b/app/Http/Controllers/SiteSettingController.php
@@ -6,6 +6,7 @@ use App\Actions\Site\DeleteSite;
 use App\Actions\Site\PreviewVhost;
 use App\Actions\Site\UpdateBasicAuth;
 use App\Actions\Site\UpdateBranch;
+use App\Actions\Site\UpdatePHPSettings;
 use App\Actions\Site\UpdatePHPVersion;
 use App\Actions\Site\UpdatePort;
 use App\Actions\Site\UpdateSiteStats;
@@ -86,6 +87,21 @@ class SiteSettingController extends Controller
         app(UpdatePHPVersion::class)->update($site, $request->input());
 
         return back()->with('success', 'PHP version updated successfully.');
+    }
+
+    /**
+     * @throws SSHError
+     */
+    #[Patch('/php-settings', name: 'site-settings.update-php-settings')]
+    public function updatePHPSettings(Request $request, Server $server, Site $site): RedirectResponse
+    {
+        $this->authorize('update', [$site, $server]);
+
+        abort_unless($site->supportsPhpSettings(), 404);
+
+        app(UpdatePHPSettings::class)->update($site, $request->input());
+
+        return back()->with('success', 'PHP settings updated successfully.');
     }
 
     /**

--- a/app/Http/Resources/SiteResource.php
+++ b/app/Http/Resources/SiteResource.php
@@ -35,6 +35,8 @@ class SiteResource extends JsonResource
             'webserver_creates_site_ssls' => $this->webserver()->createsSiteSSLs(),
             'path' => $this->path,
             'php_version' => $this->php_version,
+            'php_settings' => $this->phpSettings(),
+            'supports_php_settings' => $this->supportsPhpSettings(),
             'repository' => $this->repository,
             'branch' => $this->branch,
             'status' => $this->status->getText(),
@@ -77,6 +79,8 @@ class SiteResource extends JsonResource
     private function sanitisedTypeData(): array
     {
         $typeData = $this->type_data ?? [];
+
+        unset($typeData['php']);
 
         if (isset($typeData['basic_auth']['users']) && is_array($typeData['basic_auth']['users'])) {
             $typeData['basic_auth']['users'] = array_map(

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -204,6 +204,11 @@ class Site extends AbstractModel
             $warnings[] = ['key' => 'vhost_generation_disabled'];
         }
 
+        if (($this->vhost_template !== null || ! $this->vhost_generation_enabled)
+            && array_filter($this->phpSettings(), fn ($v) => $v !== null) !== []) {
+            $warnings[] = ['key' => 'php_settings_ignored'];
+        }
+
         $expiring = $hostedDomains->filter(
             fn ($hd) => $hd->ssl_id
                 && $hd->relationLoaded('ssl')
@@ -504,6 +509,41 @@ class Site extends AbstractModel
         }
 
         return null;
+    }
+
+    public function supportsPhpSettings(): bool
+    {
+        if (! $this->php_version) {
+            return false;
+        }
+
+        $isPhp = (bool) ($this->type()->vhostData()['is_php'] ?? false);
+        $isOctane = (bool) data_get($this->type_data, 'octane', false);
+
+        return $isPhp
+            && ! $isOctane
+            && $this->vhost_generation_enabled
+            && $this->vhost_template === null;
+    }
+
+    /**
+     * @return array{max_upload_size: int|null, max_execution_time: int|null, memory_limit: int|null, max_input_vars: int|null}
+     */
+    public function phpSettings(): array
+    {
+        return [
+            'max_upload_size' => $this->phpSetting('max_upload_size'),
+            'max_execution_time' => $this->phpSetting('max_execution_time'),
+            'memory_limit' => $this->phpSetting('memory_limit'),
+            'max_input_vars' => $this->phpSetting('max_input_vars'),
+        ];
+    }
+
+    private function phpSetting(string $key): ?int
+    {
+        $value = data_get($this->type_data, "php.{$key}");
+
+        return is_numeric($value) ? (int) $value : null;
     }
 
     public function getUrl(): string

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -204,7 +204,7 @@ class Site extends AbstractModel
             $warnings[] = ['key' => 'vhost_generation_disabled'];
         }
 
-        if (($this->vhost_template !== null || ! $this->vhost_generation_enabled)
+        if ($this->vhost_template !== null
             && array_filter($this->phpSettings(), fn ($v) => $v !== null) !== []) {
             $warnings[] = ['key' => 'php_settings_ignored'];
         }

--- a/docs/4.x/sites/settings.md
+++ b/docs/4.x/sites/settings.md
@@ -33,9 +33,9 @@ Leave a field empty to use the server's default. Vito applies these to the site'
 on Caddy), so they take effect for requests served through nginx/Caddy and are preserved across
 deployments. They do not affect the PHP CLI.
 
-Where a value is left unset, the server default applies. PHP defaults to 2&nbsp;MB uploads, a 30s
-execution time, a 128&nbsp;MB memory limit, and 1000 input vars; on nginx, requests are additionally
-capped at 1&nbsp;MB (body size) and 60s until you raise them here.
+Where a value is left unset, the server default applies. PHP defaults to 2 MB uploads, a 30s
+execution time, a 128 MB memory limit, and 1000 input vars; on nginx, requests are additionally
+capped at 1 MB (body size) and 60s until you raise them here.
 
 :::tip
 These settings are per-site. PHP-FPM process pools are shared per system user, so process-manager

--- a/docs/4.x/sites/settings.md
+++ b/docs/4.x/sites/settings.md
@@ -2,8 +2,8 @@
 
 ## Introduction
 
-In the Settings page you can manage your site's details, its PHP version, web directory, vhost
-template, basic auth, and more.
+In the Settings page you can manage your site's details, its PHP version and PHP settings, web
+directory, vhost template, basic auth, and more.
 
 ## Site details
 
@@ -17,6 +17,36 @@ You can change the PHP version of each website in their Settings page.
 
 Make sure that the PHP version you want to use is already installed in the [PHP](../servers/php#install-and-uninstall)
 page.
+
+## Configure PHP Settings
+
+For PHP sites you can tune common per-site PHP runtime limits without editing any files. Click
+**Configure** next to the PHP version on the Settings page to set:
+
+- **Max upload size** — the largest file that can be uploaded (MB).
+- **Max execution time** — how long a request may run (seconds).
+- **Memory limit** — the maximum memory a request may use (MB).
+- **Max input vars** — the maximum number of input variables, e.g. form fields.
+
+Leave a field empty to use the server's default. Vito applies these to the site's vhost (via FastCGI
+`PHP_VALUE`, together with `client_max_body_size`/`fastcgi_read_timeout` on nginx and `request_body`
+on Caddy), so they take effect for requests served through nginx/Caddy and are preserved across
+deployments. They do not affect the PHP CLI.
+
+Where a value is left unset, the server default applies. PHP defaults to 2&nbsp;MB uploads, a 30s
+execution time, a 128&nbsp;MB memory limit, and 1000 input vars; on nginx, requests are additionally
+capped at 1&nbsp;MB (body size) and 60s until you raise them here.
+
+:::tip
+These settings are per-site. PHP-FPM process pools are shared per system user, so process-manager
+tuning (such as `pm.max_children`) is not configured here.
+:::
+
+:::warning
+Configuration is available only for PHP sites that use automatic vhost generation and the default
+vhost template. If you use a custom vhost template, add the directives to your template manually — a
+banner warns you when stored PHP settings cannot be applied.
+:::
 
 ## Change branch
 

--- a/resources/js/components/dialogs/registry.ts
+++ b/resources/js/components/dialogs/registry.ts
@@ -30,6 +30,7 @@ import RestoreBackup from '@/pages/backups/components/restore-backup';
 import SiteFeatureAction from '@/pages/site-features/components/feature-action';
 import ServerFeatureAction from '@/pages/server-features/components/feature-action';
 import Fail2banForm from '@/pages/security/components/fail2ban-form';
+import PhpSettingsDialog from '@/pages/site-settings/components/php-settings-dialog';
 
 export type DialogControlProps = { open: boolean; onOpenChange: (open: boolean) => void };
 
@@ -77,6 +78,7 @@ export const dialogs = {
   siteFeatureAction: SiteFeatureAction,
   serverFeatureAction: ServerFeatureAction,
   fail2banForm: Fail2banForm,
+  phpSettings: PhpSettingsDialog,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as const satisfies Record<string, ComponentType<any>>;
 

--- a/resources/js/components/site-banners.tsx
+++ b/resources/js/components/site-banners.tsx
@@ -107,6 +107,7 @@ export default function SiteBanners({ site }: { site: Site }) {
   const pendingDomainsWarning = warnings.find((w) => w.key === 'pending_domains');
   const sslDisabledWarning = warnings.find((w) => w.key === 'ssl_disabled');
   const vhostWarning = warnings.find((w) => w.key === 'vhost_generation_disabled');
+  const phpSettingsIgnoredWarning = warnings.find((w) => w.key === 'php_settings_ignored');
   const sslExpiringWarning = warnings.find((w) => w.key === 'ssl_expiring');
   const needsFirstDeployWarning = warnings.find((w) => w.key === 'needs_first_deploy');
   const workerWarnings = warnings.filter((w): w is Extract<SiteWarning, { key: 'worker_not_running' }> => w.key === 'worker_not_running');
@@ -201,6 +202,26 @@ export default function SiteBanners({ site }: { site: Site }) {
         >
           Re-enable
         </Button>
+      ),
+    });
+  }
+
+  if (phpSettingsIgnoredWarning) {
+    items.push({
+      key: 'php-settings-ignored',
+      title: 'PHP settings are not applied',
+      description: (
+        <>
+          This site has custom PHP settings, but a custom VHost template is in use so they are not written to the server. Add the directives to your
+          template manually, or reset the template to apply them automatically.
+        </>
+      ),
+      action: (
+        <Link href={route('site-settings', { server: site.server_id, site: site.id })}>
+          <Button variant="outline" size="sm">
+            Go to Settings
+          </Button>
+        </Link>
       ),
     });
   }

--- a/resources/js/pages/site-settings/components/php-settings-dialog.tsx
+++ b/resources/js/pages/site-settings/components/php-settings-dialog.tsx
@@ -120,7 +120,7 @@ export default function PhpSettingsDialog({ open, onOpenChange, site }: { open: 
           </FormFields>
         </Form>
 
-        <DialogFooter>
+        <DialogFooter className="gap-2">
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
           </DialogClose>

--- a/resources/js/pages/site-settings/components/php-settings-dialog.tsx
+++ b/resources/js/pages/site-settings/components/php-settings-dialog.tsx
@@ -1,0 +1,135 @@
+import { FormEvent } from 'react';
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useForm } from '@inertiajs/react';
+import { Form, FormField, FormFields } from '@/components/ui/form';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import InputError from '@/components/ui/input-error';
+import { LoaderCircleIcon } from 'lucide-react';
+import { Site } from '@/types/site';
+
+type PhpSettingsForm = {
+  max_upload_size: string;
+  max_execution_time: string;
+  memory_limit: string;
+  max_input_vars: string;
+};
+
+function SettingField({
+  id,
+  label,
+  hint,
+  placeholder,
+  min,
+  value,
+  error,
+  onChange,
+}: {
+  id: keyof PhpSettingsForm;
+  label: string;
+  hint: string;
+  placeholder: string;
+  min: number;
+  value: string;
+  error?: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <FormField>
+      <Label htmlFor={id}>{label}</Label>
+      <Input id={id} type="number" min={min} placeholder={placeholder} value={value} onChange={(e) => onChange(e.target.value)} />
+      <p className="text-muted-foreground text-xs">{hint}</p>
+      <InputError message={error} />
+    </FormField>
+  );
+}
+
+export default function PhpSettingsDialog({ open, onOpenChange, site }: { open: boolean; onOpenChange: (open: boolean) => void; site: Site }) {
+  const form = useForm<PhpSettingsForm>({
+    max_upload_size: site.php_settings.max_upload_size?.toString() ?? '',
+    max_execution_time: site.php_settings.max_execution_time?.toString() ?? '',
+    memory_limit: site.php_settings.memory_limit?.toString() ?? '',
+    max_input_vars: site.php_settings.max_input_vars?.toString() ?? '',
+  });
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+    form.clearErrors();
+    form.transform((data) => ({
+      max_upload_size: data.max_upload_size === '' ? null : Number(data.max_upload_size),
+      max_execution_time: data.max_execution_time === '' ? null : Number(data.max_execution_time),
+      memory_limit: data.memory_limit === '' ? null : Number(data.memory_limit),
+      max_input_vars: data.max_input_vars === '' ? null : Number(data.max_input_vars),
+    }));
+    form.patch(route('site-settings.update-php-settings', { server: site.server_id, site: site.id }), {
+      onSuccess: () => onOpenChange(false),
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent onCloseAutoFocus={(e) => e.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle>Configure PHP settings</DialogTitle>
+          <DialogDescription>Per-site PHP runtime limits. Leave a field empty to use the server default.</DialogDescription>
+        </DialogHeader>
+
+        <Form id="php-settings-form" onSubmit={submit} className="p-4">
+          <FormFields>
+            <SettingField
+              id="max_upload_size"
+              label="Max upload size (MB)"
+              placeholder="e.g. 1024"
+              hint="Default: 2 MB (nginx caps at 1 MB)"
+              min={1}
+              value={form.data.max_upload_size}
+              error={form.errors.max_upload_size}
+              onChange={(value) => form.setData('max_upload_size', value)}
+            />
+            <SettingField
+              id="max_execution_time"
+              label="Max execution time (seconds)"
+              placeholder="e.g. 120"
+              hint="Default: 30s (nginx caps at 60s)"
+              min={1}
+              value={form.data.max_execution_time}
+              error={form.errors.max_execution_time}
+              onChange={(value) => form.setData('max_execution_time', value)}
+            />
+            <SettingField
+              id="memory_limit"
+              label="Memory limit (MB)"
+              placeholder="e.g. 256"
+              hint="Default: 128 MB"
+              min={16}
+              value={form.data.memory_limit}
+              error={form.errors.memory_limit}
+              onChange={(value) => form.setData('memory_limit', value)}
+            />
+            <SettingField
+              id="max_input_vars"
+              label="Max input vars"
+              placeholder="e.g. 5000"
+              hint="Default: 1000"
+              min={100}
+              value={form.data.max_input_vars}
+              error={form.errors.max_input_vars}
+              onChange={(value) => form.setData('max_input_vars', value)}
+            />
+          </FormFields>
+        </Form>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button form="php-settings-form" type="submit" disabled={form.processing}>
+            {form.processing && <LoaderCircleIcon className="size-4 animate-spin" />}
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/pages/site-settings/index.tsx
+++ b/resources/js/pages/site-settings/index.tsx
@@ -25,8 +25,10 @@ import ChangeSourceControl from '@/pages/site-settings/components/source-control
 import BasicAuth from '@/pages/site-settings/components/basic-auth';
 import StatsToggle from '@/pages/site-settings/components/stats-toggle';
 import WebDirectory from './components/web-directory';
+import { useDialog } from '@/hooks/use-dialog';
 
 export default function Databases() {
+  const dialog = useDialog();
   const page = usePage<{
     server: Server;
     site: Site;
@@ -181,11 +183,23 @@ export default function Databases() {
             <div className="flex items-center justify-between p-4">
               <span>PHP version</span>
               {page.props.site.php_version ? (
-                <ChangePHPVersion site={page.props.site}>
-                  <Button variant="outline" className="h-6">
-                    {page.props.site.php_version}
-                  </Button>
-                </ChangePHPVersion>
+                <div className="flex items-center gap-2">
+                  <ChangePHPVersion site={page.props.site}>
+                    <Button variant="outline" className="h-6">
+                      {page.props.site.php_version}
+                    </Button>
+                  </ChangePHPVersion>
+                  {page.props.site.supports_php_settings && (
+                    <Button
+                      variant="outline"
+                      className="h-6"
+                      aria-label="Configure PHP settings"
+                      onClick={() => dialog.phpSettings.open({ site: page.props.site })}
+                    >
+                      Configure
+                    </Button>
+                  )}
+                </div>
               ) : (
                 <span className="text-muted-foreground">-</span>
               )}

--- a/resources/js/types/site.d.ts
+++ b/resources/js/types/site.d.ts
@@ -21,6 +21,13 @@ export interface Site {
   webserver_default_ssl_method: string;
   path: string;
   php_version: string;
+  php_settings: {
+    max_upload_size: number | null;
+    max_execution_time: number | null;
+    memory_limit: number | null;
+    max_input_vars: number | null;
+  };
+  supports_php_settings: boolean;
   repository: string;
   branch?: string;
   status: string;
@@ -74,6 +81,7 @@ export type SiteWarning =
   | { key: 'pending_domains'; count: number; domains: string[] }
   | { key: 'ssl_disabled' }
   | { key: 'vhost_generation_disabled' }
+  | { key: 'php_settings_ignored' }
   | { key: 'ssl_expiring'; count: number; domains: string[]; earliest_expiry: string }
   | { key: 'needs_first_deploy' }
   | {

--- a/resources/views/ssh/services/webserver/caddy/vhost.mustache
+++ b/resources/views/ssh/services/webserver/caddy/vhost.mustache
@@ -26,8 +26,14 @@
 
     {{#is_php}}
     root * {{root}}
+    {{#request_body_max_size}}request_body {
+        max_size {{request_body_max_size}}
+    }
+    {{/request_body_max_size}}
     try_files {path} {path}/ /index.php?{query}
-    php_fastcgi {{php_socket}}
+    php_fastcgi {{php_socket}}{{#php_value}} {
+        env PHP_VALUE "@@VITO_PHP_VALUE@@"
+    }{{/php_value}}
     file_server
     {{/is_php}}
 

--- a/resources/views/ssh/services/webserver/nginx/vhost.mustache
+++ b/resources/views/ssh/services/webserver/nginx/vhost.mustache
@@ -62,6 +62,7 @@ server {
 
     server_name{{#domains}} {{name}}{{/domains}};
     root {{root}};
+    {{#client_max_body_size}}client_max_body_size {{client_max_body_size}};{{/client_max_body_size}}
 
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-Content-Type-Options "nosniff";
@@ -103,8 +104,10 @@ server {
 
     location ~ \.php$ {
         fastcgi_pass {{php_socket}};
+        {{#php_value}}fastcgi_param PHP_VALUE "@@VITO_PHP_VALUE@@";{{/php_value}}
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;
+        {{#fastcgi_read_timeout}}fastcgi_read_timeout {{fastcgi_read_timeout}};{{/fastcgi_read_timeout}}
         fastcgi_hide_header X-Powered-By;
     }
 

--- a/tests/Feature/SiteSettings/PhpSettingsTest.php
+++ b/tests/Feature/SiteSettings/PhpSettingsTest.php
@@ -219,6 +219,21 @@ class PhpSettingsTest extends TestCase
         ])->assertNotFound();
     }
 
+    public function test_route_404s_when_vhost_generation_disabled(): void
+    {
+        $this->site->vhost_generation_enabled = false;
+        $this->site->save();
+
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-php-settings', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'max_upload_size' => 64,
+        ])->assertNotFound();
+    }
+
     public function test_resource_exposes_php_settings(): void
     {
         $this->site->type_data = ['php' => ['max_upload_size' => 64, 'max_execution_time' => null, 'memory_limit' => null, 'max_input_vars' => null]];

--- a/tests/Feature/SiteSettings/PhpSettingsTest.php
+++ b/tests/Feature/SiteSettings/PhpSettingsTest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Tests\Feature\SiteSettings;
+
+use App\Facades\SSH;
+use App\Http\Resources\SiteResource;
+use App\Models\HostedDomain;
+use App\Models\User;
+use App\Services\Webserver\Caddy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PhpSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_endpoint_persists_php_settings(): void
+    {
+        SSH::fake();
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-php-settings', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'max_upload_size' => 64,
+            'max_execution_time' => 120,
+            'memory_limit' => 256,
+            'max_input_vars' => 5000,
+        ])
+            ->assertRedirect()
+            ->assertSessionDoesntHaveErrors();
+
+        $this->site->refresh();
+
+        $this->assertSame([
+            'max_upload_size' => 64,
+            'max_execution_time' => 120,
+            'memory_limit' => 256,
+            'max_input_vars' => 5000,
+        ], $this->site->type_data['php']);
+    }
+
+    public function test_blank_values_persist_as_null(): void
+    {
+        SSH::fake();
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-php-settings', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'max_upload_size' => '',
+            'max_execution_time' => null,
+        ])
+            ->assertRedirect()
+            ->assertSessionDoesntHaveErrors();
+
+        $this->site->refresh();
+
+        $this->assertNull($this->site->type_data['php']['max_upload_size']);
+        $this->assertNull($this->site->type_data['php']['memory_limit']);
+    }
+
+    public function test_nginx_vhost_includes_php_directives_intact(): void
+    {
+        HostedDomain::factory()->primary()->create([
+            'site_id' => $this->site->id,
+            'domain' => $this->site->domain,
+        ]);
+
+        $this->site->type_data = [
+            'php' => [
+                'max_upload_size' => 64,
+                'max_execution_time' => 120,
+                'memory_limit' => 256,
+                'max_input_vars' => 5000,
+            ],
+        ];
+        $this->site->save();
+
+        $vhost = $this->site->webserver()->generateVhost($this->site);
+
+        $this->assertStringContainsString('fastcgi_param PHP_VALUE "upload_max_filesize=64M', $vhost);
+        $this->assertStringContainsString("\npost_max_size=64M", $vhost);
+        $this->assertStringContainsString("\nmemory_limit=256M", $vhost);
+        $this->assertStringContainsString('max_input_vars=5000";', $vhost);
+
+        $this->assertStringContainsString('client_max_body_size 64M;', $vhost);
+        $this->assertStringContainsString('fastcgi_read_timeout 120s;', $vhost);
+    }
+
+    public function test_nginx_vhost_omits_directives_when_unset(): void
+    {
+        HostedDomain::factory()->primary()->create([
+            'site_id' => $this->site->id,
+            'domain' => $this->site->domain,
+        ]);
+
+        $vhost = $this->site->webserver()->generateVhost($this->site);
+
+        $this->assertStringNotContainsString('PHP_VALUE', $vhost);
+        $this->assertStringNotContainsString('client_max_body_size', $vhost);
+        $this->assertStringNotContainsString('fastcgi_read_timeout', $vhost);
+    }
+
+    public function test_nginx_vhost_emits_only_set_directives(): void
+    {
+        HostedDomain::factory()->primary()->create([
+            'site_id' => $this->site->id,
+            'domain' => $this->site->domain,
+        ]);
+
+        $this->site->type_data = ['php' => ['max_input_vars' => 5000]];
+        $this->site->save();
+
+        $vhost = $this->site->webserver()->generateVhost($this->site);
+
+        $this->assertStringContainsString('fastcgi_param PHP_VALUE "max_input_vars=5000";', $vhost);
+        $this->assertStringNotContainsString('client_max_body_size', $vhost);
+        $this->assertStringNotContainsString('fastcgi_read_timeout', $vhost);
+    }
+
+    public function test_caddy_vhost_includes_php_directives(): void
+    {
+        $this->server->webserver()?->update(['name' => Caddy::id()]);
+
+        HostedDomain::factory()->primary()->create([
+            'site_id' => $this->site->id,
+            'domain' => $this->site->domain,
+        ]);
+
+        $this->site->type_data = [
+            'php' => [
+                'max_upload_size' => 64,
+                'max_execution_time' => 120,
+                'memory_limit' => 256,
+                'max_input_vars' => 5000,
+            ],
+        ];
+        $this->site->save();
+
+        $vhost = $this->site->webserver()->generateVhost($this->site);
+
+        $this->assertStringContainsString('env PHP_VALUE "upload_max_filesize=64M', $vhost);
+        $this->assertStringContainsString('max_size 64MB', $vhost);
+    }
+
+    public function test_custom_template_sentinel_is_stripped(): void
+    {
+        HostedDomain::factory()->primary()->create([
+            'site_id' => $this->site->id,
+            'domain' => $this->site->domain,
+        ]);
+
+        $this->site->type_data = ['php' => ['max_upload_size' => 64]];
+        $this->site->vhost_template = "server {\n    fastcgi_param PHP_VALUE \"@@VITO_PHP_VALUE@@\";\n}";
+        $this->site->save();
+
+        $vhost = $this->site->webserver()->generateVhost($this->site);
+
+        $this->assertStringNotContainsString('@@VITO_PHP_VALUE@@', $vhost);
+    }
+
+    public function test_validation_requires_memory_limit_at_least_upload_size(): void
+    {
+        SSH::fake();
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-php-settings', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'max_upload_size' => 512,
+            'memory_limit' => 256,
+        ])->assertSessionHasErrors('memory_limit');
+    }
+
+    public function test_validation_rejects_out_of_range_values(): void
+    {
+        SSH::fake();
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-php-settings', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'max_input_vars' => 5,
+        ])->assertSessionHasErrors('max_input_vars');
+    }
+
+    public function test_route_404s_for_custom_vhost_template(): void
+    {
+        $this->site->vhost_template = 'server { }';
+        $this->site->save();
+
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-php-settings', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'max_upload_size' => 64,
+        ])->assertNotFound();
+    }
+
+    public function test_route_404s_for_octane_site(): void
+    {
+        $this->site->type_data = ['octane' => true];
+        $this->site->save();
+
+        $this->actingAs($this->user);
+
+        $this->patch(route('site-settings.update-php-settings', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'max_upload_size' => 64,
+        ])->assertNotFound();
+    }
+
+    public function test_resource_exposes_php_settings(): void
+    {
+        $this->site->type_data = ['php' => ['max_upload_size' => 64, 'max_execution_time' => null, 'memory_limit' => null, 'max_input_vars' => null]];
+        $this->site->save();
+        $this->site->load('server');
+
+        $resource = SiteResource::make($this->site)->toArray(request());
+
+        $this->assertTrue($resource['supports_php_settings']);
+        $this->assertSame(64, $resource['php_settings']['max_upload_size']);
+        $this->assertNull($resource['php_settings']['memory_limit']);
+        $this->assertArrayNotHasKey('php', $resource['type_data']);
+    }
+
+    public function test_authorization_requires_project_access(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherUser->ensureHasDefaultProject();
+
+        $this->actingAs($otherUser);
+
+        $this->patch(route('site-settings.update-php-settings', [
+            'server' => $this->server->id,
+            'site' => $this->site,
+        ]), [
+            'max_upload_size' => 64,
+        ])->assertForbidden();
+    }
+}


### PR DESCRIPTION
<img width="528" height="600" alt="image" src="https://github.com/user-attachments/assets/a6677fef-8c4f-4ace-a8c3-8cde63583004" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configure per-site PHP runtime limits including upload size, execution time, memory limit, and input variables via a new settings dialog.
  * PHP limits automatically applied to Nginx and Caddy webserver configurations.
  * Warning displayed when custom vhost templates prevent settings application.

* **Documentation**
  * Site settings documentation updated with PHP configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->