### PR TITLE
[Fix] workflow verbose log

### DIFF
--- a/app/Facades/SSH.php
+++ b/app/Facades/SSH.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Facade as FacadeAlias;
  * @method static \App\Helpers\SSH|SSHFake init(Server $server, string $asUser = null)
  * @method static setLog(?ServerLog $log)
  * @method static \App\Helpers\SSH useLog(string $disk, string $path, ?\Closure $outputCallback = null)
+ * @method static \App\Helpers\SSH clearLog()
  * @method static connect()
  * @method static string exec(string|View $command, string $log = '', int $siteId = null, ?bool $stream = false, callable $streamCallback = null, int $timeout = 0)
  * @method static string upload(string $local, string $remote, ?string $owner = null)

--- a/app/Helpers/SSH.php
+++ b/app/Helpers/SSH.php
@@ -53,9 +53,6 @@ class SSH
         $this->log = null;
         $this->asUser = null;
         $this->variables = [];
-        $this->logDisk = null;
-        $this->logPath = null;
-        $this->logOutputCallback = null;
         $this->server = $server->refresh();
         $this->user = $server->getSshUser();
         if ($asUser && $asUser !== $server->getSshUser()) {
@@ -101,7 +98,7 @@ class SSH
     /**
      * Write a chunk of output to either a file on a disk or the server log.
      */
-    private function writeOutput(string $chunk): void
+    protected function writeOutput(string $chunk): void
     {
         if ($this->logDisk && $this->logPath) {
             Storage::disk($this->logDisk)->append($this->logPath, $chunk);
@@ -128,6 +125,15 @@ class SSH
         $this->logDisk = $disk;
         $this->logPath = $path;
         $this->logOutputCallback = $outputCallback;
+
+        return $this;
+    }
+
+    public function clearLog(): self
+    {
+        $this->logDisk = null;
+        $this->logPath = null;
+        $this->logOutputCallback = null;
 
         return $this;
     }

--- a/app/Jobs/Workflow/RunJob.php
+++ b/app/Jobs/Workflow/RunJob.php
@@ -46,13 +46,17 @@ class RunJob implements ShouldQueue
             if ($this->input['inputs']) {
                 $this->executionTree->inputs = $this->input['inputs'];
             }
-            app(RunWorkflow::class)->executeAction(
-                $this->run,
-                $this->user,
-                $this->workflow,
-                $this->executionTree,
-                $this->input['inputs'] ?? [],
-            );
+            try {
+                app(RunWorkflow::class)->executeAction(
+                    $this->run,
+                    $this->user,
+                    $this->workflow,
+                    $this->executionTree,
+                    $this->input['inputs'] ?? [],
+                );
+            } finally {
+                SSH::clearLog();
+            }
             $this->run->status = WorkflowRunStatus::COMPLETED;
             $this->run->save();
             $this->broadcastRunUpdate();

--- a/app/Support/Testing/SSHFake.php
+++ b/app/Support/Testing/SSHFake.php
@@ -69,7 +69,7 @@ class SSHFake extends SSH
         $this->commands[] = $command;
 
         $output = $this->output ?? 'fake output';
-        $this->log?->write($output);
+        $this->writeOutput($output);
 
         if ($stream === true) {
             echo $output;

--- a/tests/Feature/Jobs/WorkflowRunJobTest.php
+++ b/tests/Feature/Jobs/WorkflowRunJobTest.php
@@ -4,12 +4,15 @@ namespace Tests\Feature\Jobs;
 
 use App\DTOs\WorkflowActionDTO;
 use App\Enums\WorkflowRunStatus;
+use App\Facades\SSH;
 use App\Jobs\Workflow\RunJob;
 use App\Models\Workflow;
 use App\Models\WorkflowRun;
+use App\WorkflowActions\General\RunCommand;
 use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class WorkflowRunJobTest extends TestCase
@@ -54,5 +57,88 @@ class WorkflowRunJobTest extends TestCase
                     && $context['error'] === 'Workflow execution failed';
             })
             ->once();
+    }
+
+    public function test_verbose_run_logs_command_output(): void
+    {
+        Storage::fake('server-logs');
+        SSH::fake('command-output-line');
+
+        /** @var Workflow $workflow */
+        $workflow = Workflow::factory()->create([
+            'user_id' => $this->user->id,
+            'project_id' => $this->user->current_project_id,
+        ]);
+
+        /** @var WorkflowRun $run */
+        $run = WorkflowRun::factory()->create([
+            'workflow_id' => $workflow->id,
+            'user_id' => $this->user->id,
+            'status' => WorkflowRunStatus::RUNNING,
+            'verbose' => true,
+            'log_disk' => 'server-logs',
+            'log_path' => 'workflow_run_test.log',
+        ]);
+
+        $executionTree = new WorkflowActionDTO(
+            label: 'Run Command',
+            handler: RunCommand::class,
+            outputs: [],
+            inputs: [
+                'server_id' => $this->server->id,
+                'command' => 'echo hello',
+                'user' => null,
+            ],
+            id: 'node-1',
+        );
+
+        $job = new RunJob($run, $this->user, $workflow, $executionTree, ['inputs' => []]);
+        $job->handle();
+
+        $run->refresh();
+
+        $this->assertEquals(WorkflowRunStatus::COMPLETED, $run->status);
+        $this->assertStringContainsString('command-output-line', $run->getLogContent());
+    }
+
+    public function test_verbose_log_does_not_leak_after_run(): void
+    {
+        Storage::fake('server-logs');
+        SSH::fake('command-output-line');
+
+        /** @var Workflow $workflow */
+        $workflow = Workflow::factory()->create([
+            'user_id' => $this->user->id,
+            'project_id' => $this->user->current_project_id,
+        ]);
+
+        /** @var WorkflowRun $run */
+        $run = WorkflowRun::factory()->create([
+            'workflow_id' => $workflow->id,
+            'user_id' => $this->user->id,
+            'status' => WorkflowRunStatus::RUNNING,
+            'verbose' => true,
+            'log_disk' => 'server-logs',
+            'log_path' => 'workflow_run_test.log',
+        ]);
+
+        $executionTree = new WorkflowActionDTO(
+            label: 'Run Command',
+            handler: RunCommand::class,
+            outputs: [],
+            inputs: [
+                'server_id' => $this->server->id,
+                'command' => 'echo hello',
+                'user' => null,
+            ],
+            id: 'node-1',
+        );
+
+        $job = new RunJob($run, $this->user, $workflow, $executionTree, ['inputs' => []]);
+        $job->handle();
+
+        $this->server->ssh()->exec('echo after-run');
+
+        $this->assertStringNotContainsString('after-run', $run->refresh()->getLogContent());
     }
 }


### PR DESCRIPTION
Closes #1185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of command logging so previous output no longer carries over into later runs.
  * Ensured verbose run logs only include output from the current job, even if additional commands run afterwards.
  * Preserved command output capture more reliably during workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->