### PR TITLE
[Fix] use dynamic architecture in APT source list

### DIFF
--- a/resources/views/ssh/mise/ensure-installed.blade.php
+++ b/resources/views/ssh/mise/ensure-installed.blade.php
@@ -7,7 +7,8 @@ fi
 sudo apt update -y && sudo apt install -y curl
 sudo install -dm 755 /etc/apt/keyrings
 curl -fsSL https://mise.jdx.dev/gpg-key.pub | sudo tee /etc/apt/keyrings/mise-archive-keyring.pub 1> /dev/null
-echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.pub arch=amd64] https://mise.jdx.dev/deb stable main" | sudo tee /etc/apt/sources.list.d/mise.list
+ARCH=$(dpkg --print-architecture)
+echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.pub arch=${ARCH}] https://mise.jdx.dev/deb stable main" | sudo tee /etc/apt/sources.list.d/mise.list
 sudo apt update
 sudo apt install -y mise
 


### PR DESCRIPTION
I was trying to install this on my Hetzner machine that uses arm instead of amd64, so site installations have been failing, I think it's better to dynamically request according to the current arch.

On ARM64, apt will reject this because there are no amd64 packages available for that architecture. The install silently fails and the SSH command exits with an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation support for systems using Debian architectures other than AMD64.
  * The apt repository configuration now detects the system architecture automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->