### PR TITLE
[Fix] S3 backup logs flooded by AWS CLI progress output on large transfers

### DIFF
--- a/resources/views/ssh/storage/s3/download.blade.php
+++ b/resources/views/ssh/storage/s3/download.blade.php
@@ -27,7 +27,7 @@ export AWS_SECRET_ACCESS_KEY={{ $secret }}
 export AWS_DEFAULT_REGION={{ $region }}
 export AWS_ENDPOINT_URL={{ $endpoint }}
 
-aws s3 cp --no-progress s3://{{ $bucket }}/{{ $src }} {{ $dest }} &
+aws s3 cp --no-progress "s3://{{ $bucket }}/{{ $src }}" "{{ $dest }}" &
 download_pid=$!
 
 elapsed=0
@@ -41,4 +41,7 @@ done
 
 if wait "$download_pid"; then
     echo "Download successful"
+else
+    echo "Error: Download failed"
+    exit 1
 fi

--- a/resources/views/ssh/storage/s3/download.blade.php
+++ b/resources/views/ssh/storage/s3/download.blade.php
@@ -27,6 +27,18 @@ export AWS_SECRET_ACCESS_KEY={{ $secret }}
 export AWS_DEFAULT_REGION={{ $region }}
 export AWS_ENDPOINT_URL={{ $endpoint }}
 
-if aws s3 cp s3://{{ $bucket }}/{{ $src }} {{ $dest }}; then
+aws s3 cp --no-progress s3://{{ $bucket }}/{{ $src }} {{ $dest }} &
+download_pid=$!
+
+elapsed=0
+while kill -0 "$download_pid" 2>/dev/null; do
+    sleep 30
+    elapsed=$((elapsed + 30))
+    if kill -0 "$download_pid" 2>/dev/null; then
+        echo "Download in progress... (${elapsed}s elapsed)"
+    fi
+done
+
+if wait "$download_pid"; then
     echo "Download successful"
 fi

--- a/resources/views/ssh/storage/s3/download.blade.php
+++ b/resources/views/ssh/storage/s3/download.blade.php
@@ -32,9 +32,9 @@ download_pid=$!
 
 elapsed=0
 while kill -0 "$download_pid" 2>/dev/null; do
-    sleep 30
-    elapsed=$((elapsed + 30))
-    if kill -0 "$download_pid" 2>/dev/null; then
+    sleep 1
+    elapsed=$((elapsed + 1))
+    if [ $((elapsed % 30)) -eq 0 ] && kill -0 "$download_pid" 2>/dev/null; then
         echo "Download in progress... (${elapsed}s elapsed)"
     fi
 done

--- a/resources/views/ssh/storage/s3/upload.blade.php
+++ b/resources/views/ssh/storage/s3/upload.blade.php
@@ -34,9 +34,9 @@ upload_pid=$!
 
 elapsed=0
 while kill -0 "$upload_pid" 2>/dev/null; do
-    sleep 30
-    elapsed=$((elapsed + 30))
-    if kill -0 "$upload_pid" 2>/dev/null; then
+    sleep 1
+    elapsed=$((elapsed + 1))
+    if [ $((elapsed % 30)) -eq 0 ] && kill -0 "$upload_pid" 2>/dev/null; then
         echo "Upload in progress... (${elapsed}s elapsed)"
     fi
 done

--- a/resources/views/ssh/storage/s3/upload.blade.php
+++ b/resources/views/ssh/storage/s3/upload.blade.php
@@ -29,6 +29,18 @@ export AWS_SECRET_ACCESS_KEY={{ $secret }}
 export AWS_DEFAULT_REGION={{ $region }}
 export AWS_ENDPOINT_URL={{ $endpoint }}
 
-if aws s3 cp {{ $src }} s3://{{ $bucket }}/{{ $dest }}; then
+aws s3 cp --no-progress {{ $src }} s3://{{ $bucket }}/{{ $dest }} &
+upload_pid=$!
+
+elapsed=0
+while kill -0 "$upload_pid" 2>/dev/null; do
+    sleep 30
+    elapsed=$((elapsed + 30))
+    if kill -0 "$upload_pid" 2>/dev/null; then
+        echo "Upload in progress... (${elapsed}s elapsed)"
+    fi
+done
+
+if wait "$upload_pid"; then
     echo "Upload successful"
 fi

--- a/resources/views/ssh/storage/s3/upload.blade.php
+++ b/resources/views/ssh/storage/s3/upload.blade.php
@@ -29,7 +29,7 @@ export AWS_SECRET_ACCESS_KEY={{ $secret }}
 export AWS_DEFAULT_REGION={{ $region }}
 export AWS_ENDPOINT_URL={{ $endpoint }}
 
-aws s3 cp --no-progress {{ $src }} s3://{{ $bucket }}/{{ $dest }} &
+aws s3 cp --no-progress "{{ $src }}" "s3://{{ $bucket }}/{{ $dest }}" &
 upload_pid=$!
 
 elapsed=0
@@ -43,4 +43,7 @@ done
 
 if wait "$upload_pid"; then
     echo "Upload successful"
+else
+    echo "Error: Upload failed"
+    exit 1
 fi


### PR DESCRIPTION
Replaces the AWS CLI's per-chunk progress output in the S3 upload/download scripts with --no-progress plus a 30-second heartbeat, so large transfer logs no longer cut off before the success confirmation while the periodic output still keeps the SSH connection alive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added periodic progress updates for S3 uploads and downloads, including elapsed-time reporting every 30 seconds.
  * S3 transfers now run asynchronously and only continue once completion is confirmed.

* **Bug Fixes**
  * Improved reliability of transfer completion handling by properly detecting failures and returning a non-zero exit with a clear error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->