### PR TITLE
[Fix] PHP management and updates broken by PPA label change

### DIFF
--- a/docs/3.x/servers/php.md
+++ b/docs/3.x/servers/php.md
@@ -61,3 +61,39 @@ FPM.
 
 Under the `PHP` or `Services` page, you can `start`, `stop`, `restart`, `enable`, or `disable` the FPM service for each
 PHP version.
+
+## Troubleshooting
+
+### `apt-get update` fails with "Repository ... changed its 'Label' value"
+
+When installing a PHP version, or updating a server that already has PHP installed, you may see an
+error like this:
+
+```text
+E: Repository 'https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble InRelease' changed its 'Label' value from 'PPA for PHP' to 'Use packages.sury.org/php instead'
+```
+
+Vito 3.x installs PHP from the `ondrej/php` Launchpad PPA. That PPA is being merged into
+[packages.sury.org](https://packages.sury.org/php/), and as part of the move it changed the `Label`
+field in its release metadata to announce this. APT treats a changed `Label` (along with `Origin`,
+`Suite`, or `Version`) as a potential security concern and refuses to refresh that repository's
+package list unless you explicitly allow it — which aborts the whole `apt-get update`, and with it
+the PHP install or server update that triggered it.
+
+:::warning
+This fix is only available as a manual workaround for 3.x. It is not being backported into Vito's
+3.x install/update scripts, so you'll need to apply it yourself on each affected server (once per
+server is enough).
+:::
+
+Vito keeps installing PHP from the `ondrej/php` PPA rather than migrating to `packages.sury.org`,
+because that mirror doesn't yet carry every extension package Vito needs (such as `php-redis`) for
+all PHP versions. Instead, just tell APT to accept the (expected) label change:
+
+```sh
+sudo apt-get update -o Acquire::AllowReleaseInfoChange::Label=true
+```
+
+:::info
+After that, retry the PHP install or server update in Vito — it should complete normally.
+:::

--- a/docs/4.x/servers/overview.md
+++ b/docs/4.x/servers/overview.md
@@ -57,3 +57,10 @@ complete the upgrade. Provides a **Restart** action.
 
 Shown when the server has pending OS package updates. It includes the number of updates and provides
 an **Update** action to install them.
+
+:::info
+If **Check for updates** or **Update** fails with an APT error about a repository changing its
+`Label` (or `Origin`/`Suite`/`Version`) value, see
+[PHP › Troubleshooting](/docs/4.x/servers/php#troubleshooting) — the same underlying issue also
+affects PHP installs, and the fix there resolves both.
+:::

--- a/docs/4.x/servers/php.md
+++ b/docs/4.x/servers/php.md
@@ -64,3 +64,37 @@ FPM.
 
 Under the `PHP` or `Services` page, you can `start`, `stop`, `restart`, `enable`, or `disable` the FPM service for each
 PHP version.
+
+## Troubleshooting
+
+### `apt-get update` fails with "Repository ... changed its 'Label' value"
+
+When installing a PHP version, or updating a server that already has PHP installed, you may see an
+error like this:
+
+```text
+E: Repository 'https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble InRelease' changed its 'Label' value from 'PPA for PHP' to 'Use packages.sury.org/php instead'
+```
+
+Vito installs PHP from the `ondrej/php` Launchpad PPA. That PPA is being merged into
+[packages.sury.org](https://packages.sury.org/php/), and as part of the move it changed the `Label`
+field in its release metadata to announce this. APT treats a changed `Label` (along with `Origin`,
+`Suite`, or `Version`) as a potential security concern and refuses to refresh that repository's
+package list unless you explicitly allow it — which aborts the whole `apt-get update`, and with it
+the PHP install or server update that triggered it.
+
+Vito keeps installing PHP from the `ondrej/php` PPA (the `packages.sury.org` mirror doesn't yet
+carry every extension package Vito needs, such as `php-redis`, for all PHP versions), and now passes
+`-o Acquire::AllowReleaseInfoChange::Label=true` to `apt-get update` so this specific, expected label
+change no longer blocks installs or updates.
+
+If a server is still stuck on the old error, run this once on the server as the `vito` user instead
+of waiting for a PHP install/reinstall or server update to pick up the fix:
+
+```sh
+sudo apt-get update -o Acquire::AllowReleaseInfoChange::Label=true
+```
+
+:::info
+After that, retry the PHP install or server update in Vito — it should complete normally.
+:::

--- a/resources/views/ssh/os/available-updates.blade.php
+++ b/resources/views/ssh/os/available-updates.blade.php
@@ -1,4 +1,4 @@
-sudo DEBIAN_FRONTEND=noninteractive apt-get update > /dev/null 2>&1
+sudo DEBIAN_FRONTEND=noninteractive apt-get update -o Acquire::AllowReleaseInfoChange::Label=true > /dev/null 2>&1
 
 UPGRADABLE=$(sudo DEBIAN_FRONTEND=noninteractive apt list --upgradable 2>/dev/null | tail -n +2)
 

--- a/resources/views/ssh/os/upgrade-kernel.blade.php
+++ b/resources/views/ssh/os/upgrade-kernel.blade.php
@@ -1,4 +1,4 @@
 sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get clean
-sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update
+sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -o Acquire::AllowReleaseInfoChange::Label=true
 sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade -y
 sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get autoremove -y

--- a/resources/views/ssh/os/upgrade.blade.php
+++ b/resources/views/ssh/os/upgrade.blade.php
@@ -3,7 +3,7 @@ export LC_ALL=C
 UPGRADE_LOG=$(mktemp)
 trap 'rm -f "$UPGRADE_LOG"' EXIT
 sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get clean
-sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update
+sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -o Acquire::AllowReleaseInfoChange::Label=true
 sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get upgrade -y | tee "$UPGRADE_LOG"
 sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade -y
 sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get autoremove -y

--- a/resources/views/ssh/services/php/install-php.blade.php
+++ b/resources/views/ssh/services/php/install-php.blade.php
@@ -1,6 +1,6 @@
 sudo add-apt-repository ppa:ondrej/php -y
 
-sudo DEBIAN_FRONTEND=noninteractive apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get update -o Acquire::AllowReleaseInfoChange::Label=true
 
 if ! sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php{{ $version }} php{{ $version }}-fpm php{{ $version }}-mbstring php{{ $version }}-mysql php{{ $version }}-gd php{{ $version }}-xml php{{ $version }}-curl php{{ $version }}-gettext php{{ $version }}-zip php{{ $version }}-bcmath php{{ $version }}-soap php{{ $version }}-redis php{{ $version }}-sqlite3 php{{ $version }}-tokenizer php{{ $version }}-pgsql php{{ $version }}-pdo php{{ $version }}-intl; then
     echo 'VITO_SSH_ERROR' && exit 1

--- a/resources/views/ssh/services/php/uninstall-php.blade.php
+++ b/resources/views/ssh/services/php/uninstall-php.blade.php
@@ -1,4 +1,4 @@
-sudo systemctl stop php{{ $version }}-fpm
+sudo systemctl stop php{{ $version }}-fpm 2>/dev/null || true
 
 if ! sudo DEBIAN_FRONTEND=noninteractive apt-get remove -y php{{ $version }} php{{ $version }}-fpm php{{ $version }}-mbstring php{{ $version }}-mysql php{{ $version }}-mcrypt php{{ $version }}-gd php{{ $version }}-xml php{{ $version }}-curl php{{ $version }}-gettext php{{ $version }}-zip php{{ $version }}-bcmath php{{ $version }}-soap php{{ $version }}-redis php{{ $version }}-sqlite3; then
     echo 'VITO_SSH_ERROR' && exit 1


### PR DESCRIPTION
**Root cause:** the ondrej/php PPA (Vito's PHP repo) relabeled itself to announce a merge into packages.sury.org, and APT refuses to apt-get update on a repo label change unless told otherwise - which breaks PHP installs, uninstalls, and server updates until it's acknowledged.

Automatic Fix - Update to the latest version that includes this fix, and install updates on the server

Manual Fix - SSH into your server as vito and run:
`sudo apt-get update -o Acquire::AllowReleaseInfoChange::Label=true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server update, kernel upgrade, and PHP install flows to better handle APT repository metadata changes.
  * PHP uninstall now ignores harmless service-stop errors, making removals more reliable.

* **Documentation**
  * Expanded PHP troubleshooting guidance for installation and update failures caused by repository label changes.
  * Added a note to server update status pages directing users to the relevant fix when package updates fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->