### PR TITLE
[Feat] Add WebSocket support and editing for site redirects

### DIFF
--- a/app/Actions/Redirect/CreateRedirect.php
+++ b/app/Actions/Redirect/CreateRedirect.php
@@ -24,6 +24,7 @@ class CreateRedirect
         $redirect->from = $input['from'];
         $redirect->to = $input['to'];
         $redirect->mode = $input['mode'];
+        $redirect->websocket = ((int) $input['mode'] === 1000) && ($input['websocket'] ?? false);
         $redirect->status = RedirectStatus::CREATING;
         $redirect->save();
 
@@ -56,6 +57,10 @@ class CreateRedirect
                     308,
                     1000,
                 ]),
+            ],
+            'websocket' => [
+                'nullable',
+                'boolean',
             ],
         ];
 

--- a/app/Actions/Redirect/CreateRedirect.php
+++ b/app/Actions/Redirect/CreateRedirect.php
@@ -24,7 +24,7 @@ class CreateRedirect
         $redirect->from = $input['from'];
         $redirect->to = $input['to'];
         $redirect->mode = $input['mode'];
-        $redirect->websocket = ((int) $input['mode'] === 1000) && ($input['websocket'] ?? false);
+        $redirect->websocket = ((int) $input['mode'] === Redirect::MODE_PROXY) && ($input['websocket'] ?? false);
         $redirect->status = RedirectStatus::CREATING;
         $redirect->save();
 
@@ -55,7 +55,7 @@ class CreateRedirect
                     302,
                     307,
                     308,
-                    1000,
+                    Redirect::MODE_PROXY,
                 ]),
             ],
             'websocket' => [

--- a/app/Actions/Redirect/UpdateRedirect.php
+++ b/app/Actions/Redirect/UpdateRedirect.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Actions\Redirect;
+
+use App\Enums\RedirectStatus;
+use App\Jobs\Redirect\CreateJob;
+use App\Models\Redirect;
+use App\Models\Site;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+
+class UpdateRedirect
+{
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    public function update(Site $site, Redirect $redirect, array $input): Redirect
+    {
+        $this->validate($site, $redirect, $input);
+
+        $redirect->from = $input['from'];
+        $redirect->to = $input['to'];
+        $redirect->mode = $input['mode'];
+        $redirect->websocket = ((int) $input['mode'] === 1000) && ($input['websocket'] ?? false);
+        $redirect->status = RedirectStatus::CREATING;
+        $redirect->save();
+
+        dispatch(new CreateJob($site, $redirect))->onQueue('ssh');
+
+        return $redirect->refresh();
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    private function validate(Site $site, Redirect $redirect, array $input): void
+    {
+        $rules = [
+            'from' => [
+                'required',
+                'string',
+                'max:255',
+                'not_regex:/^http(s)?:\/\//',
+                Rule::unique('redirects', 'from')->where('site_id', $site->id)->ignore($redirect->id),
+            ],
+            'to' => [
+                'required',
+                'url:http,https',
+            ],
+            'mode' => [
+                'required',
+                'integer',
+                Rule::in([
+                    301,
+                    302,
+                    307,
+                    308,
+                    1000,
+                ]),
+            ],
+            'websocket' => [
+                'nullable',
+                'boolean',
+            ],
+        ];
+
+        Validator::make($input, $rules)->validate();
+    }
+}

--- a/app/Actions/Redirect/UpdateRedirect.php
+++ b/app/Actions/Redirect/UpdateRedirect.php
@@ -21,7 +21,7 @@ class UpdateRedirect
         $redirect->from = $input['from'];
         $redirect->to = $input['to'];
         $redirect->mode = $input['mode'];
-        $redirect->websocket = ((int) $input['mode'] === 1000) && ($input['websocket'] ?? false);
+        $redirect->websocket = ((int) $input['mode'] === Redirect::MODE_PROXY) && ($input['websocket'] ?? false);
         $redirect->status = RedirectStatus::CREATING;
         $redirect->save();
 
@@ -55,7 +55,7 @@ class UpdateRedirect
                     302,
                     307,
                     308,
-                    1000,
+                    Redirect::MODE_PROXY,
                 ]),
             ],
             'websocket' => [

--- a/app/Actions/Webserver/AbstractGenerateConfig.php
+++ b/app/Actions/Webserver/AbstractGenerateConfig.php
@@ -5,6 +5,7 @@ namespace App\Actions\Webserver;
 use App\Enums\HostedDomainStatus;
 use App\Enums\HostedDomainType;
 use App\Models\HostedDomain;
+use App\Models\Redirect;
 use App\Models\Site;
 use App\Models\Ssl;
 use Illuminate\Support\Collection;
@@ -272,7 +273,7 @@ abstract class AbstractGenerateConfig
     {
         $redirects = [];
         foreach ($site->activeRedirects as $redirect) {
-            $isProxy = (int) $redirect->mode === 1000;
+            $isProxy = (int) $redirect->mode === Redirect::MODE_PROXY;
             $redirects[] = $this->buildRedirectEntry($redirect, $isProxy);
         }
 

--- a/app/Actions/Webserver/GenerateNginxConfig.php
+++ b/app/Actions/Webserver/GenerateNginxConfig.php
@@ -72,6 +72,7 @@ class GenerateNginxConfig extends AbstractGenerateConfig
             'to' => $redirect->to,
             'mode' => $redirect->mode,
             'is_proxy' => $isProxy,
+            'is_websocket' => $isProxy && (bool) $redirect->websocket,
             'to_host' => $isProxy ? parse_url($redirect->to, PHP_URL_HOST) : '',
         ];
     }

--- a/app/Http/Controllers/API/RedirectController.php
+++ b/app/Http/Controllers/API/RedirectController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API;
 
 use App\Actions\Redirect\CreateRedirect;
 use App\Actions\Redirect\DeleteRedirect;
+use App\Actions\Redirect\UpdateRedirect;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\RedirectResource;
 use App\Models\Project;
@@ -18,6 +19,7 @@ use Spatie\RouteAttributes\Attributes\Get;
 use Spatie\RouteAttributes\Attributes\Middleware;
 use Spatie\RouteAttributes\Attributes\Post;
 use Spatie\RouteAttributes\Attributes\Prefix;
+use Spatie\RouteAttributes\Attributes\Put;
 
 #[Prefix('api/projects/{project}/servers/{server}/sites/{site}/redirects')]
 #[Middleware(['auth:sanctum', 'can-see-project'])]
@@ -41,6 +43,18 @@ class RedirectController extends Controller
         $this->validateRoute($project, $server, $site);
 
         $redirect = app(CreateRedirect::class)->create($site, $request->all());
+
+        return new RedirectResource($redirect);
+    }
+
+    #[Put('/{redirect}', name: 'api.projects.servers.sites.redirects.update', middleware: 'ability:write')]
+    public function update(Request $request, Project $project, Server $server, Site $site, Redirect $redirect): RedirectResource
+    {
+        $this->authorize('update', [$redirect, $site, $server]);
+
+        $this->validateRoute($project, $server, $site);
+
+        $redirect = app(UpdateRedirect::class)->update($site, $redirect, $request->all());
 
         return new RedirectResource($redirect);
     }

--- a/app/Http/Controllers/RedirectController.php
+++ b/app/Http/Controllers/RedirectController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Actions\Redirect\CreateRedirect;
 use App\Actions\Redirect\DeleteRedirect;
+use App\Actions\Redirect\UpdateRedirect;
 use App\Http\Resources\RedirectResource;
 use App\Models\Redirect;
 use App\Models\Server;
@@ -17,6 +18,7 @@ use Spatie\RouteAttributes\Attributes\Get;
 use Spatie\RouteAttributes\Attributes\Middleware;
 use Spatie\RouteAttributes\Attributes\Post;
 use Spatie\RouteAttributes\Attributes\Prefix;
+use Spatie\RouteAttributes\Attributes\Put;
 
 #[Prefix('/servers/{server}/sites/{site}/redirects')]
 #[Middleware(['auth', 'has-project'])]
@@ -41,6 +43,17 @@ class RedirectController extends Controller
 
         return back()
             ->with('info', 'Creating the redirect');
+    }
+
+    #[Put('/{redirect}', name: 'redirects.update')]
+    public function update(Request $request, Server $server, Site $site, Redirect $redirect): RedirectResponse
+    {
+        $this->authorize('update', [$redirect, $site, $server]);
+
+        app(UpdateRedirect::class)->update($site, $redirect, $request->input());
+
+        return back()
+            ->with('info', 'Updating the redirect');
     }
 
     #[Delete('/{redirect}', name: 'redirects.destroy')]

--- a/app/Http/Resources/RedirectResource.php
+++ b/app/Http/Resources/RedirectResource.php
@@ -21,6 +21,7 @@ class RedirectResource extends JsonResource
             'from' => $this->from,
             'to' => $this->to,
             'mode' => $this->mode,
+            'websocket' => (bool) $this->websocket,
             'status' => $this->status->getText(),
             'status_color' => $this->status->getColor(),
             'created_at' => $this->created_at,

--- a/app/Models/Redirect.php
+++ b/app/Models/Redirect.php
@@ -22,6 +22,8 @@ class Redirect extends AbstractModel
     /** @use HasFactory<RedirectFactory> */
     use HasFactory;
 
+    public const int MODE_PROXY = 1000;
+
     protected $fillable = [
         'site_id',
         'from',

--- a/app/Models/Redirect.php
+++ b/app/Models/Redirect.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $from
  * @property string $to
  * @property string $mode
+ * @property bool $websocket
  * @property RedirectStatus $status
  * @property Site $site
  */
@@ -26,10 +27,12 @@ class Redirect extends AbstractModel
         'from',
         'to',
         'mode',
+        'websocket',
         'status',
     ];
 
     protected $casts = [
+        'websocket' => 'boolean',
         'status' => RedirectStatus::class,
     ];
 

--- a/app/Policies/RedirectPolicy.php
+++ b/app/Policies/RedirectPolicy.php
@@ -38,6 +38,16 @@ class RedirectPolicy
             && $siteServer->isReady();
     }
 
+    public function update(User $user, Redirect $redirect, Site $site, Server $server): bool
+    {
+        $siteServer = $site->server;
+
+        return $this->hasWriteAccess($user, $siteServer->project)
+            && $site->server_id === $server->id
+            && $server->isReady()
+            && $redirect->site_id === $site->id;
+    }
+
     public function delete(User $user, Redirect $redirect, Site $site, Server $server): bool
     {
         $siteServer = $site->server;

--- a/database/factories/RedirectFactory.php
+++ b/database/factories/RedirectFactory.php
@@ -23,6 +23,7 @@ class RedirectFactory extends Factory
             'from' => $this->faker->word,
             'to' => $this->faker->url,
             'mode' => $this->faker->randomElement([301, 302, 307, 308]),
+            'websocket' => false,
             'status' => RedirectStatus::READY,
         ];
     }

--- a/database/migrations/2026_07_03_214427_add_websocket_to_redirects_table.php
+++ b/database/migrations/2026_07_03_214427_add_websocket_to_redirects_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('redirects', function (Blueprint $table) {
+            $table->boolean('websocket')->default(false)->after('mode');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('redirects', function (Blueprint $table) {
+            $table->dropColumn('websocket');
+        });
+    }
+};

--- a/docs/4.x/plugins/laravel-reverb.md
+++ b/docs/4.x/plugins/laravel-reverb.md
@@ -1,75 +1,100 @@
 # Laravel Reverb Plugin
 
-## Introduction
+:::warning
+**The Laravel Reverb plugin is deprecated and will be removed in a future release.**
 
-VitoDeploy provides a first party plugin to setup Laravel Reverb on your server.
-
-## Supported Web Servers
-
-- Nginx
-- Caddy
-
-## Supported site types
-
-- Laravel
-
-## Supported Methods
-
-You can set up Laravel Reverb in one of two ways:
-
-- As a [site feature](#enable-as-a-site-feature) on an existing Laravel site (proxies `/app` and `/apps`).
-- As a dedicated [site type](#enable-as-a-site-type) on its own domain.
-
-## How it works
-
-Vito will use your Laravel project to run a worker command to start the Laravel Reverb server. Then it will modify your site's virtual host configuration to reverse proxy requests to your Laravel Reverb instance.
-
-If you use the site feature method, Vito will modify the website's vhost to reverse proxy `/app` and `/apps` to your Laravel Reverb instance.
-
-If your app already using those paths, You will need to use the Site Type method instead.
-
-## Installation
-
-To install the plugin, navigate to the `Admin -> Plugins` and select `Laravel Reverb` plugins in the `Official` tab.
-
-## Enable as a site feature
-
-After you successfuly setup a Laravel site, You can navigate to the `Features` side menu item, and Enable the `Laravel Reverb` feature.
-
-When enabling, you will need to provide the following information:
-
-**Port**: The port that your Laravel Reverb instance will run on. Make sure this port is not used by any other service on your server.
-
-:::info
-The port won't be exposed to internet, it will be used internally by the web server to proxy requests to your Laravel Reverb instance.
+You no longer need a dedicated plugin to run Laravel Reverb. With WebSocket support now built into
+[site redirects](../sites/redirects.md), you can set up a Reverb deployment using Vito's core features. See
+[Setting up Laravel Reverb manually](#setting-up-laravel-reverb-manually) below for the recommended approach.
 :::
 
-**Command**: The command to start your Laravel Reverb instance. The default command is `php artisan reverb:start --host=0.0.0.0 --port=REVERB_PORT`. You can change it if you have a custom command to start your Laravel Reverb instance.
+## Setting up Laravel Reverb manually
+
+This is the recommended way to run Laravel Reverb on Vito. It uses only core features — a Laravel site, a worker, and a
+proxy redirect with WebSocket support — so you don't depend on the deprecated plugin.
+
+In the steps below, replace `{domain}` with your site's domain and `{reverb port}` with the internal port your Reverb
+server will listen on (for example `8089`). This internal port is never exposed to the internet; the web server proxies
+to it.
+
+### 1. Create a Laravel site
+
+Create a new **Laravel** site as described in [Create a Site](../sites/create.md).
+
+### 2. Configure your `.env`
+
+Add the following Reverb variables to your application's `.env`:
+
+```dotenv
+REVERB_HOST={domain}
+REVERB_PORT=443            # use 443 for https, or 80 for http
+REVERB_SCHEME=https        # use https, or http
+REVERB_SERVER_HOST=0.0.0.0
+REVERB_SERVER_PORT={reverb port}
+```
+
+`REVERB_HOST`, `REVERB_PORT` and `REVERB_SCHEME` describe the public endpoint your clients connect to (through the web
+server). `REVERB_SERVER_HOST` and `REVERB_SERVER_PORT` are where the Reverb server itself listens locally — the host
+must be `0.0.0.0` and the port is the internal `{reverb port}`.
+
+### 3. Update your deployment script
+
+Add the following command to your site's [deployment script](../sites/application.md) so Reverb picks up new code on
+every deploy:
+
+```bash
+php artisan reverb:restart
+```
+
+### 4. Create a worker
+
+Create a [worker](../servers/workers.md) to keep the Reverb server running:
+
+- **Command**: `php artisan reverb:start --port={reverb port}`
+- **User**: the site's [isolated user](../sites/isolation.md)
+- **Numprocs**: `1`
 
 :::warning
-The port on the command should match the port you provided above.
-
-The host must be `0.0.0.0`
+`Numprocs` must be `1`. Running multiple Reverb processes on the same port will not work.
 :::
 
-:::info
-Make sure you read [Laravel's official documentation](https://laravel.com/docs/reverb) for the correct command.
+### 5. Create a proxy redirect with WebSocket support
+
+Create a [redirect](../sites/redirects.md) to proxy WebSocket traffic to the Reverb server:
+
+- **Mode**: `Proxy`
+- **From**: `~ ^/app(s)?/`
+- **To**: `http://0.0.0.0:{reverb port}`
+- **WebSocket support**: `Yes`
+
+### 6. Redeploy
+
+Redeploy the application, and everything should be working fine.
+
+## Migrating an existing Reverb site
+
+If you created a site using the deprecated **Laravel Reverb** site type, convert it to a standard **Laravel** site and
+set Reverb up using the [manual steps](#setting-up-laravel-reverb-manually) above.
+
+Because the site type is provided by the plugin, the site's `type` must be changed back to `laravel`. Connect to the
+database that **Vito itself** uses (not the database on your provisioned server) and run:
+
+```sql
+UPDATE sites SET type = 'laravel' WHERE type = 'laravel-reverb';
+```
+
+:::warning
+Back up your database before running any manual SQL. The statement above converts **every** site currently using the
+`laravel-reverb` type. To convert a single site, add `AND id = {site id}` to the `WHERE` clause.
 :::
 
-## Enable as a site type
+After converting the type, finish wiring the site up manually:
 
-After installing the plugin, There will be a new site type appearing when you're selecting a site type to create a new site.
-
-You can select the `Laravel Reverb` site type, and provide the same information as the [site feature method](#enable-as-a-site-feature).
-
-You'll need to change the `REVERB_HOST` in both sites (Laravel and Reverb) to point to the domain of the Reverb website.
-
-## Example Project
-
-This simple Laravel project demonstrates how to use Laravel Reverb with VitoDeploy.
-
-[Project on Github](https://github.com/saeedvaziry/laravel-reverb-demo)
-
-## Uninstall
-
-To uninstall the plugin, navigate to the `Admin -> Plugins` and you can find the `Laravel Reverb` plugins in the `Installed` tab and you can uninstall it.
+1. The proxy that the plugin injected into your vhost is no longer generated automatically. Create a
+   [proxy redirect with WebSocket support](#5-create-a-proxy-redirect-with-websocket-support) to restore it — use the
+   port your Reverb site was already running on.
+2. Add the [`.env` variables](#2-configure-your-env) and the `php artisan reverb:restart` line to your
+   [deployment script](#3-update-your-deployment-script).
+3. The plugin already created a worker named `laravel-reverb` that runs the Reverb server; it will keep running. Review
+   it against [step 4](#4-create-a-worker) and adjust the command or port if needed.
+4. Redeploy the site.

--- a/docs/4.x/sites/redirects.md
+++ b/docs/4.x/sites/redirects.md
@@ -2,8 +2,12 @@
 
 ## Introduction
 
-Vito supports URL redirections for your sites. You can redirect your site to another URL or path. This is useful when
-you want to redirect your site to a new domain or a new path.
+Vito supports URL redirections for your sites. A redirect maps a path on your site to another location — either by
+returning an HTTP redirect response (301/302/307/308) or by transparently reverse-proxying the request to another
+service (Proxy mode).
+
+This is useful when you want to move a path to a new URL, point part of your site at another application, or expose a
+background service (such as a WebSocket server) through your site's domain.
 
 :::info
 This page covers path-level redirects. To redirect a whole domain to your site's primary domain, add
@@ -11,44 +15,117 @@ a redirect domain on the [Domains](./domains.md) page instead.
 :::
 
 :::warning
-Creating or deleting site redirects will regenerate the Nginx vhost file and any manual changes to the Nginx vhost will be lost.
+Creating, editing, or deleting site redirects will regenerate the Nginx vhost file and any manual changes to the Nginx
+vhost will be lost.
 :::
+
+## How redirects are applied
+
+Each redirect is stored against your site and rendered into the site's web server configuration. When you create, edit,
+or delete a redirect, Vito connects to the server over SSH, regenerates the vhost file, and reloads the web server. The
+redirect moves through a short status lifecycle (`creating` → `ready`) while this happens, and the row updates in place
+once it is applied.
+
+Both **Nginx** and **Caddy** are supported — Vito generates the appropriate directives for whichever web server your
+site uses.
 
 ## Supported Redirect Types
 
-Vito supports the following types of redirects:
+Vito supports the following redirect modes.
 
 ### 301 Moved Permanently
 
-The HTTP 301 Moved Permanently redirection response status code indicates that the requested resource has been
-permanently moved to the URL in the Location header.
+Indicates that the requested resource has been **permanently** moved to the URL in the `Location` header. Browsers and
+search engines cache this aggressively — use it only when the move is permanent.
 
 ### 302 Found
 
-The HTTP 302 Found redirection response status code indicates that the requested resource has been temporarily moved to
-the URL in the Location header.
+Indicates that the requested resource has been **temporarily** moved to the URL in the `Location` header. The original
+URL should keep being used in the future.
 
 ### 307 Temporary Redirect
 
-The HTTP 307 Temporary Redirect redirection response status code indicates that the resource requested has been
-temporarily moved to the URL in the Location header.
+Like a 302, but guarantees that the request **method and body are not changed** when the redirected request is made.
+Prefer this over 302 for non-`GET` requests.
 
 ### 308 Permanent Redirect
 
-The HTTP 308 Permanent Redirect redirection response status code indicates that the requested resource has been
-permanently moved to the URL given by the Location header.
+Like a 301, but guarantees that the request **method and body are not changed**. Prefer this over 301 for non-`GET`
+requests.
 
 ### Proxy
 
-Instead of returning an HTTP redirect, the Proxy mode reverse-proxies the requests from the given path to the target
-URL (e.g. proxy `/docs` to `https://docs.example.com`). The path stays the same in the browser while the content is
-served from the target.
+Instead of returning an HTTP redirect, the Proxy mode reverse-proxies requests from the given path to the target URL
+(e.g. proxy `/docs` to `https://docs.example.com`). The path stays the same in the browser while the content is served
+from the target.
 
+:::info
+In Proxy mode the **From** field is used as an Nginx `location` expression, so you can use a prefix (`/docs`) or a
+regular expression (`~ ^/app(s)?/`). The other modes use an exact match.
+:::
+
+#### WebSocket support
+
+When using the Proxy mode, you can enable **WebSocket support** to allow the proxied connection to upgrade to a
+WebSocket. This adds the required upgrade headers to the generated configuration so that persistent WebSocket
+connections work through the proxy.
+
+Enable this when the target serves WebSocket traffic — for example when proxying to a Laravel Reverb server (see the
+[example](#example-laravel-reverb-over-websockets) below).
+
+:::info
+WebSocket support only applies to the `Proxy` mode. Caddy proxies WebSocket connections automatically, so this option
+only affects Nginx.
+:::
 
 ## Create a Redirect
 
-To create a redirect, you need to fill the following fields:
+To create a redirect, fill in the following fields:
 
-- **From**: The path you want to redirect from. (e.g. `/old-path`)
-- **To**: Full URL or path you want to redirect to. (e.g. `https://example.com/new-path`)
-- **Mode**: The type of redirect you want to create. (e.g. 301 Moved Permanently)
+- **Mode**: The redirect mode to use (e.g. `301 Moved Permanently` or `Proxy`).
+- **From**: The path to redirect from. For redirect modes this is an exact path (e.g. `/old-path`); for Proxy mode it is
+  an Nginx location expression (e.g. `/docs` or `~ ^/app(s)?/`). It must not start with `http://` or `https://`, and
+  must be unique for the site.
+- **To**: The destination. For redirect modes, a full URL (e.g. `https://example.com/new-path`). For Proxy mode, the
+  address of the target service, which may be an internal address (e.g. `http://0.0.0.0:8089`).
+- **WebSocket support**: Only shown when the mode is `Proxy`. Enable it to proxy WebSocket connections (see
+  [WebSocket support](#websocket-support)).
+
+## Edit a Redirect
+
+You can edit an existing redirect from its row actions in the redirects table. Editing lets you change the **From**,
+**To**, **Mode**, and **WebSocket support** of a redirect without having to delete and recreate it. Saving your changes
+regenerates the vhost file and reloads the web server.
+
+## Delete a Redirect
+
+Deleting a redirect from its row actions removes it from the site's configuration and regenerates the vhost file. The
+proxied or redirected path stops responding once the change is applied.
+
+## Example: proxy a path to another service
+
+To serve documentation hosted elsewhere under `/docs` on your own domain:
+
+- **Mode**: `Proxy`
+- **From**: `/docs`
+- **To**: `https://docs.example.com`
+
+Requests to `https://your-site.com/docs` are now served transparently from `docs.example.com` without changing the URL
+in the browser.
+
+## Example: Laravel Reverb over WebSockets
+
+You can expose a [Laravel Reverb](https://laravel.com/docs/reverb) server running on your site through a proxy redirect
+with WebSocket support, instead of using the deprecated Laravel Reverb plugin.
+
+Assuming Reverb is running on your server on internal port `8089` (started by a [worker](../servers/workers.md)), create
+the following redirect:
+
+- **Mode**: `Proxy`
+- **From**: `~ ^/app(s)?/`
+- **To**: `http://0.0.0.0:8089`
+- **WebSocket support**: `Yes`
+
+Requests to `/app` and `/apps` on your site are now proxied to Reverb with the WebSocket upgrade headers in place. For
+the full walkthrough — including the `.env` variables, the deployment script change, and the worker — see
+[Setting up Laravel Reverb manually](../plugins/laravel-reverb.md#setting-up-laravel-reverb-manually).

--- a/public/api-docs/openapi/schemas/Redirect.yaml
+++ b/public/api-docs/openapi/schemas/Redirect.yaml
@@ -19,6 +19,9 @@ properties:
     type: integer
     enum: [301, 302, 307, 308, 1000]
     example: 301
+  websocket:
+    type: boolean
+    example: false
   status:
     type: string
     enum: ['creating', 'ready', 'deleting', 'failed']

--- a/public/api-docs/openapi/schemas/Redirect.yaml
+++ b/public/api-docs/openapi/schemas/Redirect.yaml
@@ -21,6 +21,7 @@ properties:
     example: 301
   websocket:
     type: boolean
+    description: 'Enable WebSocket upgrade support (only applies when mode is 1000 / proxy)'
     example: false
   status:
     type: string

--- a/public/api-docs/openapi/sites.yaml
+++ b/public/api-docs/openapi/sites.yaml
@@ -1634,6 +1634,120 @@ paths:
                 $ref: '/api-docs/openapi/schemas/ValidationError.yaml'
 
   /api/projects/{project}/servers/{server}/sites/{site}/redirects/{redirect}:
+    put:
+      summary: Update redirect
+      description: Update an existing redirect for a site
+      tags:
+        - Redirects
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: project
+          in: path
+          required: true
+          description: Project ID
+          schema:
+            type: integer
+            example: 1
+        - name: server
+          in: path
+          required: true
+          description: Server ID
+          schema:
+            type: integer
+            example: 1
+        - name: site
+          in: path
+          required: true
+          description: Site ID
+          schema:
+            type: integer
+            example: 1
+        - name: redirect
+          in: path
+          required: true
+          description: Redirect ID
+          schema:
+            type: integer
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - from
+                - to
+                - mode
+              properties:
+                from:
+                  type: string
+                  maxLength: 255
+                  description: 'Source path to redirect from (must not start with http:// or https://)'
+                  example: 'old-path'
+                to:
+                  type: string
+                  format: uri
+                  description: 'Destination URL to redirect to'
+                  example: 'https://example.com/new-path'
+                mode:
+                  type: integer
+                  enum: [301, 302, 307, 308, 1000]
+                  description: 'HTTP redirect mode'
+                  example: 301
+                websocket:
+                  type: boolean
+                  description: 'Enable WebSocket upgrade support (only applies when mode is 1000 / proxy)'
+                  example: false
+            example:
+              from: 'old-path'
+              to: 'https://example.com/new-path'
+              mode: 301
+              websocket: false
+      responses:
+        '200':
+          description: Redirect updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '/api-docs/openapi/schemas/Redirect.yaml'
+              example:
+                id: 1
+                server_id: 1
+                site_id: 1
+                from: 'old-path'
+                to: 'https://example.com/new-path'
+                mode: 301
+                websocket: false
+                status: 'creating'
+                status_color: 'warning'
+                created_at: '2024-01-01T00:00:00.000000Z'
+                updated_at: '2024-01-01T00:00:00.000000Z'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '/api-docs/openapi/schemas/ErrorResponse.yaml'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '/api-docs/openapi/schemas/ErrorResponse.yaml'
+        '404':
+          description: Redirect not found
+          content:
+            application/json:
+              schema:
+                $ref: '/api-docs/openapi/schemas/ErrorResponse.yaml'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '/api-docs/openapi/schemas/ValidationError.yaml'
     delete:
       summary: Delete redirect
       description: Delete a redirect from a site

--- a/public/api-docs/openapi/sites.yaml
+++ b/public/api-docs/openapi/sites.yaml
@@ -1589,6 +1589,7 @@ paths:
               from: 'old-path'
               to: 'https://example.com/new-path'
               mode: 301
+              websocket: false
       responses:
         '200':
           description: Redirect created successfully

--- a/public/api-docs/openapi/sites.yaml
+++ b/public/api-docs/openapi/sites.yaml
@@ -1584,6 +1584,7 @@ paths:
                 websocket:
                   type: boolean
                   description: 'Enable WebSocket upgrade support (only applies when mode is 1000 / proxy)'
+                  default: false
                   example: false
             example:
               from: 'old-path'
@@ -1700,6 +1701,7 @@ paths:
                 websocket:
                   type: boolean
                   description: 'Enable WebSocket upgrade support (only applies when mode is 1000 / proxy)'
+                  default: false
                   example: false
             example:
               from: 'old-path'

--- a/public/api-docs/openapi/sites.yaml
+++ b/public/api-docs/openapi/sites.yaml
@@ -1490,6 +1490,7 @@ paths:
                     from: 'old-path'
                     to: 'https://example.com/new-path'
                     mode: 301
+                    websocket: false
                     status: 'ready'
                     status_color: 'success'
                     created_at: '2024-01-01T00:00:00.000000Z'
@@ -1580,6 +1581,10 @@ paths:
                   enum: [301, 302, 307, 308, 1000]
                   description: 'HTTP redirect mode'
                   example: 301
+                websocket:
+                  type: boolean
+                  description: 'Enable WebSocket upgrade support (only applies when mode is 1000 / proxy)'
+                  example: false
             example:
               from: 'old-path'
               to: 'https://example.com/new-path'
@@ -1598,6 +1603,7 @@ paths:
                 from: 'old-path'
                 to: 'https://example.com/new-path'
                 mode: 301
+                websocket: false
                 status: 'creating'
                 status_color: 'warning'
                 created_at: '2024-01-01T00:00:00.000000Z'

--- a/resources/js/components/dialogs/registry.ts
+++ b/resources/js/components/dialogs/registry.ts
@@ -25,6 +25,7 @@ import ServerIpForm from '@/pages/server-network/components/form';
 import RecordForm from '@/pages/domains/components/record-form';
 import ScriptForm from '@/pages/scripts/components/form';
 import EditCommand from '@/pages/commands/components/edit-command';
+import EditRedirect from '@/pages/redirects/components/edit-redirect';
 import CreateBackup from '@/pages/backups/components/create-backup';
 import EditBackup from '@/pages/backups/components/edit-backup';
 import RestoreBackup from '@/pages/backups/components/restore-backup';
@@ -74,6 +75,7 @@ export const dialogs = {
   dnsRecordForm: RecordForm,
   scriptForm: ScriptForm,
   commandEdit: EditCommand,
+  redirectEdit: EditRedirect,
   backupCreate: CreateBackup,
   backupEdit: EditBackup,
   backupRestore: RestoreBackup,

--- a/resources/js/pages/redirects/components/columns.tsx
+++ b/resources/js/pages/redirects/components/columns.tsx
@@ -7,6 +7,12 @@ import DateTime from '@/components/date-time';
 import { Redirect } from '@/types/redirect';
 import { useDialog } from '@/hooks/use-dialog';
 
+function Edit({ redirect }: { redirect: Redirect }) {
+  const dialog = useDialog();
+
+  return <DropdownMenuItem onSelect={() => dialog.redirectEdit.open({ redirect })}>Edit</DropdownMenuItem>;
+}
+
 function Delete({ redirect }: { redirect: Redirect }) {
   const dialog = useDialog();
 
@@ -48,7 +54,7 @@ export const columns: ColumnDef<Redirect>[] = [
     enableColumnFilter: true,
     enableSorting: true,
     cell: ({ row }) => {
-      return row.original.mode === '1000' ? 'Proxy' : row.original.mode;
+      return String(row.original.mode) === '1000' ? 'Proxy' : row.original.mode;
     },
   },
   {
@@ -84,6 +90,7 @@ export const columns: ColumnDef<Redirect>[] = [
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              <Edit redirect={row.original} />
               <Delete redirect={row.original} />
             </DropdownMenuContent>
           </DropdownMenu>

--- a/resources/js/pages/redirects/components/create-redirect.tsx
+++ b/resources/js/pages/redirects/components/create-redirect.tsx
@@ -17,12 +17,14 @@ import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import InputError from '@/components/ui/input-error';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Site } from '@/types/site';
 
 type CreateForm = {
   mode: string;
   from: string;
   to: string;
+  websocket: boolean;
 };
 
 export default function CreateRedirect({ site, children }: { site: Site; children: ReactNode }) {
@@ -32,7 +34,16 @@ export default function CreateRedirect({ site, children }: { site: Site; childre
     mode: '',
     from: '',
     to: '',
+    websocket: false,
   });
+
+  const onModeChange = (value: string) => {
+    form.setData((data) => ({
+      ...data,
+      mode: value,
+      websocket: value === '1000' ? data.websocket : false,
+    }));
+  };
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
@@ -56,7 +67,7 @@ export default function CreateRedirect({ site, children }: { site: Site; childre
           <FormFields>
             <FormField>
               <Label htmlFor="mode">Mode</Label>
-              <Select onValueChange={(value) => form.setData('mode', value)} defaultValue={form.data.mode}>
+              <Select onValueChange={onModeChange} defaultValue={form.data.mode}>
                 <SelectTrigger id="mode">
                   <SelectValue placeholder="Select mode" />
                 </SelectTrigger>
@@ -94,6 +105,20 @@ export default function CreateRedirect({ site, children }: { site: Site; childre
               />
               <InputError message={form.errors.to} />
             </FormField>
+            {form.data.mode === '1000' && (
+              <FormField>
+                <div className="flex items-center gap-3">
+                  <Checkbox
+                    id="websocket"
+                    name="websocket"
+                    checked={form.data.websocket}
+                    onClick={() => form.setData('websocket', !form.data.websocket)}
+                  />
+                  <Label htmlFor="websocket">Support WebSockets</Label>
+                </div>
+                <InputError message={form.errors.websocket} />
+              </FormField>
+            )}
           </FormFields>
         </Form>
         <DialogFooter>

--- a/resources/js/pages/redirects/components/create-redirect.tsx
+++ b/resources/js/pages/redirects/components/create-redirect.tsx
@@ -53,7 +53,7 @@ export default function CreateRedirect({ site, children }: { site: Site; childre
               Cancel
             </Button>
           </DialogClose>
-          <Button type="button" onClick={submit} disabled={form.processing}>
+          <Button form="create-redirect-form" type="submit" disabled={form.processing}>
             {form.processing && <LoaderCircle className="animate-spin" />}
             Create
           </Button>

--- a/resources/js/pages/redirects/components/create-redirect.tsx
+++ b/resources/js/pages/redirects/components/create-redirect.tsx
@@ -9,41 +9,22 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { Form, FormField, FormFields } from '@/components/ui/form';
+import { Form } from '@/components/ui/form';
 import { useForm } from '@inertiajs/react';
 import { Button } from '@/components/ui/button';
 import { LoaderCircle } from 'lucide-react';
-import { Label } from '@/components/ui/label';
-import { Input } from '@/components/ui/input';
-import InputError from '@/components/ui/input-error';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Checkbox } from '@/components/ui/checkbox';
 import { Site } from '@/types/site';
-
-type CreateForm = {
-  mode: string;
-  from: string;
-  to: string;
-  websocket: boolean;
-};
+import RedirectFormFields, { RedirectForm } from './redirect-form-fields';
 
 export default function CreateRedirect({ site, children }: { site: Site; children: ReactNode }) {
   const [open, setOpen] = useState(false);
 
-  const form = useForm<CreateForm>({
+  const form = useForm<RedirectForm>({
     mode: '',
     from: '',
     to: '',
     websocket: false,
   });
-
-  const onModeChange = (value: string) => {
-    form.setData((data) => ({
-      ...data,
-      mode: value,
-      websocket: value === '1000' ? data.websocket : false,
-    }));
-  };
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
@@ -64,62 +45,7 @@ export default function CreateRedirect({ site, children }: { site: Site; childre
           <DialogDescription className="sr-only">Create new Redirect</DialogDescription>
         </DialogHeader>
         <Form className="p-4" id="create-redirect-form" onSubmit={submit}>
-          <FormFields>
-            <FormField>
-              <Label htmlFor="mode">Mode</Label>
-              <Select onValueChange={onModeChange} defaultValue={form.data.mode}>
-                <SelectTrigger id="mode">
-                  <SelectValue placeholder="Select mode" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="301">301 - Moved Permanently</SelectItem>
-                  <SelectItem value="302">302 - Found</SelectItem>
-                  <SelectItem value="307">307 - Temporary Redirect</SelectItem>
-                  <SelectItem value="308">308 - Permanent Redirect</SelectItem>
-                  <SelectItem value="1000">Proxy (/docs to https://docs.example.com)</SelectItem>
-                </SelectContent>
-              </Select>
-              <InputError message={form.errors.mode} />
-            </FormField>
-            <FormField>
-              <Label htmlFor="from">From</Label>
-              <Input
-                type="text"
-                id="from"
-                name="from"
-                value={form.data.from}
-                onChange={(e) => form.setData('from', e.target.value)}
-                placeholder="/path/to/redirect/"
-              />
-              <InputError message={form.errors.from} />
-            </FormField>
-            <FormField>
-              <Label htmlFor="to">To</Label>
-              <Input
-                type="text"
-                id="to"
-                name="to"
-                value={form.data.to}
-                onChange={(e) => form.setData('to', e.target.value)}
-                placeholder="https://new-url/"
-              />
-              <InputError message={form.errors.to} />
-            </FormField>
-            {form.data.mode === '1000' && (
-              <FormField>
-                <div className="flex items-center gap-3">
-                  <Checkbox
-                    id="websocket"
-                    name="websocket"
-                    checked={form.data.websocket}
-                    onClick={() => form.setData('websocket', !form.data.websocket)}
-                  />
-                  <Label htmlFor="websocket">Support WebSockets</Label>
-                </div>
-                <InputError message={form.errors.websocket} />
-              </FormField>
-            )}
-          </FormFields>
+          <RedirectFormFields form={form} />
         </Form>
         <DialogFooter>
           <DialogClose asChild>

--- a/resources/js/pages/redirects/components/edit-redirect.tsx
+++ b/resources/js/pages/redirects/components/edit-redirect.tsx
@@ -1,0 +1,57 @@
+import { FormEvent } from 'react';
+import { Form } from '@/components/ui/form';
+import { useForm } from '@inertiajs/react';
+import { Button } from '@/components/ui/button';
+import { LoaderCircle } from 'lucide-react';
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Redirect } from '@/types/redirect';
+import RedirectFormFields, { RedirectForm } from './redirect-form-fields';
+
+export default function EditRedirect({
+  open,
+  onOpenChange,
+  redirect,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  redirect: Redirect;
+}) {
+  const form = useForm<RedirectForm>({
+    mode: String(redirect.mode),
+    from: redirect.from,
+    to: redirect.to,
+    websocket: redirect.websocket,
+  });
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+    form.put(route('redirects.update', { server: redirect.server_id, site: redirect.site_id, redirect: redirect.id }), {
+      onSuccess: () => onOpenChange(false),
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg" onCloseAutoFocus={(e) => e.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle>Edit Redirect</DialogTitle>
+          <DialogDescription className="sr-only">Edit Redirect</DialogDescription>
+        </DialogHeader>
+        <Form className="p-4" id="edit-redirect-form" onSubmit={submit}>
+          <RedirectFormFields form={form} />
+        </Form>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline">
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button type="button" onClick={submit} disabled={form.processing}>
+            {form.processing && <LoaderCircle className="animate-spin" />}
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/pages/redirects/components/edit-redirect.tsx
+++ b/resources/js/pages/redirects/components/edit-redirect.tsx
@@ -46,7 +46,7 @@ export default function EditRedirect({
               Cancel
             </Button>
           </DialogClose>
-          <Button type="button" onClick={submit} disabled={form.processing}>
+          <Button form="edit-redirect-form" type="submit" disabled={form.processing}>
             {form.processing && <LoaderCircle className="animate-spin" />}
             Save
           </Button>

--- a/resources/js/pages/redirects/components/redirect-form-fields.tsx
+++ b/resources/js/pages/redirects/components/redirect-form-fields.tsx
@@ -1,0 +1,83 @@
+import { InertiaFormProps } from '@inertiajs/react';
+import { FormField, FormFields } from '@/components/ui/form';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import InputError from '@/components/ui/input-error';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+
+export type RedirectForm = {
+  mode: string;
+  from: string;
+  to: string;
+  websocket: boolean;
+};
+
+export default function RedirectFormFields({ form }: { form: InertiaFormProps<RedirectForm> }) {
+  const onModeChange = (value: string) => {
+    form.setData((data) => ({
+      ...data,
+      mode: value,
+      websocket: value === '1000' ? data.websocket : false,
+    }));
+  };
+
+  return (
+    <FormFields>
+      <FormField>
+        <Label htmlFor="mode">Mode</Label>
+        <Select onValueChange={onModeChange} value={form.data.mode}>
+          <SelectTrigger id="mode">
+            <SelectValue placeholder="Select mode" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="301">301 - Moved Permanently</SelectItem>
+            <SelectItem value="302">302 - Found</SelectItem>
+            <SelectItem value="307">307 - Temporary Redirect</SelectItem>
+            <SelectItem value="308">308 - Permanent Redirect</SelectItem>
+            <SelectItem value="1000">Proxy (/docs to https://docs.example.com)</SelectItem>
+          </SelectContent>
+        </Select>
+        <InputError message={form.errors.mode} />
+      </FormField>
+      <FormField>
+        <Label htmlFor="from">From</Label>
+        <Input
+          type="text"
+          id="from"
+          name="from"
+          value={form.data.from}
+          onChange={(e) => form.setData('from', e.target.value)}
+          placeholder="/path/to/redirect/"
+        />
+        <InputError message={form.errors.from} />
+      </FormField>
+      <FormField>
+        <Label htmlFor="to">To</Label>
+        <Input
+          type="text"
+          id="to"
+          name="to"
+          value={form.data.to}
+          onChange={(e) => form.setData('to', e.target.value)}
+          placeholder="https://new-url/"
+        />
+        <InputError message={form.errors.to} />
+      </FormField>
+      {form.data.mode === '1000' && (
+        <FormField>
+          <div className="flex items-center gap-3">
+            <Checkbox
+              id="websocket"
+              name="websocket"
+              checked={form.data.websocket}
+              onClick={() => form.setData('websocket', !form.data.websocket)}
+            />
+            <Label htmlFor="websocket">WebSocket support</Label>
+          </div>
+          <InputError message={form.errors.websocket} />
+        </FormField>
+      )}
+    </FormFields>
+  );
+}

--- a/resources/js/types/redirect.d.ts
+++ b/resources/js/types/redirect.d.ts
@@ -5,6 +5,7 @@ export interface Redirect {
   from: string;
   to: string;
   mode: string;
+  websocket: boolean;
   status: string;
   status_color: 'gray' | 'success' | 'info' | 'warning' | 'danger';
   created_at: string;

--- a/resources/views/ssh/services/webserver/nginx/vhost.mustache
+++ b/resources/views/ssh/services/webserver/nginx/vhost.mustache
@@ -178,6 +178,21 @@ server {
 
     {{#redirects}}
     {{#is_proxy}}
+    {{#is_websocket}}
+    location {{from}} {
+        proxy_pass {{to}};
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+    {{/is_websocket}}
+
+    {{^is_websocket}}
     location {{from}} {
         proxy_pass {{to}};
         proxy_set_header Host {{to_host}};
@@ -186,6 +201,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_ssl_server_name on;
     }
+    {{/is_websocket}}
     {{/is_proxy}}
 
     {{^is_proxy}}

--- a/resources/views/ssh/services/webserver/nginx/vhost.mustache
+++ b/resources/views/ssh/services/webserver/nginx/vhost.mustache
@@ -189,6 +189,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 60s;
+        proxy_ssl_server_name on;
     }
     {{/is_websocket}}
 

--- a/tests/Feature/API/RedirectsTest.php
+++ b/tests/Feature/API/RedirectsTest.php
@@ -37,6 +37,32 @@ class RedirectsTest extends TestCase
             ]);
     }
 
+    public function test_update_redirect(): void
+    {
+        SSH::fake();
+
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        $this->json('PUT', route('api.projects.servers.sites.redirects.update', [
+            'project' => $this->server->project,
+            'server' => $this->server,
+            'site' => $this->site,
+            'redirect' => $this->redirect->id,
+        ]), [
+            'from' => 'updated/path',
+            'to' => 'https://updated.example.com',
+            'mode' => 302,
+        ])
+            ->assertSuccessful()
+            ->assertJsonFragment([
+                'id' => $this->redirect->id,
+                'from' => 'updated/path',
+                'to' => 'https://updated.example.com',
+                'mode' => 302,
+                'status' => RedirectStatus::READY,
+            ]);
+    }
+
     public function test_see_redirects_list(): void
     {
         Sanctum::actingAs($this->user, ['read']);

--- a/tests/Feature/RedirectsTest.php
+++ b/tests/Feature/RedirectsTest.php
@@ -125,4 +125,97 @@ class RedirectsTest extends TestCase
             'websocket' => false,
         ]);
     }
+
+    public function test_update_redirect(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+
+        $redirect = Redirect::factory()->create([
+            'site_id' => $this->site->id,
+            'mode' => 301,
+        ]);
+
+        $this->put(route('redirects.update', [
+            'server' => $this->server,
+            'site' => $this->site,
+            'redirect' => $redirect,
+        ]), [
+            'from' => 'updated-path',
+            'to' => 'https://example.com/updated',
+            'mode' => 302,
+        ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('redirects', [
+            'id' => $redirect->id,
+            'from' => 'updated-path',
+            'to' => 'https://example.com/updated',
+            'mode' => 302,
+            'status' => RedirectStatus::READY,
+        ]);
+    }
+
+    public function test_update_redirect_to_proxy_with_websocket(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+
+        $redirect = Redirect::factory()->create([
+            'site_id' => $this->site->id,
+            'mode' => 301,
+            'websocket' => false,
+        ]);
+
+        $this->put(route('redirects.update', [
+            'server' => $this->server,
+            'site' => $this->site,
+            'redirect' => $redirect,
+        ]), [
+            'from' => 'ws-path',
+            'to' => 'https://backend.example.com',
+            'mode' => 1000,
+            'websocket' => true,
+        ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('redirects', [
+            'id' => $redirect->id,
+            'mode' => 1000,
+            'websocket' => true,
+        ]);
+    }
+
+    public function test_update_redirect_away_from_proxy_forces_websocket_off(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+
+        $redirect = Redirect::factory()->create([
+            'site_id' => $this->site->id,
+            'mode' => 1000,
+            'websocket' => true,
+        ]);
+
+        $this->put(route('redirects.update', [
+            'server' => $this->server,
+            'site' => $this->site,
+            'redirect' => $redirect,
+        ]), [
+            'from' => 'plain-path',
+            'to' => 'https://example.com/plain',
+            'mode' => 301,
+            'websocket' => true,
+        ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('redirects', [
+            'id' => $redirect->id,
+            'mode' => 301,
+            'websocket' => false,
+        ]);
+    }
 }

--- a/tests/Feature/RedirectsTest.php
+++ b/tests/Feature/RedirectsTest.php
@@ -75,4 +75,54 @@ class RedirectsTest extends TestCase
             'status' => RedirectStatus::READY,
         ]);
     }
+
+    public function test_create_proxy_redirect_with_websocket(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+
+        $this->post(route('redirects.store', [
+            'server' => $this->server,
+            'site' => $this->site,
+        ]), [
+            'from' => '/app',
+            'to' => 'https://backend.example.com',
+            'mode' => 1000,
+            'websocket' => true,
+        ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('redirects', [
+            'from' => '/app',
+            'to' => 'https://backend.example.com',
+            'mode' => 1000,
+            'websocket' => true,
+            'status' => RedirectStatus::READY,
+        ]);
+    }
+
+    public function test_websocket_forced_off_when_not_proxy_mode(): void
+    {
+        SSH::fake();
+
+        $this->actingAs($this->user);
+
+        $this->post(route('redirects.store', [
+            'server' => $this->server,
+            'site' => $this->site,
+        ]), [
+            'from' => '/app',
+            'to' => 'https://example.com/redirect',
+            'mode' => 301,
+            'websocket' => true,
+        ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('redirects', [
+            'from' => '/app',
+            'mode' => 301,
+            'websocket' => false,
+        ]);
+    }
 }

--- a/tests/Feature/Webserver/RedirectBlockTest.php
+++ b/tests/Feature/Webserver/RedirectBlockTest.php
@@ -36,7 +36,7 @@ class RedirectBlockTest extends TestCase
         $this->assertStringContainsString('proxy_set_header Upgrade $http_upgrade;', $vhost);
         $this->assertStringContainsString('proxy_set_header Connection "upgrade";', $vhost);
         $this->assertStringContainsString('proxy_read_timeout 60s;', $vhost);
-        $this->assertStringNotContainsString('proxy_ssl_server_name on;', $vhost);
+        $this->assertStringContainsString('proxy_ssl_server_name on;', $vhost);
     }
 
     public function test_nginx_renders_plain_proxy_block_without_websocket(): void

--- a/tests/Feature/Webserver/RedirectBlockTest.php
+++ b/tests/Feature/Webserver/RedirectBlockTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Webserver;
+
+use App\Enums\RedirectStatus;
+use App\Models\HostedDomain;
+use App\Models\Redirect;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RedirectBlockTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_nginx_renders_websocket_upgrade_headers_for_proxy_redirect(): void
+    {
+        HostedDomain::factory()->primary()->create([
+            'site_id' => $this->site->id,
+            'domain' => $this->site->domain,
+        ]);
+
+        Redirect::factory()->create([
+            'site_id' => $this->site->id,
+            'from' => '/app',
+            'to' => 'https://backend.example.com',
+            'mode' => 1000,
+            'websocket' => true,
+            'status' => RedirectStatus::READY,
+        ]);
+
+        $vhost = $this->site->webserver()->generateVhost($this->site);
+
+        $this->assertStringContainsString('location /app {', $vhost);
+        $this->assertStringContainsString('proxy_pass https://backend.example.com;', $vhost);
+        $this->assertStringContainsString('proxy_http_version 1.1;', $vhost);
+        $this->assertStringContainsString('proxy_set_header Upgrade $http_upgrade;', $vhost);
+        $this->assertStringContainsString('proxy_set_header Connection "upgrade";', $vhost);
+        $this->assertStringContainsString('proxy_read_timeout 60s;', $vhost);
+        $this->assertStringNotContainsString('proxy_ssl_server_name on;', $vhost);
+    }
+
+    public function test_nginx_renders_plain_proxy_block_without_websocket(): void
+    {
+        HostedDomain::factory()->primary()->create([
+            'site_id' => $this->site->id,
+            'domain' => $this->site->domain,
+        ]);
+
+        Redirect::factory()->create([
+            'site_id' => $this->site->id,
+            'from' => '/app',
+            'to' => 'https://backend.example.com',
+            'mode' => 1000,
+            'websocket' => false,
+            'status' => RedirectStatus::READY,
+        ]);
+
+        $vhost = $this->site->webserver()->generateVhost($this->site);
+
+        $this->assertStringContainsString('location /app {', $vhost);
+        $this->assertStringContainsString('proxy_set_header Host backend.example.com;', $vhost);
+        $this->assertStringContainsString('proxy_ssl_server_name on;', $vhost);
+        $this->assertStringNotContainsString('proxy_set_header Upgrade $http_upgrade;', $vhost);
+    }
+}


### PR DESCRIPTION
Adds an optional "WebSocket support" toggle to Proxy-mode site redirects (emitting the required Nginx upgrade headers) along with a full edit interface for existing redirects, and updates the v4 docs to cover both and to document Laravel Reverb setup via redirects as the Reverb plugin is deprecated.  Supported by caddy OOTB, so no template edits required. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now edit existing redirects from both the UI and API.
  * Added WebSocket support for proxy-style redirects, including a WebSocket toggle/flag in redirect forms and API payloads/responses.
  * Proxy redirects now generate WebSocket-capable server configuration.
* **Bug Fixes**
  * WebSocket is automatically enabled/disabled to match proxy mode.
* **Documentation**
  * Updated redirect and Reverb documentation with the new WebSocket proxy workflow.
* **Tests**
  * Added coverage for redirect create/update WebSocket behaviour and Nginx rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->