### PR TITLE
[Fix] Firewall rule mask prefill and guidance

### DIFF
--- a/app/Tables/Servers/FirewallRuleTable.php
+++ b/app/Tables/Servers/FirewallRuleTable.php
@@ -29,6 +29,7 @@ class FirewallRuleTable extends Table
             EnumColumn::make('status', 'Status')->sortable(),
             Column::data('id'),
             Column::data('server_id'),
+            Column::data('mask'),
             ActionsColumn::make(),
         ];
     }

--- a/resources/js/pages/firewall/components/form.tsx
+++ b/resources/js/pages/firewall/components/form.tsx
@@ -3,12 +3,13 @@ import { FormEvent } from 'react';
 import { Form, FormField, FormFields } from '@/components/ui/form';
 import { Button } from '@/components/ui/button';
 import { useForm } from '@inertiajs/react';
-import { LoaderCircleIcon } from 'lucide-react';
+import { InfoIcon, LoaderCircleIcon } from 'lucide-react';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import InputError from '@/components/ui/input-error';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { FirewallRule } from '@/types/firewall';
 
 export default function RuleForm({
@@ -37,7 +38,7 @@ export default function RuleForm({
     port: firewallRule?.port?.toString() || '',
     source_any: !firewallRule?.source,
     source: firewallRule?.source || '',
-    mask: firewallRule?.mask?.toString() || '',
+    mask: firewallRule?.mask?.toString() || '32',
   });
 
   const submit = (e: FormEvent) => {
@@ -133,6 +134,15 @@ export default function RuleForm({
                 <FormField>
                   <Label htmlFor="mask">Mask</Label>
                   <Input type="text" id="mask" value={form.data.mask} onChange={(e) => form.setData('mask', e.target.value)} />
+                  <Alert>
+                    <InfoIcon />
+                    <AlertDescription>
+                      <p>
+                        The mask sets how many IP addresses this rule covers. Use <code>32</code> for just this one IP, <code>24</code> for its
+                        whole local network (256 addresses), and smaller numbers to cover even more. Lower number = wider range.
+                      </p>
+                    </AlertDescription>
+                  </Alert>
                   <InputError message={form.errors.mask} />
                 </FormField>
               </>


### PR DESCRIPTION
Fixes the firewall edit form not prefilling the mask, defaults new rules to `32`, and adds a plain-language help box
  explaining the mask.
<img width="1020" height="440" alt="image" src="https://github.com/user-attachments/assets/978547e6-c302-4afd-b6b9-3b32a90a9252" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Firewall rule mask field now defaults to '32' to streamline the rule creation process and improve user experience
  * Added informational guidance to the mask input field explaining how mask values affect IP address range coverage, including practical examples and recommendations to help users understand the implications of selecting lower versus higher values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->