### PR TITLE
[Fix] Wait for cloud-init and apt

### DIFF
--- a/app/Actions/Server/InstallServer.php
+++ b/app/Actions/Server/InstallServer.php
@@ -54,6 +54,8 @@ class InstallServer
      */
     public function install(): void
     {
+        $this->progress(5, 'preparing-system');
+        $this->server->os()->waitForBoot();
         $this->createUser();
         $this->progress(15, 'installing-updates');
         $this->server->os()->upgrade();

--- a/app/SSH/OS/OS.php
+++ b/app/SSH/OS/OS.php
@@ -26,6 +26,19 @@ class OS
     /**
      * @throws SSHError
      */
+    public function waitForBoot(int $timeout = 300): void
+    {
+        $this->server->ssh()->exec(
+            view('ssh.os.wait-for-boot', [
+                'timeout' => $timeout,
+            ]),
+            'wait-for-boot'
+        );
+    }
+
+    /**
+     * @throws SSHError
+     */
     public function installDependencies(): void
     {
         $this->server->ssh()->exec(

--- a/resources/views/ssh/os/wait-for-boot.blade.php
+++ b/resources/views/ssh/os/wait-for-boot.blade.php
@@ -1,11 +1,14 @@
 echo "Waiting for cloud-init and apt to finish first-boot tasks..."
 
 if command -v cloud-init >/dev/null 2>&1; then
-    sudo timeout {{ $timeout }} cloud-init status --wait >/dev/null 2>&1
-    __vito_ci_exit=$?
-    if [ "$__vito_ci_exit" -eq 124 ]; then
-        echo "Timed out after {{ $timeout }}s waiting for cloud-init to finish." >&2
-        exit 1
+    __vito_ci_state=$(sudo cloud-init status 2>/dev/null | awk '/^status:/ {print $2; exit}')
+    if [ "$__vito_ci_state" = "running" ]; then
+        __vito_ci_exit=0
+        sudo timeout {{ $timeout }} cloud-init status --wait >/dev/null 2>&1 || __vito_ci_exit=$?
+        if [ "$__vito_ci_exit" -eq 124 ]; then
+            echo "Timed out after {{ $timeout }}s waiting for cloud-init to finish." >&2
+            exit 1
+        fi
     fi
 fi
 
@@ -20,6 +23,8 @@ if command -v fuser >/dev/null 2>&1; then
         echo "apt/dpkg is locked by another process, waiting..."
         sleep 10
     done
+else
+    echo "fuser not available; unable to wait for apt/dpkg locks (install psmisc to enable)." >&2
 fi
 
 echo "System is ready for provisioning."

--- a/resources/views/ssh/os/wait-for-boot.blade.php
+++ b/resources/views/ssh/os/wait-for-boot.blade.php
@@ -1,0 +1,20 @@
+echo "Waiting for cloud-init and apt to finish first-boot tasks..."
+
+if command -v cloud-init >/dev/null 2>&1; then
+    sudo cloud-init status --wait >/dev/null 2>&1 || true
+fi
+
+if command -v fuser >/dev/null 2>&1; then
+    __vito_wait_start=$(date +%s)
+    __vito_timeout={{ $timeout }}
+    while sudo fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; do
+        if [ "$(( $(date +%s) - __vito_wait_start ))" -ge "$__vito_timeout" ]; then
+            echo "Timed out after ${__vito_timeout}s waiting for apt/dpkg locks; continuing."
+            break
+        fi
+        echo "apt/dpkg is locked by another process, waiting..."
+        sleep 10
+    done
+fi
+
+echo "System is ready for provisioning."

--- a/resources/views/ssh/os/wait-for-boot.blade.php
+++ b/resources/views/ssh/os/wait-for-boot.blade.php
@@ -1,7 +1,12 @@
 echo "Waiting for cloud-init and apt to finish first-boot tasks..."
 
 if command -v cloud-init >/dev/null 2>&1; then
-    sudo cloud-init status --wait >/dev/null 2>&1 || true
+    sudo timeout {{ $timeout }} cloud-init status --wait >/dev/null 2>&1
+    __vito_ci_exit=$?
+    if [ "$__vito_ci_exit" -eq 124 ]; then
+        echo "Timed out after {{ $timeout }}s waiting for cloud-init to finish." >&2
+        exit 1
+    fi
 fi
 
 if command -v fuser >/dev/null 2>&1; then
@@ -9,8 +14,8 @@ if command -v fuser >/dev/null 2>&1; then
     __vito_timeout={{ $timeout }}
     while sudo fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; do
         if [ "$(( $(date +%s) - __vito_wait_start ))" -ge "$__vito_timeout" ]; then
-            echo "Timed out after ${__vito_timeout}s waiting for apt/dpkg locks; continuing."
-            break
+            echo "Timed out after ${__vito_timeout}s waiting for apt/dpkg locks to be released." >&2
+            exit 1
         fi
         echo "apt/dpkg is locked by another process, waiting..."
         sleep 10


### PR DESCRIPTION
Wait for cloud-init and apt locks to clear before provisioning starts, so new servers (notably DigitalOcean) no longer fail with "Could not get lock /var/cache/apt/archives/lock".

Closes #1205

New command executed at the start:
<img width="1033" height="630" alt="image" src="https://github.com/user-attachments/assets/7337decc-e691-45b0-9e28-97d9eb8066b7" />

Server continues past the upgrade process:
<img width="1010" height="398" alt="image" src="https://github.com/user-attachments/assets/bb057718-2097-4760-8bce-3dbf37bcf898" />

DO 1CPU/1GB RAM VPS provisions successfully (where it previously failed):
<img width="1047" height="590" alt="image" src="https://github.com/user-attachments/assets/47734d2d-dc24-4d41-8e86-b0089ace9108" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server installation now advances to **“preparing-system”** and then waits for the operating system to complete initial boot readiness.
  * Provisioning now pauses until first-boot prerequisites finish, including:
    * waiting for `cloud-init` when it’s in the running state, and
    * waiting for package manager lock releases (via `fuser`).
  * Added timeout-based safeguards for both boot readiness and provisioning checks, with clear error messaging when limits are exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->