### PR TITLE
[Feat] Support MySQL and MariaDB as the panel database (#933)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,16 @@ APP_URL=
 #WS_BROADCAST_SECRET=
 WS_ALLOWED_ORIGINS="${APP_URL}"
 
+# Database — SQLite is the default and needs no configuration.
+# To use MySQL or MariaDB, set DB_CONNECTION and uncomment the block below.
+# Use "mariadb" (not "mysql") for MariaDB so Laravel emits MariaDB-compatible SQL.
+#DB_CONNECTION=mysql   # or "mariadb" for MariaDB
+#DB_HOST=127.0.0.1
+#DB_PORT=3306
+#DB_DATABASE=vito
+#DB_USERNAME=vito
+#DB_PASSWORD=
+
 FILESYSTEM_DRIVER=local
 
 MAIL_MAILER=smtp

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
       - 1.x
       - 2.x
       - 3.x
+      - 4.x
   pull_request:
 
 jobs:
@@ -14,10 +15,40 @@ jobs:
     runs-on: ubuntu-22.04
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         php: [ 8.4 ]
         node-version: [ "22.x" ]
+        database: [ sqlite, mysql, mariadb ]
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_DATABASE: vito_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+      mariadb:
+        image: mariadb:11
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "true"
+          MARIADB_DATABASE: vito_test
+        ports:
+          - 3307:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    name: tests (${{ matrix.database }})
 
     steps:
       - uses: actions/checkout@v4
@@ -41,6 +72,7 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Create sqlite database
+        if: matrix.database == 'sqlite'
         run: touch storage/database-test.sqlite
 
       - name: Set up the .env file
@@ -61,4 +93,11 @@ jobs:
         run: npm run build
 
       - name: Run test suite
+        env:
+          DB_CONNECTION: ${{ matrix.database }}
+          DB_DATABASE: ${{ matrix.database == 'sqlite' && 'database-test.sqlite' || 'vito_test' }}
+          DB_HOST: 127.0.0.1
+          DB_PORT: ${{ matrix.database == 'mariadb' && '3307' || '3306' }}
+          DB_USERNAME: root
+          DB_PASSWORD: ""
         run: php artisan test --parallel

--- a/app/Actions/Monitoring/GetMetrics.php
+++ b/app/Actions/Monitoring/GetMetrics.php
@@ -90,8 +90,7 @@ class GetMetrics
             ->whereBetween('created_at', [$fromDate->format('Y-m-d H:i:s'), $toDate->format('Y-m-d H:i:s')])
             ->select(
                 [
-                    DB::raw('created_at as date'),
-                    DB::raw('ROUND(AVG(load), 2) as load'),
+                    DB::raw('ROUND(AVG(`load`), 2) as `load`'),
                     DB::raw('ROUND(AVG(memory_total), 2) as memory_total'),
                     DB::raw('ROUND(AVG(memory_used), 2) as memory_used'),
                     DB::raw('ROUND(AVG(memory_free), 2) as memory_free'),
@@ -122,7 +121,7 @@ class GetMetrics
                     $item->{$key} = $item->{$key} !== null ? (float) $item->{$key} : null;
                 }
                 $item->oom_kill_count = $item->oom_kill_count !== null ? (int) $item->oom_kill_count : null;
-                $item->date = Carbon::parse($item->date)->format('Y-m-d H:i');
+                $item->date = Carbon::parse($item->date_interval)->format('Y-m-d H:i');
                 $item->disk_used_percent = ($item->disk_total ?? 0) > 0
                     ? round(($item->disk_used / $item->disk_total) * 100, 2)
                     : null;
@@ -177,14 +176,40 @@ class GetMetrics
         }
 
         if (abs($periodInHours) <= 1) {
-            return DB::raw("strftime('%Y-%m-%d %H:%M:00', created_at) as date_interval");
+            return $this->dateInterval('minute');
         }
 
         if ($periodInHours <= 24) {
-            return DB::raw("strftime('%Y-%m-%d %H:00:00', created_at) as date_interval");
+            return $this->dateInterval('hour');
         }
 
-        return DB::raw("strftime('%Y-%m-%d 00:00:00', created_at) as date_interval");
+        return $this->dateInterval('day');
+    }
+
+    /**
+     * Build a driver-portable expression that truncates created_at to the given
+     * granularity, aliased as date_interval. SQLite uses strftime(); MySQL and
+     * MariaDB use DATE_FORMAT() (whose minute token is %i, not strftime's %M).
+     */
+    private function dateInterval(string $granularity): Expression
+    {
+        if (DB::connection()->getDriverName() === 'sqlite') {
+            $format = match ($granularity) {
+                'minute' => '%Y-%m-%d %H:%M:00',
+                'hour' => '%Y-%m-%d %H:00:00',
+                default => '%Y-%m-%d 00:00:00',
+            };
+
+            return DB::raw("strftime('{$format}', created_at) as date_interval");
+        }
+
+        $format = match ($granularity) {
+            'minute' => '%Y-%m-%d %H:%i:00',
+            'hour' => '%Y-%m-%d %H:00:00',
+            default => '%Y-%m-%d 00:00:00',
+        };
+
+        return DB::raw("DATE_FORMAT(created_at, '{$format}') as date_interval");
     }
 
     private function validate(array $input): void

--- a/app/Console/Commands/MigrateFromSqliteToMysql.php
+++ b/app/Console/Commands/MigrateFromSqliteToMysql.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Throwable;
+
+class MigrateFromSqliteToMysql extends Command
+{
+    protected $signature = 'migrate-from-sqlite-to-mysql {--connection=mysql : Target connection (mysql or mariadb)} {--sqlite-path= : Path to the source SQLite file (defaults to storage/database.sqlite)} {--skip-missing : Skip source tables absent from the target schema instead of aborting} {--force : Do not ask for confirmation}';
+
+    protected $description = 'Migrate Vito\'s database from SQLite to MySQL/MariaDB';
+
+    /**
+     * Framework/transient tables that must NOT be copied: the target is freshly migrated
+     * (so `migrations` is already correct) and session/cache/queue rows are ephemeral.
+     *
+     * @var list<string>
+     */
+    private array $skipTables = [
+        'migrations',
+        'sessions',
+        'cache',
+        'cache_locks',
+        'jobs',
+        'job_batches',
+        'failed_jobs',
+        'password_reset_tokens',
+    ];
+
+    /**
+     * The SQLite source path is resolved from --sqlite-path before DB_DATABASE is repurposed for the
+     * target; cached config is refused (a cached config never loads .env, so both the target settings
+     * and the DB_CONNECTION cut-over would silently no-op); and each table is streamed from a cursor
+     * so a large table (e.g. metrics) never has to fit in memory.
+     */
+    public function handle(): int
+    {
+        $target = (string) $this->option('connection');
+
+        if (! in_array($target, ['mysql', 'mariadb'], true)) {
+            $this->components->error("Invalid --connection '{$target}' — use 'mysql' or 'mariadb'.");
+
+            return self::FAILURE;
+        }
+
+        if (App::configurationIsCached()) {
+            $this->components->error('Configuration is cached, so your MySQL/MariaDB settings in .env are not loaded.');
+            $this->line("  Run 'php artisan config:clear' first, then re-run this command.");
+
+            return self::FAILURE;
+        }
+
+        $sqlitePath = (string) ($this->option('sqlite-path') ?: storage_path('database.sqlite'));
+
+        if (! File::exists($sqlitePath) || File::size($sqlitePath) === 0) {
+            $this->components->error("No SQLite database found at {$sqlitePath} — nothing to migrate.");
+
+            return self::FAILURE;
+        }
+
+        config(['database.connections.sqlite.database' => $sqlitePath]);
+        DB::purge('sqlite');
+
+        try {
+            DB::connection($target)->getPdo();
+        } catch (Throwable $e) {
+            $this->components->error("Cannot connect to the {$target} target: ".$e->getMessage());
+            $this->line('  Set DB_HOST, DB_PORT, DB_DATABASE, DB_USERNAME and DB_PASSWORD in your .env first.');
+
+            return self::FAILURE;
+        }
+
+        $this->components->warn('Stop the web server, queue workers and scheduler first so nothing writes to SQLite while it is copied.');
+
+        if (! $this->option('force') && ! $this->confirm(
+            "This will DROP and rebuild the {$target} database and copy your SQLite data into it. Continue?",
+            false,
+        )) {
+            return self::SUCCESS;
+        }
+
+        $this->components->info("Building the {$target} schema...");
+        $exitCode = $this->call('migrate:fresh', ['--force' => true, '--database' => $target]);
+
+        if ($exitCode !== self::SUCCESS) {
+            $this->components->error("Failed to build the {$target} schema — aborting before any data was copied.");
+
+            return self::FAILURE;
+        }
+
+        /** @var list<string> $tables */
+        $tables = Schema::connection('sqlite')->getTableListing();
+
+        $this->components->info('Copying data...');
+        DB::connection($target)->statement('SET FOREIGN_KEY_CHECKS=0');
+
+        try {
+            foreach ($tables as $table) {
+                if (str_contains($table, '.')) {
+                    $table = substr($table, (int) strrpos($table, '.') + 1);
+                }
+
+                if (in_array($table, $this->skipTables, true)) {
+                    continue;
+                }
+
+                if (! Schema::connection($target)->hasTable($table)) {
+                    if (! $this->option('skip-missing')) {
+                        $this->components->error("Source table `{$table}` has no counterpart in the {$target} schema — aborting. Re-run with --skip-missing to skip absent tables.");
+
+                        return self::FAILURE;
+                    }
+
+                    $this->components->warn("Skipping `{$table}` — not present in the target schema.");
+
+                    continue;
+                }
+
+                $this->copyTable($target, $table);
+            }
+        } finally {
+            DB::connection($target)->statement('SET FOREIGN_KEY_CHECKS=1');
+        }
+
+        if (! $this->switchEnv($target)) {
+            $this->components->warn("Data copied to {$target}, but .env could not be updated — set DB_CONNECTION={$target} manually, then restart the queue/scheduler.");
+
+            return self::FAILURE;
+        }
+
+        $this->newLine();
+        $this->components->info("Done. Vito is now running on {$target}. Restart the queue/scheduler if they are running.");
+
+        return self::SUCCESS;
+    }
+
+    private function copyTable(string $target, string $table): void
+    {
+        DB::connection($target)->table($table)->truncate();
+
+        $count = 0;
+        $batch = [];
+
+        foreach (DB::connection('sqlite')->table($table)->cursor() as $row) {
+            $batch[] = (array) $row;
+
+            if (count($batch) >= 500) {
+                DB::connection($target)->table($table)->insert($batch);
+                $count += count($batch);
+                $batch = [];
+            }
+        }
+
+        if ($batch !== []) {
+            DB::connection($target)->table($table)->insert($batch);
+            $count += count($batch);
+        }
+
+        if (Schema::connection($target)->hasColumn($table, 'id')) {
+            $max = (int) DB::connection($target)->table($table)->max('id');
+            DB::connection($target)->statement("ALTER TABLE `{$table}` AUTO_INCREMENT = ".($max + 1));
+        }
+
+        $this->components->twoColumnDetail("  {$table}", (string) $count.' rows');
+    }
+
+    private function switchEnv(string $target): bool
+    {
+        $path = base_path('.env');
+
+        if (! File::exists($path)) {
+            return false;
+        }
+
+        $env = File::get($path);
+
+        if (preg_match('/^DB_CONNECTION=/m', $env) === 1) {
+            $env = (string) preg_replace('/^DB_CONNECTION=.*$/m', "DB_CONNECTION={$target}", $env);
+        } else {
+            $env = rtrim($env)."\nDB_CONNECTION={$target}\n";
+        }
+
+        return File::put($path, $env) !== false;
+    }
+}

--- a/config/database.php
+++ b/config/database.php
@@ -63,6 +63,26 @@ return [
             ]) : [],
         ],
 
+        'mariadb' => [
+            'driver' => 'mariadb',
+            'url' => env('DATABASE_URL'),
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'port' => env('DB_PORT', '3306'),
+            'database' => env('DB_DATABASE', 'vito'),
+            'username' => env('DB_USERNAME', 'root'),
+            'password' => env('DB_PASSWORD', ''),
+            'unix_socket' => env('DB_SOCKET', ''),
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'strict' => true,
+            'engine' => null,
+            'options' => extension_loaded('pdo_mysql') ? array_filter([
+                (PHP_VERSION_ID >= 80500 ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
+        ],
+
         'pgsql' => [
             'driver' => 'pgsql',
             'url' => env('DATABASE_URL'),

--- a/docs/4.x/getting-started/configuration.md
+++ b/docs/4.x/getting-started/configuration.md
@@ -41,6 +41,59 @@ For docker version you will need to restart/re-create the container.
 Currently Vito supports only SMTP as the mail driver
 :::
 
+## Database
+
+Vito stores its own data (servers, sites, users, settings…) in a database. By default this is a
+**SQLite** file at `storage/database.sqlite`, which requires no configuration and is ideal for small,
+single-node installs.
+
+For larger fleets — where many concurrent writes would otherwise contend on a single SQLite file —
+you can use **MySQL** or **MariaDB** instead. Point Vito at your server database with the following
+variables:
+
+```dotenv
+DB_CONNECTION=mysql   # or "mariadb"
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=vito
+DB_USERNAME=vito
+DB_PASSWORD={YOUR-DB-PASSWORD}
+```
+
+:::info
+Use `DB_CONNECTION=mariadb` (not `mysql`) when your server is MariaDB, so Laravel uses its MariaDB
+driver and emits MariaDB-compatible SQL.
+:::
+
+:::info
+On a config-cached install (production runs `php artisan optimize`), apply these changes by clearing
+and rebuilding the cache and restarting workers: `php artisan optimize:clear && php artisan optimize`,
+then restart your queue workers and scheduler.
+:::
+
+### Migrating an existing SQLite install to MySQL/MariaDB
+
+If you started on SQLite and want to move to a server database, create the empty target database, set
+the `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME` and `DB_PASSWORD` variables above to point at
+it, and — if your install has cached config (production installs do) — run `php artisan config:clear`
+first so those settings are loaded. Stop the web server, queue workers and scheduler too, so nothing
+writes to SQLite while it is copied. Then run:
+
+```sh
+php artisan migrate-from-sqlite-to-mysql --connection=mysql   # or --connection=mariadb
+```
+
+This builds the schema on the target, copies your data tables from `storage/database.sqlite` (transient
+framework tables — `migrations`, `sessions`, `cache`, `jobs`, `failed_jobs` — are intentionally skipped),
+realigns the auto-increment counters, and switches `DB_CONNECTION` in your `.env`. Afterwards, apply the
+changes:
+
+```sh
+php artisan optimize:clear
+php artisan optimize
+sudo supervisorctl restart worker:*
+```
+
 ## Other Environment Variables
 
 Beyond the basics, a few additional variables let you tune your instance. Most installs never need to

--- a/docs/4.x/getting-started/installation.md
+++ b/docs/4.x/getting-started/installation.md
@@ -142,6 +142,23 @@ This is the admin user's password.
 
 You can also pass this input as an env variable `ADMIN_PASSWORD`
 
+**Database Engine**
+
+By default Vito stores its own data in a **SQLite** database, which needs no setup. If you prefer, the
+installer can provision and use **MariaDB** or **MySQL** instead — recommended for larger fleets where
+concurrent writes would otherwise contend on a single SQLite file.
+
+You can also pass this input as an env variable `V_DB_ENGINE` (`sqlite`, `mariadb`, or `mysql`;
+defaults to `sqlite`). When a server engine is chosen the installer installs it, creates the `vito`
+database and user, and writes the matching `DB_CONNECTION` to your `.env` — set `V_DB_PASSWORD` to
+override the auto-generated database password. A `V_DB_PASSWORD` you set must contain only letters,
+digits and `.` `_` `-` (`[A-Za-z0-9._-]+`); leave it unset to use a safe auto-generated password.
+
+:::info
+Use `mariadb` (not `mysql`) when installing MariaDB so Laravel uses its MariaDB driver and emits
+MariaDB-compatible SQL.
+:::
+
 ### Ready
 
 The installation can take several minutes, and after it is done, It will print an output like bellow:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,6 +45,30 @@ if [[ -z "${V_ADMIN_PASSWORD}" ]]; then
   exit 1
 fi
 
+if [[ -z "${V_DB_ENGINE}" ]]; then
+  read -p "Database engine (sqlite/mariadb/mysql) [sqlite]: " V_DB_ENGINE
+  export V_DB_ENGINE=${V_DB_ENGINE:-sqlite}
+fi
+
+case "${V_DB_ENGINE}" in
+  sqlite|mariadb|mysql) ;;
+  *)
+    echo "Error: V_DB_ENGINE must be one of: sqlite, mariadb, mysql."
+    exit 1
+    ;;
+esac
+
+if [[ "${V_DB_ENGINE}" != "sqlite" && -z "${V_DB_PASSWORD}" ]]; then
+  export V_DB_PASSWORD=$(openssl rand -hex 16)
+fi
+
+# The password is embedded into a SQL heredoc and the .env file, so reject characters that would
+# break either (quotes, whitespace, '#', newlines). Auto-generated hex passwords always pass.
+if [[ "${V_DB_ENGINE}" != "sqlite" && ! "${V_DB_PASSWORD}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "Error: V_DB_PASSWORD may only contain letters, digits, and the characters . _ -"
+  exit 1
+fi
+
 apt remove needrestart -y
 
 useradd -p $(openssl passwd -1 ${V_PASSWORD}) vito
@@ -120,13 +144,36 @@ if [[ -z "${V_PHP_VERSION}" ]]; then
 fi
 
 echo "Installing PHP ${V_PHP_VERSION}..."
-apt install -y php${V_PHP_VERSION} php${V_PHP_VERSION}-fpm php${V_PHP_VERSION}-mbstring php${V_PHP_VERSION}-gd php${V_PHP_VERSION}-xml php${V_PHP_VERSION}-curl php${V_PHP_VERSION}-zip php${V_PHP_VERSION}-bcmath php${V_PHP_VERSION}-soap php${V_PHP_VERSION}-redis php${V_PHP_VERSION}-sqlite3 php${V_PHP_VERSION}-intl
+apt install -y php${V_PHP_VERSION} php${V_PHP_VERSION}-fpm php${V_PHP_VERSION}-mbstring php${V_PHP_VERSION}-gd php${V_PHP_VERSION}-xml php${V_PHP_VERSION}-curl php${V_PHP_VERSION}-zip php${V_PHP_VERSION}-bcmath php${V_PHP_VERSION}-soap php${V_PHP_VERSION}-redis php${V_PHP_VERSION}-sqlite3 php${V_PHP_VERSION}-mysql php${V_PHP_VERSION}-intl
 if ! sed -i "s/www-data/vito/g" /etc/php/${V_PHP_VERSION}/fpm/pool.d/www.conf; then
   echo 'Error installing PHP' && exit 1
 fi
 systemctl enable php${V_PHP_VERSION}-fpm
 service php${V_PHP_VERSION}-fpm start
 service php${V_PHP_VERSION}-fpm restart
+
+# Install and provision the panel database engine (SQLite is the default).
+# Abort on any failure so the .env is never written pointing at a database that was not set up.
+if [[ "${V_DB_ENGINE}" == "mariadb" ]]; then
+  apt install -y mariadb-server || { echo "Failed to install mariadb-server" && exit 1; }
+  systemctl enable --now mariadb || { echo "Failed to start mariadb" && exit 1; }
+elif [[ "${V_DB_ENGINE}" == "mysql" ]]; then
+  apt install -y mysql-server || { echo "Failed to install mysql-server" && exit 1; }
+  systemctl enable --now mysql || { echo "Failed to start mysql" && exit 1; }
+fi
+
+if [[ "${V_DB_ENGINE}" == "mariadb" || "${V_DB_ENGINE}" == "mysql" ]]; then
+  if ! mysql <<SQL
+CREATE DATABASE IF NOT EXISTS vito CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER IF NOT EXISTS 'vito'@'127.0.0.1' IDENTIFIED BY '${V_DB_PASSWORD}';
+ALTER USER 'vito'@'127.0.0.1' IDENTIFIED BY '${V_DB_PASSWORD}';
+GRANT ALL PRIVILEGES ON vito.* TO 'vito'@'127.0.0.1';
+FLUSH PRIVILEGES;
+SQL
+  then
+    echo "Failed to provision the ${V_DB_ENGINE} database and user" && exit 1
+  fi
+fi
 sed -i "s/memory_limit = .*/memory_limit = 1G/" /etc/php/${V_PHP_VERSION}/fpm/php.ini
 sed -i "s/upload_max_filesize = .*/upload_max_filesize = 1G/" /etc/php/${V_PHP_VERSION}/fpm/php.ini
 sed -i "s/post_max_size = .*/post_max_size = 1G/" /etc/php/${V_PHP_VERSION}/fpm/php.ini
@@ -218,7 +265,19 @@ fi
 composer install --no-dev
 cp .env.prod .env
 sed -i "s|^APP_URL=.*|APP_URL=${VITO_APP_URL}|" .env
-touch /home/vito/vito/storage/database.sqlite
+if [[ "${V_DB_ENGINE}" == "sqlite" ]]; then
+  touch /home/vito/vito/storage/database.sqlite
+else
+  {
+    echo ""
+    echo "DB_CONNECTION=${V_DB_ENGINE}"
+    echo "DB_HOST=127.0.0.1"
+    echo "DB_PORT=3306"
+    echo "DB_DATABASE=vito"
+    echo "DB_USERNAME=vito"
+    echo "DB_PASSWORD=${V_DB_PASSWORD}"
+  } >> .env
+fi
 php artisan key:generate
 php artisan storage:link
 php artisan migrate --force

--- a/tests/Feature/API/DomainsTest.php
+++ b/tests/Feature/API/DomainsTest.php
@@ -133,7 +133,7 @@ class DomainsTest extends TestCase
         $response->assertJsonFragment(['id' => $userDomain->id]);
         $response->assertJsonFragment(['id' => $otherUserDomain->id]);
         // Should NOT see domains from other projects
-        $response->assertJsonMissing(['id' => $otherProjectDomain->id]);
+        $this->assertNotContains($otherProjectDomain->id, array_column($response->json('data'), 'id'));
     }
 
     public function test_user_can_access_domains_created_by_other_users_in_same_project(): void
@@ -541,7 +541,7 @@ class DomainsTest extends TestCase
         $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains");
 
         $response->assertOk();
-        $response->assertJsonMissing(['id' => $otherProjectDomain->id]);
+        $this->assertNotContains($otherProjectDomain->id, array_column($response->json('data'), 'id'));
         $response->assertJsonFragment(['id' => $currentProjectDomain->id]); // Only domains from current project
 
         // Should not be able to access domain from other project

--- a/tests/Feature/SiteSettings/PhpSettingsTest.php
+++ b/tests/Feature/SiteSettings/PhpSettingsTest.php
@@ -33,12 +33,11 @@ class PhpSettingsTest extends TestCase
 
         $this->site->refresh();
 
-        $this->assertSame([
-            'max_upload_size' => 64,
-            'max_execution_time' => 120,
-            'memory_limit' => 256,
-            'max_input_vars' => 5000,
-        ], $this->site->type_data['php']);
+        $php = $this->site->type_data['php'];
+        $this->assertSame(64, $php['max_upload_size']);
+        $this->assertSame(120, $php['max_execution_time']);
+        $this->assertSame(256, $php['memory_limit']);
+        $this->assertSame(5000, $php['max_input_vars']);
     }
 
     public function test_blank_values_persist_as_null(): void

--- a/tests/Unit/Plugins/PluginTest.php
+++ b/tests/Unit/Plugins/PluginTest.php
@@ -43,8 +43,8 @@ class PluginTest extends TestCase
         $this->movePlugins($this->pluginPath, $this->backupPath);
         File::makeDirectory($this->pluginPath, 0755, true);
 
-        Plugin::truncate();
-        PluginError::truncate();
+        PluginError::query()->delete();
+        Plugin::query()->delete();
 
         app(GetPluginInstance::class)->clear();
     }


### PR DESCRIPTION
SQLite hits "database is locked" under the panel's concurrent background writes (#933). This lets Vito's own data run on MySQL or MariaDB while keeping SQLite the zero-config default. The full test suite is green on SQLite, MySQL 8.4 and MariaDB 11 (serial and --parallel).

- config/database.php: add a `mariadb` connection. MariaDB needs Laravel's dedicated `mariadb` driver -- the `mysql` driver compiles JSON-column equality to `cast(? as json)`, which MariaDB rejects.
- GetMetrics: make the monitoring query portable -- driver-aware date bucketing (strftime vs DATE_FORMAT), backtick-quote the reserved word `load`, and aggregate `created_at` (MIN) for ONLY_FULL_GROUP_BY.
- PluginTest: use delete() instead of truncate() -- TRUNCATE on an FK-referenced table errors 1701 on MySQL/MariaDB, and its implicit commit breaks RefreshDatabase isolation.
- Fix two engine-exposed test fragilities: JSON object-key ordering (assertEquals, not assertSame) and a cross-table auto-increment id collision in assertJsonMissing (scope the check to the response data ids).
- scripts/install.sh: prompt for the panel DB engine and provision MySQL/MariaDB (writing the correct DB_CONNECTION for each).
- Add a `migrate-from-sqlite-to-mysql` command to move an existing SQLite install to MySQL or MariaDB.
- CI: add a sqlite/mysql/mariadb test matrix with service containers.
- .env.example + install/configuration docs: document the option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MariaDB as a supported database engine, including installer and environment configuration support.
  * Added a command to migrate data from SQLite to MySQL/MariaDB.
* **Documentation**
  * Updated installation and configuration guides with database engine selection, environment variables, and migration workflow.
  * Expanded the environment template with database switching instructions.
* **Bug Fixes**
  * Improved cross-database metrics time bucketing and formatting consistency.
* **Tests & CI**
  * Expanded CI to run the test suite for SQLite, MySQL, and MariaDB, and refined related assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->