### PR TITLE
[Feat] Enforce PR title prefixes and group release notes

### DIFF
--- a/.github/scripts/group-release-notes.sh
+++ b/.github/scripts/group-release-notes.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Group auto-generated GitHub release notes by PR title prefix.
+#
+# Reads raw release notes (as produced by GitHub's "generate_release_notes")
+# on stdin and writes grouped notes to stdout. Changelog entries under the
+# "What's Changed" heading are sorted into three sections based on their title
+# prefix:
+#
+#   [Feat] ... -> ### Features
+#   [Fix]  ... -> ### Fixes
+#   anything else -> ### Others
+#
+# The [Feat]/[Fix] prefix is stripped from each line once it has been sorted
+# into its section. Anything outside the "What's Changed" list (the
+# "New Contributors" block, the "Full Changelog" link, etc.) is preserved
+# verbatim and printed after the grouped sections.
+#
+# Usage:
+#   group-release-notes.sh < raw-notes.md > grouped-notes.md
+
+set -euo pipefail
+
+features=""
+fixes=""
+others=""
+trailer=""
+
+# GitHub puts changelog entries under a "## What's Changed" heading and any
+# additional info (e.g. "## New Contributors") under later headings. Only list
+# items in the changelog section should be categorized.
+in_changelog="false"
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  if [[ "$line" =~ ^##[[:space:]]+ ]]; then
+    if [[ "$line" =~ [Ww]hat\'?s[[:space:]]+[Cc]hanged ]]; then
+      in_changelog="true"
+    else
+      in_changelog="false"
+      trailer+="${line}"$'\n'
+    fi
+    continue
+  fi
+
+  # Changelog entries are markdown list items: "* ..." or "- ...".
+  if [[ "$in_changelog" == "true" && "$line" =~ ^[*-][[:space:]]+(.*)$ ]]; then
+    entry="${BASH_REMATCH[1]}"
+
+    if [[ "$entry" =~ ^\[Feat\][[:space:]]*(.*)$ ]]; then
+      features+="* ${BASH_REMATCH[1]}"$'\n'
+    elif [[ "$entry" =~ ^\[Fix\][[:space:]]*(.*)$ ]]; then
+      fixes+="* ${BASH_REMATCH[1]}"$'\n'
+    else
+      others+="* ${entry}"$'\n'
+    fi
+
+    continue
+  fi
+
+  # A non-blank, non-list line inside the changelog section (e.g. the
+  # "Full Changelog" link that follows the list) marks the end of the list.
+  if [[ "$in_changelog" == "true" && -n "$line" ]]; then
+    in_changelog="false"
+  fi
+
+  # Outside the changelog list: keep lines (e.g. the New Contributors entries
+  # and the Full Changelog link, with their spacing) for the trailer.
+  if [[ "$in_changelog" != "true" ]]; then
+    trailer+="${line}"$'\n'
+  fi
+done
+
+output=""
+
+if [[ -n "$features" ]]; then
+  output+="### Features"$'\n\n'"$features"$'\n'
+fi
+
+if [[ -n "$fixes" ]]; then
+  output+="### Fixes"$'\n\n'"$fixes"$'\n'
+fi
+
+if [[ -n "$others" ]]; then
+  output+="### Others"$'\n\n'"$others"$'\n'
+fi
+
+if [[ -n "$trailer" ]]; then
+  # Drop leading blank lines so the trailer hugs the last grouped section.
+  while [[ "$trailer" == $'\n'* ]]; do
+    trailer="${trailer#$'\n'}"
+  done
+  output+="$trailer"
+fi
+
+# Trim a trailing blank line for tidy output.
+printf '%s' "${output%$'\n'}"
+printf '\n'

--- a/.github/scripts/group-release-notes.sh
+++ b/.github/scripts/group-release-notes.sh
@@ -46,9 +46,9 @@ while IFS= read -r line || [[ -n "$line" ]]; do
   if [[ "$in_changelog" == "true" && "$line" =~ ^[*-][[:space:]]+(.*)$ ]]; then
     entry="${BASH_REMATCH[1]}"
 
-    if [[ "$entry" =~ ^\[Feat\][[:space:]]*(.*)$ ]]; then
+    if [[ "$entry" =~ ^\[Feat\]\ (.*)$ ]]; then
       features+="* ${BASH_REMATCH[1]}"$'\n'
-    elif [[ "$entry" =~ ^\[Fix\][[:space:]]*(.*)$ ]]; then
+    elif [[ "$entry" =~ ^\[Fix\]\ (.*)$ ]]; then
       fixes+="* ${BASH_REMATCH[1]}"$'\n'
     else
       others+="* ${entry}"$'\n'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,37 @@
+name: pr-title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+    branches:
+      - 2.x
+      - 3.x
+      - 4.x
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+
+    name: Validate PR title
+
+    steps:
+      - name: Check title prefix
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ "$PR_TITLE" =~ ^\[(Feat|Fix)\]\ .+ ]]; then
+            echo "PR title is valid: $PR_TITLE"
+            exit 0
+          fi
+
+          echo "::error::Invalid PR title: \"$PR_TITLE\""
+          echo "::error::PR titles must start with [Feat] or [Fix], followed by a space and a description."
+          echo "::error::Examples: \"[Feat] Add per-site PHP runtime settings\" or \"[Fix] Resolve backup failure\"."
+          exit 1

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,5 +1,9 @@
 name: pr-title
 
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -115,12 +115,15 @@ jobs:
           prerelease: ${{ inputs.prerelease == 'true' }}
           generate_release_notes: true
 
-      - name: Get release notes from GitHub API
+      - name: Group release notes by prefix
         id: fetch-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          NOTES=$(gh release view ${{ steps.version.outputs.version }} --json body -q .body)
+          RAW_NOTES=$(gh release view "$VERSION" --json body -q .body)
+          NOTES=$(printf '%s' "$RAW_NOTES" | .github/scripts/group-release-notes.sh)
+          gh release edit "$VERSION" --notes "$NOTES"
           {
             echo "notes<<EOF"
             echo "$NOTES"

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -122,7 +122,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           RAW_NOTES=$(gh release view "$VERSION" --json body -q .body)
-          NOTES=$(printf '%s' "$RAW_NOTES" | .github/scripts/group-release-notes.sh)
+          NOTES=$(printf '%s' "$RAW_NOTES" | bash .github/scripts/group-release-notes.sh)
           gh release edit "$VERSION" --notes "$NOTES"
           {
             echo "notes<<EOF"


### PR DESCRIPTION
## Summary

Two CI/release changes:

1. **Enforce PR title prefixes** — new `.github/workflows/pr-title.yml` runs on PR open/edit/reopen/sync and fails any PR whose title does not start with exactly `[Feat]` or `[Fix]` followed by a space and a description.
2. **Group release notes** — auto-generated release notes are reorganized into **Features** / **Fixes** / **Others** sections, with the `[Feat]`/`[Fix]` prefix stripped from each entry. Applied to both the GitHub release page (`gh release edit`) and the Discord notification.

## Details

- `.github/scripts/group-release-notes.sh` — reusable script that takes GitHub's generated notes on stdin and emits the grouped markdown. The `## New Contributors` block and `**Full Changelog**` link are preserved verbatim; empty sections are omitted.
- `.github/workflows/releases.yml` — the former "Get release notes" step now pipes the generated body through the grouping script, writes it back to the release, and exposes it as the `notes` output. The Discord step re-reads the (now grouped) body and continues to strip the `by @user in <pull-url>` attribution.

## Notes / follow-ups

- To actually **block merges** on a bad title, add the `pr-title / Validate PR title` check as a required status check in branch protection — the workflow alone can't enforce that.
- The rule is strict: titles like `[Improvement]` / `[CI/CD]` or prefix-less titles now fail the check and would land under **Others** in release notes. Shout if you'd prefer to map `[Improvement]` somewhere specific or loosen the rule.

## Testing

- Verified the grouping script against several note shapes (with/without New Contributors block, fixes-only, no-prefix-only, empty input).
- Both workflow files validated as YAML; the script passes `bash -n`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release notes are now automatically reorganised by category, grouping “feature” and “fix” items for clearer presentation.

* **Chores**
  * Pull request titles are now validated more strictly to enforce a consistent `[Feat]` / `[Fix]` naming convention.
  * Release note processing in the release workflow now generates grouped notes and updates the published release text accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->