### PR TITLE
[Fix] Use Cobertura for cover-diffs in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Run test suite with coverage
         if: github.event_name == 'pull_request'
-        run: php artisan test --parallel --coverage-clover=build/logs/clover.xml
+        run: php artisan test --parallel --coverage-cobertura=build/logs/cobertura.xml
 
       - name: Setup Python
         if: github.event_name == 'pull_request'
@@ -104,7 +104,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          diff-cover build/logs/clover.xml \
+          diff-cover build/logs/cobertura.xml \
             --compare-branch="origin/$BASE_REF" \
             --fail-under=75 \
             --markdown-report=build/diff-cover.md

--- a/composer.json
+++ b/composer.json
@@ -89,15 +89,15 @@
     ],
     "test:coverage": [
       "@putenv XDEBUG_MODE=coverage",
-      "@php artisan test --parallel --coverage --coverage-clover=build/logs/clover.xml"
+      "@php artisan test --parallel --coverage --coverage-cobertura=build/logs/cobertura.xml"
     ],
-    "test:coverage:herd": "herd coverage php artisan test --parallel --coverage --coverage-clover=build/logs/clover.xml",
+    "test:coverage:herd": "herd coverage php artisan test --parallel --coverage --coverage-cobertura=build/logs/cobertura.xml",
     "test:coverage:lerd": [
       "@putenv XDEBUG_MODE=coverage",
-      "lerd artisan test --parallel --coverage --coverage-clover=build/logs/clover.xml"
+      "lerd artisan test --parallel --coverage --coverage-cobertura=build/logs/cobertura.xml"
     ],
-    "test:coverage:yerd": "phpcover artisan test --parallel --coverage --coverage-clover=build/logs/clover.xml",
-    "coverage:diff": "diff-cover build/logs/clover.xml --compare-branch=origin/4.x --fail-under=75",
+    "test:coverage:yerd": "phpcover artisan test --parallel --coverage --coverage-cobertura=build/logs/cobertura.xml",
+    "coverage:diff": "diff-cover build/logs/cobertura.xml --compare-branch=origin/4.x --fail-under=75",
     "test:coverage-diff": [
       "@test:coverage",
       "@coverage:diff"


### PR DESCRIPTION
This pull request updates the test coverage reporting format throughout the project, switching from Clover XML to Cobertura XML. This change ensures consistency in how coverage data is generated and consumed by various tools in both the GitHub Actions workflow and local scripts.

@coderabbitai ignore