### PR TITLE
[Feat] Service status updates with polling & vito agent

### DIFF
--- a/app/Actions/Monitoring/StoreAgentMetric.php
+++ b/app/Actions/Monitoring/StoreAgentMetric.php
@@ -57,16 +57,21 @@ class StoreAgentMetric
      */
     private function syncServiceStatuses(Server $server, array $services): void
     {
+        $entries = [];
+        foreach ($services as $entry) {
+            $entries[(int) $entry['id']] = $entry;
+        }
+
         $serverServices = $server->services()
-            ->whereIn('id', array_column($services, 'id'))
+            ->whereIn('id', array_keys($entries))
             ->whereIn('status', SyncServiceStatus::SETTLED_STATUSES)
             ->where('type', '!=', 'monitoring')
             ->get()
             ->keyBy('id');
 
-        foreach ($services as $entry) {
+        foreach ($entries as $id => $entry) {
             /** @var ?Service $service */
-            $service = $serverServices->get((int) $entry['id']);
+            $service = $serverServices->get($id);
             if (! $service || ! $service->hasHandler() || ! $service->handler()->canBeManaged()) {
                 continue;
             }

--- a/app/Actions/Monitoring/StoreAgentMetric.php
+++ b/app/Actions/Monitoring/StoreAgentMetric.php
@@ -2,8 +2,11 @@
 
 namespace App\Actions\Monitoring;
 
+use App\Actions\Service\SyncServiceStatus;
 use App\Models\Metric;
 use App\Models\Server;
+use App\Models\Service;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 
 class StoreAgentMetric
@@ -34,11 +37,40 @@ class StoreAgentMetric
             'oom_kill_count' => 'nullable|integer',
             'uptime_seconds' => 'nullable|numeric',
             'reboot_required' => 'nullable|boolean',
+            'services' => 'nullable|array|max:100',
+            'services.*.id' => 'required|integer',
+            'services.*.status' => 'required|string|max:32',
         ])->validate();
 
         /** @var Metric $metric */
-        $metric = $server->metrics()->create(array_merge($validated, ['server_id' => $server->id]));
+        $metric = $server->metrics()->create(array_merge(Arr::except($validated, ['services']), ['server_id' => $server->id]));
+
+        if (! empty($validated['services'])) {
+            $this->syncServiceStatuses($server, $validated['services']);
+        }
 
         return $metric;
+    }
+
+    /**
+     * @param  array<int, array{id: int, status: string}>  $services
+     */
+    private function syncServiceStatuses(Server $server, array $services): void
+    {
+        $serverServices = $server->services()
+            ->whereIn('id', array_column($services, 'id'))
+            ->whereIn('status', SyncServiceStatus::SETTLED_STATUSES)
+            ->where('type', '!=', 'monitoring')
+            ->get()
+            ->keyBy('id');
+
+        foreach ($services as $entry) {
+            /** @var ?Service $service */
+            $service = $serverServices->get((int) $entry['id']);
+            if (! $service || ! $service->hasHandler() || ! $service->handler()->shouldCheckStatus()) {
+                continue;
+            }
+            app(SyncServiceStatus::class)->sync($server, $service, $entry['status']);
+        }
     }
 }

--- a/app/Actions/Monitoring/StoreAgentMetric.php
+++ b/app/Actions/Monitoring/StoreAgentMetric.php
@@ -67,7 +67,7 @@ class StoreAgentMetric
         foreach ($services as $entry) {
             /** @var ?Service $service */
             $service = $serverServices->get((int) $entry['id']);
-            if (! $service || ! $service->hasHandler() || ! $service->handler()->shouldCheckStatus()) {
+            if (! $service || ! $service->hasHandler() || ! $service->handler()->canBeManaged()) {
                 continue;
             }
             app(SyncServiceStatus::class)->sync($server, $service, $entry['status']);

--- a/app/Actions/Service/CheckServiceStatuses.php
+++ b/app/Actions/Service/CheckServiceStatuses.php
@@ -22,12 +22,12 @@ class CheckServiceStatuses
             if (! $service->hasHandler()) {
                 continue;
             }
-            $handler = $service->handler();
-            if (! $handler->canBeManaged()) {
+            $unit = $service->handler()->unit();
+            if ($unit === '') {
                 continue;
             }
             $checkable[] = $service;
-            $units[] = $handler->unit();
+            $units[] = $unit;
         }
 
         if ($units === []) {

--- a/app/Actions/Service/CheckServiceStatuses.php
+++ b/app/Actions/Service/CheckServiceStatuses.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Actions\Service;
+
+use App\DTOs\SocketEventDTO;
+use App\Enums\ServiceStatus;
+use App\Events\ServiceStatusChanged;
+use App\Events\SocketEvent;
+use App\Exceptions\SSHError;
+use App\Http\Resources\ServiceResource;
+use App\Models\Server;
+use App\Models\Service;
+
+class CheckServiceStatuses
+{
+    private const array SETTLED_STATUSES = [
+        ServiceStatus::READY,
+        ServiceStatus::STOPPED,
+        ServiceStatus::FAILED,
+        ServiceStatus::DISABLED,
+    ];
+
+    /**
+     * @throws SSHError
+     */
+    public function check(Server $server): void
+    {
+        $services = $server->services()
+            ->whereIn('status', self::SETTLED_STATUSES)
+            ->get();
+
+        $checkable = [];
+        $units = [];
+        foreach ($services as $service) {
+            if (! $service->hasHandler()) {
+                continue;
+            }
+            $handler = $service->handler();
+            if (! $handler->shouldCheckStatus()) {
+                continue;
+            }
+            $checkable[] = $service;
+            $units[] = $handler->unit();
+        }
+
+        if ($units === []) {
+            return;
+        }
+
+        $states = $server->systemd()->activeStates($units);
+
+        if ($states === []) {
+            return;
+        }
+
+        foreach ($checkable as $index => $service) {
+            $this->syncStatus($server, $service, $states[$index] ?? '');
+        }
+    }
+
+    private function syncStatus(Server $server, Service $service, string $state): void
+    {
+        $newStatus = match ($state) {
+            'active' => ServiceStatus::READY,
+            'inactive' => ServiceStatus::STOPPED,
+            'failed' => ServiceStatus::FAILED,
+            default => null,
+        };
+
+        $previousStatus = $service->status;
+
+        if (! $newStatus instanceof ServiceStatus || $newStatus === $previousStatus) {
+            return;
+        }
+
+        if ($previousStatus === ServiceStatus::DISABLED && $newStatus === ServiceStatus::STOPPED) {
+            return;
+        }
+
+        $updated = Service::query()
+            ->where('id', $service->id)
+            ->where('status', $previousStatus)
+            ->update(['status' => $newStatus]);
+
+        if ($updated === 0) {
+            return;
+        }
+
+        $service->refresh();
+
+        ServiceStatusChanged::dispatch($service, $previousStatus, $newStatus);
+
+        SocketEvent::dispatch(new SocketEventDTO(
+            projectId: $server->project_id,
+            type: 'service.updated',
+            data: new ServiceResource($service),
+        ));
+    }
+}

--- a/app/Actions/Service/CheckServiceStatuses.php
+++ b/app/Actions/Service/CheckServiceStatuses.php
@@ -4,7 +4,6 @@ namespace App\Actions\Service;
 
 use App\Exceptions\SSHError;
 use App\Models\Server;
-use Illuminate\Support\Facades\Cache;
 
 class CheckServiceStatuses
 {
@@ -12,24 +11,6 @@ class CheckServiceStatuses
      * @throws SSHError
      */
     public function check(Server $server): void
-    {
-        $lock = Cache::lock("unique-queue:server-{$server->id}", 60);
-
-        if (! $lock->get()) {
-            return;
-        }
-
-        try {
-            $this->poll($server);
-        } finally {
-            $lock->release();
-        }
-    }
-
-    /**
-     * @throws SSHError
-     */
-    private function poll(Server $server): void
     {
         $services = $server->services()
             ->whereIn('status', SyncServiceStatus::SETTLED_STATUSES)

--- a/app/Actions/Service/CheckServiceStatuses.php
+++ b/app/Actions/Service/CheckServiceStatuses.php
@@ -4,6 +4,7 @@ namespace App\Actions\Service;
 
 use App\Exceptions\SSHError;
 use App\Models\Server;
+use Illuminate\Support\Facades\Cache;
 
 class CheckServiceStatuses
 {
@@ -11,6 +12,24 @@ class CheckServiceStatuses
      * @throws SSHError
      */
     public function check(Server $server): void
+    {
+        $lock = Cache::lock("unique-queue:server-{$server->id}", 60);
+
+        if (! $lock->get()) {
+            return;
+        }
+
+        try {
+            $this->poll($server);
+        } finally {
+            $lock->release();
+        }
+    }
+
+    /**
+     * @throws SSHError
+     */
+    private function poll(Server $server): void
     {
         $services = $server->services()
             ->whereIn('status', SyncServiceStatus::SETTLED_STATUSES)
@@ -23,7 +42,7 @@ class CheckServiceStatuses
                 continue;
             }
             $handler = $service->handler();
-            if (! $handler->shouldCheckStatus()) {
+            if (! $handler->canBeManaged()) {
                 continue;
             }
             $checkable[] = $service;

--- a/app/Actions/Service/CheckServiceStatuses.php
+++ b/app/Actions/Service/CheckServiceStatuses.php
@@ -2,31 +2,18 @@
 
 namespace App\Actions\Service;
 
-use App\DTOs\SocketEventDTO;
-use App\Enums\ServiceStatus;
-use App\Events\ServiceStatusChanged;
-use App\Events\SocketEvent;
 use App\Exceptions\SSHError;
-use App\Http\Resources\ServiceResource;
 use App\Models\Server;
-use App\Models\Service;
 
 class CheckServiceStatuses
 {
-    private const array SETTLED_STATUSES = [
-        ServiceStatus::READY,
-        ServiceStatus::STOPPED,
-        ServiceStatus::FAILED,
-        ServiceStatus::DISABLED,
-    ];
-
     /**
      * @throws SSHError
      */
     public function check(Server $server): void
     {
         $services = $server->services()
-            ->whereIn('status', self::SETTLED_STATUSES)
+            ->whereIn('status', SyncServiceStatus::SETTLED_STATUSES)
             ->get();
 
         $checkable = [];
@@ -54,46 +41,7 @@ class CheckServiceStatuses
         }
 
         foreach ($checkable as $index => $service) {
-            $this->syncStatus($server, $service, $states[$index] ?? '');
+            app(SyncServiceStatus::class)->sync($server, $service, $states[$index] ?? '');
         }
-    }
-
-    private function syncStatus(Server $server, Service $service, string $state): void
-    {
-        $newStatus = match ($state) {
-            'active' => ServiceStatus::READY,
-            'inactive' => ServiceStatus::STOPPED,
-            'failed' => ServiceStatus::FAILED,
-            default => null,
-        };
-
-        $previousStatus = $service->status;
-
-        if (! $newStatus instanceof ServiceStatus || $newStatus === $previousStatus) {
-            return;
-        }
-
-        if ($previousStatus === ServiceStatus::DISABLED && $newStatus === ServiceStatus::STOPPED) {
-            return;
-        }
-
-        $updated = Service::query()
-            ->where('id', $service->id)
-            ->where('status', $previousStatus)
-            ->update(['status' => $newStatus]);
-
-        if ($updated === 0) {
-            return;
-        }
-
-        $service->refresh();
-
-        ServiceStatusChanged::dispatch($service, $previousStatus, $newStatus);
-
-        SocketEvent::dispatch(new SocketEventDTO(
-            projectId: $server->project_id,
-            type: 'service.updated',
-            data: new ServiceResource($service),
-        ));
     }
 }

--- a/app/Actions/Service/SyncServiceStatus.php
+++ b/app/Actions/Service/SyncServiceStatus.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Actions\Service;
+
+use App\DTOs\SocketEventDTO;
+use App\Enums\ServiceStatus;
+use App\Events\ServiceStatusChanged;
+use App\Events\SocketEvent;
+use App\Http\Resources\ServiceResource;
+use App\Models\Server;
+use App\Models\Service;
+
+class SyncServiceStatus
+{
+    public const array SETTLED_STATUSES = [
+        ServiceStatus::READY,
+        ServiceStatus::STOPPED,
+        ServiceStatus::FAILED,
+        ServiceStatus::DISABLED,
+    ];
+
+    public function sync(Server $server, Service $service, string $state): void
+    {
+        $newStatus = match ($state) {
+            'active' => ServiceStatus::READY,
+            'inactive' => ServiceStatus::STOPPED,
+            'failed' => ServiceStatus::FAILED,
+            default => null,
+        };
+
+        $previousStatus = $service->status;
+
+        if (! $newStatus instanceof ServiceStatus || $newStatus === $previousStatus) {
+            return;
+        }
+
+        if ($previousStatus === ServiceStatus::DISABLED && $newStatus === ServiceStatus::STOPPED) {
+            return;
+        }
+
+        $updated = Service::query()
+            ->where('id', $service->id)
+            ->where('status', $previousStatus)
+            ->update(['status' => $newStatus]);
+
+        if ($updated === 0) {
+            return;
+        }
+
+        $service = $service->fresh();
+        if (! $service instanceof Service) {
+            return;
+        }
+
+        ServiceStatusChanged::dispatch($service, $previousStatus, $newStatus);
+
+        SocketEvent::dispatch(new SocketEventDTO(
+            projectId: $server->project_id,
+            type: 'service.updated',
+            data: new ServiceResource($service),
+        ));
+    }
+}

--- a/app/Actions/Service/SyncServiceStatus.php
+++ b/app/Actions/Service/SyncServiceStatus.php
@@ -9,6 +9,7 @@ use App\Events\SocketEvent;
 use App\Http\Resources\ServiceResource;
 use App\Models\Server;
 use App\Models\Service;
+use Illuminate\Support\Facades\Cache;
 
 class SyncServiceStatus
 {
@@ -28,15 +29,24 @@ class SyncServiceStatus
             default => null,
         };
 
+        if (! $newStatus instanceof ServiceStatus) {
+            return;
+        }
+
         $previousStatus = $service->status;
 
-        if (! $newStatus instanceof ServiceStatus || $newStatus === $previousStatus) {
+        if ($newStatus === $previousStatus
+            || ($previousStatus === ServiceStatus::DISABLED && $newStatus === ServiceStatus::STOPPED)) {
+            Cache::forget($this->pendingKey($service));
+
             return;
         }
 
-        if ($previousStatus === ServiceStatus::DISABLED && $newStatus === ServiceStatus::STOPPED) {
+        if ($newStatus !== ServiceStatus::READY && ! $this->confirmed($service, $newStatus)) {
             return;
         }
+
+        Cache::forget($this->pendingKey($service));
 
         $updated = Service::query()
             ->where('id', $service->id)
@@ -59,5 +69,23 @@ class SyncServiceStatus
             type: 'service.updated',
             data: new ServiceResource($service),
         ));
+    }
+
+    private function pendingKey(Service $service): string
+    {
+        return "service-status-pending:{$service->id}";
+    }
+
+    private function confirmed(Service $service, ServiceStatus $newStatus): bool
+    {
+        $key = $this->pendingKey($service);
+
+        if (Cache::get($key) === $newStatus->value) {
+            return true;
+        }
+
+        Cache::put($key, $newStatus->value, now()->addHour());
+
+        return false;
     }
 }

--- a/app/Console/Commands/GetMetricsCommand.php
+++ b/app/Console/Commands/GetMetricsCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Actions\Service\CheckServiceStatuses;
 use App\Enums\ServerStatus;
 use App\Models\Server;
 use Illuminate\Console\Command;
@@ -32,6 +33,14 @@ class GetMetricsCommand extends Command
                         $checkedMetrics++;
                     } catch (Throwable $e) {
                         Log::warning('Failed to collect metrics for server', [
+                            'server_id' => $server->id,
+                            'error' => $e->getMessage(),
+                        ]);
+                    }
+                    try {
+                        app(CheckServiceStatuses::class)->check($server);
+                    } catch (Throwable $e) {
+                        Log::warning('Failed to check service statuses for server', [
                             'server_id' => $server->id,
                             'error' => $e->getMessage(),
                         ]);

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,7 +16,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('backups:reconcile')->everyThirtyMinutes();
         $schedule->command('metrics:delete-older-metrics')->daily();
         $schedule->command('db:vacuum')->daily();
-        $schedule->command('metrics:get')->everyMinute();
+        $schedule->command('metrics:get')->everyMinute()->withoutOverlapping();
         $schedule->command('servers:check')->everyFiveMinutes();
         $schedule->command('servers:check-updates')->dailyAt('02:00');
         $schedule->command('servers:auto-update')->everyMinute()->withoutOverlapping();

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,7 +16,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('backups:reconcile')->everyThirtyMinutes();
         $schedule->command('metrics:delete-older-metrics')->daily();
         $schedule->command('db:vacuum')->daily();
-        $schedule->command('metrics:get')->everyMinute()->withoutOverlapping();
+        $schedule->command('metrics:get')->everyMinute()->withoutOverlapping(5);
         $schedule->command('servers:check')->everyFiveMinutes();
         $schedule->command('servers:check-updates')->dailyAt('02:00');
         $schedule->command('servers:auto-update')->everyMinute()->withoutOverlapping();

--- a/app/Events/ServiceStatusChanged.php
+++ b/app/Events/ServiceStatusChanged.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Events;
+
+use App\Enums\ServiceStatus;
+use App\Models\Service;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class ServiceStatusChanged
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Service $service,
+        public readonly ServiceStatus $previousStatus,
+        public readonly ServiceStatus $newStatus,
+    ) {}
+}

--- a/app/Helpers/SSH.php
+++ b/app/Helpers/SSH.php
@@ -299,7 +299,7 @@ class SSH
             $storageDisk->put($tmpName, $content);
             $tmpRemotePath = '/tmp/'.$tmpName;
             $this->upload($storageDisk->path($tmpName), $tmpRemotePath, $owner, $log, $siteId);
-            $this->asUser($owner)->exec('cat '.$tmpRemotePath.' > '.$remotePath);
+            $this->asUser($owner)->exec('cat '.$tmpRemotePath.' > '.$remotePath.' && rm -f '.$tmpRemotePath);
         } catch (Throwable $e) {
             throw new SSHCommandError(
                 message: $e->getMessage()

--- a/app/Http/Controllers/API/AgentController.php
+++ b/app/Http/Controllers/API/AgentController.php
@@ -18,7 +18,7 @@ class AgentController extends Controller
         /** @var ?Service $service */
         $service = $server->services()->find($id);
 
-        $expected = $service?->handler()->data()['secret'] ?? null;
+        $expected = $service?->hasHandler() ? ($service->handler()->data()['secret'] ?? null) : null;
         $provided = (string) $request->header('secret');
 
         if (! $service || ! is_string($expected) || $expected === '' || ! hash_equals($expected, $provided)) {

--- a/app/Http/Controllers/ConsoleController.php
+++ b/app/Http/Controllers/ConsoleController.php
@@ -54,7 +54,7 @@ class ConsoleController extends Controller
         $host = $appUrl['host'] ?? 'localhost';
         $port = $appUrl['port'] ?? ($isSecure ? 443 : 80);
 
-        if (app()->environment('local')) {
+        if (app()->environment('local') && ! config('app.ws_url')) {
             $wsPort = config('core.ws_port', 8085);
             $result['url'] = "{$wsProtocol}://{$host}:{$wsPort}/ws/terminal";
         } else {

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -25,7 +25,7 @@ class EventsController extends Controller
         $host = $appUrl['host'] ?? 'localhost';
         $port = $appUrl['port'] ?? ($isSecure ? 443 : 80);
 
-        if (app()->environment('local')) {
+        if (app()->environment('local') && ! config('app.ws_url')) {
             $wsPort = config('core.ws_port', 8085);
             $result['url'] = "{$wsProtocol}://{$host}:{$wsPort}/ws/events";
         } else {

--- a/app/Http/Resources/ServiceResource.php
+++ b/app/Http/Resources/ServiceResource.php
@@ -5,6 +5,7 @@ namespace App\Http\Resources;
 use App\Models\Service;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Arr;
 
 /** @mixin Service */
 class ServiceResource extends JsonResource
@@ -18,7 +19,7 @@ class ServiceResource extends JsonResource
             'id' => $this->id,
             'server_id' => $this->server_id,
             'type' => $this->type,
-            'type_data' => $this->type_data,
+            'type_data' => $this->type_data !== null ? Arr::except($this->type_data, ['secret']) : null,
             'config_paths' => config("service.services.{$this->name}.config_paths", []),
             'name' => $this->name,
             'version' => $this->version,

--- a/app/Jobs/Service/InstallJob.php
+++ b/app/Jobs/Service/InstallJob.php
@@ -23,7 +23,8 @@ class InstallJob implements ShouldQueue
 
     public function handle(): void
     {
-        $this->run("server-{$this->service->server_id}", function () {
+        $succeeded = false;
+        $this->run("server-{$this->service->server_id}", function () use (&$succeeded) {
             Log::info("Installing service ID {$this->service->id} on server ID {$this->service->server_id}");
 
             $this->service->newLog();
@@ -34,7 +35,12 @@ class InstallJob implements ShouldQueue
             $this->service->save();
             $this->broadcastServiceUpdate('service.updated');
             Log::info("Service ID {$this->service->id} installed successfully");
+            $succeeded = true;
         });
+
+        if ($succeeded) {
+            UpdateVitoAgentConfigJob::dispatchFor($this->service);
+        }
     }
 
     public function failed(Exception $e): void

--- a/app/Jobs/Service/UninstallJob.php
+++ b/app/Jobs/Service/UninstallJob.php
@@ -22,7 +22,8 @@ class UninstallJob implements ShouldQueue
 
     public function handle(): void
     {
-        $this->run("server-{$this->service->server_id}", function () {
+        $succeeded = false;
+        $this->run("server-{$this->service->server_id}", function () use (&$succeeded) {
             $projectId = $this->service->server->project_id;
             $serviceId = $this->service->id;
             $this->service->handler()->uninstall();
@@ -33,7 +34,12 @@ class UninstallJob implements ShouldQueue
                 type: 'service.deleted',
                 data: ['id' => $serviceId],
             ));
+            $succeeded = true;
         });
+
+        if ($succeeded) {
+            UpdateVitoAgentConfigJob::dispatchFor($this->service);
+        }
     }
 
     public function failed(Exception $e): void

--- a/app/Jobs/Service/UpdateVitoAgentConfigJob.php
+++ b/app/Jobs/Service/UpdateVitoAgentConfigJob.php
@@ -25,7 +25,7 @@ class UpdateVitoAgentConfigJob implements ShouldQueue
             return;
         }
 
-        if (! $service->hasHandler() || ! $service->handler()->shouldCheckStatus()) {
+        if (! $service->hasHandler() || ! $service->handler()->canBeManaged()) {
             return;
         }
 

--- a/app/Jobs/Service/UpdateVitoAgentConfigJob.php
+++ b/app/Jobs/Service/UpdateVitoAgentConfigJob.php
@@ -11,6 +11,7 @@ use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class UpdateVitoAgentConfigJob implements ShouldQueue
 {
@@ -21,20 +22,27 @@ class UpdateVitoAgentConfigJob implements ShouldQueue
 
     public static function dispatchFor(Service $service): void
     {
-        if ($service->name === VitoAgent::id()) {
-            return;
-        }
+        try {
+            if ($service->name === VitoAgent::id()) {
+                return;
+            }
 
-        if (! $service->hasHandler() || ! $service->handler()->canBeManaged()) {
-            return;
-        }
+            if (! $service->hasHandler() || ! $service->handler()->canBeManaged()) {
+                return;
+            }
 
-        $monitoring = $service->server->monitoring();
-        if (! $monitoring instanceof Service || $monitoring->name !== VitoAgent::id()) {
-            return;
-        }
+            $monitoring = $service->server->monitoring();
+            if (! $monitoring instanceof Service || $monitoring->name !== VitoAgent::id()) {
+                return;
+            }
 
-        dispatch(new self($service->server))->onQueue('ssh');
+            dispatch(new self($service->server))->onQueue('ssh');
+        } catch (Throwable $e) {
+            Log::warning('Failed to dispatch vito-agent config update', [
+                'service_id' => $service->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     public function handle(): void

--- a/app/Jobs/Service/UpdateVitoAgentConfigJob.php
+++ b/app/Jobs/Service/UpdateVitoAgentConfigJob.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Jobs\Service;
+
+use App\Enums\ServiceStatus;
+use App\Models\Server;
+use App\Models\Service;
+use App\Services\Monitoring\VitoAgent\VitoAgent;
+use App\Traits\UniqueQueue;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+class UpdateVitoAgentConfigJob implements ShouldQueue
+{
+    use Queueable;
+    use UniqueQueue;
+
+    public function __construct(protected Server $server) {}
+
+    public static function dispatchFor(Service $service): void
+    {
+        if ($service->name === VitoAgent::id()) {
+            return;
+        }
+
+        if (! $service->hasHandler() || ! $service->handler()->shouldCheckStatus()) {
+            return;
+        }
+
+        $monitoring = $service->server->monitoring();
+        if (! $monitoring instanceof Service || $monitoring->name !== VitoAgent::id()) {
+            return;
+        }
+
+        dispatch(new self($service->server))->onQueue('ssh');
+    }
+
+    public function handle(): void
+    {
+        $this->run("server-{$this->server->id}", function () {
+            $monitoring = $this->server->monitoring();
+
+            if (! $monitoring instanceof Service || $monitoring->status !== ServiceStatus::READY) {
+                return;
+            }
+
+            $handler = $monitoring->handler();
+            if (! $handler instanceof VitoAgent) {
+                return;
+            }
+
+            $handler->updateConfig();
+        });
+    }
+
+    public function failed(Exception $e): void
+    {
+        Log::warning('Failed to update vito-agent config', [
+            'server_id' => $this->server->id,
+            'error' => $e->getMessage(),
+        ]);
+    }
+}

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -21,7 +21,7 @@ use InvalidArgumentException;
  * @property int $server_id
  * @property ?int $log_id
  * @property string $type
- * @property array<string, mixed> $type_data
+ * @property ?array<string, mixed> $type_data
  * @property string $name
  * @property string $version
  * @property string $installed_version

--- a/app/SSH/OS/Systemd.php
+++ b/app/SSH/OS/Systemd.php
@@ -4,6 +4,7 @@ namespace App\SSH\OS;
 
 use App\Exceptions\SSHError;
 use App\Models\Server;
+use Illuminate\Support\Facades\Log;
 
 class Systemd
 {
@@ -19,6 +20,37 @@ class Systemd
         EOD;
 
         return $this->server->ssh()->exec($command, sprintf('status-%s', $unit));
+    }
+
+    /**
+     * @param  array<int, string>  $units
+     * @return array<int, string>
+     *
+     * @throws SSHError
+     */
+    public function activeStates(array $units): array
+    {
+        if ($units === []) {
+            return [];
+        }
+
+        $command = 'sudo systemctl is-active '.implode(' ', array_map(escapeshellarg(...), $units)).' 2>/dev/null || true';
+
+        $output = $this->server->ssh()->exec($command, timeout: 5);
+
+        $states = array_values(array_filter(array_map(trim(...), preg_split('/\R/', $output) ?: []), fn (string $state): bool => $state !== ''));
+
+        if (count($states) !== count($units)) {
+            Log::warning('Unexpected systemctl is-active output', [
+                'server_id' => $this->server->id,
+                'units' => $units,
+                'output' => $output,
+            ]);
+
+            return [];
+        }
+
+        return $states;
     }
 
     /**

--- a/app/Services/AbstractService.php
+++ b/app/Services/AbstractService.php
@@ -48,11 +48,6 @@ abstract class AbstractService implements ServiceInterface
         return (bool) $this->unit();
     }
 
-    public function shouldCheckStatus(): bool
-    {
-        return (bool) $this->unit();
-    }
-
     public function manage(string $action): bool
     {
         $expectedState = in_array($action, ['stop', 'disable'], true) ? 'Active: inactive' : 'Active: active';

--- a/app/Services/AbstractService.php
+++ b/app/Services/AbstractService.php
@@ -48,6 +48,11 @@ abstract class AbstractService implements ServiceInterface
         return (bool) $this->unit();
     }
 
+    public function shouldCheckStatus(): bool
+    {
+        return (bool) $this->unit();
+    }
+
     public function manage(string $action): bool
     {
         $expectedState = in_array($action, ['stop', 'disable'], true) ? 'Active: inactive' : 'Active: active';

--- a/app/Services/Monitoring/VitoAgent/VitoAgent.php
+++ b/app/Services/Monitoring/VitoAgent/VitoAgent.php
@@ -123,6 +123,11 @@ class VitoAgent extends AbstractService
             'root'
         );
 
+        $this->service->server->ssh()->exec(
+            'sudo chmod 600 /etc/vito-agent/config.json',
+            'secure-vito-agent-config'
+        );
+
         $this->service->server->systemd()->restart($this->unit());
     }
 
@@ -137,7 +142,7 @@ class VitoAgent extends AbstractService
                 continue;
             }
             $handler = $service->handler();
-            if (! $handler->shouldCheckStatus()) {
+            if (! $handler->canBeManaged()) {
                 continue;
             }
             $services[] = ['id' => $service->id, 'unit' => $handler->unit()];

--- a/app/Services/Monitoring/VitoAgent/VitoAgent.php
+++ b/app/Services/Monitoring/VitoAgent/VitoAgent.php
@@ -10,6 +10,7 @@ use Closure;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Validation\Rule;
+use JsonException;
 use Ramsey\Uuid\Uuid;
 
 class VitoAgent extends AbstractService
@@ -108,6 +109,7 @@ class VitoAgent extends AbstractService
 
     /**
      * @throws SSHError
+     * @throws JsonException
      */
     public function updateConfig(): void
     {
@@ -119,7 +121,7 @@ class VitoAgent extends AbstractService
 
         $this->service->server->ssh()->write(
             '/etc/vito-agent/config.json',
-            (string) json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+            json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
             'root'
         );
 

--- a/app/Services/Monitoring/VitoAgent/VitoAgent.php
+++ b/app/Services/Monitoring/VitoAgent/VitoAgent.php
@@ -126,7 +126,8 @@ class VitoAgent extends AbstractService
         );
 
         $this->service->server->ssh()->exec(
-            'sudo chmod 600 /etc/vito-agent/config.json',
+            'sudo chmod 600 /etc/vito-agent/config.json'."\n".
+            'echo '.escapeshellarg('vito-agent config updated. Monitoring services: '.json_encode($config['services'], JSON_THROW_ON_ERROR)),
             'secure-vito-agent-config'
         );
 
@@ -143,11 +144,11 @@ class VitoAgent extends AbstractService
             if ($service->id === $this->service->id || ! $service->hasHandler()) {
                 continue;
             }
-            $handler = $service->handler();
-            if (! $handler->canBeManaged()) {
+            $unit = $service->handler()->unit();
+            if ($unit === '') {
                 continue;
             }
-            $services[] = ['id' => $service->id, 'unit' => $handler->unit()];
+            $services[] = ['id' => $service->id, 'unit' => $unit];
         }
 
         return $services;

--- a/app/Services/Monitoring/VitoAgent/VitoAgent.php
+++ b/app/Services/Monitoring/VitoAgent/VitoAgent.php
@@ -100,9 +100,50 @@ class VitoAgent extends AbstractService
                 ]),
                 'install-vito-agent'
             );
+        $this->updateConfig();
         $status = $this->service->server->systemd()->status($this->unit());
         event('service.installed', $this->service);
         $this->service->validateInstall($status);
+    }
+
+    /**
+     * @throws SSHError
+     */
+    public function updateConfig(): void
+    {
+        $config = [
+            'url' => $this->data()['url'],
+            'secret' => $this->data()['secret'],
+            'services' => $this->configServices(),
+        ];
+
+        $this->service->server->ssh()->write(
+            '/etc/vito-agent/config.json',
+            (string) json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+            'root'
+        );
+
+        $this->service->server->systemd()->restart($this->unit());
+    }
+
+    /**
+     * @return array<int, array{id: int, unit: string}>
+     */
+    private function configServices(): array
+    {
+        $services = [];
+        foreach ($this->service->server->services()->get() as $service) {
+            if ($service->id === $this->service->id || ! $service->hasHandler()) {
+                continue;
+            }
+            $handler = $service->handler();
+            if (! $handler->shouldCheckStatus()) {
+                continue;
+            }
+            $services[] = ['id' => $service->id, 'unit' => $handler->unit()];
+        }
+
+        return $services;
     }
 
     /**

--- a/app/Services/ServiceInterface.php
+++ b/app/Services/ServiceInterface.php
@@ -40,5 +40,7 @@ interface ServiceInterface
 
     public function canBeManaged(): bool;
 
+    public function shouldCheckStatus(): bool;
+
     public function manage(string $action): bool;
 }

--- a/app/Services/ServiceInterface.php
+++ b/app/Services/ServiceInterface.php
@@ -40,7 +40,5 @@ interface ServiceInterface
 
     public function canBeManaged(): bool;
 
-    public function shouldCheckStatus(): bool;
-
     public function manage(string $action): bool;
 }

--- a/tests/Feature/API/AgentControllerTest.php
+++ b/tests/Feature/API/AgentControllerTest.php
@@ -3,8 +3,12 @@
 namespace Tests\Feature\API;
 
 use App\Enums\ServiceStatus;
+use App\Events\ServiceStatusChanged;
+use App\Events\SocketEvent;
+use App\Models\Server;
 use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
 class AgentControllerTest extends TestCase
@@ -159,5 +163,166 @@ class AgentControllerTest extends TestCase
             ['load' => 'not-a-number'],
             ['secret' => 'test-secret']
         )->assertStatus(422);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function minimalPayload(): array
+    {
+        return [
+            'load' => 0.5,
+            'memory_total' => '1000',
+            'memory_used' => '500',
+            'memory_free' => '500',
+            'disk_total' => '100',
+            'disk_used' => '50',
+            'disk_free' => '50',
+        ];
+    }
+
+    public function test_store_metrics_without_services_key_changes_no_statuses(): void
+    {
+        Event::fake([ServiceStatusChanged::class]);
+
+        $service = $this->agentService();
+
+        $this->json(
+            'POST',
+            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+            $this->minimalPayload(),
+            ['secret' => 'test-secret']
+        )->assertSuccessful();
+
+        $this->assertDatabaseHas('metrics', ['server_id' => $this->server->id, 'load' => 0.5]);
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+    }
+
+    public function test_store_metrics_with_services_updates_statuses(): void
+    {
+        Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
+
+        $service = $this->agentService();
+        $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
+
+        $this->json(
+            'POST',
+            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+            array_merge($this->minimalPayload(), [
+                'services' => [['id' => $nginx->id, 'status' => 'inactive']],
+            ]),
+            ['secret' => 'test-secret']
+        )->assertSuccessful();
+
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::STOPPED]);
+        $this->assertDatabaseHas('metrics', ['server_id' => $this->server->id, 'load' => 0.5]);
+        Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $nginx->id
+            && $event->previousStatus === ServiceStatus::READY
+            && $event->newStatus === ServiceStatus::STOPPED);
+        Event::assertDispatched(SocketEvent::class);
+    }
+
+    public function test_services_entry_for_other_server_is_ignored(): void
+    {
+        Event::fake([ServiceStatusChanged::class]);
+
+        $service = $this->agentService();
+        $otherServer = Server::factory()->create([
+            'user_id' => $this->user->id,
+            'project_id' => $this->user->current_project_id,
+        ]);
+        $otherService = Service::factory()->create([
+            'server_id' => $otherServer->id,
+            'name' => 'nginx',
+            'type' => 'webserver',
+            'version' => 'latest',
+            'status' => ServiceStatus::READY,
+        ]);
+
+        $this->json(
+            'POST',
+            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+            array_merge($this->minimalPayload(), [
+                'services' => [['id' => $otherService->id, 'status' => 'inactive']],
+            ]),
+            ['secret' => 'test-secret']
+        )->assertSuccessful();
+
+        $this->assertDatabaseHas('services', ['id' => $otherService->id, 'status' => ServiceStatus::READY]);
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+    }
+
+    public function test_services_entry_for_transitional_service_is_ignored(): void
+    {
+        Event::fake([ServiceStatusChanged::class]);
+
+        $service = $this->agentService();
+        $mysql = $this->server->services()->where('name', 'mysql')->firstOrFail();
+        $mysql->update(['status' => ServiceStatus::INSTALLING]);
+
+        $this->json(
+            'POST',
+            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+            array_merge($this->minimalPayload(), [
+                'services' => [['id' => $mysql->id, 'status' => 'active']],
+            ]),
+            ['secret' => 'test-secret']
+        )->assertSuccessful();
+
+        $this->assertDatabaseHas('services', ['id' => $mysql->id, 'status' => ServiceStatus::INSTALLING]);
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+    }
+
+    public function test_services_entry_with_unknown_status_is_ignored(): void
+    {
+        Event::fake([ServiceStatusChanged::class]);
+
+        $service = $this->agentService();
+        $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
+
+        $this->json(
+            'POST',
+            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+            array_merge($this->minimalPayload(), [
+                'services' => [['id' => $nginx->id, 'status' => 'activating']],
+            ]),
+            ['secret' => 'test-secret']
+        )->assertSuccessful();
+
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+    }
+
+    public function test_services_entry_for_monitoring_service_is_ignored(): void
+    {
+        Event::fake([ServiceStatusChanged::class]);
+
+        $service = $this->agentService();
+
+        $this->json(
+            'POST',
+            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+            array_merge($this->minimalPayload(), [
+                'services' => [['id' => $service->id, 'status' => 'inactive']],
+            ]),
+            ['secret' => 'test-secret']
+        )->assertSuccessful();
+
+        $this->assertDatabaseHas('services', ['id' => $service->id, 'status' => ServiceStatus::READY]);
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+    }
+
+    public function test_services_must_be_an_array(): void
+    {
+        $service = $this->agentService();
+
+        $this->json(
+            'POST',
+            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+            array_merge($this->minimalPayload(), ['services' => 'nope']),
+            ['secret' => 'test-secret']
+        )->assertStatus(422);
+
+        $this->assertDatabaseCount('metrics', 0);
     }
 }

--- a/tests/Feature/API/AgentControllerTest.php
+++ b/tests/Feature/API/AgentControllerTest.php
@@ -205,14 +205,8 @@ class AgentControllerTest extends TestCase
         $service = $this->agentService();
         $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
 
-        $this->json(
-            'POST',
-            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
-            array_merge($this->minimalPayload(), [
-                'services' => [['id' => $nginx->id, 'status' => 'inactive']],
-            ]),
-            ['secret' => 'test-secret']
-        )->assertSuccessful();
+        $this->reportServiceStatus($service, $nginx, 'inactive');
+        $this->reportServiceStatus($service, $nginx, 'inactive');
 
         $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::STOPPED]);
         $this->assertDatabaseHas('metrics', ['server_id' => $this->server->id, 'load' => 0.5]);
@@ -220,6 +214,46 @@ class AgentControllerTest extends TestCase
             && $event->previousStatus === ServiceStatus::READY
             && $event->newStatus === ServiceStatus::STOPPED);
         Event::assertDispatched(SocketEvent::class);
+    }
+
+    public function test_single_inactive_report_does_not_change_status(): void
+    {
+        Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
+
+        $service = $this->agentService();
+        $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
+
+        $this->reportServiceStatus($service, $nginx, 'inactive');
+
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+    }
+
+    public function test_agent_reported_restart_flap_does_not_change_status(): void
+    {
+        Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
+
+        $service = $this->agentService();
+        $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
+
+        $this->reportServiceStatus($service, $nginx, 'inactive');
+        $this->reportServiceStatus($service, $nginx, 'active');
+        $this->reportServiceStatus($service, $nginx, 'inactive');
+
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+    }
+
+    private function reportServiceStatus(Service $service, Service $target, string $status): void
+    {
+        $this->json(
+            'POST',
+            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+            array_merge($this->minimalPayload(), [
+                'services' => [['id' => $target->id, 'status' => $status]],
+            ]),
+            ['secret' => 'test-secret']
+        )->assertSuccessful();
     }
 
     public function test_services_entry_for_other_server_is_ignored(): void

--- a/tests/Feature/API/AgentControllerTest.php
+++ b/tests/Feature/API/AgentControllerTest.php
@@ -229,6 +229,29 @@ class AgentControllerTest extends TestCase
         Event::assertNotDispatched(ServiceStatusChanged::class);
     }
 
+    public function test_duplicate_service_entries_count_as_one_reading(): void
+    {
+        Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
+
+        $service = $this->agentService();
+        $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
+
+        $this->json(
+            'POST',
+            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+            array_merge($this->minimalPayload(), [
+                'services' => [
+                    ['id' => $nginx->id, 'status' => 'inactive'],
+                    ['id' => $nginx->id, 'status' => 'inactive'],
+                ],
+            ]),
+            ['secret' => 'test-secret']
+        )->assertSuccessful();
+
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+    }
+
     public function test_agent_reported_restart_flap_does_not_change_status(): void
     {
         Event::fake([ServiceStatusChanged::class, SocketEvent::class]);

--- a/tests/Feature/API/ServicesTest.php
+++ b/tests/Feature/API/ServicesTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\API;
 
 use App\Enums\ServiceStatus;
 use App\Facades\SSH;
+use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -12,6 +13,32 @@ use Tests\TestCase;
 class ServicesTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function test_services_list_redacts_type_data_secret(): void
+    {
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        Service::factory()->create([
+            'server_id' => $this->server->id,
+            'name' => 'vito-agent',
+            'type' => 'monitoring',
+            'type_data' => [
+                'url' => 'https://vito.test/agent-endpoint',
+                'secret' => 'agent-secret',
+                'data_retention' => 7,
+            ],
+            'version' => 'latest',
+            'status' => ServiceStatus::READY,
+        ]);
+
+        $this->json('GET', route('api.projects.servers.services', [
+            'project' => $this->server->project,
+            'server' => $this->server,
+        ]))
+            ->assertSuccessful()
+            ->assertJsonFragment(['url' => 'https://vito.test/agent-endpoint'])
+            ->assertJsonMissing(['secret' => 'agent-secret']);
+    }
 
     public function test_see_services_list(): void
     {

--- a/tests/Unit/Actions/Service/CheckServiceStatusesTest.php
+++ b/tests/Unit/Actions/Service/CheckServiceStatusesTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Unit\Actions\Service;
+
+use App\Actions\Service\CheckServiceStatuses;
+use App\Enums\ServiceStatus;
+use App\Events\ServiceStatusChanged;
+use App\Events\SocketEvent;
+use App\Facades\SSH;
+use App\Models\Service;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class CheckServiceStatusesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_updates_changed_statuses_and_dispatches_events(): void
+    {
+        SSH::fake("active\ninactive\nfailed");
+        Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
+
+        $this->server->services()->delete();
+        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::READY);
+        $mysql = $this->createService('database', 'mysql', ServiceStatus::READY);
+        $redis = $this->createService('memory_database', 'redis', ServiceStatus::STOPPED);
+
+        app(CheckServiceStatuses::class)->check($this->server);
+
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+        $this->assertDatabaseHas('services', ['id' => $mysql->id, 'status' => ServiceStatus::STOPPED]);
+        $this->assertDatabaseHas('services', ['id' => $redis->id, 'status' => ServiceStatus::FAILED]);
+
+        Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $mysql->id
+            && $event->previousStatus === ServiceStatus::READY
+            && $event->newStatus === ServiceStatus::STOPPED);
+        Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $redis->id
+            && $event->previousStatus === ServiceStatus::STOPPED
+            && $event->newStatus === ServiceStatus::FAILED);
+        Event::assertNotDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $nginx->id);
+        Event::assertDispatchedTimes(SocketEvent::class, 2);
+    }
+
+    public function test_disabled_service_reported_inactive_stays_disabled(): void
+    {
+        SSH::fake('inactive');
+        Event::fake([ServiceStatusChanged::class]);
+
+        $this->server->services()->delete();
+        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::DISABLED);
+
+        app(CheckServiceStatuses::class)->check($this->server);
+
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::DISABLED]);
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+    }
+
+    public function test_disabled_service_reported_active_becomes_ready(): void
+    {
+        SSH::fake('active');
+        Event::fake([ServiceStatusChanged::class]);
+
+        $this->server->services()->delete();
+        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::DISABLED);
+
+        app(CheckServiceStatuses::class)->check($this->server);
+
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+        Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $nginx->id
+            && $event->previousStatus === ServiceStatus::DISABLED
+            && $event->newStatus === ServiceStatus::READY);
+    }
+
+    public function test_transitional_and_unitless_services_are_not_checked(): void
+    {
+        SSH::fake('active');
+        Event::fake([ServiceStatusChanged::class]);
+
+        $this->server->services()->delete();
+        $this->createService('webserver', 'nginx', ServiceStatus::INSTALLING);
+        $this->createService('nodejs', 'nodejs', ServiceStatus::READY);
+        $this->createService('log_analysis', 'goaccess', ServiceStatus::READY);
+        $mysql = $this->createService('database', 'mysql', ServiceStatus::READY);
+
+        app(CheckServiceStatuses::class)->check($this->server);
+
+        SSH::assertExecutedContains('mysql');
+        SSH::assertNotExecutedContains('nginx');
+        SSH::assertNotExecutedContains('nodejs');
+        SSH::assertNotExecutedContains('goaccess');
+        $this->assertDatabaseHas('services', ['id' => $mysql->id, 'status' => ServiceStatus::READY]);
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+    }
+
+    public function test_skips_ssh_when_no_pollable_services(): void
+    {
+        SSH::fake('active');
+        Event::fake([ServiceStatusChanged::class]);
+
+        $this->server->services()->delete();
+        $this->createService('nodejs', 'nodejs', ServiceStatus::READY);
+
+        app(CheckServiceStatuses::class)->check($this->server);
+
+        SSH::assertNotExecutedContains('is-active');
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+    }
+
+    public function test_mismatched_output_updates_nothing(): void
+    {
+        SSH::fake('active');
+        Event::fake([ServiceStatusChanged::class]);
+
+        $this->server->services()->delete();
+        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::STOPPED);
+        $mysql = $this->createService('database', 'mysql', ServiceStatus::STOPPED);
+
+        app(CheckServiceStatuses::class)->check($this->server);
+
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::STOPPED]);
+        $this->assertDatabaseHas('services', ['id' => $mysql->id, 'status' => ServiceStatus::STOPPED]);
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+    }
+
+    private function createService(string $type, string $name, ServiceStatus $status): Service
+    {
+        /** @var Service $service */
+        $service = $this->server->services()->create([
+            'type' => $type,
+            'name' => $name,
+            'version' => 'latest',
+            'status' => $status,
+        ]);
+
+        return $service;
+    }
+}

--- a/tests/Unit/Actions/Service/CheckServiceStatusesTest.php
+++ b/tests/Unit/Actions/Service/CheckServiceStatusesTest.php
@@ -9,6 +9,7 @@ use App\Events\SocketEvent;
 use App\Facades\SSH;
 use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
@@ -121,6 +122,41 @@ class CheckServiceStatusesTest extends TestCase
         $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::STOPPED]);
         $this->assertDatabaseHas('services', ['id' => $mysql->id, 'status' => ServiceStatus::STOPPED]);
         Event::assertNotDispatched(ServiceStatusChanged::class);
+    }
+
+    public function test_skips_check_while_server_is_locked(): void
+    {
+        SSH::fake('inactive');
+        Event::fake([ServiceStatusChanged::class]);
+
+        $this->server->services()->delete();
+        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::READY);
+
+        $lock = Cache::lock("unique-queue:server-{$this->server->id}", 60);
+        $this->assertTrue($lock->get());
+
+        app(CheckServiceStatuses::class)->check($this->server);
+
+        SSH::assertNotExecutedContains('is-active');
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+
+        $lock->release();
+    }
+
+    public function test_releases_lock_after_check(): void
+    {
+        SSH::fake('active');
+        Event::fake([ServiceStatusChanged::class]);
+
+        $this->server->services()->delete();
+        $this->createService('webserver', 'nginx', ServiceStatus::READY);
+
+        app(CheckServiceStatuses::class)->check($this->server);
+
+        $lock = Cache::lock("unique-queue:server-{$this->server->id}", 60);
+        $this->assertTrue($lock->get());
+        $lock->release();
     }
 
     private function createService(string $type, string $name, ServiceStatus $status): Service

--- a/tests/Unit/Actions/Service/CheckServiceStatusesTest.php
+++ b/tests/Unit/Actions/Service/CheckServiceStatusesTest.php
@@ -9,7 +9,6 @@ use App\Events\SocketEvent;
 use App\Facades\SSH;
 use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
@@ -27,6 +26,7 @@ class CheckServiceStatusesTest extends TestCase
         $mysql = $this->createService('database', 'mysql', ServiceStatus::READY);
         $redis = $this->createService('memory_database', 'redis', ServiceStatus::STOPPED);
 
+        app(CheckServiceStatuses::class)->check($this->server);
         app(CheckServiceStatuses::class)->check($this->server);
 
         $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
@@ -124,7 +124,42 @@ class CheckServiceStatusesTest extends TestCase
         Event::assertNotDispatched(ServiceStatusChanged::class);
     }
 
-    public function test_skips_check_while_server_is_locked(): void
+    public function test_single_inactive_reading_does_not_change_status(): void
+    {
+        SSH::fake('inactive');
+        Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
+
+        $this->server->services()->delete();
+        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::READY);
+
+        app(CheckServiceStatuses::class)->check($this->server);
+
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+        Event::assertNotDispatched(SocketEvent::class);
+    }
+
+    public function test_restart_flap_does_not_change_status(): void
+    {
+        Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
+
+        $this->server->services()->delete();
+        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::READY);
+
+        SSH::fake('inactive');
+        app(CheckServiceStatuses::class)->check($this->server);
+
+        SSH::fake('active');
+        app(CheckServiceStatuses::class)->check($this->server);
+
+        SSH::fake('inactive');
+        app(CheckServiceStatuses::class)->check($this->server);
+
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+        Event::assertNotDispatched(ServiceStatusChanged::class);
+    }
+
+    public function test_two_consecutive_inactive_readings_change_status(): void
     {
         SSH::fake('inactive');
         Event::fake([ServiceStatusChanged::class]);
@@ -132,31 +167,25 @@ class CheckServiceStatusesTest extends TestCase
         $this->server->services()->delete();
         $nginx = $this->createService('webserver', 'nginx', ServiceStatus::READY);
 
-        $lock = Cache::lock("unique-queue:server-{$this->server->id}", 60);
-        $this->assertTrue($lock->get());
-
+        app(CheckServiceStatuses::class)->check($this->server);
         app(CheckServiceStatuses::class)->check($this->server);
 
-        SSH::assertNotExecutedContains('is-active');
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
-        Event::assertNotDispatched(ServiceStatusChanged::class);
-
-        $lock->release();
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::STOPPED]);
+        Event::assertDispatchedTimes(ServiceStatusChanged::class, 1);
     }
 
-    public function test_releases_lock_after_check(): void
+    public function test_recovery_to_active_applies_immediately(): void
     {
         SSH::fake('active');
         Event::fake([ServiceStatusChanged::class]);
 
         $this->server->services()->delete();
-        $this->createService('webserver', 'nginx', ServiceStatus::READY);
+        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::STOPPED);
 
         app(CheckServiceStatuses::class)->check($this->server);
 
-        $lock = Cache::lock("unique-queue:server-{$this->server->id}", 60);
-        $this->assertTrue($lock->get());
-        $lock->release();
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+        Event::assertDispatchedTimes(ServiceStatusChanged::class, 1);
     }
 
     private function createService(string $type, string $name, ServiceStatus $status): Service

--- a/tests/Unit/Actions/Service/CheckServiceStatusesTest.php
+++ b/tests/Unit/Actions/Service/CheckServiceStatusesTest.php
@@ -82,7 +82,7 @@ class CheckServiceStatusesTest extends TestCase
         $this->createService('webserver', 'nginx', ServiceStatus::INSTALLING);
         $this->createService('nodejs', 'nodejs', ServiceStatus::READY);
         $this->createService('log_analysis', 'goaccess', ServiceStatus::READY);
-        $mysql = $this->createService('database', 'mysql', ServiceStatus::READY);
+        $mysql = $this->createService('database', 'mysql', ServiceStatus::STOPPED);
 
         app(CheckServiceStatuses::class)->check($this->server);
 
@@ -90,8 +90,9 @@ class CheckServiceStatusesTest extends TestCase
         SSH::assertNotExecutedContains('nginx');
         SSH::assertNotExecutedContains('nodejs');
         SSH::assertNotExecutedContains('goaccess');
+        SSH::assertNotExecutedContains("''");
         $this->assertDatabaseHas('services', ['id' => $mysql->id, 'status' => ServiceStatus::READY]);
-        Event::assertNotDispatched(ServiceStatusChanged::class);
+        Event::assertDispatchedTimes(ServiceStatusChanged::class, 1);
     }
 
     public function test_skips_ssh_when_no_pollable_services(): void

--- a/tests/Unit/Actions/Service/InstallTest.php
+++ b/tests/Unit/Actions/Service/InstallTest.php
@@ -5,7 +5,10 @@ namespace Tests\Unit\Actions\Service;
 use App\Actions\Service\Install;
 use App\Enums\ServiceStatus;
 use App\Facades\SSH;
+use App\Jobs\Service\UpdateVitoAgentConfigJob;
+use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Validation\ValidationException;
 use Tests\TestCase;
@@ -167,6 +170,119 @@ class InstallTest extends TestCase
             'server_id' => $this->server->id,
             'name' => 'redis',
             'type' => 'memory_database',
+            'version' => 'latest',
+            'status' => ServiceStatus::READY,
+        ]);
+    }
+
+    public function test_installing_service_dispatches_agent_config_update(): void
+    {
+        SSH::fake('Active: active');
+        Bus::fake([UpdateVitoAgentConfigJob::class]);
+
+        $this->createVitoAgent();
+        $this->server->memoryDatabase()->delete();
+
+        app(Install::class)->install($this->server, [
+            'type' => 'memory_database',
+            'name' => 'redis',
+            'version' => 'latest',
+        ]);
+
+        Bus::assertDispatched(UpdateVitoAgentConfigJob::class);
+    }
+
+    public function test_installing_service_without_unit_does_not_dispatch_agent_config_update(): void
+    {
+        SSH::fake('Active: active');
+        Bus::fake([UpdateVitoAgentConfigJob::class]);
+
+        $this->createVitoAgent();
+        $this->server->services()->where('name', 'nodejs')->delete();
+
+        app(Install::class)->install($this->server, [
+            'type' => 'nodejs',
+            'name' => 'nodejs',
+            'version' => '20',
+        ]);
+
+        Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
+    }
+
+    public function test_failed_install_does_not_dispatch_agent_config_update(): void
+    {
+        SSH::fake('inactive');
+        Bus::fake([UpdateVitoAgentConfigJob::class]);
+
+        $this->createVitoAgent();
+        $this->server->memoryDatabase()->delete();
+
+        app(Install::class)->install($this->server, [
+            'type' => 'memory_database',
+            'name' => 'redis',
+            'version' => 'latest',
+        ]);
+
+        $this->assertDatabaseHas('services', [
+            'server_id' => $this->server->id,
+            'name' => 'redis',
+            'status' => ServiceStatus::INSTALLATION_FAILED,
+        ]);
+        Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
+    }
+
+    public function test_installing_service_without_vito_agent_does_not_dispatch_agent_config_update(): void
+    {
+        SSH::fake('Active: active');
+        Bus::fake([UpdateVitoAgentConfigJob::class]);
+
+        $this->server->memoryDatabase()->delete();
+
+        app(Install::class)->install($this->server, [
+            'type' => 'memory_database',
+            'name' => 'redis',
+            'version' => 'latest',
+        ]);
+
+        Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
+    }
+
+    public function test_installing_vito_agent_writes_config_with_services(): void
+    {
+        SSH::fake('Active: active');
+        Bus::fake([UpdateVitoAgentConfigJob::class]);
+        Http::fake([
+            'https://api.github.com/repos/vitodeploy/agent/tags' => Http::response([['name' => '0.1.0']]),
+        ]);
+
+        $this->server->monitoring()?->delete();
+
+        app(Install::class)->install($this->server, [
+            'type' => 'monitoring',
+            'name' => 'vito-agent',
+            'version' => 'latest',
+        ]);
+
+        $config = json_decode(SSH::getUploadedContent(), true);
+        $this->assertNotEmpty($config['url']);
+        $this->assertNotEmpty($config['secret']);
+        $this->assertArrayNotHasKey('data_retention', $config);
+        $this->assertContains('nginx', array_column($config['services'], 'unit'));
+
+        Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
+    }
+
+    private function createVitoAgent(): void
+    {
+        Service::factory()->create([
+            'server_id' => $this->server->id,
+            'name' => 'vito-agent',
+            'type' => 'monitoring',
+            'type_data' => [
+                'url' => 'https://vito.test/agent-endpoint',
+                'secret' => 'agent-secret',
+                'data_retention' => 7,
+            ],
             'version' => 'latest',
             'status' => ServiceStatus::READY,
         ]);

--- a/tests/Unit/Actions/Service/UninstallTest.php
+++ b/tests/Unit/Actions/Service/UninstallTest.php
@@ -5,10 +5,12 @@ namespace Tests\Unit\Actions\Service;
 use App\Actions\Service\Uninstall;
 use App\Enums\ServiceStatus;
 use App\Facades\SSH;
+use App\Jobs\Service\UpdateVitoAgentConfigJob;
 use App\Models\Database;
 use App\Models\Service;
 use App\Models\Worker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Validation\ValidationException;
 use Tests\TestCase;
 
@@ -35,6 +37,52 @@ class UninstallTest extends TestCase
         $this->assertDatabaseMissing('services', [
             'id' => $service->id,
         ]);
+    }
+
+    public function test_uninstalling_service_dispatches_agent_config_update(): void
+    {
+        SSH::fake();
+        Bus::fake([UpdateVitoAgentConfigJob::class]);
+
+        Service::factory()->create([
+            'server_id' => $this->server->id,
+            'name' => 'vito-agent',
+            'type' => 'monitoring',
+            'type_data' => [
+                'url' => 'https://vito.test/agent-endpoint',
+                'secret' => 'agent-secret',
+                'data_retention' => 7,
+            ],
+            'version' => 'latest',
+            'status' => ServiceStatus::READY,
+        ]);
+
+        $redis = $this->server->services()->where('name', 'redis')->firstOrFail();
+
+        app(Uninstall::class)->uninstall($redis);
+
+        $this->assertDatabaseMissing('services', ['id' => $redis->id]);
+        Bus::assertDispatched(UpdateVitoAgentConfigJob::class);
+    }
+
+    public function test_uninstalling_vito_agent_does_not_dispatch_agent_config_update(): void
+    {
+        SSH::fake();
+        Bus::fake([UpdateVitoAgentConfigJob::class]);
+
+        $this->server->monitoring()?->delete();
+
+        Service::factory()->create([
+            'server_id' => $this->server->id,
+            'name' => 'vito-agent',
+            'type' => 'monitoring',
+            'version' => 'latest',
+            'status' => ServiceStatus::READY,
+        ]);
+
+        app(Uninstall::class)->uninstall($this->server->monitoring());
+
+        Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
     }
 
     /**

--- a/tests/Unit/Commands/GetMetricsCommandTest.php
+++ b/tests/Unit/Commands/GetMetricsCommandTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Unit\Commands;
 
 use App\Enums\ServiceStatus;
+use App\Events\ServiceStatusChanged;
 use App\Facades\SSH;
 use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
 class GetMetricsCommandTest extends TestCase
@@ -70,6 +72,38 @@ class GetMetricsCommandTest extends TestCase
             'oom_kill_count' => 3,
             'cpu_per_core_usage_percent' => null,
         ]);
+    }
+
+    public function test_checks_service_statuses(): void
+    {
+        SSH::fake('active');
+        Event::fake([ServiceStatusChanged::class]);
+
+        $this->server->services()->delete();
+        Service::factory()->create([
+            'server_id' => $this->server->id,
+            'name' => 'remote-monitor',
+            'type' => 'monitoring',
+            'type_data' => [
+                'data_retention' => 7,
+            ],
+            'version' => 'latest',
+            'status' => ServiceStatus::READY,
+        ]);
+        $nginx = $this->server->services()->create([
+            'type' => 'webserver',
+            'name' => 'nginx',
+            'version' => 'latest',
+            'status' => ServiceStatus::STOPPED,
+        ]);
+
+        $this->artisan('metrics:get')->assertSuccessful();
+
+        SSH::assertExecutedContains('is-active');
+        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+        Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $nginx->id
+            && $event->previousStatus === ServiceStatus::STOPPED
+            && $event->newStatus === ServiceStatus::READY);
     }
 
     public function test_get_metrics_with_missing_extended_fields(): void

--- a/tests/Unit/Jobs/UpdateVitoAgentConfigJobTest.php
+++ b/tests/Unit/Jobs/UpdateVitoAgentConfigJobTest.php
@@ -19,12 +19,20 @@ class UpdateVitoAgentConfigJobTest extends TestCase
         SSH::fake();
 
         $agent = $this->createAgent(ServiceStatus::READY);
+        $this->server->services()->create([
+            'type' => 'log_analysis',
+            'name' => 'goaccess',
+            'version' => 'latest',
+            'status' => ServiceStatus::READY,
+        ]);
 
         dispatch(new UpdateVitoAgentConfigJob($this->server));
 
         SSH::assertExecutedContains('/etc/vito-agent/config.json');
         SSH::assertExecutedContains('&& rm -f /tmp/');
         SSH::assertExecutedContains('chmod 600 /etc/vito-agent/config.json');
+        SSH::assertExecutedContains('Monitoring services: ');
+        SSH::assertNotExecutedContains('agent-secret');
         SSH::assertExecutedContains('restart vito-agent');
 
         $config = json_decode(SSH::getUploadedContent(), true);
@@ -40,6 +48,7 @@ class UpdateVitoAgentConfigJobTest extends TestCase
         $this->assertContains('ufw', $units);
         $this->assertContains('supervisor', $units);
         $this->assertContains('redis-server', $units);
+        $this->assertNotContains('', $units);
         $this->assertArrayNotHasKey($agent->id, $units);
     }
 

--- a/tests/Unit/Jobs/UpdateVitoAgentConfigJobTest.php
+++ b/tests/Unit/Jobs/UpdateVitoAgentConfigJobTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Unit\Jobs;
+
+use App\Enums\ServiceStatus;
+use App\Facades\SSH;
+use App\Jobs\Service\UpdateVitoAgentConfigJob;
+use App\Models\Service;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UpdateVitoAgentConfigJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_updates_config_and_restarts_agent(): void
+    {
+        SSH::fake();
+
+        $agent = $this->createAgent(ServiceStatus::READY);
+
+        dispatch(new UpdateVitoAgentConfigJob($this->server));
+
+        SSH::assertExecutedContains('/etc/vito-agent/config.json');
+        SSH::assertExecutedContains('&& rm -f /tmp/');
+        SSH::assertExecutedContains('restart vito-agent');
+
+        $config = json_decode(SSH::getUploadedContent(), true);
+        $this->assertSame('https://vito.test/agent-endpoint', $config['url']);
+        $this->assertSame('agent-secret', $config['secret']);
+        $this->assertArrayNotHasKey('data_retention', $config);
+
+        $units = array_column($config['services'], 'unit', 'id');
+        $this->assertCount(6, $units);
+        $this->assertContains('nginx', $units);
+        $this->assertContains('mysql', $units);
+        $this->assertContains('php8.2-fpm', $units);
+        $this->assertContains('ufw', $units);
+        $this->assertContains('supervisor', $units);
+        $this->assertContains('redis-server', $units);
+        $this->assertArrayNotHasKey($agent->id, $units);
+    }
+
+    public function test_does_nothing_without_vito_agent(): void
+    {
+        SSH::fake();
+
+        dispatch(new UpdateVitoAgentConfigJob($this->server));
+
+        SSH::assertNotExecutedContains('vito-agent');
+        $this->assertSame('', SSH::getUploadedContent());
+    }
+
+    public function test_does_nothing_when_agent_is_not_ready(): void
+    {
+        SSH::fake();
+
+        $this->createAgent(ServiceStatus::STOPPED);
+
+        dispatch(new UpdateVitoAgentConfigJob($this->server));
+
+        SSH::assertNotExecutedContains('restart vito-agent');
+        $this->assertSame('', SSH::getUploadedContent());
+    }
+
+    private function createAgent(ServiceStatus $status): Service
+    {
+        /** @var Service $service */
+        $service = Service::factory()->create([
+            'server_id' => $this->server->id,
+            'name' => 'vito-agent',
+            'type' => 'monitoring',
+            'type_data' => [
+                'url' => 'https://vito.test/agent-endpoint',
+                'secret' => 'agent-secret',
+                'data_retention' => 7,
+            ],
+            'version' => 'latest',
+            'status' => $status,
+        ]);
+
+        return $service;
+    }
+}

--- a/tests/Unit/Jobs/UpdateVitoAgentConfigJobTest.php
+++ b/tests/Unit/Jobs/UpdateVitoAgentConfigJobTest.php
@@ -23,6 +23,7 @@ class UpdateVitoAgentConfigJobTest extends TestCase
 
         SSH::assertExecutedContains('/etc/vito-agent/config.json');
         SSH::assertExecutedContains('&& rm -f /tmp/');
+        SSH::assertExecutedContains('chmod 600 /etc/vito-agent/config.json');
         SSH::assertExecutedContains('restart vito-agent');
 
         $config = json_decode(SSH::getUploadedContent(), true);

--- a/tests/Unit/Jobs/UpdateVitoAgentConfigJobTest.php
+++ b/tests/Unit/Jobs/UpdateVitoAgentConfigJobTest.php
@@ -7,6 +7,7 @@ use App\Facades\SSH;
 use App\Jobs\Service\UpdateVitoAgentConfigJob;
 use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
 class UpdateVitoAgentConfigJobTest extends TestCase
@@ -62,6 +63,26 @@ class UpdateVitoAgentConfigJobTest extends TestCase
 
         SSH::assertNotExecutedContains('restart vito-agent');
         $this->assertSame('', SSH::getUploadedContent());
+    }
+
+    public function test_dispatch_for_never_throws_into_the_calling_job(): void
+    {
+        Queue::fake();
+
+        $this->createAgent(ServiceStatus::READY);
+        config()->set('service.services.broken.handler', 'App\Services\DoesNotExist');
+
+        /** @var Service $broken */
+        $broken = $this->server->services()->create([
+            'type' => 'broken',
+            'name' => 'broken',
+            'version' => 'latest',
+            'status' => ServiceStatus::READY,
+        ]);
+
+        UpdateVitoAgentConfigJob::dispatchFor($broken);
+
+        Queue::assertNotPushed(UpdateVitoAgentConfigJob::class);
     }
 
     private function createAgent(ServiceStatus $status): Service


### PR DESCRIPTION
Service status updates are a cheap addition (very minor overhead) that can be added to the metrics:get polling and vito-agent stats collection process.   This PR ensures full backwards compatibility with the current vito agent. 

Companion PR: https://github.com/vitodeploy/agent/pull/4

You can test by updating `app/Services/Monitoring/VitoAgent/VitoAgent.php` with the following;
```
class VitoAgent extends AbstractService
{
    const string TAGS_URL = 'https://api.github.com/repos/RichardAnderson/vito-agent/tags';

    const string DOWNLOAD_URL = 'https://github.com/RichardAnderson/vito-agent/releases/download/%s';
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **New Features**
  * Service statuses can now be synchronised from submitted service readings, using confirmed transitions to minimise restart flapping.
  * Service status changes emit real-time updates to the event system and socket notifications.
  * Vito Agent configuration is automatically updated after successful service installs and removals.
* **Bug Fixes**
  * Service secrets are redacted from API responses.
  * SSH file updates now clean up temporary remote files.
* **Chores**
  * The scheduled metrics job is now prevented from overlapping runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->