### PR TITLE
[Feat] Scripts on events (#1070)

### DIFF
--- a/app/Actions/Bootstrap/GetBootstrap.php
+++ b/app/Actions/Bootstrap/GetBootstrap.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Bootstrap;
 
+use App\Enums\ScriptEventHookEvent;
 use App\Models\GithubApp;
 use App\Tooling\ToolingRegistry;
 use Illuminate\Support\Facades\Cache;
@@ -95,6 +96,17 @@ final class GetBootstrap
                 'installed' => GithubApp::query()->exists(),
             ],
             'tooling' => $this->tooling(),
+            'script_event_hooks' => [
+                'events' => array_map(
+                    fn (ScriptEventHookEvent $e): array => [
+                        'value' => $e->value,
+                        'label' => $e->getText(),
+                        'color' => $e->getColor(),
+                        'variables' => array_keys($e->variables()),
+                    ],
+                    ScriptEventHookEvent::cases()
+                ),
+            ],
         ];
     }
 

--- a/app/Actions/Script/ExecuteScript.php
+++ b/app/Actions/Script/ExecuteScript.php
@@ -27,29 +27,10 @@ class ExecuteScript
 
         $variables = [];
         foreach ($script->getVariables() as $variable) {
-            $variables[$variable] = $eventVariables[$variable] ?? '';
+            $variables[$variable] = $this->sanitizeVariable($eventVariables[$variable] ?? '');
         }
 
-        return DB::transaction(function () use ($script, $hook, $variables): ScriptExecution {
-            $execution = new ScriptExecution([
-                'script_id' => $script->id,
-                'server_id' => $hook->server_id,
-                'user' => $hook->user,
-                'variables' => $variables,
-                'status' => ScriptExecutionStatus::EXECUTING,
-            ]);
-            $execution->save();
-
-            $log = ServerLog::newLog($hook->server, 'script-'.$script->id.'-'.strtotime('now'));
-            $log->save();
-
-            $execution->server_log_id = $log->id;
-            $execution->save();
-
-            dispatch(new ExecuteJob($execution, $log))->onQueue('ssh');
-
-            return $execution;
-        });
+        return $this->startExecution($script, $hook->server, $hook->user, $variables);
     }
 
     /**
@@ -73,24 +54,44 @@ class ExecuteScript
             abort(403, 'You do not have permission to execute scripts on this server.');
         }
 
-        $execution = new ScriptExecution([
-            'script_id' => $script->id,
-            'server_id' => $input['server'],
-            'user' => $input['user'],
-            'variables' => $variables,
-            'status' => ScriptExecutionStatus::EXECUTING,
-        ]);
-        $execution->save();
+        return $this->startExecution($script, $server, $input['user'], $variables);
+    }
 
-        $log = ServerLog::newLog($execution->server, 'script-'.$script->id.'-'.strtotime('now'));
-        $log->save();
+    /**
+     * @param  array<string, string>  $variables
+     */
+    private function startExecution(Script $script, Server $server, string $user, array $variables): ScriptExecution
+    {
+        /** @var array{0: ScriptExecution, 1: ServerLog} $result */
+        $result = DB::transaction(function () use ($script, $server, $user, $variables): array {
+            $execution = new ScriptExecution([
+                'script_id' => $script->id,
+                'server_id' => $server->id,
+                'user' => $user,
+                'variables' => $variables,
+                'status' => ScriptExecutionStatus::EXECUTING,
+            ]);
+            $execution->save();
 
-        $execution->server_log_id = $log->id;
-        $execution->save();
+            $log = ServerLog::newLog($server, 'script-'.$script->id.'-'.strtotime('now'));
+            $log->save();
+
+            $execution->server_log_id = $log->id;
+            $execution->save();
+
+            return [$execution, $log];
+        });
+
+        [$execution, $log] = $result;
 
         dispatch(new ExecuteJob($execution, $log))->onQueue('ssh');
 
         return $execution;
+    }
+
+    private function sanitizeVariable(string $value): string
+    {
+        return preg_replace('/[^A-Za-z0-9 ._\-\/:@]/', '', $value) ?? '';
     }
 
     private function validate(Script $script, array $input): void

--- a/app/Actions/Script/ExecuteScript.php
+++ b/app/Actions/Script/ExecuteScript.php
@@ -5,15 +5,53 @@ namespace App\Actions\Script;
 use App\Enums\ScriptExecutionStatus;
 use App\Jobs\Script\ExecuteJob;
 use App\Models\Script;
+use App\Models\ScriptEventHook;
 use App\Models\ScriptExecution;
 use App\Models\Server;
 use App\Models\ServerLog;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 
 class ExecuteScript
 {
+    /**
+     * Execute a script triggered by an event hook, injecting event context as variables.
+     *
+     * @param  array<string, string>  $eventVariables
+     */
+    public function executeForHook(ScriptEventHook $hook, array $eventVariables): ScriptExecution
+    {
+        $script = $hook->script;
+
+        $variables = [];
+        foreach ($script->getVariables() as $variable) {
+            $variables[$variable] = $eventVariables[$variable] ?? '';
+        }
+
+        return DB::transaction(function () use ($script, $hook, $variables): ScriptExecution {
+            $execution = new ScriptExecution([
+                'script_id' => $script->id,
+                'server_id' => $hook->server_id,
+                'user' => $hook->user,
+                'variables' => $variables,
+                'status' => ScriptExecutionStatus::EXECUTING,
+            ]);
+            $execution->save();
+
+            $log = ServerLog::newLog($hook->server, 'script-'.$script->id.'-'.strtotime('now'));
+            $log->save();
+
+            $execution->server_log_id = $log->id;
+            $execution->save();
+
+            dispatch(new ExecuteJob($execution, $log))->onQueue('ssh');
+
+            return $execution;
+        });
+    }
+
     /**
      * @param  array<string, mixed>  $input
      */

--- a/app/Actions/ScriptEventHook/CreateScriptEventHook.php
+++ b/app/Actions/ScriptEventHook/CreateScriptEventHook.php
@@ -3,20 +3,16 @@
 namespace App\Actions\ScriptEventHook;
 
 use App\Enums\ScriptEventHookEvent;
-use App\Models\Project;
 use App\Models\Script;
 use App\Models\ScriptEventHook;
 use App\Models\Server;
 use App\Models\User;
-use App\Traits\HasRolePolicies;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 
 class CreateScriptEventHook
 {
-    use HasRolePolicies;
-
     /**
      * @param  array<string, mixed>  $input
      *
@@ -24,15 +20,16 @@ class CreateScriptEventHook
      */
     public function create(User $user, Script $script, array $input): ScriptEventHook
     {
-        $this->validate($user, $input);
+        $server = $this->validate($input);
 
-        /** @var Server $server */
-        $server = Server::query()->findOrFail($input['server_id']);
+        if (! $user->can('update', $server)) {
+            abort(403, 'You do not have permission to run scripts on this server.');
+        }
 
         $hook = new ScriptEventHook([
             'script_id' => $script->id,
             'user_id' => $user->id,
-            'project_id' => $input['project_id'],
+            'project_id' => $server->project_id,
             'server_id' => $server->id,
             'event' => $input['event'],
             'user' => $input['user'],
@@ -48,8 +45,9 @@ class CreateScriptEventHook
      *
      * @throws ValidationException
      */
-    private function validate(User $user, array $input): void
+    private function validate(array $input): Server
     {
+        $server = null;
         $users = ['root'];
         if (isset($input['server_id'])) {
             $server = Server::query()->find($input['server_id']);
@@ -59,10 +57,6 @@ class CreateScriptEventHook
         }
 
         Validator::make($input, [
-            'project_id' => [
-                'required',
-                Rule::exists('projects', 'id'),
-            ],
             'event' => [
                 'required',
                 Rule::enum(ScriptEventHookEvent::class),
@@ -80,16 +74,7 @@ class CreateScriptEventHook
             ],
         ])->validate();
 
-        /** @var Project $project */
-        $project = Project::query()->findOrFail($input['project_id']);
-        if (! $this->hasWriteAccess($user, $project)) {
-            throw ValidationException::withMessages(['project_id' => 'You do not have write access to this project.']);
-        }
-
         /** @var Server $server */
-        $server = Server::query()->findOrFail($input['server_id']);
-        if (! $this->hasWriteAccess($user, $server->project)) {
-            throw ValidationException::withMessages(['server_id' => 'You do not have write access to this server\'s project.']);
-        }
+        return $server;
     }
 }

--- a/app/Actions/ScriptEventHook/CreateScriptEventHook.php
+++ b/app/Actions/ScriptEventHook/CreateScriptEventHook.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Actions\ScriptEventHook;
+
+use App\Enums\ScriptEventHookEvent;
+use App\Models\Project;
+use App\Models\Script;
+use App\Models\ScriptEventHook;
+use App\Models\Server;
+use App\Models\User;
+use App\Traits\HasRolePolicies;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+class CreateScriptEventHook
+{
+    use HasRolePolicies;
+
+    /**
+     * @param  array<string, mixed>  $input
+     *
+     * @throws ValidationException
+     */
+    public function create(User $user, Script $script, array $input): ScriptEventHook
+    {
+        $this->validate($user, $input);
+
+        /** @var Server $server */
+        $server = Server::query()->findOrFail($input['server_id']);
+
+        $hook = new ScriptEventHook([
+            'script_id' => $script->id,
+            'user_id' => $user->id,
+            'project_id' => $input['project_id'],
+            'server_id' => $server->id,
+            'event' => $input['event'],
+            'user' => $input['user'],
+            'enabled' => $input['enabled'] ?? true,
+        ]);
+        $hook->save();
+
+        return $hook;
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     *
+     * @throws ValidationException
+     */
+    private function validate(User $user, array $input): void
+    {
+        $users = ['root'];
+        if (isset($input['server_id'])) {
+            $server = Server::query()->find($input['server_id']);
+            if ($server) {
+                $users = $server->getSshUsers();
+            }
+        }
+
+        Validator::make($input, [
+            'project_id' => [
+                'required',
+                Rule::exists('projects', 'id'),
+            ],
+            'event' => [
+                'required',
+                Rule::enum(ScriptEventHookEvent::class),
+            ],
+            'server_id' => [
+                'required',
+                Rule::exists('servers', 'id'),
+            ],
+            'user' => [
+                'required',
+                Rule::in($users),
+            ],
+            'enabled' => [
+                'boolean',
+            ],
+        ])->validate();
+
+        /** @var Project $project */
+        $project = Project::query()->findOrFail($input['project_id']);
+        if (! $this->hasWriteAccess($user, $project)) {
+            throw ValidationException::withMessages(['project_id' => 'You do not have write access to this project.']);
+        }
+
+        /** @var Server $server */
+        $server = Server::query()->findOrFail($input['server_id']);
+        if (! $this->hasWriteAccess($user, $server->project)) {
+            throw ValidationException::withMessages(['server_id' => 'You do not have write access to this server\'s project.']);
+        }
+    }
+}

--- a/app/Actions/ScriptEventHook/UpdateScriptEventHook.php
+++ b/app/Actions/ScriptEventHook/UpdateScriptEventHook.php
@@ -6,15 +6,12 @@ use App\Enums\ScriptEventHookEvent;
 use App\Models\ScriptEventHook;
 use App\Models\Server;
 use App\Models\User;
-use App\Traits\HasRolePolicies;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 
 class UpdateScriptEventHook
 {
-    use HasRolePolicies;
-
     /**
      * @param  array<string, mixed>  $input
      *
@@ -22,11 +19,16 @@ class UpdateScriptEventHook
      */
     public function update(ScriptEventHook $hook, User $user, array $input): ScriptEventHook
     {
-        $this->validate($user, $input);
+        $server = $this->validate($input);
+
+        if ($server && ! $user->can('update', $server)) {
+            abort(403, 'You do not have permission to run scripts on this server.');
+        }
 
         $hook->fill([
             'event' => $input['event'] ?? $hook->event->value,
-            'server_id' => $input['server_id'] ?? $hook->server_id,
+            'server_id' => $server->id ?? $hook->server_id,
+            'project_id' => $server->project_id ?? $hook->project_id,
             'user' => $input['user'] ?? $hook->user,
             'enabled' => $input['enabled'] ?? $hook->enabled,
         ]);
@@ -40,7 +42,7 @@ class UpdateScriptEventHook
      *
      * @throws ValidationException
      */
-    private function validate(User $user, array $input): void
+    private function validate(array $input): ?Server
     {
         $users = ['root'];
         $server = null;
@@ -70,8 +72,6 @@ class UpdateScriptEventHook
             ],
         ])->validate();
 
-        if ($server && ! $this->hasWriteAccess($user, $server->project)) {
-            throw ValidationException::withMessages(['server_id' => "You do not have write access to this server's project."]);
-        }
+        return $server;
     }
 }

--- a/app/Actions/ScriptEventHook/UpdateScriptEventHook.php
+++ b/app/Actions/ScriptEventHook/UpdateScriptEventHook.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Actions\ScriptEventHook;
+
+use App\Enums\ScriptEventHookEvent;
+use App\Models\ScriptEventHook;
+use App\Models\Server;
+use App\Models\User;
+use App\Traits\HasRolePolicies;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+class UpdateScriptEventHook
+{
+    use HasRolePolicies;
+
+    /**
+     * @param  array<string, mixed>  $input
+     *
+     * @throws ValidationException
+     */
+    public function update(ScriptEventHook $hook, User $user, array $input): ScriptEventHook
+    {
+        $this->validate($user, $input);
+
+        $hook->fill([
+            'event' => $input['event'] ?? $hook->event->value,
+            'server_id' => $input['server_id'] ?? $hook->server_id,
+            'user' => $input['user'] ?? $hook->user,
+            'enabled' => $input['enabled'] ?? $hook->enabled,
+        ]);
+        $hook->save();
+
+        return $hook;
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     *
+     * @throws ValidationException
+     */
+    private function validate(User $user, array $input): void
+    {
+        $users = ['root'];
+        $server = null;
+        if (isset($input['server_id'])) {
+            $server = Server::query()->find($input['server_id']);
+            if ($server) {
+                $users = $server->getSshUsers();
+            }
+        }
+
+        Validator::make($input, [
+            'event' => [
+                'sometimes',
+                Rule::enum(ScriptEventHookEvent::class),
+            ],
+            'server_id' => [
+                'sometimes',
+                Rule::exists('servers', 'id'),
+            ],
+            'user' => [
+                'required_with:server_id',
+                Rule::in($users),
+            ],
+            'enabled' => [
+                'sometimes',
+                'boolean',
+            ],
+        ])->validate();
+
+        if ($server && ! $this->hasWriteAccess($user, $server->project)) {
+            throw ValidationException::withMessages(['server_id' => "You do not have write access to this server's project."]);
+        }
+    }
+}

--- a/app/Actions/Server/DeleteServer.php
+++ b/app/Actions/Server/DeleteServer.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Server;
 
+use App\Events\ServerDeletedEvent;
 use App\Models\Server;
 use App\ServerProviders\Custom;
 use Illuminate\Support\Facades\Validator;
@@ -23,7 +24,14 @@ class DeleteServer
             $server->deleteFromProvider = filter_var($input['delete_from_provider'], FILTER_VALIDATE_BOOLEAN);
         }
 
+        $serverId = $server->id;
+        $serverName = $server->name;
+        $serverIp = $server->ip;
+        $projectId = $server->project_id;
+
         $server->delete();
+
+        ServerDeletedEvent::dispatch($serverId, $serverName, $serverIp, $projectId);
     }
 
     /**

--- a/app/Actions/Server/InstallServer.php
+++ b/app/Actions/Server/InstallServer.php
@@ -5,6 +5,7 @@ namespace App\Actions\Server;
 use App\DTOs\SocketEventDTO;
 use App\Enums\ServerStatus;
 use App\Enums\ServiceStatus;
+use App\Events\ServerInstalledEvent;
 use App\Events\SocketEvent;
 use App\Exceptions\SSHConnectionError;
 use App\Exceptions\SSHError;
@@ -47,6 +48,7 @@ class InstallServer
         ]);
         dispatch(new RefreshServerIpsJob($this->server))->onQueue('ssh');
         Notifier::send($this->server, new ServerInstallationSucceed($this->server));
+        ServerInstalledEvent::dispatch($this->server);
     }
 
     /**

--- a/app/Enums/ScriptEventHookEvent.php
+++ b/app/Enums/ScriptEventHookEvent.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Enums;
+
+use App\Contracts\VitoEnum;
+
+enum ScriptEventHookEvent: string implements VitoEnum
+{
+    case SITE_CREATED = 'site_created';
+    case SITE_DELETED = 'site_deleted';
+    case SERVER_INSTALLED = 'server_installed';
+    case SERVER_DELETED = 'server_deleted';
+    case SERVICE_INSTALLED = 'service_installed';
+    case SERVICE_UNINSTALLED = 'service_uninstalled';
+
+    public function getColor(): string
+    {
+        return 'gray';
+    }
+
+    public function getText(): string
+    {
+        return match ($this) {
+            self::SITE_CREATED => 'Site Created',
+            self::SITE_DELETED => 'Site Deleted',
+            self::SERVER_INSTALLED => 'Server Installed',
+            self::SERVER_DELETED => 'Server Deleted',
+            self::SERVICE_INSTALLED => 'Service Installed',
+            self::SERVICE_UNINSTALLED => 'Service Uninstalled',
+        };
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function variables(): array
+    {
+        return match ($this) {
+            self::SITE_CREATED => [
+                'site_domain' => 'The domain of the created site',
+                'site_path' => 'The path of the created site',
+                'site_type' => 'The type of the created site',
+                'server_name' => 'The name of the server',
+                'server_ip' => 'The IP address of the server',
+            ],
+            self::SITE_DELETED => [
+                'site_domain' => 'The domain of the deleted site',
+                'server_name' => 'The name of the server',
+                'server_ip' => 'The IP address of the server',
+            ],
+            self::SERVER_INSTALLED => [
+                'server_name' => 'The name of the installed server',
+                'server_ip' => 'The IP address of the installed server',
+            ],
+            self::SERVER_DELETED => [
+                'server_name' => 'The name of the deleted server',
+                'server_ip' => 'The IP address of the deleted server',
+            ],
+            self::SERVICE_INSTALLED => [
+                'service_name' => 'The name of the installed service',
+                'service_type' => 'The type of the installed service',
+                'service_version' => 'The version of the installed service',
+                'server_name' => 'The name of the server',
+                'server_ip' => 'The IP address of the server',
+            ],
+            self::SERVICE_UNINSTALLED => [
+                'service_name' => 'The name of the uninstalled service',
+                'service_type' => 'The type of the uninstalled service',
+                'server_name' => 'The name of the server',
+                'server_ip' => 'The IP address of the server',
+            ],
+        };
+    }
+}

--- a/app/Events/ServerDeletedEvent.php
+++ b/app/Events/ServerDeletedEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class ServerDeletedEvent
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly int $serverId,
+        public readonly string $serverName,
+        public readonly string $serverIp,
+        public readonly int $projectId,
+    ) {}
+}

--- a/app/Events/ServerInstalledEvent.php
+++ b/app/Events/ServerInstalledEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Server;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class ServerInstalledEvent
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Server $server,
+    ) {}
+}

--- a/app/Events/ServiceInstalledEvent.php
+++ b/app/Events/ServiceInstalledEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Service;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class ServiceInstalledEvent
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Service $service,
+    ) {}
+}

--- a/app/Events/ServiceUninstalledEvent.php
+++ b/app/Events/ServiceUninstalledEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class ServiceUninstalledEvent
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly int $serviceId,
+        public readonly string $serviceName,
+        public readonly string $serviceType,
+        public readonly int $serverId,
+        public readonly int $projectId,
+    ) {}
+}

--- a/app/Http/Controllers/ScriptHookController.php
+++ b/app/Http/Controllers/ScriptHookController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\ScriptEventHook\CreateScriptEventHook;
+use App\Actions\ScriptEventHook\UpdateScriptEventHook;
+use App\Http\Resources\ScriptEventHookResource;
+use App\Models\Script;
+use App\Models\ScriptEventHook;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+use Spatie\RouteAttributes\Attributes\Delete;
+use Spatie\RouteAttributes\Attributes\Get;
+use Spatie\RouteAttributes\Attributes\Middleware;
+use Spatie\RouteAttributes\Attributes\Post;
+use Spatie\RouteAttributes\Attributes\Prefix;
+use Spatie\RouteAttributes\Attributes\Put;
+
+#[Prefix('scripts/{script}/hooks')]
+#[Middleware(['auth'])]
+class ScriptHookController extends Controller
+{
+    #[Get('/', name: 'scripts.hooks')]
+    public function index(Script $script): Response
+    {
+        $this->authorize('viewAny', [ScriptEventHook::class, $script]);
+
+        return Inertia::render('scripts/hooks', [
+            'script' => $script,
+            'hooks' => ScriptEventHookResource::collection(
+                $script->hooks()->with('server')->latest()->simplePaginate(config('web.pagination_size'))
+            ),
+        ]);
+    }
+
+    #[Post('/', name: 'scripts.hooks.store')]
+    public function store(Request $request, Script $script): RedirectResponse
+    {
+        $this->authorize('create', [ScriptEventHook::class, $script]);
+
+        app(CreateScriptEventHook::class)->create(user(), $script, $request->input());
+
+        return back()->with('success', 'Hook created.');
+    }
+
+    #[Put('/{hook}', name: 'scripts.hooks.update')]
+    public function update(Request $request, Script $script, ScriptEventHook $hook): RedirectResponse
+    {
+        abort_if($hook->script_id !== $script->id, 404);
+        $this->authorize('update', $hook);
+
+        app(UpdateScriptEventHook::class)->update($hook, user(), $request->input());
+
+        return back()->with('success', 'Hook updated.');
+    }
+
+    #[Delete('/{hook}', name: 'scripts.hooks.destroy')]
+    public function destroy(Script $script, ScriptEventHook $hook): RedirectResponse
+    {
+        abort_if($hook->script_id !== $script->id, 404);
+        $this->authorize('delete', $hook);
+
+        $hook->delete();
+
+        return back()->with('success', 'Hook deleted.');
+    }
+}

--- a/app/Http/Resources/ScriptEventHookResource.php
+++ b/app/Http/Resources/ScriptEventHookResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\ScriptEventHook;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin ScriptEventHook */
+class ScriptEventHookResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'script_id' => $this->script_id,
+            'user_id' => $this->user_id,
+            'project_id' => $this->project_id,
+            'server_id' => $this->server_id,
+            'server' => new ServerResource($this->whenLoaded('server')),
+            'event' => $this->event->getText(),
+            'event_value' => $this->event->value,
+            'event_color' => $this->event->getColor(),
+            'user' => $this->user,
+            'enabled' => $this->enabled,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Jobs/Service/InstallJob.php
+++ b/app/Jobs/Service/InstallJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs\Service;
 
 use App\DTOs\SocketEventDTO;
 use App\Enums\ServiceStatus;
+use App\Events\ServiceInstalledEvent;
 use App\Events\SocketEvent;
 use App\Http\Resources\ServiceResource;
 use App\Models\ServerLog;
@@ -33,6 +34,7 @@ class InstallJob implements ShouldQueue
             $this->service->installed_version = $this->service->handler()->version();
             $this->service->save();
             $this->broadcastServiceUpdate('service.updated');
+            ServiceInstalledEvent::dispatch($this->service);
             Log::info("Service ID {$this->service->id} installed successfully");
         });
     }

--- a/app/Jobs/Service/UninstallJob.php
+++ b/app/Jobs/Service/UninstallJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs\Service;
 
 use App\DTOs\SocketEventDTO;
 use App\Enums\ServiceStatus;
+use App\Events\ServiceUninstalledEvent;
 use App\Events\SocketEvent;
 use App\Http\Resources\ServiceResource;
 use App\Models\ServerLog;
@@ -25,8 +26,12 @@ class UninstallJob implements ShouldQueue
         $this->run("server-{$this->service->server_id}", function () {
             $projectId = $this->service->server->project_id;
             $serviceId = $this->service->id;
+            $serviceName = $this->service->name;
+            $serviceType = $this->service->type;
+            $serverId = $this->service->server_id;
             $this->service->handler()->uninstall();
             $this->service->delete();
+            ServiceUninstalledEvent::dispatch($serviceId, $serviceName, $serviceType, $serverId, $projectId);
 
             SocketEvent::dispatch(new SocketEventDTO(
                 projectId: $projectId,

--- a/app/Listeners/RunScriptEventHooks.php
+++ b/app/Listeners/RunScriptEventHooks.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Actions\Script\ExecuteScript;
+use App\Enums\ScriptEventHookEvent;
+use App\Events\ServerDeletedEvent;
+use App\Events\ServerInstalledEvent;
+use App\Events\ServiceInstalledEvent;
+use App\Events\ServiceUninstalledEvent;
+use App\Events\SiteCreatedEvent;
+use App\Events\SiteDeletedEvent;
+use App\Models\ScriptEventHook;
+use App\Models\Server;
+use Illuminate\Support\Facades\Log;
+
+class RunScriptEventHooks
+{
+    public function handle(
+        SiteCreatedEvent|SiteDeletedEvent|ServerInstalledEvent|ServerDeletedEvent|ServiceInstalledEvent|ServiceUninstalledEvent $event
+    ): void {
+        [$eventEnum, $projectId, $variables] = $this->extractContext($event);
+
+        ScriptEventHook::query()
+            ->where('project_id', $projectId)
+            ->where('event', $eventEnum->value)
+            ->where('enabled', true)
+            ->with(['script', 'server'])
+            ->get()
+            ->each(function (ScriptEventHook $hook) use ($eventEnum, $variables): void {
+                try {
+                    app(ExecuteScript::class)->executeForHook($hook, $variables);
+                } catch (\Throwable $e) {
+                    Log::error('Script event hook failed', [
+                        'hook_id' => $hook->id,
+                        'event' => $eventEnum->value,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            });
+    }
+
+    /**
+     * @return array{0: ScriptEventHookEvent, 1: int, 2: array<string, string>}
+     */
+    private function extractContext(
+        SiteCreatedEvent|SiteDeletedEvent|ServerInstalledEvent|ServerDeletedEvent|ServiceInstalledEvent|ServiceUninstalledEvent $event
+    ): array {
+        if ($event instanceof SiteCreatedEvent) {
+            return [
+                ScriptEventHookEvent::SITE_CREATED,
+                $event->site->server->project_id,
+                [
+                    'site_domain' => $event->site->domain,
+                    'site_path' => $event->site->path,
+                    'site_type' => $event->site->type,
+                    'server_name' => $event->site->server->name,
+                    'server_ip' => $event->site->server->ip,
+                ],
+            ];
+        }
+
+        if ($event instanceof SiteDeletedEvent) {
+            return [
+                ScriptEventHookEvent::SITE_DELETED,
+                $event->server->project_id,
+                [
+                    'site_domain' => $event->domain,
+                    'server_name' => $event->server->name,
+                    'server_ip' => $event->server->ip,
+                ],
+            ];
+        }
+
+        if ($event instanceof ServerInstalledEvent) {
+            return [
+                ScriptEventHookEvent::SERVER_INSTALLED,
+                $event->server->project_id,
+                [
+                    'server_name' => $event->server->name,
+                    'server_ip' => $event->server->ip,
+                ],
+            ];
+        }
+
+        if ($event instanceof ServerDeletedEvent) {
+            return [
+                ScriptEventHookEvent::SERVER_DELETED,
+                $event->projectId,
+                [
+                    'server_name' => $event->serverName,
+                    'server_ip' => $event->serverIp,
+                ],
+            ];
+        }
+
+        if ($event instanceof ServiceInstalledEvent) {
+            return [
+                ScriptEventHookEvent::SERVICE_INSTALLED,
+                $event->service->server->project_id,
+                [
+                    'service_name' => $event->service->name,
+                    'service_type' => $event->service->type,
+                    'service_version' => $event->service->installed_version ?? $event->service->version,
+                    'server_name' => $event->service->server->name,
+                    'server_ip' => $event->service->server->ip,
+                ],
+            ];
+        }
+
+        $server = Server::query()->find($event->serverId);
+
+        return [
+            ScriptEventHookEvent::SERVICE_UNINSTALLED,
+            $event->projectId,
+            [
+                'service_name' => $event->serviceName,
+                'service_type' => $event->serviceType,
+                'server_name' => $server?->name ?? '',
+                'server_ip' => $server?->ip ?? '',
+            ],
+        ];
+    }
+}

--- a/app/Listeners/RunScriptEventHooks.php
+++ b/app/Listeners/RunScriptEventHooks.php
@@ -13,6 +13,7 @@ use App\Events\SiteDeletedEvent;
 use App\Models\ScriptEventHook;
 use App\Models\Server;
 use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class RunScriptEventHooks
 {
@@ -30,7 +31,7 @@ class RunScriptEventHooks
             ->each(function (ScriptEventHook $hook) use ($eventEnum, $variables): void {
                 try {
                     app(ExecuteScript::class)->executeForHook($hook, $variables);
-                } catch (\Throwable $e) {
+                } catch (Throwable $e) {
                     Log::error('Script event hook failed', [
                         'hook_id' => $hook->id,
                         'event' => $eventEnum->value,

--- a/app/Listeners/RunScriptEventHooks.php
+++ b/app/Listeners/RunScriptEventHooks.php
@@ -116,8 +116,8 @@ class RunScriptEventHooks
             [
                 'service_name' => $event->serviceName,
                 'service_type' => $event->serviceType,
-                'server_name' => $server?->name ?? '',
-                'server_ip' => $server?->ip ?? '',
+                'server_name' => $server->name ?? '',
+                'server_ip' => $server->ip ?? '',
             ],
         ];
     }

--- a/app/Models/Script.php
+++ b/app/Models/Script.php
@@ -48,7 +48,6 @@ class Script extends AbstractModel
 
         static::deleting(function (Script $script): void {
             $script->executions()->delete();
-            $script->hooks()->delete();
         });
     }
 

--- a/app/Models/Script.php
+++ b/app/Models/Script.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Collection;
  * @property User $user
  * @property ?int $project_id
  * @property ?Project $project
+ * @property Collection<int, ScriptEventHook> $hooks
  */
 class Script extends AbstractModel
 {
@@ -47,6 +48,7 @@ class Script extends AbstractModel
 
         static::deleting(function (Script $script): void {
             $script->executions()->delete();
+            $script->hooks()->delete();
         });
     }
 
@@ -92,6 +94,14 @@ class Script extends AbstractModel
     public function lastExecution(): HasOne
     {
         return $this->hasOne(ScriptExecution::class)->latest();
+    }
+
+    /**
+     * @return HasMany<ScriptEventHook, covariant $this>
+     */
+    public function hooks(): HasMany
+    {
+        return $this->hasMany(ScriptEventHook::class);
     }
 
     /**

--- a/app/Models/ScriptEventHook.php
+++ b/app/Models/ScriptEventHook.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ScriptEventHookEvent;
+use Carbon\Carbon;
+use Database\Factories\ScriptEventHookFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $script_id
+ * @property int $user_id
+ * @property int $project_id
+ * @property int $server_id
+ * @property ScriptEventHookEvent $event
+ * @property string $user
+ * @property bool $enabled
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property Script $script
+ * @property User $creator
+ * @property Project $project
+ * @property Server $server
+ */
+class ScriptEventHook extends AbstractModel
+{
+    /** @use HasFactory<ScriptEventHookFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'script_id',
+        'user_id',
+        'project_id',
+        'server_id',
+        'event',
+        'user',
+        'enabled',
+    ];
+
+    protected $casts = [
+        'script_id' => 'integer',
+        'user_id' => 'integer',
+        'project_id' => 'integer',
+        'server_id' => 'integer',
+        'event' => ScriptEventHookEvent::class,
+        'enabled' => 'boolean',
+    ];
+
+    /**
+     * @return BelongsTo<Script, covariant $this>
+     */
+    public function script(): BelongsTo
+    {
+        return $this->belongsTo(Script::class);
+    }
+
+    /**
+     * @return BelongsTo<User, covariant $this>
+     */
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    /**
+     * @return BelongsTo<Project, covariant $this>
+     */
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    /**
+     * @return BelongsTo<Server, covariant $this>
+     */
+    public function server(): BelongsTo
+    {
+        return $this->belongsTo(Server::class);
+    }
+}

--- a/app/Policies/ScriptEventHookPolicy.php
+++ b/app/Policies/ScriptEventHookPolicy.php
@@ -23,7 +23,7 @@ class ScriptEventHookPolicy
 
     public function update(User $user, ScriptEventHook $hook): bool
     {
-        return $user->id === $hook->user_id;
+        return $user->id === $hook->user_id && $this->hasWriteAccess($user, $hook->server->project);
     }
 
     public function delete(User $user, ScriptEventHook $hook): bool

--- a/app/Policies/ScriptEventHookPolicy.php
+++ b/app/Policies/ScriptEventHookPolicy.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Script;
+use App\Models\ScriptEventHook;
+use App\Models\User;
+use App\Traits\HasRolePolicies;
+
+class ScriptEventHookPolicy
+{
+    use HasRolePolicies;
+
+    public function viewAny(User $user, Script $script): bool
+    {
+        return $user->id === $script->user_id;
+    }
+
+    public function create(User $user, Script $script): bool
+    {
+        return $user->id === $script->user_id;
+    }
+
+    public function update(User $user, ScriptEventHook $hook): bool
+    {
+        return $user->id === $hook->user_id;
+    }
+
+    public function delete(User $user, ScriptEventHook $hook): bool
+    {
+        return $user->id === $hook->user_id;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Events\ServerDeletedEvent;
+use App\Events\ServerInstalledEvent;
+use App\Events\ServiceInstalledEvent;
+use App\Events\ServiceUninstalledEvent;
 use App\Events\SiteCreatedEvent;
 use App\Events\SiteDeletedEvent;
 use App\Events\SocketEvent;
@@ -11,6 +15,7 @@ use App\Helpers\SFTP;
 use App\Helpers\SSH;
 use App\Listeners\HandleSiteCreatedStats;
 use App\Listeners\HandleSiteDeletedStats;
+use App\Listeners\RunScriptEventHooks;
 use App\Listeners\SocketEventListener;
 use App\Models\PersonalAccessToken;
 use Illuminate\Http\Resources\Json\ResourceCollection;
@@ -45,5 +50,11 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(SocketEvent::class, SocketEventListener::class);
         Event::listen(SiteCreatedEvent::class, HandleSiteCreatedStats::class);
         Event::listen(SiteDeletedEvent::class, HandleSiteDeletedStats::class);
+        Event::listen(SiteCreatedEvent::class, RunScriptEventHooks::class);
+        Event::listen(SiteDeletedEvent::class, RunScriptEventHooks::class);
+        Event::listen(ServerInstalledEvent::class, RunScriptEventHooks::class);
+        Event::listen(ServerDeletedEvent::class, RunScriptEventHooks::class);
+        Event::listen(ServiceInstalledEvent::class, RunScriptEventHooks::class);
+        Event::listen(ServiceUninstalledEvent::class, RunScriptEventHooks::class);
     }
 }

--- a/database/factories/ScriptEventHookFactory.php
+++ b/database/factories/ScriptEventHookFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ScriptEventHook;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ScriptEventHook>
+ */
+class ScriptEventHookFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'event' => \App\Enums\ScriptEventHookEvent::SITE_CREATED,
+            'user' => 'root',
+            'enabled' => true,
+        ];
+    }
+}

--- a/database/factories/ScriptEventHookFactory.php
+++ b/database/factories/ScriptEventHookFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\ScriptEventHookEvent;
 use App\Models\ScriptEventHook;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -18,7 +19,7 @@ class ScriptEventHookFactory extends Factory
     public function definition(): array
     {
         return [
-            'event' => \App\Enums\ScriptEventHookEvent::SITE_CREATED,
+            'event' => ScriptEventHookEvent::SITE_CREATED,
             'user' => 'root',
             'enabled' => true,
         ];

--- a/database/migrations/2026_07_06_185832_create_script_event_hooks_table.php
+++ b/database/migrations/2026_07_06_185832_create_script_event_hooks_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('script_event_hooks', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('script_id')->constrained('scripts')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('project_id')->constrained('projects')->cascadeOnDelete();
+            $table->foreignId('server_id')->constrained('servers')->cascadeOnDelete();
+            $table->string('event');
+            $table->string('user');
+            $table->boolean('enabled')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('script_event_hooks');
+    }
+};

--- a/database/migrations/2026_07_06_185832_create_script_event_hooks_table.php
+++ b/database/migrations/2026_07_06_185832_create_script_event_hooks_table.php
@@ -21,6 +21,7 @@ return new class extends Migration
             $table->string('user');
             $table->boolean('enabled')->default(true);
             $table->timestamps();
+            $table->index(['project_id', 'event', 'enabled']);
         });
     }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,7 @@
   <php>
     <env name="APP_ENV" value="testing"/>
     <env name="APP_KEY" value="base64:d9kZW60V4lFEw2SPn6UiJ0cfi04v80EWP0GZ6kzoxNg="/>
+    <env name="DB_CONNECTION" value="sqlite"/>
     <env name="DB_DATABASE" value="database-test.sqlite"/>
     <env name="BCRYPT_ROUNDS" value="4"/>
     <env name="CACHE_DRIVER" value="array"/>

--- a/resources/js/components/dialogs/registry.ts
+++ b/resources/js/components/dialogs/registry.ts
@@ -24,6 +24,7 @@ import FirewallRuleForm from '@/pages/firewall/components/form';
 import ServerIpForm from '@/pages/server-network/components/form';
 import RecordForm from '@/pages/domains/components/record-form';
 import ScriptForm from '@/pages/scripts/components/form';
+import ScriptHookForm from '@/pages/scripts/components/hook-form';
 import EditCommand from '@/pages/commands/components/edit-command';
 import CreateBackup from '@/pages/backups/components/create-backup';
 import EditBackup from '@/pages/backups/components/edit-backup';
@@ -73,6 +74,7 @@ export const dialogs = {
   serverIpForm: ServerIpForm,
   dnsRecordForm: RecordForm,
   scriptForm: ScriptForm,
+  scriptHookForm: ScriptHookForm,
   commandEdit: EditCommand,
   backupCreate: CreateBackup,
   backupEdit: EditBackup,

--- a/resources/js/pages/scripts/components/hook-columns.tsx
+++ b/resources/js/pages/scripts/components/hook-columns.tsx
@@ -1,0 +1,80 @@
+import { ColumnDef } from '@tanstack/react-table';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+import { MoreVerticalIcon } from 'lucide-react';
+import { ScriptEventHook } from '@/types/script-event-hook';
+import { Script } from '@/types/script';
+import { useDialog } from '@/hooks/use-dialog';
+import { Badge } from '@/components/ui/badge';
+
+function Actions({ hook, script }: { hook: ScriptEventHook; script: Script }) {
+  const dialog = useDialog();
+
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="h-8 w-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreVerticalIcon />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={() => dialog.scriptHookForm.open({ script, hook })}>Edit</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          variant="destructive"
+          onSelect={() =>
+            dialog.confirm.open({
+              title: 'Delete hook',
+              description: 'Are you sure you want to delete this event hook?',
+              variant: 'destructive',
+              confirmLabel: 'Delete',
+              method: 'delete',
+              url: route('scripts.hooks.destroy', { script: hook.script_id, hook: hook.id }),
+            })
+          }
+        >
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export function hookColumns(script: Script): ColumnDef<ScriptEventHook>[] {
+  return [
+    {
+      accessorKey: 'event',
+      header: 'Event',
+      cell: ({ row }) => (
+        <Badge variant={row.original.event_color}>
+          {row.original.event}
+        </Badge>
+      ),
+    },
+    {
+      accessorKey: 'server',
+      header: 'Server',
+      cell: ({ row }) => row.original.server?.name ?? row.original.server_id,
+    },
+    {
+      accessorKey: 'user',
+      header: 'SSH User',
+    },
+    {
+      accessorKey: 'enabled',
+      header: 'Enabled',
+      cell: ({ row }) => (row.original.enabled ? 'Yes' : 'No'),
+    },
+    {
+      id: 'actions',
+      enableColumnFilter: false,
+      enableSorting: false,
+      cell: ({ row }) => (
+        <div className="flex items-center justify-end">
+          <Actions hook={row.original} script={script} />
+        </div>
+      ),
+    },
+  ];
+}

--- a/resources/js/pages/scripts/components/hook-columns.tsx
+++ b/resources/js/pages/scripts/components/hook-columns.tsx
@@ -46,11 +46,7 @@ export function hookColumns(script: Script): ColumnDef<ScriptEventHook>[] {
     {
       accessorKey: 'event',
       header: 'Event',
-      cell: ({ row }) => (
-        <Badge variant={row.original.event_color}>
-          {row.original.event}
-        </Badge>
-      ),
+      cell: ({ row }) => <Badge variant={row.original.event_color}>{row.original.event}</Badge>,
     },
     {
       accessorKey: 'server',

--- a/resources/js/pages/scripts/components/hook-columns.tsx
+++ b/resources/js/pages/scripts/components/hook-columns.tsx
@@ -6,6 +6,7 @@ import { ScriptEventHook } from '@/types/script-event-hook';
 import { Script } from '@/types/script';
 import { useDialog } from '@/hooks/use-dialog';
 import { Badge } from '@/components/ui/badge';
+import { Link } from '@inertiajs/react';
 
 function Actions({ hook, script }: { hook: ScriptEventHook; script: Script }) {
   const dialog = useDialog();
@@ -51,7 +52,14 @@ export function hookColumns(script: Script): ColumnDef<ScriptEventHook>[] {
     {
       accessorKey: 'server',
       header: 'Server',
-      cell: ({ row }) => row.original.server?.name ?? row.original.server_id,
+      cell: ({ row }) =>
+        row.original.server ? (
+          <Link href={route('servers.show', { server: row.original.server_id })} className="hover:underline">
+            {row.original.server.name} ({row.original.server.ip})
+          </Link>
+        ) : (
+          '-'
+        ),
     },
     {
       accessorKey: 'user',

--- a/resources/js/pages/scripts/components/hook-form.tsx
+++ b/resources/js/pages/scripts/components/hook-form.tsx
@@ -9,12 +9,10 @@ import InputError from '@/components/ui/input-error';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
 import { useConfigs } from '@/stores/bootstrap-store';
-import { ProjectSelect } from '@/components/project-select';
 import ServerSelect from '@/pages/servers/components/server-select';
 import { Script } from '@/types/script';
 import { ScriptEventHook } from '@/types/script-event-hook';
 import { Server } from '@/types/server';
-import { Project } from '@/types/project';
 
 export default function HookForm({
   open,
@@ -27,24 +25,23 @@ export default function HookForm({
   script: Script;
   hook?: ScriptEventHook;
 }) {
-  const configs = useConfigs();
+  const configs = useConfigs()!;
   const [server, setServer] = useState<Server | undefined>(hook?.server);
 
   const form = useForm<{
     event: string;
-    project_id: string;
     server_id: string;
     user: string;
     enabled: boolean;
   }>({
     event: hook?.event_value ?? '',
-    project_id: hook?.project_id?.toString() ?? '',
     server_id: hook?.server_id?.toString() ?? '',
     user: hook?.user ?? '',
     enabled: hook?.enabled ?? true,
   });
 
-  const selectedEvent = configs?.script_event_hooks?.events.find((e) => e.value === form.data.event);
+  const selectedEvent = configs.script_event_hooks.events.find((e) => e.value === form.data.event);
+  const sshUsers = server?.ssh_users ?? (hook ? [hook.user] : []);
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
@@ -77,7 +74,7 @@ export default function HookForm({
                 </SelectTrigger>
                 <SelectContent>
                   <SelectGroup>
-                    {configs?.script_event_hooks?.events.map((event) => (
+                    {configs.script_event_hooks.events.map((event) => (
                       <SelectItem key={event.value} value={event.value}>
                         {event.label}
                       </SelectItem>
@@ -100,24 +97,9 @@ export default function HookForm({
             </FormField>
 
             <FormField>
-              <Label htmlFor="project_id">Project</Label>
-              <ProjectSelect
-                value={form.data.project_id}
-                onValueChange={(value: string, project: Project) => {
-                  form.setData('project_id', value);
-                  if (project.id.toString() !== form.data.project_id) {
-                    form.setData('server_id', '');
-                    form.setData('user', '');
-                    setServer(undefined);
-                  }
-                }}
-              />
-              <InputError message={form.errors.project_id} />
-            </FormField>
-
-            <FormField>
               <Label htmlFor="server_id">Server</Label>
               <ServerSelect
+                id="server_id"
                 value={form.data.server_id}
                 onValueChange={(value) => {
                   form.setData('server_id', value ? value.id.toString() : '');
@@ -136,7 +118,7 @@ export default function HookForm({
                 </SelectTrigger>
                 <SelectContent>
                   <SelectGroup>
-                    {server?.ssh_users?.map((u) => (
+                    {sshUsers.map((u) => (
                       <SelectItem key={`user-${u}`} value={u}>
                         {u}
                       </SelectItem>

--- a/resources/js/pages/scripts/components/hook-form.tsx
+++ b/resources/js/pages/scripts/components/hook-form.tsx
@@ -149,11 +149,7 @@ export default function HookForm({
 
             <FormField>
               <div className="flex items-center gap-2">
-                <Checkbox
-                  id="enabled"
-                  checked={form.data.enabled}
-                  onCheckedChange={(checked) => form.setData('enabled', checked === true)}
-                />
+                <Checkbox id="enabled" checked={form.data.enabled} onCheckedChange={(checked) => form.setData('enabled', checked === true)} />
                 <Label htmlFor="enabled">Enabled</Label>
               </div>
               <InputError message={form.errors.enabled} />

--- a/resources/js/pages/scripts/components/hook-form.tsx
+++ b/resources/js/pages/scripts/components/hook-form.tsx
@@ -1,0 +1,177 @@
+import { FormEvent, useState } from 'react';
+import { Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { Form, FormField, FormFields } from '@/components/ui/form';
+import { useForm } from '@inertiajs/react';
+import { Button } from '@/components/ui/button';
+import { LoaderCircle } from 'lucide-react';
+import { Label } from '@/components/ui/label';
+import InputError from '@/components/ui/input-error';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import { useConfigs } from '@/stores/bootstrap-store';
+import { ProjectSelect } from '@/components/project-select';
+import ServerSelect from '@/pages/servers/components/server-select';
+import { Script } from '@/types/script';
+import { ScriptEventHook } from '@/types/script-event-hook';
+import { Server } from '@/types/server';
+import { Project } from '@/types/project';
+
+export default function HookForm({
+  open,
+  onOpenChange,
+  script,
+  hook,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  script: Script;
+  hook?: ScriptEventHook;
+}) {
+  const configs = useConfigs();
+  const [server, setServer] = useState<Server | undefined>(hook?.server);
+
+  const form = useForm<{
+    event: string;
+    project_id: string;
+    server_id: string;
+    user: string;
+    enabled: boolean;
+  }>({
+    event: hook?.event_value ?? '',
+    project_id: hook?.project_id?.toString() ?? '',
+    server_id: hook?.server_id?.toString() ?? '',
+    user: hook?.user ?? '',
+    enabled: hook?.enabled ?? true,
+  });
+
+  const selectedEvent = configs?.script_event_hooks?.events.find((e) => e.value === form.data.event);
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+    if (hook) {
+      form.put(route('scripts.hooks.update', { script: script.id, hook: hook.id }), {
+        onSuccess: () => onOpenChange(false),
+      });
+      return;
+    }
+
+    form.post(route('scripts.hooks.store', { script: script.id }), {
+      onSuccess: () => onOpenChange(false),
+    });
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="sm:max-w-lg" onCloseAutoFocus={(e) => e.preventDefault()}>
+        <SheetHeader>
+          <SheetTitle>{hook ? 'Edit' : 'Add'} Event Hook</SheetTitle>
+          <SheetDescription className="sr-only">{hook ? 'Edit' : 'Add'} event hook</SheetDescription>
+        </SheetHeader>
+        <Form id="hook-form" onSubmit={submit} className="p-4">
+          <FormFields>
+            <FormField>
+              <Label htmlFor="event">Event</Label>
+              <Select value={form.data.event} onValueChange={(value) => form.setData('event', value)}>
+                <SelectTrigger id="event">
+                  <SelectValue placeholder="Select an event..." />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {configs?.script_event_hooks?.events.map((event) => (
+                      <SelectItem key={event.value} value={event.value}>
+                        {event.label}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              {selectedEvent && selectedEvent.variables.length > 0 && (
+                <p className="text-muted-foreground text-xs">
+                  Available variables:{' '}
+                  {selectedEvent.variables.map((v, i) => (
+                    <span key={v}>
+                      <code className="bg-muted rounded px-1">${'{' + v + '}'}</code>
+                      {i < selectedEvent.variables.length - 1 ? ', ' : ''}
+                    </span>
+                  ))}
+                </p>
+              )}
+              <InputError message={form.errors.event} />
+            </FormField>
+
+            <FormField>
+              <Label htmlFor="project_id">Project</Label>
+              <ProjectSelect
+                value={form.data.project_id}
+                onValueChange={(value: string, project: Project) => {
+                  form.setData('project_id', value);
+                  if (project.id.toString() !== form.data.project_id) {
+                    form.setData('server_id', '');
+                    form.setData('user', '');
+                    setServer(undefined);
+                  }
+                }}
+              />
+              <InputError message={form.errors.project_id} />
+            </FormField>
+
+            <FormField>
+              <Label htmlFor="server_id">Server</Label>
+              <ServerSelect
+                value={form.data.server_id}
+                onValueChange={(value) => {
+                  form.setData('server_id', value ? value.id.toString() : '');
+                  form.setData('user', '');
+                  setServer(value);
+                }}
+              />
+              <InputError message={form.errors.server_id} />
+            </FormField>
+
+            <FormField>
+              <Label htmlFor="user">SSH User</Label>
+              <Select value={form.data.user} onValueChange={(value) => form.setData('user', value)}>
+                <SelectTrigger id="user">
+                  <SelectValue placeholder="Select a user..." />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {server?.ssh_users?.map((u) => (
+                      <SelectItem key={`user-${u}`} value={u}>
+                        {u}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              <InputError message={form.errors.user} />
+            </FormField>
+
+            <FormField>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="enabled"
+                  checked={form.data.enabled}
+                  onCheckedChange={(checked) => form.setData('enabled', checked === true)}
+                />
+                <Label htmlFor="enabled">Enabled</Label>
+              </div>
+              <InputError message={form.errors.enabled} />
+            </FormField>
+          </FormFields>
+        </Form>
+        <SheetFooter>
+          <div className="flex items-center gap-2">
+            <Button form="hook-form" type="submit" disabled={form.processing}>
+              {form.processing && <LoaderCircle className="animate-spin" />}
+              {hook ? 'Save' : 'Add Hook'}
+            </Button>
+            <SheetClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </SheetClose>
+          </div>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/resources/js/pages/scripts/hooks.tsx
+++ b/resources/js/pages/scripts/hooks.tsx
@@ -1,0 +1,50 @@
+import { Head, usePage } from '@inertiajs/react';
+import Container from '@/components/container';
+import HeaderContainer from '@/components/header-container';
+import Heading from '@/components/heading';
+import { BreadcrumbHeader } from '@/components/breadcrumb-header';
+import { DataTable } from '@/components/data-table';
+import { BreadcrumbItem, PaginatedData } from '@/types';
+import { hookColumns } from '@/pages/scripts/components/hook-columns';
+import { Script } from '@/types/script';
+import { ScriptEventHook } from '@/types/script-event-hook';
+import Layout from '@/layouts/app/layout';
+import { Button } from '@/components/ui/button';
+import { PlusIcon } from 'lucide-react';
+import { useDialog } from '@/hooks/use-dialog';
+
+type Page = {
+  script: Script;
+  hooks: PaginatedData<ScriptEventHook>;
+};
+
+export default function Hooks() {
+  const page = usePage<Page>();
+  const dialog = useDialog();
+
+  const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Scripts', href: route('scripts') },
+    { title: page.props.script.name, href: route('scripts.show', { script: page.props.script.id }) },
+    { title: 'Event Hooks', href: route('scripts.hooks', { script: page.props.script.id }) },
+  ];
+
+  return (
+    <Layout>
+      <Head title={`Event Hooks — ${page.props.script.name}`} />
+
+      <Container className="max-w-5xl">
+        <HeaderContainer>
+          <BreadcrumbHeader breadcrumbs={breadcrumbs}>
+            <Heading title="Event Hooks" description="Automatically run this script when lifecycle events occur" />
+          </BreadcrumbHeader>
+          <Button onClick={() => dialog.scriptHookForm.open({ script: page.props.script })}>
+            <PlusIcon />
+            Add Hook
+          </Button>
+        </HeaderContainer>
+
+        <DataTable columns={hookColumns(page.props.script)} paginatedData={page.props.hooks} />
+      </Container>
+    </Layout>
+  );
+}

--- a/resources/js/pages/scripts/show.tsx
+++ b/resources/js/pages/scripts/show.tsx
@@ -1,4 +1,4 @@
-import { Head, usePage } from '@inertiajs/react';
+import { Head, Link, usePage } from '@inertiajs/react';
 import Container from '@/components/container';
 import HeaderContainer from '@/components/header-container';
 import Heading from '@/components/heading';
@@ -10,6 +10,7 @@ import { Script } from '@/types/script';
 import { ScriptExecution } from '@/types/script-execution';
 import Layout from '@/layouts/app/layout';
 import { useRealtime } from '@/hooks/use-socket-events';
+import { Button } from '@/components/ui/button';
 
 type Page = {
   script: Script;
@@ -40,6 +41,9 @@ export default function Show() {
           <BreadcrumbHeader breadcrumbs={breadcrumbs}>
             <Heading title={`History of ${page.props.script.name}`} description="Here you can see the script executions" />
           </BreadcrumbHeader>
+          <Button variant="outline" asChild>
+            <Link href={route('scripts.hooks', { script: page.props.script.id })}>Event Hooks</Link>
+          </Button>
         </HeaderContainer>
 
         <DataTable columns={columns} paginatedData={executions} />

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -117,6 +117,14 @@ export interface Configs {
     installed: boolean;
   };
   tooling: ToolingDescriptor[];
+  script_event_hooks: {
+    events: Array<{
+      value: string;
+      label: string;
+      color: string;
+      variables: string[];
+    }>;
+  };
 
   [key: string]: unknown;
 }

--- a/resources/js/types/script-event-hook.d.ts
+++ b/resources/js/types/script-event-hook.d.ts
@@ -9,7 +9,7 @@ export interface ScriptEventHook {
   server?: Server;
   event: string;
   event_value: string;
-  event_color: string;
+  event_color: 'gray' | 'success' | 'info' | 'warning' | 'danger';
   user: string;
   enabled: boolean;
   created_at: string;

--- a/resources/js/types/script-event-hook.d.ts
+++ b/resources/js/types/script-event-hook.d.ts
@@ -1,0 +1,19 @@
+import { Server } from '@/types/server';
+
+export interface ScriptEventHook {
+  id: number;
+  script_id: number;
+  user_id: number;
+  project_id: number;
+  server_id: number;
+  server?: Server;
+  event: string;
+  event_value: string;
+  event_color: string;
+  user: string;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+
+  [key: string]: unknown;
+}

--- a/tests/Feature/ScriptEventHookTest.php
+++ b/tests/Feature/ScriptEventHookTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Actions\Script\ExecuteScript;
 use App\Enums\ScriptEventHookEvent;
 use App\Enums\ScriptExecutionStatus;
+use App\Enums\UserRole;
 use App\Events\ServerDeletedEvent;
 use App\Events\ServerInstalledEvent;
 use App\Events\ServiceInstalledEvent;
@@ -52,7 +53,6 @@ class ScriptEventHookTest extends TestCase
 
         $this->post(route('scripts.hooks.store', ['script' => $script->id]), [
             'event' => ScriptEventHookEvent::SITE_CREATED->value,
-            'project_id' => $this->server->project_id,
             'server_id' => $this->server->id,
             'user' => 'root',
             'enabled' => true,
@@ -61,10 +61,29 @@ class ScriptEventHookTest extends TestCase
         $this->assertDatabaseHas('script_event_hooks', [
             'script_id' => $script->id,
             'event' => ScriptEventHookEvent::SITE_CREATED->value,
+            'project_id' => $this->server->project_id,
             'server_id' => $this->server->id,
             'user' => 'root',
             'enabled' => true,
         ]);
+    }
+
+    public function test_cannot_create_hook_without_server_write_access(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherUser->ensureHasDefaultProject();
+        $this->actingAs($otherUser);
+
+        $script = Script::factory()->create(['user_id' => $otherUser->id]);
+
+        $this->post(route('scripts.hooks.store', ['script' => $script->id]), [
+            'event' => ScriptEventHookEvent::SITE_CREATED->value,
+            'server_id' => $this->server->id,
+            'user' => 'root',
+            'enabled' => true,
+        ])->assertForbidden();
+
+        $this->assertDatabaseMissing('script_event_hooks', ['script_id' => $script->id]);
     }
 
     public function test_update_hook(): void
@@ -90,6 +109,34 @@ class ScriptEventHookTest extends TestCase
             'id' => $hook->id,
             'event' => ScriptEventHookEvent::SITE_DELETED->value,
             'enabled' => false,
+        ]);
+    }
+
+    public function test_creator_without_project_write_access_cannot_update_hook(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherUser->ensureHasDefaultProject();
+        $this->server->project->users()->create([
+            'user_id' => $otherUser->id,
+            'role' => UserRole::USER,
+        ]);
+        $this->actingAs($otherUser);
+
+        $script = Script::factory()->create(['user_id' => $otherUser->id]);
+        $hook = ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $otherUser->id,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+        ]);
+
+        $this->put(route('scripts.hooks.update', ['script' => $script->id, 'hook' => $hook->id]), [
+            'enabled' => false,
+        ])->assertForbidden();
+
+        $this->assertDatabaseHas('script_event_hooks', [
+            'id' => $hook->id,
+            'enabled' => true,
         ]);
     }
 
@@ -330,6 +377,34 @@ class ScriptEventHookTest extends TestCase
             ->firstOrFail();
 
         $this->assertEquals($this->site->domain, $execution->variables['site_domain']);
+    }
+
+    public function test_event_variables_are_sanitized(): void
+    {
+        SSH::fake();
+
+        $this->server->update(['name' => 'srv;$(reboot)`rm`']);
+        $this->site->load('server');
+
+        $script = Script::factory()->create([
+            'user_id' => $this->user->id,
+            'content' => 'echo ${server_name}',
+        ]);
+        ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $this->user->id,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+            'event' => ScriptEventHookEvent::SITE_CREATED,
+        ]);
+
+        SiteCreatedEvent::dispatch($this->site);
+
+        $execution = ScriptExecution::query()
+            ->where('script_id', $script->id)
+            ->firstOrFail();
+
+        $this->assertEquals('srvrebootrm', $execution->variables['server_name']);
     }
 
     public function test_hook_exception_does_not_propagate(): void

--- a/tests/Feature/ScriptEventHookTest.php
+++ b/tests/Feature/ScriptEventHookTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Actions\Script\ExecuteScript;
 use App\Enums\ScriptEventHookEvent;
 use App\Enums\ScriptExecutionStatus;
 use App\Events\ServerDeletedEvent;
@@ -13,6 +14,7 @@ use App\Events\SiteDeletedEvent;
 use App\Facades\SSH;
 use App\Models\Script;
 use App\Models\ScriptEventHook;
+use App\Models\ScriptExecution;
 use App\Models\Service;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -323,7 +325,7 @@ class ScriptEventHookTest extends TestCase
             'status' => ScriptExecutionStatus::COMPLETED,
         ]);
 
-        $execution = \App\Models\ScriptExecution::query()
+        $execution = ScriptExecution::query()
             ->where('script_id', $script->id)
             ->firstOrFail();
 
@@ -342,7 +344,7 @@ class ScriptEventHookTest extends TestCase
         ]);
 
         // Make executeForHook throw by binding a mock that always throws
-        $this->mock(\App\Actions\Script\ExecuteScript::class, function ($mock): void {
+        $this->mock(ExecuteScript::class, function ($mock): void {
             $mock->shouldReceive('executeForHook')->andThrow(new \RuntimeException('simulated failure'));
         });
 

--- a/tests/Feature/ScriptEventHookTest.php
+++ b/tests/Feature/ScriptEventHookTest.php
@@ -1,0 +1,354 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ScriptEventHookEvent;
+use App\Enums\ScriptExecutionStatus;
+use App\Events\ServerDeletedEvent;
+use App\Events\ServerInstalledEvent;
+use App\Events\ServiceInstalledEvent;
+use App\Events\ServiceUninstalledEvent;
+use App\Events\SiteCreatedEvent;
+use App\Events\SiteDeletedEvent;
+use App\Facades\SSH;
+use App\Models\Script;
+use App\Models\ScriptEventHook;
+use App\Models\Service;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ScriptEventHookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_see_hooks_requires_auth(): void
+    {
+        $script = Script::factory()->create(['user_id' => $this->user->id]);
+
+        $this->get(route('scripts.hooks', ['script' => $script->id]))
+            ->assertRedirect();
+    }
+
+    public function test_other_user_cannot_see_hooks(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherUser->ensureHasDefaultProject();
+        $this->actingAs($otherUser);
+
+        $script = Script::factory()->create(['user_id' => $this->user->id]);
+
+        $this->get(route('scripts.hooks', ['script' => $script->id]))
+            ->assertForbidden();
+    }
+
+    public function test_create_hook(): void
+    {
+        $this->actingAs($this->user);
+
+        $script = Script::factory()->create(['user_id' => $this->user->id]);
+
+        $this->post(route('scripts.hooks.store', ['script' => $script->id]), [
+            'event' => ScriptEventHookEvent::SITE_CREATED->value,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+            'user' => 'root',
+            'enabled' => true,
+        ])->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('script_event_hooks', [
+            'script_id' => $script->id,
+            'event' => ScriptEventHookEvent::SITE_CREATED->value,
+            'server_id' => $this->server->id,
+            'user' => 'root',
+            'enabled' => true,
+        ]);
+    }
+
+    public function test_update_hook(): void
+    {
+        $this->actingAs($this->user);
+
+        $script = Script::factory()->create(['user_id' => $this->user->id]);
+        $hook = ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $this->user->id,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+        ]);
+
+        $this->put(route('scripts.hooks.update', ['script' => $script->id, 'hook' => $hook->id]), [
+            'event' => ScriptEventHookEvent::SITE_DELETED->value,
+            'server_id' => $this->server->id,
+            'user' => 'root',
+            'enabled' => false,
+        ])->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('script_event_hooks', [
+            'id' => $hook->id,
+            'event' => ScriptEventHookEvent::SITE_DELETED->value,
+            'enabled' => false,
+        ]);
+    }
+
+    public function test_delete_hook(): void
+    {
+        $this->actingAs($this->user);
+
+        $script = Script::factory()->create(['user_id' => $this->user->id]);
+        $hook = ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $this->user->id,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+        ]);
+
+        $this->delete(route('scripts.hooks.destroy', ['script' => $script->id, 'hook' => $hook->id]))
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseMissing('script_event_hooks', ['id' => $hook->id]);
+    }
+
+    public function test_other_user_cannot_delete_hook(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherUser->ensureHasDefaultProject();
+        $this->actingAs($otherUser);
+
+        $script = Script::factory()->create(['user_id' => $this->user->id]);
+        $hook = ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $this->user->id,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+        ]);
+
+        $this->delete(route('scripts.hooks.destroy', ['script' => $script->id, 'hook' => $hook->id]))
+            ->assertForbidden();
+    }
+
+    public function test_site_created_event_triggers_hook(): void
+    {
+        SSH::fake();
+
+        $script = Script::factory()->create(['user_id' => $this->user->id, 'content' => 'echo "site created"']);
+        ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $this->user->id,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+            'event' => ScriptEventHookEvent::SITE_CREATED,
+        ]);
+
+        SiteCreatedEvent::dispatch($this->site);
+
+        $this->assertDatabaseHas('script_executions', [
+            'script_id' => $script->id,
+            'server_id' => $this->server->id,
+            'status' => ScriptExecutionStatus::COMPLETED,
+        ]);
+    }
+
+    public function test_site_deleted_event_triggers_hook(): void
+    {
+        SSH::fake();
+
+        $script = Script::factory()->create(['user_id' => $this->user->id, 'content' => 'echo "site deleted"']);
+        ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $this->user->id,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+            'event' => ScriptEventHookEvent::SITE_DELETED,
+        ]);
+
+        SiteDeletedEvent::dispatch($this->server, $this->site->id, $this->site->domain);
+
+        $this->assertDatabaseHas('script_executions', [
+            'script_id' => $script->id,
+            'status' => ScriptExecutionStatus::COMPLETED,
+        ]);
+    }
+
+    public function test_server_installed_event_triggers_hook(): void
+    {
+        SSH::fake();
+
+        $script = Script::factory()->create(['user_id' => $this->user->id, 'content' => 'echo "server installed"']);
+        ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $this->user->id,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+            'event' => ScriptEventHookEvent::SERVER_INSTALLED,
+        ]);
+
+        ServerInstalledEvent::dispatch($this->server);
+
+        $this->assertDatabaseHas('script_executions', [
+            'script_id' => $script->id,
+            'status' => ScriptExecutionStatus::COMPLETED,
+        ]);
+    }
+
+    public function test_server_deleted_event_triggers_hook(): void
+    {
+        SSH::fake();
+
+        $script = Script::factory()->create(['user_id' => $this->user->id, 'content' => 'echo "server deleted"']);
+        ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $this->user->id,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+            'event' => ScriptEventHookEvent::SERVER_DELETED,
+        ]);
+
+        ServerDeletedEvent::dispatch($this->server->id, $this->server->name, $this->server->ip, $this->server->project_id);
+
+        $this->assertDatabaseHas('script_executions', [
+            'script_id' => $script->id,
+            'status' => ScriptExecutionStatus::COMPLETED,
+        ]);
+    }
+
+    public function test_service_installed_event_triggers_hook(): void
+    {
+        SSH::fake();
+
+        /** @var Service $service */
+        $service = $this->server->services()->first();
+
+        $script = Script::factory()->create(['user_id' => $this->user->id, 'content' => 'echo "service installed"']);
+        ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $this->user->id,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+            'event' => ScriptEventHookEvent::SERVICE_INSTALLED,
+        ]);
+
+        ServiceInstalledEvent::dispatch($service);
+
+        $this->assertDatabaseHas('script_executions', [
+            'script_id' => $script->id,
+            'status' => ScriptExecutionStatus::COMPLETED,
+        ]);
+    }
+
+    public function test_service_uninstalled_event_triggers_hook(): void
+    {
+        SSH::fake();
+
+        /** @var Service $service */
+        $service = $this->server->services()->first();
+
+        $script = Script::factory()->create(['user_id' => $this->user->id, 'content' => 'echo "service uninstalled"']);
+        ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $this->user->id,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+            'event' => ScriptEventHookEvent::SERVICE_UNINSTALLED,
+        ]);
+
+        ServiceUninstalledEvent::dispatch($service->id, $service->name, $service->type, $service->server_id, $service->server->project_id);
+
+        $this->assertDatabaseHas('script_executions', [
+            'script_id' => $script->id,
+            'status' => ScriptExecutionStatus::COMPLETED,
+        ]);
+    }
+
+    public function test_disabled_hook_is_not_executed(): void
+    {
+        SSH::fake();
+
+        $script = Script::factory()->create(['user_id' => $this->user->id, 'content' => 'echo "test"']);
+        ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $this->user->id,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+            'event' => ScriptEventHookEvent::SITE_CREATED,
+            'enabled' => false,
+        ]);
+
+        SiteCreatedEvent::dispatch($this->site);
+
+        $this->assertDatabaseMissing('script_executions', ['script_id' => $script->id]);
+    }
+
+    public function test_hook_for_different_project_is_not_triggered(): void
+    {
+        SSH::fake();
+
+        $otherUser = User::factory()->create();
+        $otherUser->ensureHasDefaultProject();
+
+        $script = Script::factory()->create(['user_id' => $otherUser->id, 'content' => 'echo "test"']);
+        ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $otherUser->id,
+            'project_id' => $otherUser->current_project_id,
+            'server_id' => $this->server->id,
+            'event' => ScriptEventHookEvent::SITE_CREATED,
+        ]);
+
+        SiteCreatedEvent::dispatch($this->site);
+
+        $this->assertDatabaseMissing('script_executions', ['script_id' => $script->id]);
+    }
+
+    public function test_event_variables_are_injected_into_script(): void
+    {
+        SSH::fake();
+
+        $script = Script::factory()->create([
+            'user_id' => $this->user->id,
+            'content' => 'echo ${site_domain}',
+        ]);
+        ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $this->user->id,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+            'event' => ScriptEventHookEvent::SITE_CREATED,
+        ]);
+
+        SiteCreatedEvent::dispatch($this->site);
+
+        $this->assertDatabaseHas('script_executions', [
+            'script_id' => $script->id,
+            'status' => ScriptExecutionStatus::COMPLETED,
+        ]);
+
+        $execution = \App\Models\ScriptExecution::query()
+            ->where('script_id', $script->id)
+            ->firstOrFail();
+
+        $this->assertEquals($this->site->domain, $execution->variables['site_domain']);
+    }
+
+    public function test_hook_exception_does_not_propagate(): void
+    {
+        $script = Script::factory()->create(['user_id' => $this->user->id, 'content' => 'echo "test"']);
+        ScriptEventHook::factory()->create([
+            'script_id' => $script->id,
+            'user_id' => $this->user->id,
+            'project_id' => $this->server->project_id,
+            'server_id' => $this->server->id,
+            'event' => ScriptEventHookEvent::SITE_CREATED,
+        ]);
+
+        // Make executeForHook throw by binding a mock that always throws
+        $this->mock(\App\Actions\Script\ExecuteScript::class, function ($mock): void {
+            $mock->shouldReceive('executeForHook')->andThrow(new \RuntimeException('simulated failure'));
+        });
+
+        // Should not throw — listener catches and logs errors per hook
+        SiteCreatedEvent::dispatch($this->site);
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Closes #1070

Attach an existing Script to a lifecycle event so it runs automatically whenever that event fires in a given project.

## Events
| Event | Injected variables |
|---|---|
| Site created | `site_domain`, `site_path`, `site_type`, `server_name`, `server_ip` |
| Site deleted | `site_domain`, `server_name`, `server_ip` |
| Server installed | `server_name`, `server_ip` |
| Server deleted | `server_name`, `server_ip` |
| Service installed | `service_name`, `service_type`, `service_version`, `server_name`, `server_ip` |
| Service uninstalled | `service_name`, `service_type`, `server_name`, `server_ip` |

## Design notes
- Hooks are **project-scoped** — only fire for events in the configured project.
- Delete events carry **scalar primitives** (name, IP, project ID) because the model row is gone by the time listeners run.
- Hook failures are **caught and logged** per-hook; they never surface to the originating action.
- Script variables not present in the event map are filled with `''` (no prompt, no abort).

## Changes
- `ScriptEventHook` model + migration + factory
- `CreateScriptEventHook` / `UpdateScriptEventHook` actions (project write-access enforced)
- `ScriptHookController` + `ScriptEventHookPolicy` + `ScriptEventHookResource`
- `RunScriptEventHooks` listener wired to all 6 events in `AppServiceProvider`
- `ExecuteScript::executeForHook()` — transaction-wrapped, bypasses user auth
- New events: `ServerInstalledEvent`, `ServerDeletedEvent`, `ServiceInstalledEvent`, `ServiceUninstalledEvent`
- UI: hooks management sheet + table on the script show page

## Testing
16 new feature tests covering CRUD, all 6 event types, disabled/cross-project skip, variable injection, and exception isolation.