### PR TITLE
[Feat] Migrate test suite to Pest 5

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -99,7 +99,7 @@ reviews:
 
     - path: "tests/**"
       instructions: |
-        - PHPUnit 12 only. `RefreshDatabase` trait, factories, `assertDatabaseHas()` for DB assertions.
+        - Pest 5 only. `RefreshDatabase` trait, factories, `assertDatabaseHas()` for DB assertions.
         - `TestCase` provides `$this->user`, `$this->server`, `$this->site` pre-configured.
         - Use `SSH::fake()` for SSH and `Http::fake()` for HTTP — never real connections.
         - Don't over-test trivial logic that PHP handles natively. Flag removed tests.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Copilot Instructions — Vito
 
-Vito is a self-hosted server management tool. Stack: Laravel 13 (L10 structure), PHP 8.4, Inertia v2, React 19, Tailwind v4, PHPUnit 12.
+Vito is a self-hosted server management tool. Stack: Laravel 13 (L10 structure), PHP 8.4, Inertia v2, React 19, Tailwind v4, Pest 5 / PHPUnit 13.
 
 ## Architecture
 
@@ -30,7 +30,7 @@ Vito is a self-hosted server management tool. Stack: Laravel 13 (L10 structure),
 
 ## Testing
 
-- PHPUnit only. `RefreshDatabase` trait. Use factories.
+- Pest 5 only. `RefreshDatabase` trait. Use factories.
 - `TestCase` provides `$this->user`, `$this->server`, `$this->site` with services pre-configured.
 - Use `SSH::fake()` for SSH operations, `Http::fake()` for HTTP calls.
 - Don't over-test trivial logic that PHP handles natively.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 
 ## Stack
 
-Laravel 13 (L10 structure), PHP 8.4, Inertia v2, React 19, Tailwind v4, PHPUnit 12
+Laravel 13 (L10 structure), PHP 8.4, Inertia v2, React 19, Tailwind v4, Pest 5 / PHPUnit 13
 
 ## Laravel Boost MCP Tools
 
@@ -78,7 +78,7 @@ Vito has a specific architecture. Match these patterns exactly:
 
 ## Testing
 
-- PHPUnit only. Create with `php artisan make:test --phpunit`.
+- Pest 5 only. Create with `php artisan make:test --pest`.
 - `TestCase` provides `$this->user`, `$this->server`, `$this->site` pre-configured.
 - Test logic only, not framework. Use factories. RefreshDatabase trait.
 - Add to existing test files when possible. Run minimal tests with `--filter`.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ bash <(curl -Ls https://raw.githubusercontent.com/vitodeploy/vito/4.x/scripts/in
 - ReactJS
 - Shadcn UI
 - PHPSecLib
-- PHPUnit
+- Pest
 - Tailwindcss
 - Vite
 - Prettier

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
     "tightenco/ziggy": "^2.5"
   },
   "require-dev": {
-    "brianium/paratest": "^7.8.5",
     "fakerphp/faker": "^1.9.1",
     "larastan/larastan": "^3.1",
     "laravel/boost": "^2.0",
@@ -41,7 +40,8 @@
     "laravel/sail": "^1.18",
     "mockery/mockery": "^1.4.4",
     "nunomaduro/collision": "^8.1",
-    "phpunit/phpunit": "^12.0",
+    "pestphp/pest": "^5.0",
+    "pestphp/pest-plugin-laravel": "^5.0",
     "rector/rector": "^2.0",
     "spatie/laravel-ignition": "^2.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "787bd34e897cb164197d01155f2ea829",
+    "content-hash": "ffa2c365bbb1da4e8d29787360bf8d98",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1060,26 +1060,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.12.1",
+            "version": "7.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425"
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d34627490fbc03bf5c5d7cfed81f2faa19519425",
-                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.12.1",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -1087,8 +1087,8 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.5.1",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -1168,7 +1168,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.12.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
             },
             "funding": [
                 {
@@ -1184,20 +1184,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-18T14:12:49+00:00"
+            "time": "2026-07-26T23:23:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
                 "shasum": ""
             },
             "require": {
@@ -1252,7 +1252,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
             },
             "funding": [
                 {
@@ -1268,20 +1268,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:23:43+00:00"
+            "time": "2026-07-08T15:48:39+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.1",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
-                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
@@ -1290,7 +1290,7 @@
                 "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -1371,7 +1371,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -1387,7 +1387,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-18T09:49:37+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -1614,20 +1614,20 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v13.16.1",
+            "version": "v13.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "6135650d69bd9442e470bb1b343422081b076f1e"
+                "reference": "92a707229148e57f08a249211c8a5a194159c619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/6135650d69bd9442e470bb1b343422081b076f1e",
-                "reference": "6135650d69bd9442e470bb1b343422081b076f1e",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/92a707229148e57f08a249211c8a5a194159c619",
+                "reference": "92a707229148e57f08a249211c8a5a194159c619",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.14.2 || ^0.15 || ^0.16 || ^0.17",
+                "brick/math": "^0.14.2 || ^0.15 || ^0.16 || ^0.17 || ^0.18",
                 "composer-runtime-api": "^2.2",
                 "doctrine/inflector": "^2.0.5",
                 "dragonmantank/cron-expression": "^3.4",
@@ -1649,7 +1649,7 @@
                 "league/flysystem": "^3.25.1",
                 "league/flysystem-local": "^3.25.1",
                 "league/uri": "^7.5.1",
-                "monolog/monolog": "^3.0",
+                "monolog/monolog": "^3.10",
                 "nesbot/carbon": "^3.8.4",
                 "nunomaduro/termwind": "^2.0",
                 "php": "^8.3",
@@ -1702,6 +1702,7 @@
                 "illuminate/filesystem": "self.version",
                 "illuminate/hashing": "self.version",
                 "illuminate/http": "self.version",
+                "illuminate/image": "self.version",
                 "illuminate/json-schema": "self.version",
                 "illuminate/log": "self.version",
                 "illuminate/macroable": "self.version",
@@ -1728,6 +1729,7 @@
                 "ext-gmp": "*",
                 "fakerphp/faker": "^1.24",
                 "guzzlehttp/psr7": "^2.9",
+                "intervention/image": "^4.0",
                 "laravel/pint": "^1.18",
                 "league/flysystem-aws-s3-v3": "^3.25.1",
                 "league/flysystem-ftp": "^3.25.1",
@@ -1764,6 +1766,7 @@
                 "ext-redis": "Required to use the Redis cache and queue drivers (^4.0 || ^5.0 || ^6.0).",
                 "fakerphp/faker": "Required to generate fake data using the fake() helper (^1.23).",
                 "filp/whoops": "Required for friendly error pages in development (^2.14.3).",
+                "intervention/image": "Required to use the image processing features (^4.0).",
                 "laravel/tinker": "Required to use the tinker console command (^2.0).",
                 "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.25.1).",
                 "league/flysystem-ftp": "Required to use the Flysystem FTP driver (^3.25.1).",
@@ -1834,7 +1837,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-06-16T16:07:50+00:00"
+            "time": "2026-07-27T14:48:58+00:00"
         },
         {
             "name": "laravel/horizon",
@@ -3402,20 +3405,19 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.7.0",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -3454,9 +3456,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-12-06T11:56:16+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -5856,16 +5858,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v8.1.0",
+            "version": "v8.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f5a856c6ecb56b3c21ed94a5b7bf940d857d110a"
+                "reference": "535e18a1b8925f6c01a55b171d157ab66c2ace15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f5a856c6ecb56b3c21ed94a5b7bf940d857d110a",
-                "reference": "f5a856c6ecb56b3c21ed94a5b7bf940d857d110a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/535e18a1b8925f6c01a55b171d157ab66c2ace15",
+                "reference": "535e18a1b8925f6c01a55b171d157ab66c2ace15",
                 "shasum": ""
             },
             "require": {
@@ -5932,7 +5934,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v8.1.0"
+                "source": "https://github.com/symfony/console/tree/v8.1.2"
             },
             "funding": [
                 {
@@ -5952,7 +5954,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-07-27T13:58:19+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -9341,16 +9343,16 @@
     "packages-dev": [
         {
             "name": "brianium/paratest",
-            "version": "v7.20.0",
+            "version": "v7.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paratestphp/paratest.git",
-                "reference": "81c80677c9ec0ed4ef16b246167f11dec81a6e3d"
+                "reference": "6b2aaf7d0e8d5220710d78921f28e5464a816596"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/81c80677c9ec0ed4ef16b246167f11dec81a6e3d",
-                "reference": "81c80677c9ec0ed4ef16b246167f11dec81a6e3d",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/6b2aaf7d0e8d5220710d78921f28e5464a816596",
+                "reference": "6b2aaf7d0e8d5220710d78921f28e5464a816596",
                 "shasum": ""
             },
             "require": {
@@ -9360,25 +9362,25 @@
                 "ext-simplexml": "*",
                 "fidry/cpu-core-counter": "^1.3.0",
                 "jean85/pretty-package-versions": "^2.1.1",
-                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-                "phpunit/php-code-coverage": "^12.5.3 || ^13.0.1",
-                "phpunit/php-file-iterator": "^6.0.1 || ^7",
-                "phpunit/php-timer": "^8 || ^9",
-                "phpunit/phpunit": "^12.5.14 || ^13.0.5",
-                "sebastian/environment": "^8.0.3 || ^9",
-                "symfony/console": "^7.4.7 || ^8.0.7",
-                "symfony/process": "^7.4.5 || ^8.0.5"
+                "php": "~8.4.0 || ~8.5.0",
+                "phpunit/php-code-coverage": "^14.2.3",
+                "phpunit/php-file-iterator": "^7",
+                "phpunit/php-timer": "^9",
+                "phpunit/phpunit": "^13.2.5",
+                "sebastian/environment": "^9.3.2",
+                "symfony/console": "^7.4.8 || ^8.1.1",
+                "symfony/process": "^7.4.8 || ^8.1.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^14.0.0",
                 "ext-pcntl": "*",
                 "ext-pcov": "*",
                 "ext-posix": "*",
-                "phpstan/phpstan": "^2.1.44",
-                "phpstan/phpstan-deprecation-rules": "^2.0.4",
-                "phpstan/phpstan-phpunit": "^2.0.16",
-                "phpstan/phpstan-strict-rules": "^2.0.10",
-                "symfony/filesystem": "^7.4.6 || ^8.0.6"
+                "phpstan/phpstan": "^2.2.6",
+                "phpstan/phpstan-deprecation-rules": "^2.0.5",
+                "phpstan/phpstan-phpunit": "^2.0.18",
+                "phpstan/phpstan-strict-rules": "^2.0.12",
+                "symfony/filesystem": "^7.4.8 || ^8.1.0"
             },
             "bin": [
                 "bin/paratest",
@@ -9418,7 +9420,7 @@
             ],
             "support": {
                 "issues": "https://github.com/paratestphp/paratest/issues",
-                "source": "https://github.com/paratestphp/paratest/tree/v7.20.0"
+                "source": "https://github.com/paratestphp/paratest/tree/v7.23.1"
             },
             "funding": [
                 {
@@ -9430,7 +9432,7 @@
                     "type": "paypal"
                 }
             ],
-            "time": "2026-03-29T15:46:14+00:00"
+            "time": "2026-07-28T13:47:02+00:00"
         },
         {
             "name": "fakerphp/faker",
@@ -10426,23 +10428,23 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v8.9.4",
+            "version": "v8.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "716af8f95a470e9094cfca09ed897b023be191a5"
+                "reference": "fb53eacd509a1d303858e2d20cfebf2d630254ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/716af8f95a470e9094cfca09ed897b023be191a5",
-                "reference": "716af8f95a470e9094cfca09ed897b023be191a5",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/fb53eacd509a1d303858e2d20cfebf2d630254ec",
+                "reference": "fb53eacd509a1d303858e2d20cfebf2d630254ec",
                 "shasum": ""
             },
             "require": {
                 "filp/whoops": "^2.18.4",
                 "nunomaduro/termwind": "^2.4.0",
                 "php": "^8.2.0",
-                "symfony/console": "^7.4.8 || ^8.0.8"
+                "symfony/console": "^7.4.14 || ^8.1.1"
             },
             "conflict": {
                 "laravel/framework": "<11.48.0 || >=14.0.0",
@@ -10450,12 +10452,12 @@
             },
             "require-dev": {
                 "brianium/paratest": "^7.8.5",
-                "larastan/larastan": "^3.9.6",
-                "laravel/framework": "^11.48.0 || ^12.56.0 || ^13.5.0",
-                "laravel/pint": "^1.29.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.12.1 || ^11.2.1",
-                "pestphp/pest": "^3.8.5 || ^4.4.3 || ^5.0.0",
-                "sebastian/environment": "^7.2.1 || ^8.0.4 || ^9.3.0"
+                "larastan/larastan": "^3.10.0",
+                "laravel/framework": "^11.48.0 || ^12.56.0 || ^13.20.0",
+                "laravel/pint": "^1.29.3",
+                "orchestra/testbench-core": "^9.12.0 || ^10.12.1 || ^11.3.5",
+                "pestphp/pest": "^3.8.5 || ^4.7.5 || ^5.0.0",
+                "sebastian/environment": "^7.2.1 || ^8.1.2 || ^9.3.2"
             },
             "type": "library",
             "extra": {
@@ -10518,7 +10520,485 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-04-21T14:04:20+00:00"
+            "time": "2026-07-15T19:09:14+00:00"
+        },
+        {
+            "name": "pestphp/pest",
+            "version": "v5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest.git",
+                "reference": "ae080becd6f036a2c83d9ebdd90079a06de118b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/ae080becd6f036a2c83d9ebdd90079a06de118b3",
+                "reference": "ae080becd6f036a2c83d9ebdd90079a06de118b3",
+                "shasum": ""
+            },
+            "require": {
+                "brianium/paratest": "^7.23.1",
+                "nunomaduro/collision": "^8.9.5",
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest-plugin": "^5.0.0",
+                "pestphp/pest-plugin-arch": "^5.0.0",
+                "pestphp/pest-plugin-mutate": "^5.0.0",
+                "pestphp/pest-plugin-profanity": "^5.0.0",
+                "php": "^8.4",
+                "phpunit/phpunit": "^13.2.6",
+                "symfony/process": "^8.1.0"
+            },
+            "conflict": {
+                "filp/whoops": "<2.18.3",
+                "phpunit/phpunit": ">13.2.6",
+                "sebastian/exporter": "<7.0.0",
+                "webmozart/assert": "<1.11.0"
+            },
+            "require-dev": {
+                "laravel/pao": "^1.1.3",
+                "pestphp/pest-dev-tools": "^5.0.0",
+                "pestphp/pest-plugin-browser": "^5.0.0",
+                "pestphp/pest-plugin-phpstan": "^5.0.0",
+                "pestphp/pest-plugin-rector": "^5.0.0",
+                "pestphp/pest-plugin-type-coverage": "^5.0.0",
+                "psy/psysh": "^0.12.24"
+            },
+            "bin": [
+                "bin/pest"
+            ],
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Mutate\\Plugins\\Mutate",
+                        "Pest\\Plugins\\Configuration",
+                        "Pest\\Plugins\\Bail",
+                        "Pest\\Plugins\\Cache",
+                        "Pest\\Plugins\\Coverage",
+                        "Pest\\Plugins\\Init",
+                        "Pest\\Plugins\\Environment",
+                        "Pest\\Plugins\\Help",
+                        "Pest\\Plugins\\Memory",
+                        "Pest\\Plugins\\Only",
+                        "Pest\\Plugins\\Printer",
+                        "Pest\\Plugins\\ProcessIsolation",
+                        "Pest\\Plugins\\Profile",
+                        "Pest\\Plugins\\Retry",
+                        "Pest\\Plugins\\Snapshot",
+                        "Pest\\Plugins\\Verbose",
+                        "Pest\\Plugins\\Version",
+                        "Pest\\Plugins\\Shard",
+                        "Pest\\Plugins\\Tia",
+                        "Pest\\Plugins\\Parallel"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php",
+                    "src/Pest.php"
+                ],
+                "psr-4": {
+                    "Pest\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "The elegant PHP Testing Framework.",
+            "keywords": [
+                "framework",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "issues": "https://github.com/pestphp/pest/issues",
+                "source": "https://github.com/pestphp/pest/tree/v5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-29T19:27:11+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin",
+            "version": "v5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin.git",
+                "reference": "87283f41aafa2561b7618be53eab00f2d06f4140"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin/zipball/87283f41aafa2561b7618be53eab00f2d06f4140",
+                "reference": "87283f41aafa2561b7618be53eab00f2d06f4140",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0.0",
+                "composer-runtime-api": "^2.2.2",
+                "php": "^8.4"
+            },
+            "conflict": {
+                "pestphp/pest": "<5.0.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.10.2",
+                "pestphp/pest": "^5.0.0",
+                "pestphp/pest-dev-tools": "^5.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Pest\\Plugin\\Manager"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Plugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest plugin manager",
+            "keywords": [
+                "framework",
+                "manager",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin/tree/v5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-07-18T17:10:45+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-arch",
+            "version": "v5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-arch.git",
+                "reference": "244465d5dc9ea9fb5ac5c9badb7eb47d1594e4c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-arch/zipball/244465d5dc9ea9fb5ac5c9badb7eb47d1594e4c1",
+                "reference": "244465d5dc9ea9fb5ac5c9badb7eb47d1594e4c1",
+                "shasum": ""
+            },
+            "require": {
+                "pestphp/pest-plugin": "^5.0.0",
+                "php": "^8.4",
+                "ta-tikoma/phpunit-architecture-test": "^0.8.7"
+            },
+            "conflict": {
+                "pestphp/pest": "<5.0.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^5.0.0",
+                "pestphp/pest-dev-tools": "^5.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Arch\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Arch\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Arch plugin for Pest PHP.",
+            "keywords": [
+                "arch",
+                "architecture",
+                "framework",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-arch/tree/v5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-21T07:48:55+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-laravel",
+            "version": "v5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-laravel.git",
+                "reference": "d1564646e3198f1b607e64a36501d6edff7d104e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-laravel/zipball/d1564646e3198f1b607e64a36501d6edff7d104e",
+                "reference": "d1564646e3198f1b607e64a36501d6edff7d104e",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": "^13.23.0",
+                "pestphp/pest": "^5.0.1",
+                "php": "^8.4"
+            },
+            "conflict": {
+                "pestphp/pest": "<5.0.0"
+            },
+            "require-dev": {
+                "laravel/dusk": "^8.6.0",
+                "orchestra/testbench": "^11.1",
+                "pestphp/pest-dev-tools": "^5.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Laravel\\Plugin"
+                    ]
+                },
+                "laravel": {
+                    "providers": [
+                        "Pest\\Laravel\\PestServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Laravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest Laravel Plugin",
+            "keywords": [
+                "framework",
+                "laravel",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-laravel/tree/v5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-29T18:19:36+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-mutate",
+            "version": "v5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-mutate.git",
+                "reference": "fc4a0b3d3bc75bad1148d4c046cf0fa66c508f77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-mutate/zipball/fc4a0b3d3bc75bad1148d4c046cf0fa66c508f77",
+                "reference": "fc4a0b3d3bc75bad1148d4c046cf0fa66c508f77",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.8.0",
+                "pestphp/pest-plugin": "^5.0.0",
+                "php": "^8.4",
+                "psr/simple-cache": "^3.0.0"
+            },
+            "conflict": {
+                "pestphp/pest": "<5.0.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^5.0.0",
+                "pestphp/pest-dev-tools": "^5.0.0",
+                "pestphp/pest-plugin-type-coverage": "^5.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Mutate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                },
+                {
+                    "name": "Sandro Gehri",
+                    "email": "sandrogehri@gmail.com"
+                }
+            ],
+            "description": "Mutates your code to find untested cases",
+            "keywords": [
+                "framework",
+                "mutate",
+                "mutation",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-mutate/tree/v5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/gehrisandro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-21T07:48:56+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-profanity",
+            "version": "v5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-profanity.git",
+                "reference": "3dedf9ea6e2876b5b31f7733d3eacbd86f4653b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-profanity/zipball/3dedf9ea6e2876b5b31f7733d3eacbd86f4653b9",
+                "reference": "3dedf9ea6e2876b5b31f7733d3eacbd86f4653b9",
+                "shasum": ""
+            },
+            "require": {
+                "pestphp/pest-plugin": "^5.0.0",
+                "php": "^8.4"
+            },
+            "conflict": {
+                "pestphp/pest": "<5.0.0"
+            },
+            "require-dev": {
+                "faissaloux/pest-plugin-inside": "^1.11",
+                "pestphp/pest": "^5.0.0",
+                "pestphp/pest-dev-tools": "^5.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Profanity\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Profanity\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest Profanity Plugin",
+            "keywords": [
+                "framework",
+                "pest",
+                "php",
+                "plugin",
+                "profanity",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-profanity/tree/v5.0.0"
+            },
+            "time": "2026-07-21T07:48:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -10704,33 +11184,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.7",
+            "version": "14.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "186dab580576598076de6818596d12b61801880e"
+                "reference": "048a5c12bdb4580f4767ce2761793a16b170fbe4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/186dab580576598076de6818596d12b61801880e",
-                "reference": "186dab580576598076de6818596d12b61801880e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/048a5c12bdb4580f4767ce2761793a16b170fbe4",
+                "reference": "048a5c12bdb4580f4767ce2761793a16b170fbe4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
+                "ext-mbstring": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^5.7.0",
-                "php": ">=8.3",
-                "phpunit/php-text-template": "^5.0",
-                "sebastian/complexity": "^5.0",
-                "sebastian/environment": "^8.1.2",
-                "sebastian/lines-of-code": "^4.0.1",
-                "sebastian/version": "^6.0",
+                "nikic/php-parser": "^5.8.0",
+                "php": ">=8.4",
+                "phpunit/php-text-template": "^6.0",
+                "sebastian/complexity": "^6.0",
+                "sebastian/environment": "^9.3.2",
+                "sebastian/git-state": "^1.0",
+                "sebastian/lines-of-code": "^5.0.1",
+                "sebastian/version": "^7.0",
                 "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.5.28"
+                "phpunit/phpunit": "^13.2.2"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -10739,7 +11221,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "12.5.x-dev"
+                    "dev-main": "14.2.x-dev"
                 }
             },
             "autoload": {
@@ -10768,7 +11250,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.7"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.2.4"
             },
             "funding": [
                 {
@@ -10788,32 +11270,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-01T13:24:19+00:00"
+            "time": "2026-07-30T17:01:07+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "6.0.1",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
+                "reference": "6e5aa1fb0a95b1703d83e721299ee18bb4e2de50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
-                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6e5aa1fb0a95b1703d83e721299ee18bb4e2de50",
+                "reference": "6e5aa1fb0a95b1703d83e721299ee18bb4e2de50",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -10841,7 +11323,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/7.0.0"
             },
             "funding": [
                 {
@@ -10861,28 +11343,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-02T14:04:18+00:00"
+            "time": "2026-02-06T04:33:26+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "6.0.0",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
+                "reference": "42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
-                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88",
+                "reference": "42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -10890,7 +11372,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -10917,40 +11399,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
                 "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/7.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-invoker",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:58:58+00:00"
+            "time": "2026-02-06T04:34:47+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "5.0.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
+                "reference": "a47af19f93f76aa3368303d752aa5272ca3299f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
-                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/a47af19f93f76aa3368303d752aa5272ca3299f4",
+                "reference": "a47af19f93f76aa3368303d752aa5272ca3299f4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -10977,40 +11471,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/6.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-text-template",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:59:16+00:00"
+            "time": "2026-02-06T04:36:37+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "8.0.0",
+            "version": "9.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
+                "reference": "a0e12065831f6ab0d83120dc61513eb8d9a966f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
-                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/a0e12065831f6ab0d83120dc61513eb8d9a966f6",
+                "reference": "a0e12065831f6ab0d83120dc61513eb8d9a966f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "9.0-dev"
                 }
             },
             "autoload": {
@@ -11037,56 +11543,70 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
                 "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/9.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-timer",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:59:38+00:00"
+            "time": "2026-02-06T04:37:53+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.30",
+            "version": "13.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "900400a5b616d6fb306f9549f6da33ba615d3fbb"
+                "reference": "5d2afe181339a56348ef9a80fa7eb806b7eae508"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/900400a5b616d6fb306f9549f6da33ba615d3fbb",
-                "reference": "900400a5b616d6fb306f9549f6da33ba615d3fbb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5d2afe181339a56348ef9a80fa7eb806b7eae508",
+                "reference": "5d2afe181339a56348ef9a80fa7eb806b7eae508",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.7",
-                "phpunit/php-file-iterator": "^6.0.1",
-                "phpunit/php-invoker": "^6.0.0",
-                "phpunit/php-text-template": "^5.0.0",
-                "phpunit/php-timer": "^8.0.0",
-                "sebastian/cli-parser": "^4.2.1",
-                "sebastian/comparator": "^7.1.8",
-                "sebastian/diff": "^7.0.0",
-                "sebastian/environment": "^8.1.2",
-                "sebastian/exporter": "^7.0.3",
-                "sebastian/global-state": "^8.0.3",
-                "sebastian/object-enumerator": "^7.0.0",
-                "sebastian/recursion-context": "^7.0.1",
-                "sebastian/type": "^6.0.4",
-                "sebastian/version": "^6.0.0",
+                "php": ">=8.4.1",
+                "phpunit/php-code-coverage": "^14.2.3",
+                "phpunit/php-file-iterator": "^7.0.0",
+                "phpunit/php-invoker": "^7.0.0",
+                "phpunit/php-text-template": "^6.0.0",
+                "phpunit/php-timer": "^9.0.0",
+                "sebastian/cli-parser": "^5.0.0",
+                "sebastian/comparator": "^8.3.0",
+                "sebastian/diff": "^9.0",
+                "sebastian/environment": "^9.3.2",
+                "sebastian/exporter": "^8.1.1",
+                "sebastian/file-filter": "^1.0",
+                "sebastian/git-state": "^1.0",
+                "sebastian/global-state": "^9.0.1",
+                "sebastian/object-enumerator": "^8.0.0",
+                "sebastian/recursion-context": "^8.0.0",
+                "sebastian/type": "^7.0.1",
+                "sebastian/version": "^7.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
             },
             "bin": [
@@ -11095,7 +11615,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "12.5-dev"
+                    "dev-main": "13.2-dev"
                 }
             },
             "autoload": {
@@ -11127,7 +11647,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.30"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.2.6"
             },
             "funding": [
                 {
@@ -11135,7 +11655,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-06-15T13:12:30+00:00"
+            "time": "2026-07-28T14:00:09+00:00"
         },
         {
             "name": "rector/rector",
@@ -11199,28 +11719,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "4.2.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15"
+                "reference": "48a4654fa5e48c1c81214e9930048a572d4b23ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/7d05781b13f7dec9043a629a21d086ed74582a15",
-                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/48a4654fa5e48c1c81214e9930048a572d4b23ca",
+                "reference": "48a4654fa5e48c1c81214e9930048a572d4b23ca",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.5.25"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.2-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -11244,7 +11764,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/5.0.0"
             },
             "funding": [
                 {
@@ -11264,31 +11784,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-17T05:29:34+00:00"
+            "time": "2026-02-06T04:39:44+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "7.1.8",
+            "version": "8.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "7c65c1e79836812819705b473a90c12399542485"
+                "reference": "c025fc7604afab3f195fab7cdaf72327331af241"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/7c65c1e79836812819705b473a90c12399542485",
-                "reference": "7c65c1e79836812819705b473a90c12399542485",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c025fc7604afab3f195fab7cdaf72327331af241",
+                "reference": "c025fc7604afab3f195fab7cdaf72327331af241",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
-                "php": ">=8.3",
-                "sebastian/diff": "^7.0",
-                "sebastian/exporter": "^7.0.3"
+                "php": ">=8.4",
+                "sebastian/diff": "^9.0",
+                "sebastian/exporter": "^8.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.5.25"
+                "phpunit/phpunit": "^13.2"
             },
             "suggest": {
                 "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -11296,7 +11816,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.1-dev"
+                    "dev-main": "8.3-dev"
                 }
             },
             "autoload": {
@@ -11336,7 +11856,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/8.3.0"
             },
             "funding": [
                 {
@@ -11356,33 +11876,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-21T04:45:25+00:00"
+            "time": "2026-06-05T03:06:45+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "5.0.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
+                "reference": "c5651c795c98093480df79350cb050813fc7a2f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
-                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/c5651c795c98093480df79350cb050813fc7a2f3",
+                "reference": "c5651c795c98093480df79350cb050813fc7a2f3",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^5.0",
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -11406,41 +11926,53 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/6.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/complexity",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:55:25+00:00"
+            "time": "2026-02-06T04:41:32+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "7.0.0",
+            "version": "9.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
+                "reference": "a3fb6a298a265ff487a91bbea46e03cd01dbb226"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/a3fb6a298a265ff487a91bbea46e03cd01dbb226",
+                "reference": "a3fb6a298a265ff487a91bbea46e03cd01dbb226",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0",
-                "symfony/process": "^7.2"
+                "phpunit/phpunit": "^13.2",
+                "symfony/process": "^7.4.13"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "9.0-dev"
                 }
             },
             "autoload": {
@@ -11473,35 +12005,47 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/diff/tree/9.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/diff",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:55:46+00:00"
+            "time": "2026-06-05T03:04:51+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "8.1.2",
+            "version": "9.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439"
+                "reference": "6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/9d32c685773823b1983e256ae4ecd48a10d6e439",
-                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e",
+                "reference": "6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.5.26"
+                "phpunit/phpunit": "^13.1.11"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -11509,7 +12053,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.1-dev"
+                    "dev-main": "9.3-dev"
                 }
             },
             "autoload": {
@@ -11537,7 +12081,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.2"
+                "source": "https://github.com/sebastianbergmann/environment/tree/9.3.2"
             },
             "funding": [
                 {
@@ -11557,34 +12101,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T13:40:20+00:00"
+            "time": "2026-05-25T13:41:38+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "7.0.3",
+            "version": "8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23"
+                "reference": "cfaa77c750dcad6f44c9bac8f62ac486e1c82c26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
-                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/cfaa77c750dcad6f44c9bac8f62ac486e1c82c26",
+                "reference": "cfaa77c750dcad6f44c9bac8f62ac486e1c82c26",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.3",
-                "sebastian/recursion-context": "^7.0.1"
+                "php": ">=8.4",
+                "sebastian/recursion-context": "^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.5.25"
+                "phpunit/phpunit": "^13.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -11627,7 +12171,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/8.1.1"
             },
             "funding": [
                 {
@@ -11647,35 +12191,173 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T04:37:17+00:00"
+            "time": "2026-07-13T11:35:11+00:00"
         },
         {
-            "name": "sebastian/global-state",
-            "version": "8.0.3",
+            "name": "sebastian/file-filter",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9"
+                "url": "https://github.com/sebastianbergmann/file-filter.git",
+                "reference": "33a26f394330f6faa7684bb9cc73afb7727aae93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b164d3274d6537ab462591c5755f76a8f5b1aae9",
-                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9",
+                "url": "https://api.github.com/repos/sebastianbergmann/file-filter/zipball/33a26f394330f6faa7684bb9cc73afb7727aae93",
+                "reference": "33a26f394330f6faa7684bb9cc73afb7727aae93",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3",
-                "sebastian/object-reflector": "^5.0",
-                "sebastian/recursion-context": "^7.0.1"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "ext-dom": "*",
-                "phpunit/phpunit": "^12.5.28"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for filtering files",
+            "homepage": "https://github.com/sebastianbergmann/file-filter",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/file-filter/issues",
+                "security": "https://github.com/sebastianbergmann/file-filter/security/policy",
+                "source": "https://github.com/sebastianbergmann/file-filter/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/file-filter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-22T07:20:04+00:00"
+        },
+        {
+            "name": "sebastian/git-state",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/git-state.git",
+                "reference": "792a952e0eba55b6960a48aeceb9f371aad1f76b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/git-state/zipball/792a952e0eba55b6960a48aeceb9f371aad1f76b",
+                "reference": "792a952e0eba55b6960a48aeceb9f371aad1f76b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for describing the state of a Git checkout",
+            "homepage": "https://github.com/sebastianbergmann/git-state",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/git-state/issues",
+                "security": "https://github.com/sebastianbergmann/git-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/git-state/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/git-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-21T12:54:28+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "9.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "ba68ba79da690cf7eddefd3ce5b78b20b9ba9945"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ba68ba79da690cf7eddefd3ce5b78b20b9ba9945",
+                "reference": "ba68ba79da690cf7eddefd3ce5b78b20b9ba9945",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "sebastian/object-reflector": "^6.0",
+                "sebastian/recursion-context": "^8.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^13.1.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0-dev"
                 }
             },
             "autoload": {
@@ -11701,7 +12383,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.3"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/9.0.1"
             },
             "funding": [
                 {
@@ -11721,33 +12403,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-01T15:10:33+00:00"
+            "time": "2026-06-01T15:11:33+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "4.0.1",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e"
+                "reference": "d1b6f8fce682505dbd048977f1abedf1b8ad3ff8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d543b8ef219dcd8da262cbb958639a96bedba10e",
-                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d1b6f8fce682505dbd048977f1abedf1b8ad3ff8",
+                "reference": "d1b6f8fce682505dbd048977f1abedf1b8ad3ff8",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^5.7.0",
-                "php": ">=8.3"
+                "nikic/php-parser": "^5.8.0",
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.5.25"
+                "phpunit/phpunit": "^13.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -11771,7 +12453,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/5.0.2"
             },
             "funding": [
                 {
@@ -11791,34 +12473,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-19T16:22:07+00:00"
+            "time": "2026-07-09T08:42:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "7.0.0",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
+                "reference": "b39ab125fd9a7434b0ecbc4202eebce11a98cfc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
-                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/b39ab125fd9a7434b0ecbc4202eebce11a98cfc5",
+                "reference": "b39ab125fd9a7434b0ecbc4202eebce11a98cfc5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3",
-                "sebastian/object-reflector": "^5.0",
-                "sebastian/recursion-context": "^7.0"
+                "php": ">=8.4",
+                "sebastian/object-reflector": "^6.0",
+                "sebastian/recursion-context": "^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -11841,40 +12523,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
                 "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/8.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/object-enumerator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:57:48+00:00"
+            "time": "2026-02-06T04:46:36+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "5.0.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
+                "reference": "3ca042c2c60b0eab094f8a1b6a7093f4d4c72200"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
-                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/3ca042c2c60b0eab094f8a1b6a7093f4d4c72200",
+                "reference": "3ca042c2c60b0eab094f8a1b6a7093f4d4c72200",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -11897,40 +12591,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
                 "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/6.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/object-reflector",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:58:17+00:00"
+            "time": "2026-02-06T04:47:13+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "7.0.1",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
+                "reference": "74c5af21f6a5833e91767ca068c4d3dfec15317e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
-                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/74c5af21f6a5833e91767ca068c4d3dfec15317e",
+                "reference": "74c5af21f6a5833e91767ca068c4d3dfec15317e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -11961,7 +12667,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
                 "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/8.0.0"
             },
             "funding": [
                 {
@@ -11981,32 +12687,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T04:44:59+00:00"
+            "time": "2026-02-06T04:51:28+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "6.0.4",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "82ff822c2edc46724be9f7411d3163021f602773"
+                "reference": "fee0309275847fefd7636167085e379c1dbf6990"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/82ff822c2edc46724be9f7411d3163021f602773",
-                "reference": "82ff822c2edc46724be9f7411d3163021f602773",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fee0309275847fefd7636167085e379c1dbf6990",
+                "reference": "fee0309275847fefd7636167085e379c1dbf6990",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.5.25"
+                "phpunit/phpunit": "^13.1.10"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -12030,7 +12736,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/6.0.4"
+                "source": "https://github.com/sebastianbergmann/type/tree/7.0.1"
             },
             "funding": [
                 {
@@ -12050,29 +12756,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T06:45:45+00:00"
+            "time": "2026-05-20T06:49:11+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "6.0.0",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
+                "reference": "ad37a5552c8e2b88572249fdc19b6da7792e021b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
-                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/ad37a5552c8e2b88572249fdc19b6da7792e021b",
+                "reference": "ad37a5552c8e2b88572249fdc19b6da7792e021b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -12096,15 +12802,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
                 "security": "https://github.com/sebastianbergmann/version/security/policy",
-                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
+                "source": "https://github.com/sebastianbergmann/version/tree/7.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/version",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T05:00:38+00:00"
+            "time": "2026-02-06T04:52:52+00:00"
         },
         {
             "name": "spatie/backtrace",
@@ -12542,6 +13260,65 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "ta-tikoma/phpunit-architecture-test",
+            "version": "0.8.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ta-tikoma/phpunit-architecture-test.git",
+                "reference": "1248f3f506ca9641d4f68cebcd538fa489754db8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/1248f3f506ca9641d4f68cebcd538fa489754db8",
+                "reference": "1248f3f506ca9641d4f68cebcd538fa489754db8",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18.0 || ^5.0.0",
+                "php": "^8.1.0",
+                "phpdocumentor/reflection-docblock": "^5.3.0 || ^6.0.0",
+                "phpunit/phpunit": "^10.5.5 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+                "symfony/finder": "^6.4.0 || ^7.0.0 || ^8.0.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.13.7",
+                "phpstan/phpstan": "^1.10.52"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPUnit\\Architecture\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ni Shi",
+                    "email": "futik0ma011@gmail.com"
+                },
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Methods for testing application architecture",
+            "keywords": [
+                "architecture",
+                "phpunit",
+                "stucture",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/ta-tikoma/phpunit-architecture-test/issues",
+                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.7"
+            },
+            "time": "2026-02-17T17:25:14+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/database/factories/ServiceFactory.php
+++ b/database/factories/ServiceFactory.php
@@ -23,4 +23,19 @@ class ServiceFactory extends Factory
             'status' => ServiceStatus::READY,
         ];
     }
+
+    public function vitoAgent(): static
+    {
+        return $this->state(fn (): array => [
+            'name' => 'vito-agent',
+            'type' => 'monitoring',
+            'type_data' => [
+                'url' => 'https://vito.test/agent-endpoint',
+                'secret' => 'agent-secret',
+                'data_retention' => 7,
+            ],
+            'version' => 'latest',
+            'status' => ServiceStatus::READY,
+        ]);
+    }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.0/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
   <testsuites>
     <testsuite name="Feature">
       <directory suffix="Test.php">./tests/Feature</directory>

--- a/sail
+++ b/sail
@@ -80,8 +80,8 @@ function display_help {
     echo "  ${GREEN}sail debug queue:work${NC}"
     echo
     echo "${YELLOW}Running Tests:${NC}"
-    echo "  ${GREEN}sail test${NC}          Run the PHPUnit tests via the Artisan test command"
-    echo "  ${GREEN}sail phpunit ...${NC}   Run PHPUnit"
+    echo "  ${GREEN}sail test${NC}          Run the tests via the Artisan test command"
+    echo "  ${GREEN}sail pest ...${NC}      Run Pest"
     echo "  ${GREEN}sail pint ...${NC}      Run Pint"
     echo "  ${GREEN}sail dusk${NC}          Run the Dusk tests (Requires the laravel/dusk package)"
     echo "  ${GREEN}sail dusk:fails${NC}    Re-run previously failed Dusk tests (Requires the laravel/dusk package)"
@@ -273,14 +273,14 @@ elif [ "$1" == "test" ]; then
         sail_is_not_running
     fi
 
-# Proxy the "phpunit" command to "php vendor/bin/phpunit"...
-elif [ "$1" == "phpunit" ]; then
+# Proxy the "pest" command to "php vendor/bin/pest"...
+elif [ "$1" == "pest" ]; then
     shift 1
 
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" php vendor/bin/phpunit "$@")
+        ARGS+=("$APP_SERVICE" php vendor/bin/pest "$@")
     else
         sail_is_not_running
     fi

--- a/tests/Feature/API/AgentControllerTest.php
+++ b/tests/Feature/API/AgentControllerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\ServiceStatus;
 use App\Events\ServiceStatusChanged;
 use App\Events\SocketEvent;
@@ -9,377 +7,358 @@ use App\Models\Server;
 use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
-use Tests\TestCase;
 
-class AgentControllerTest extends TestCase
+uses(RefreshDatabase::class);
+
+function vitoPestFeatureAPIAgentControllerTestAgentService(string $secret = 'test-secret'): Service
 {
-    use RefreshDatabase;
-
-    private function agentService(string $secret = 'test-secret'): Service
-    {
-        return Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'vito-agent',
-            'type' => 'monitoring',
-            'type_data' => [
-                'url' => '',
-                'secret' => $secret,
-                'data_retention' => 7,
-            ],
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-    }
-
-    public function test_store_metrics_with_full_payload(): void
-    {
-        $service = $this->agentService();
-
-        $payload = [
-            'load' => 0.09,
-            'disk_total' => '76571',
-            'disk_free' => '70927',
-            'disk_used' => '2471',
-            'memory_total' => '7937236',
-            'memory_free' => '7008596',
-            'memory_used' => '928640',
-            'cpu_cores' => 4,
-            'cpu_physical_cores' => 4,
-            'cpu_usage_percent' => 0.9900990099009901,
-            'cpu_per_core_usage_percent' => [0, 0, 0, 0],
-            'cpu_steal_percent' => 0,
-            'swap_total' => '0',
-            'swap_free' => '0',
-            'swap_used' => '0',
-            'swap_used_percent' => 0,
-            'oom_kill_count' => 0,
-            'uptime_seconds' => 26759.36,
-            'reboot_required' => false,
-        ];
-
-        $this->json(
-            'POST',
-            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
-            $payload,
-            ['secret' => 'test-secret']
-        )->assertSuccessful();
-
-        $this->assertDatabaseHas('metrics', [
-            'server_id' => $this->server->id,
-            'load' => 0.09,
-            'cpu_cores' => 4,
-            'cpu_physical_cores' => 4,
-            'cpu_usage_percent' => 0.99,
-            'cpu_steal_percent' => 0,
-            'swap_total' => 0,
-            'swap_used_percent' => 0,
-            'oom_kill_count' => 0,
-            'uptime_seconds' => 26759.36,
-            'reboot_required' => false,
-        ]);
-
-        $metric = $this->server->metrics()->latest('id')->first();
-        $this->assertNotNull($metric);
-        $this->assertEquals([0.0, 0.0, 0.0, 0.0], $metric->cpu_per_core_usage_percent);
-    }
-
-    public function test_store_metrics_with_minimal_payload(): void
-    {
-        $service = $this->agentService();
-
-        $payload = [
-            'load' => 0.5,
-            'memory_total' => '1000',
-            'memory_used' => '500',
-            'memory_free' => '500',
-            'disk_total' => '100',
-            'disk_used' => '50',
-            'disk_free' => '50',
-        ];
-
-        $this->json(
-            'POST',
-            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
-            $payload,
-            ['secret' => 'test-secret']
-        )->assertSuccessful();
-
-        $this->assertDatabaseHas('metrics', [
-            'server_id' => $this->server->id,
-            'load' => 0.5,
-            'cpu_cores' => null,
-            'cpu_usage_percent' => null,
-            'swap_total' => null,
-            'oom_kill_count' => null,
-            'uptime_seconds' => null,
-            'reboot_required' => null,
-        ]);
-    }
-
-    public function test_invalid_secret_returns_401_without_validating_payload(): void
-    {
-        $service = $this->agentService('correct-secret');
-
-        $this->json(
-            'POST',
-            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
-            ['anything' => 'goes'],
-            ['secret' => 'wrong-secret']
-        )->assertStatus(401);
-
-        $this->assertDatabaseCount('metrics', 0);
-    }
-
-    public function test_service_without_secret_cannot_be_used_as_agent_endpoint(): void
-    {
-        $service = Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'remote-monitor',
-            'type' => 'monitoring',
-            'type_data' => [
-                'data_retention' => 7,
-            ],
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-
-        $this->json(
-            'POST',
-            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
-            ['load' => 0.5, 'memory_total' => 1, 'memory_used' => 1, 'memory_free' => 1, 'disk_total' => 1, 'disk_used' => 1, 'disk_free' => 1],
-            ['secret' => '']
-        )->assertStatus(401);
-
-        $this->assertDatabaseCount('metrics', 0);
-    }
-
-    public function test_invalid_payload_returns_422(): void
-    {
-        $service = $this->agentService();
-
-        $this->json(
-            'POST',
-            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
-            ['load' => 'not-a-number'],
-            ['secret' => 'test-secret']
-        )->assertStatus(422);
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function minimalPayload(): array
-    {
-        return [
-            'load' => 0.5,
-            'memory_total' => '1000',
-            'memory_used' => '500',
-            'memory_free' => '500',
-            'disk_total' => '100',
-            'disk_used' => '50',
-            'disk_free' => '50',
-        ];
-    }
-
-    public function test_store_metrics_without_services_key_changes_no_statuses(): void
-    {
-        Event::fake([ServiceStatusChanged::class]);
-
-        $service = $this->agentService();
-
-        $this->json(
-            'POST',
-            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
-            $this->minimalPayload(),
-            ['secret' => 'test-secret']
-        )->assertSuccessful();
-
-        $this->assertDatabaseHas('metrics', ['server_id' => $this->server->id, 'load' => 0.5]);
-        Event::assertNotDispatched(ServiceStatusChanged::class);
-    }
-
-    public function test_store_metrics_with_services_updates_statuses(): void
-    {
-        Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
-
-        $service = $this->agentService();
-        $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
-
-        $this->reportServiceStatus($service, $nginx, 'inactive');
-        $this->reportServiceStatus($service, $nginx, 'inactive');
-
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::STOPPED]);
-        $this->assertDatabaseHas('metrics', ['server_id' => $this->server->id, 'load' => 0.5]);
-        Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $nginx->id
-            && $event->previousStatus === ServiceStatus::READY
-            && $event->newStatus === ServiceStatus::STOPPED);
-        Event::assertDispatched(SocketEvent::class);
-    }
-
-    public function test_single_inactive_report_does_not_change_status(): void
-    {
-        Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
-
-        $service = $this->agentService();
-        $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
-
-        $this->reportServiceStatus($service, $nginx, 'inactive');
-
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
-        Event::assertNotDispatched(ServiceStatusChanged::class);
-    }
-
-    public function test_duplicate_service_entries_count_as_one_reading(): void
-    {
-        Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
-
-        $service = $this->agentService();
-        $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
-
-        $this->json(
-            'POST',
-            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
-            array_merge($this->minimalPayload(), [
-                'services' => [
-                    ['id' => $nginx->id, 'status' => 'inactive'],
-                    ['id' => $nginx->id, 'status' => 'inactive'],
-                ],
-            ]),
-            ['secret' => 'test-secret']
-        )->assertSuccessful();
-
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
-        Event::assertNotDispatched(ServiceStatusChanged::class);
-    }
-
-    public function test_agent_reported_restart_flap_does_not_change_status(): void
-    {
-        Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
-
-        $service = $this->agentService();
-        $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
-
-        $this->reportServiceStatus($service, $nginx, 'inactive');
-        $this->reportServiceStatus($service, $nginx, 'active');
-        $this->reportServiceStatus($service, $nginx, 'inactive');
-
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
-        Event::assertNotDispatched(ServiceStatusChanged::class);
-    }
-
-    private function reportServiceStatus(Service $service, Service $target, string $status): void
-    {
-        $this->json(
-            'POST',
-            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
-            array_merge($this->minimalPayload(), [
-                'services' => [['id' => $target->id, 'status' => $status]],
-            ]),
-            ['secret' => 'test-secret']
-        )->assertSuccessful();
-    }
-
-    public function test_services_entry_for_other_server_is_ignored(): void
-    {
-        Event::fake([ServiceStatusChanged::class]);
-
-        $service = $this->agentService();
-        $otherServer = Server::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-        $otherService = Service::factory()->create([
-            'server_id' => $otherServer->id,
-            'name' => 'nginx',
-            'type' => 'webserver',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-
-        $this->json(
-            'POST',
-            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
-            array_merge($this->minimalPayload(), [
-                'services' => [['id' => $otherService->id, 'status' => 'inactive']],
-            ]),
-            ['secret' => 'test-secret']
-        )->assertSuccessful();
-
-        $this->assertDatabaseHas('services', ['id' => $otherService->id, 'status' => ServiceStatus::READY]);
-        Event::assertNotDispatched(ServiceStatusChanged::class);
-    }
-
-    public function test_services_entry_for_transitional_service_is_ignored(): void
-    {
-        Event::fake([ServiceStatusChanged::class]);
-
-        $service = $this->agentService();
-        $mysql = $this->server->services()->where('name', 'mysql')->firstOrFail();
-        $mysql->update(['status' => ServiceStatus::INSTALLING]);
-
-        $this->json(
-            'POST',
-            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
-            array_merge($this->minimalPayload(), [
-                'services' => [['id' => $mysql->id, 'status' => 'active']],
-            ]),
-            ['secret' => 'test-secret']
-        )->assertSuccessful();
-
-        $this->assertDatabaseHas('services', ['id' => $mysql->id, 'status' => ServiceStatus::INSTALLING]);
-        Event::assertNotDispatched(ServiceStatusChanged::class);
-    }
-
-    public function test_services_entry_with_unknown_status_is_ignored(): void
-    {
-        Event::fake([ServiceStatusChanged::class]);
-
-        $service = $this->agentService();
-        $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
-
-        $this->json(
-            'POST',
-            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
-            array_merge($this->minimalPayload(), [
-                'services' => [['id' => $nginx->id, 'status' => 'activating']],
-            ]),
-            ['secret' => 'test-secret']
-        )->assertSuccessful();
-
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
-        Event::assertNotDispatched(ServiceStatusChanged::class);
-    }
-
-    public function test_services_entry_for_monitoring_service_is_ignored(): void
-    {
-        Event::fake([ServiceStatusChanged::class]);
-
-        $service = $this->agentService();
-
-        $this->json(
-            'POST',
-            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
-            array_merge($this->minimalPayload(), [
-                'services' => [['id' => $service->id, 'status' => 'inactive']],
-            ]),
-            ['secret' => 'test-secret']
-        )->assertSuccessful();
-
-        $this->assertDatabaseHas('services', ['id' => $service->id, 'status' => ServiceStatus::READY]);
-        Event::assertNotDispatched(ServiceStatusChanged::class);
-    }
-
-    public function test_services_must_be_an_array(): void
-    {
-        $service = $this->agentService();
-
-        $this->json(
-            'POST',
-            route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
-            array_merge($this->minimalPayload(), ['services' => 'nope']),
-            ['secret' => 'test-secret']
-        )->assertStatus(422);
-
-        $this->assertDatabaseCount('metrics', 0);
-    }
+    return Service::factory()->create([
+        'server_id' => test()->server->id,
+        'name' => 'vito-agent',
+        'type' => 'monitoring',
+        'type_data' => [
+            'url' => '',
+            'secret' => $secret,
+            'data_retention' => 7,
+        ],
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
 }
+
+test('store metrics with full payload', function () {
+    $service = vitoPestFeatureAPIAgentControllerTestAgentService();
+
+    $payload = [
+        'load' => 0.09,
+        'disk_total' => '76571',
+        'disk_free' => '70927',
+        'disk_used' => '2471',
+        'memory_total' => '7937236',
+        'memory_free' => '7008596',
+        'memory_used' => '928640',
+        'cpu_cores' => 4,
+        'cpu_physical_cores' => 4,
+        'cpu_usage_percent' => 0.9900990099009901,
+        'cpu_per_core_usage_percent' => [0, 0, 0, 0],
+        'cpu_steal_percent' => 0,
+        'swap_total' => '0',
+        'swap_free' => '0',
+        'swap_used' => '0',
+        'swap_used_percent' => 0,
+        'oom_kill_count' => 0,
+        'uptime_seconds' => 26759.36,
+        'reboot_required' => false,
+    ];
+
+    $this->json(
+        'POST',
+        route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+        $payload,
+        ['secret' => 'test-secret']
+    )->assertSuccessful();
+
+    $this->assertDatabaseHas('metrics', [
+        'server_id' => $this->server->id,
+        'load' => 0.09,
+        'cpu_cores' => 4,
+        'cpu_physical_cores' => 4,
+        'cpu_usage_percent' => 0.99,
+        'cpu_steal_percent' => 0,
+        'swap_total' => 0,
+        'swap_used_percent' => 0,
+        'oom_kill_count' => 0,
+        'uptime_seconds' => 26759.36,
+        'reboot_required' => false,
+    ]);
+
+    $metric = $this->server->metrics()->latest('id')->first();
+    expect($metric)->not->toBeNull();
+    expect($metric->cpu_per_core_usage_percent)->toEqual([0.0, 0.0, 0.0, 0.0]);
+});
+
+test('store metrics with minimal payload', function () {
+    $service = vitoPestFeatureAPIAgentControllerTestAgentService();
+
+    $payload = [
+        'load' => 0.5,
+        'memory_total' => '1000',
+        'memory_used' => '500',
+        'memory_free' => '500',
+        'disk_total' => '100',
+        'disk_used' => '50',
+        'disk_free' => '50',
+    ];
+
+    $this->json(
+        'POST',
+        route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+        $payload,
+        ['secret' => 'test-secret']
+    )->assertSuccessful();
+
+    $this->assertDatabaseHas('metrics', [
+        'server_id' => $this->server->id,
+        'load' => 0.5,
+        'cpu_cores' => null,
+        'cpu_usage_percent' => null,
+        'swap_total' => null,
+        'oom_kill_count' => null,
+        'uptime_seconds' => null,
+        'reboot_required' => null,
+    ]);
+});
+
+test('invalid secret returns 401 without validating payload', function () {
+    $service = vitoPestFeatureAPIAgentControllerTestAgentService('correct-secret');
+
+    $this->json(
+        'POST',
+        route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+        ['anything' => 'goes'],
+        ['secret' => 'wrong-secret']
+    )->assertStatus(401);
+
+    $this->assertDatabaseCount('metrics', 0);
+});
+
+test('service without secret cannot be used as agent endpoint', function () {
+    $service = Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'remote-monitor',
+        'type' => 'monitoring',
+        'type_data' => [
+            'data_retention' => 7,
+        ],
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+
+    $this->json(
+        'POST',
+        route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+        ['load' => 0.5, 'memory_total' => 1, 'memory_used' => 1, 'memory_free' => 1, 'disk_total' => 1, 'disk_used' => 1, 'disk_free' => 1],
+        ['secret' => '']
+    )->assertStatus(401);
+
+    $this->assertDatabaseCount('metrics', 0);
+});
+
+test('invalid payload returns 422', function () {
+    $service = vitoPestFeatureAPIAgentControllerTestAgentService();
+
+    $this->json(
+        'POST',
+        route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+        ['load' => 'not-a-number'],
+        ['secret' => 'test-secret']
+    )->assertStatus(422);
+});
+
+/**
+ * @return array<string, mixed>
+ */
+function vitoPestFeatureAPIAgentControllerTestMinimalPayload(): array
+{
+    return [
+        'load' => 0.5,
+        'memory_total' => '1000',
+        'memory_used' => '500',
+        'memory_free' => '500',
+        'disk_total' => '100',
+        'disk_used' => '50',
+        'disk_free' => '50',
+    ];
+}
+
+test('store metrics without services key changes no statuses', function () {
+    Event::fake([ServiceStatusChanged::class]);
+
+    $service = vitoPestFeatureAPIAgentControllerTestAgentService();
+
+    $this->json(
+        'POST',
+        route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+        vitoPestFeatureAPIAgentControllerTestMinimalPayload(),
+        ['secret' => 'test-secret']
+    )->assertSuccessful();
+
+    $this->assertDatabaseHas('metrics', ['server_id' => $this->server->id, 'load' => 0.5]);
+    Event::assertNotDispatched(ServiceStatusChanged::class);
+});
+
+test('store metrics with services updates statuses', function () {
+    Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
+
+    $service = vitoPestFeatureAPIAgentControllerTestAgentService();
+    $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
+
+    vitoPestFeatureAPIAgentControllerTestReportServiceStatus($service, $nginx, 'inactive');
+    vitoPestFeatureAPIAgentControllerTestReportServiceStatus($service, $nginx, 'inactive');
+
+    $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::STOPPED]);
+    $this->assertDatabaseHas('metrics', ['server_id' => $this->server->id, 'load' => 0.5]);
+    Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $nginx->id
+        && $event->previousStatus === ServiceStatus::READY
+        && $event->newStatus === ServiceStatus::STOPPED);
+    Event::assertDispatched(SocketEvent::class);
+});
+
+test('single inactive report does not change status', function () {
+    Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
+
+    $service = vitoPestFeatureAPIAgentControllerTestAgentService();
+    $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
+
+    vitoPestFeatureAPIAgentControllerTestReportServiceStatus($service, $nginx, 'inactive');
+
+    $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+    Event::assertNotDispatched(ServiceStatusChanged::class);
+});
+
+test('duplicate service entries count as one reading', function () {
+    Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
+
+    $service = vitoPestFeatureAPIAgentControllerTestAgentService();
+    $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
+
+    $this->json(
+        'POST',
+        route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+        array_merge(vitoPestFeatureAPIAgentControllerTestMinimalPayload(), [
+            'services' => [
+                ['id' => $nginx->id, 'status' => 'inactive'],
+                ['id' => $nginx->id, 'status' => 'inactive'],
+            ],
+        ]),
+        ['secret' => 'test-secret']
+    )->assertSuccessful();
+
+    $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+    Event::assertNotDispatched(ServiceStatusChanged::class);
+});
+
+test('agent reported restart flap does not change status', function () {
+    Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
+
+    $service = vitoPestFeatureAPIAgentControllerTestAgentService();
+    $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
+
+    vitoPestFeatureAPIAgentControllerTestReportServiceStatus($service, $nginx, 'inactive');
+    vitoPestFeatureAPIAgentControllerTestReportServiceStatus($service, $nginx, 'active');
+    vitoPestFeatureAPIAgentControllerTestReportServiceStatus($service, $nginx, 'inactive');
+
+    $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+    Event::assertNotDispatched(ServiceStatusChanged::class);
+});
+
+function vitoPestFeatureAPIAgentControllerTestReportServiceStatus(Service $service, Service $target, string $status): void
+{
+    test()->json(
+        'POST',
+        route('api.servers.agent', ['server' => test()->server, 'id' => $service->id]),
+        array_merge(vitoPestFeatureAPIAgentControllerTestMinimalPayload(), [
+            'services' => [['id' => $target->id, 'status' => $status]],
+        ]),
+        ['secret' => 'test-secret']
+    )->assertSuccessful();
+}
+
+test('services entry for other server is ignored', function () {
+    Event::fake([ServiceStatusChanged::class]);
+
+    $service = vitoPestFeatureAPIAgentControllerTestAgentService();
+    $otherServer = Server::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+    $otherService = Service::factory()->create([
+        'server_id' => $otherServer->id,
+        'name' => 'nginx',
+        'type' => 'webserver',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+
+    $this->json(
+        'POST',
+        route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+        array_merge(vitoPestFeatureAPIAgentControllerTestMinimalPayload(), [
+            'services' => [['id' => $otherService->id, 'status' => 'inactive']],
+        ]),
+        ['secret' => 'test-secret']
+    )->assertSuccessful();
+
+    $this->assertDatabaseHas('services', ['id' => $otherService->id, 'status' => ServiceStatus::READY]);
+    Event::assertNotDispatched(ServiceStatusChanged::class);
+});
+
+test('services entry for transitional service is ignored', function () {
+    Event::fake([ServiceStatusChanged::class]);
+
+    $service = vitoPestFeatureAPIAgentControllerTestAgentService();
+    $mysql = $this->server->services()->where('name', 'mysql')->firstOrFail();
+    $mysql->update(['status' => ServiceStatus::INSTALLING]);
+
+    $this->json(
+        'POST',
+        route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+        array_merge(vitoPestFeatureAPIAgentControllerTestMinimalPayload(), [
+            'services' => [['id' => $mysql->id, 'status' => 'active']],
+        ]),
+        ['secret' => 'test-secret']
+    )->assertSuccessful();
+
+    $this->assertDatabaseHas('services', ['id' => $mysql->id, 'status' => ServiceStatus::INSTALLING]);
+    Event::assertNotDispatched(ServiceStatusChanged::class);
+});
+
+test('services entry with unknown status is ignored', function () {
+    Event::fake([ServiceStatusChanged::class]);
+
+    $service = vitoPestFeatureAPIAgentControllerTestAgentService();
+    $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
+
+    $this->json(
+        'POST',
+        route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+        array_merge(vitoPestFeatureAPIAgentControllerTestMinimalPayload(), [
+            'services' => [['id' => $nginx->id, 'status' => 'activating']],
+        ]),
+        ['secret' => 'test-secret']
+    )->assertSuccessful();
+
+    $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+    Event::assertNotDispatched(ServiceStatusChanged::class);
+});
+
+test('services entry for monitoring service is ignored', function () {
+    Event::fake([ServiceStatusChanged::class]);
+
+    $service = vitoPestFeatureAPIAgentControllerTestAgentService();
+
+    $this->json(
+        'POST',
+        route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+        array_merge(vitoPestFeatureAPIAgentControllerTestMinimalPayload(), [
+            'services' => [['id' => $service->id, 'status' => 'inactive']],
+        ]),
+        ['secret' => 'test-secret']
+    )->assertSuccessful();
+
+    $this->assertDatabaseHas('services', ['id' => $service->id, 'status' => ServiceStatus::READY]);
+    Event::assertNotDispatched(ServiceStatusChanged::class);
+});
+
+test('services must be an array', function () {
+    $service = vitoPestFeatureAPIAgentControllerTestAgentService();
+
+    $this->json(
+        'POST',
+        route('api.servers.agent', ['server' => $this->server, 'id' => $service->id]),
+        array_merge(vitoPestFeatureAPIAgentControllerTestMinimalPayload(), ['services' => 'nope']),
+        ['secret' => 'test-secret']
+    )->assertStatus(422);
+
+    $this->assertDatabaseCount('metrics', 0);
+});

--- a/tests/Feature/API/ApiKeyScopeTest.php
+++ b/tests/Feature/API/ApiKeyScopeTest.php
@@ -1,278 +1,255 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\UserRole;
 use App\Models\PersonalAccessToken;
 use App\Models\Project;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 
-class ApiKeyScopeTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_full_access_token_can_see_all_projects(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('full access token can see all projects', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        /** @var Project $project2 */
-        $project2 = Project::factory()->create();
-        $project2->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
+    /** @var Project $project2 */
+    $project2 = Project::factory()->create();
+    $project2->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
 
-        $this->json('GET', '/api/projects')
-            ->assertSuccessful()
-            ->assertJsonFragment(['id' => $this->user->currentProject->id])
-            ->assertJsonFragment(['id' => $project2->id]);
-    }
+    $this->json('GET', '/api/projects')
+        ->assertSuccessful()
+        ->assertJsonFragment(['id' => $this->user->currentProject->id])
+        ->assertJsonFragment(['id' => $project2->id]);
+});
 
-    public function test_token_with_no_project_scope_has_access_to_all(): void
-    {
-        $token = $this->user->createToken('full-access-token', ['read', 'write']);
+test('token with no project scope has access to all', function () {
+    $token = $this->user->createToken('full-access-token', ['read', 'write']);
 
-        /** @var PersonalAccessToken $accessToken */
-        $accessToken = $token->accessToken;
+    /** @var PersonalAccessToken $accessToken */
+    $accessToken = $token->accessToken;
 
-        $this->assertTrue($accessToken->hasProjectAccess($this->user->currentProject));
+    expect($accessToken->hasProjectAccess($this->user->currentProject))->toBeTrue();
 
-        /** @var Project $project2 */
-        $project2 = Project::factory()->create();
-        $this->assertTrue($accessToken->hasProjectAccess($project2));
-        $this->assertEmpty($accessToken->getProjectIds());
-    }
+    /** @var Project $project2 */
+    $project2 = Project::factory()->create();
+    expect($accessToken->hasProjectAccess($project2))->toBeTrue();
+    expect($accessToken->getProjectIds())->toBeEmpty();
+});
 
-    public function test_scoped_token_has_project_ids_in_abilities(): void
-    {
-        $projectId = $this->user->current_project_id;
-        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$projectId]);
+test('scoped token has project ids in abilities', function () {
+    $projectId = $this->user->current_project_id;
+    $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$projectId]);
 
-        /** @var PersonalAccessToken $accessToken */
-        $accessToken = $token->accessToken;
+    /** @var PersonalAccessToken $accessToken */
+    $accessToken = $token->accessToken;
 
-        $this->assertEquals([$projectId], $accessToken->getProjectIds());
-        $this->assertTrue($accessToken->hasProjectAccess($this->user->currentProject));
-    }
+    expect($accessToken->getProjectIds())->toEqual([$projectId]);
+    expect($accessToken->hasProjectAccess($this->user->currentProject))->toBeTrue();
+});
 
-    public function test_scoped_token_denies_access_to_unscoped_project(): void
-    {
-        /** @var Project $project1 */
-        $project1 = Project::factory()->create();
-        $project1->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
+test('scoped token denies access to unscoped project', function () {
+    /** @var Project $project1 */
+    $project1 = Project::factory()->create();
+    $project1->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
 
-        /** @var Project $project2 */
-        $project2 = Project::factory()->create();
-        $project2->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
+    /** @var Project $project2 */
+    $project2 = Project::factory()->create();
+    $project2->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
 
-        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$project1->id]);
+    $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$project1->id]);
 
-        /** @var PersonalAccessToken $accessToken */
-        $accessToken = $token->accessToken;
+    /** @var PersonalAccessToken $accessToken */
+    $accessToken = $token->accessToken;
 
-        $this->assertTrue($accessToken->hasProjectAccess($project1));
-        $this->assertFalse($accessToken->hasProjectAccess($project2));
-    }
+    expect($accessToken->hasProjectAccess($project1))->toBeTrue();
+    expect($accessToken->hasProjectAccess($project2))->toBeFalse();
+});
 
-    public function test_scoped_token_cannot_access_servers_in_unscoped_project(): void
-    {
-        /** @var Project $project2 */
-        $project2 = Project::factory()->create();
-        $project2->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
+test('scoped token cannot access servers in unscoped project', function () {
+    /** @var Project $project2 */
+    $project2 = Project::factory()->create();
+    $project2->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
 
-        // Token scoped to project2 only
-        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$project2->id]);
+    // Token scoped to project2 only
+    $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$project2->id]);
 
-        // Try accessing servers in the default project (not scoped)
-        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
-            ->json('GET', route('api.projects.servers', [
-                'project' => $this->user->current_project_id,
-            ]))
-            ->assertForbidden();
-    }
+    // Try accessing servers in the default project (not scoped)
+    $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+        ->json('GET', route('api.projects.servers', [
+            'project' => $this->user->current_project_id,
+        ]))
+        ->assertForbidden();
+});
 
-    public function test_scoped_token_can_access_servers_in_scoped_project(): void
-    {
-        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$this->user->current_project_id]);
+test('scoped token can access servers in scoped project', function () {
+    $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$this->user->current_project_id]);
 
-        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
-            ->json('GET', route('api.projects.servers', [
-                'project' => $this->user->current_project_id,
-            ]))
-            ->assertSuccessful();
-    }
+    $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+        ->json('GET', route('api.projects.servers', [
+            'project' => $this->user->current_project_id,
+        ]))
+        ->assertSuccessful();
+});
 
-    public function test_full_access_token_can_access_any_project_servers(): void
-    {
-        $token = $this->user->createToken('full-access-token', ['read', 'write']);
+test('full access token can access any project servers', function () {
+    $token = $this->user->createToken('full-access-token', ['read', 'write']);
 
-        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
-            ->json('GET', route('api.projects.servers', [
-                'project' => $this->user->current_project_id,
-            ]))
-            ->assertSuccessful();
-    }
+    $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+        ->json('GET', route('api.projects.servers', [
+            'project' => $this->user->current_project_id,
+        ]))
+        ->assertSuccessful();
+});
 
-    public function test_read_only_token_cannot_write(): void
-    {
-        $token = $this->user->createToken('read-only-token', ['read']);
+test('read only token cannot write', function () {
+    $token = $this->user->createToken('read-only-token', ['read']);
 
-        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
-            ->json('POST', '/api/projects', [
-                'name' => 'test-project',
-            ])
-            ->assertForbidden();
-    }
+    $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+        ->json('POST', '/api/projects', [
+            'name' => 'test-project',
+        ])
+        ->assertForbidden();
+});
 
-    public function test_read_only_token_can_read(): void
-    {
-        $token = $this->user->createToken('read-only-token', ['read']);
+test('read only token can read', function () {
+    $token = $this->user->createToken('read-only-token', ['read']);
 
-        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
-            ->json('GET', '/api/projects')
-            ->assertSuccessful();
-    }
+    $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+        ->json('GET', '/api/projects')
+        ->assertSuccessful();
+});
 
-    public function test_scoped_token_filters_project_index(): void
-    {
-        /** @var Project $project2 */
-        $project2 = Project::factory()->create();
-        $project2->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
+test('scoped token filters project index', function () {
+    /** @var Project $project2 */
+    $project2 = Project::factory()->create();
+    $project2->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
 
-        $token = $this->user->createToken('scoped-token', ['read', 'project:'.$project2->id]);
+    $token = $this->user->createToken('scoped-token', ['read', 'project:'.$project2->id]);
 
-        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
-            ->json('GET', '/api/projects')
-            ->assertSuccessful()
-            ->assertJsonFragment(['id' => $project2->id])
-            ->assertJsonMissing(['id' => $this->user->currentProject->id]);
-    }
+    $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+        ->json('GET', '/api/projects')
+        ->assertSuccessful()
+        ->assertJsonFragment(['id' => $project2->id])
+        ->assertJsonMissing(['id' => $this->user->currentProject->id]);
+});
 
-    public function test_scoped_token_cannot_show_unscoped_project(): void
-    {
-        /** @var Project $project2 */
-        $project2 = Project::factory()->create();
-        $project2->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
+test('scoped token cannot show unscoped project', function () {
+    /** @var Project $project2 */
+    $project2 = Project::factory()->create();
+    $project2->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
 
-        $token = $this->user->createToken('scoped-token', ['read', 'project:'.$this->user->current_project_id]);
+    $token = $this->user->createToken('scoped-token', ['read', 'project:'.$this->user->current_project_id]);
 
-        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
-            ->json('GET', "/api/projects/{$project2->id}")
-            ->assertForbidden();
-    }
+    $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+        ->json('GET', "/api/projects/{$project2->id}")
+        ->assertForbidden();
+});
 
-    public function test_scoped_token_can_show_scoped_project(): void
-    {
-        $token = $this->user->createToken('scoped-token', ['read', 'project:'.$this->user->current_project_id]);
+test('scoped token can show scoped project', function () {
+    $token = $this->user->createToken('scoped-token', ['read', 'project:'.$this->user->current_project_id]);
 
-        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
-            ->json('GET', "/api/projects/{$this->user->currentProject->id}")
-            ->assertSuccessful();
-    }
+    $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+        ->json('GET', "/api/projects/{$this->user->currentProject->id}")
+        ->assertSuccessful();
+});
 
-    public function test_scoped_token_cannot_update_unscoped_project(): void
-    {
-        /** @var Project $project2 */
-        $project2 = Project::factory()->create();
-        $project2->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
+test('scoped token cannot update unscoped project', function () {
+    /** @var Project $project2 */
+    $project2 = Project::factory()->create();
+    $project2->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
 
-        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$this->user->current_project_id]);
+    $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$this->user->current_project_id]);
 
-        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
-            ->json('PUT', "/api/projects/{$project2->id}", [
-                'name' => 'updated-name',
-            ])
-            ->assertForbidden();
-    }
+    $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+        ->json('PUT', "/api/projects/{$project2->id}", [
+            'name' => 'updated-name',
+        ])
+        ->assertForbidden();
+});
 
-    public function test_scoped_token_can_update_scoped_project(): void
-    {
-        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$this->user->current_project_id]);
+test('scoped token can update scoped project', function () {
+    $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$this->user->current_project_id]);
 
-        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
-            ->json('PUT', "/api/projects/{$this->user->currentProject->id}", [
-                'name' => 'updated-name',
-            ])
-            ->assertSuccessful();
-    }
+    $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+        ->json('PUT', "/api/projects/{$this->user->currentProject->id}", [
+            'name' => 'updated-name',
+        ])
+        ->assertSuccessful();
+});
 
-    public function test_scoped_token_cannot_delete_unscoped_project(): void
-    {
-        /** @var Project $project2 */
-        $project2 = Project::factory()->create();
-        $project2->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
+test('scoped token cannot delete unscoped project', function () {
+    /** @var Project $project2 */
+    $project2 = Project::factory()->create();
+    $project2->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
 
-        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$this->user->current_project_id]);
+    $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$this->user->current_project_id]);
 
-        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
-            ->json('DELETE', "/api/projects/{$project2->id}", [
-                'name' => $project2->name,
-            ])
-            ->assertForbidden();
-    }
+    $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+        ->json('DELETE', "/api/projects/{$project2->id}", [
+            'name' => $project2->name,
+        ])
+        ->assertForbidden();
+});
 
-    public function test_scoped_token_can_delete_scoped_project(): void
-    {
-        /** @var Project $project2 */
-        $project2 = Project::factory()->create();
-        $project2->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::OWNER,
-        ]);
+test('scoped token can delete scoped project', function () {
+    /** @var Project $project2 */
+    $project2 = Project::factory()->create();
+    $project2->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::OWNER,
+    ]);
 
-        $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$project2->id]);
+    $token = $this->user->createToken('scoped-token', ['read', 'write', 'project:'.$project2->id]);
 
-        $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
-            ->json('DELETE', "/api/projects/{$project2->id}", [
-                'name' => $project2->name,
-            ])
-            ->assertSuccessful();
-    }
+    $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+        ->json('DELETE', "/api/projects/{$project2->id}", [
+            'name' => $project2->name,
+        ])
+        ->assertSuccessful();
+});
 
-    public function test_multiple_project_scopes(): void
-    {
-        /** @var Project $project2 */
-        $project2 = Project::factory()->create();
-        $project2->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
+test('multiple project scopes', function () {
+    /** @var Project $project2 */
+    $project2 = Project::factory()->create();
+    $project2->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
 
-        $token = $this->user->createToken('multi-scoped', [
-            'read',
-            'write',
-            'project:'.$this->user->current_project_id,
-            'project:'.$project2->id,
-        ]);
+    $token = $this->user->createToken('multi-scoped', [
+        'read',
+        'write',
+        'project:'.$this->user->current_project_id,
+        'project:'.$project2->id,
+    ]);
 
-        /** @var PersonalAccessToken $accessToken */
-        $accessToken = $token->accessToken;
+    /** @var PersonalAccessToken $accessToken */
+    $accessToken = $token->accessToken;
 
-        $this->assertTrue($accessToken->hasProjectAccess($this->user->currentProject));
-        $this->assertTrue($accessToken->hasProjectAccess($project2));
-        $this->assertCount(2, $accessToken->getProjectIds());
-    }
-}
+    expect($accessToken->hasProjectAccess($this->user->currentProject))->toBeTrue();
+    expect($accessToken->hasProjectAccess($project2))->toBeTrue();
+    expect($accessToken->getProjectIds())->toHaveCount(2);
+});

--- a/tests/Feature/API/CronjobTest.php
+++ b/tests/Feature/API/CronjobTest.php
@@ -1,102 +1,92 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\CronjobStatus;
 use App\Facades\SSH;
 use App\Models\CronJob;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 
-class CronjobTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_see_cronjobs_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('see cronjobs list', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->json('GET', route('api.projects.servers.cron-jobs', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'command' => $cronjob->command,
+            'frequency' => $cronjob->frequency,
         ]);
+});
 
-        $this->json('GET', route('api.projects.servers.cron-jobs', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'command' => $cronjob->command,
-                'frequency' => $cronjob->frequency,
-            ]);
-    }
+test('create cronjob', function () {
+    SSH::fake();
 
-    public function test_create_cronjob(): void
-    {
-        SSH::fake();
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $this->json('POST', route('api.projects.servers.cron-jobs.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
+    $this->json('POST', route('api.projects.servers.cron-jobs.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'command' => 'ls -la',
             'user' => 'vito',
             'frequency' => '* * * * *',
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'command' => 'ls -la',
-                'user' => 'vito',
-                'frequency' => '* * * * *',
-                'status' => CronjobStatus::READY,
-            ]);
-    }
-
-    public function test_delete_cronjob(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'vito',
+            'status' => CronjobStatus::READY,
         ]);
+});
 
-        $this->json('DELETE', route('api.projects.servers.cron-jobs.delete', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'cronJob' => $cronjob,
-        ]))
-            ->assertSuccessful()
-            ->assertNoContent();
-    }
+test('delete cronjob', function () {
+    SSH::fake();
 
-    public function test_cannot_create_cronjob_with_invalid_site_id_api(): void
-    {
-        SSH::fake();
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('POST', route('api.projects.servers.cron-jobs.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
-            'command' => 'ls -la',
-            'user' => 'vito',
-            'frequency' => '* * * * *',
-            'site_id' => 99999, // Non-existent site ID
-        ])
-            ->assertStatus(422)
-            ->assertJsonValidationErrors(['site_id']);
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'vito',
+    ]);
 
-        $this->assertDatabaseMissing('cron_jobs', [
-            'server_id' => $this->server->id,
-            'site_id' => 99999,
-        ]);
-    }
-}
+    $this->json('DELETE', route('api.projects.servers.cron-jobs.delete', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'cronJob' => $cronjob,
+    ]))
+        ->assertSuccessful()
+        ->assertNoContent();
+});
+
+test('cannot create cronjob with invalid site id api', function () {
+    SSH::fake();
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $this->json('POST', route('api.projects.servers.cron-jobs.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+        'site_id' => 99999, // Non-existent site ID
+    ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['site_id']);
+
+    $this->assertDatabaseMissing('cron_jobs', [
+        'server_id' => $this->server->id,
+        'site_id' => 99999,
+    ]);
+});

--- a/tests/Feature/API/DNSProvidersTest.php
+++ b/tests/Feature/API/DNSProvidersTest.php
@@ -1,693 +1,652 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\DNSProviders\Cloudflare;
 use App\Models\DNSProvider;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Laravel\Sanctum\Sanctum;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class DNSProvidersTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    /**
-     * @param  array<string, mixed>  $input
-     */
-    #[DataProvider('data')]
-    public function test_connect_provider(string $provider, array $input): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('connect provider', function (string $provider, array $input) {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'success' => true,
-                'result' => ['id' => 'test-user-id'],
-            ], 200),
-        ]);
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'success' => true,
+            'result' => ['id' => 'test-user-id'],
+        ], 200),
+    ]);
 
-        $data = array_merge([
+    $data = array_merge([
+        'name' => 'Test DNS Provider',
+        'provider' => $provider,
+    ], $input);
+
+    $this->json('POST', route('api.dns-providers.create'), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'provider' => $provider,
             'name' => 'Test DNS Provider',
-            'provider' => $provider,
-        ], $input);
-
-        $this->json('POST', route('api.dns-providers.create'), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'provider' => $provider,
-                'name' => 'Test DNS Provider',
-                'connected' => true,
-            ]);
-    }
-
-    /**
-     * @param  array<string, mixed>  $input
-     */
-    #[DataProvider('data')]
-    public function test_cannot_connect_to_provider(string $provider, array $input): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        Http::fake([
-            '*' => Http::response([], 401),
-        ]);
-
-        $data = array_merge([
-            'name' => 'Test DNS Provider',
-            'provider' => $provider,
-        ], $input);
-
-        $this->json('POST', route('api.dns-providers.create'), $data)
-            ->assertJsonValidationErrorFor('provider');
-    }
-
-    public function test_see_dns_providers_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var DNSProvider $dnsProvider */
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $this->json('GET', route('api.dns-providers'))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'id' => $dnsProvider->id,
-                'provider' => $dnsProvider->provider,
-                'name' => $dnsProvider->name,
-            ]);
-    }
-
-    public function test_show_specific_dns_provider(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var DNSProvider $dnsProvider */
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $this->json('GET', route('api.dns-providers.show', $dnsProvider))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'id' => $dnsProvider->id,
-                'provider' => $dnsProvider->provider,
-                'name' => $dnsProvider->name,
-                'connected' => $dnsProvider->connected,
-            ]);
-    }
-
-    #[DataProvider('data')]
-    public function test_delete_dns_provider(string $provider, array $input): void
-    {
-        unset($input);
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var DNSProvider $dnsProvider */
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => $provider,
-        ]);
-
-        $this->json('DELETE', route('api.dns-providers.destroy', $dnsProvider))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'message' => 'DNS provider deleted successfully',
-            ]);
-    }
-
-    public function test_update_dns_provider(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var DNSProvider $dnsProvider */
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $data = [
-            'name' => 'Updated DNS Provider Name',
-        ];
-
-        $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'id' => $dnsProvider->id,
-                'name' => 'Updated DNS Provider Name',
-            ]);
-
-        $dnsProvider->refresh();
-        $this->assertEquals('Updated DNS Provider Name', $dnsProvider->name);
-    }
-
-    public function test_api_user_cannot_access_other_users_dns_provider(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
-
-        $this->json('GET', route('api.dns-providers.show', $dnsProvider))
-            ->assertForbidden();
-    }
-
-    public function test_api_user_cannot_update_other_users_dns_provider(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
-
-        $this->json('PUT', route('api.dns-providers.update', $dnsProvider), [
-            'name' => 'hacked',
-        ])
-            ->assertForbidden();
-    }
-
-    public function test_api_user_cannot_delete_other_users_dns_provider(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
-
-        $this->json('DELETE', route('api.dns-providers.destroy', $dnsProvider))
-            ->assertForbidden();
-    }
-
-    public function test_api_guest_cannot_access_dns_providers(): void
-    {
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->json('GET', route('api.dns-providers'))
-            ->assertUnauthorized();
-
-        $this->json('POST', route('api.dns-providers.create'), [])
-            ->assertUnauthorized();
-
-        $this->json('GET', route('api.dns-providers.show', $dnsProvider))
-            ->assertUnauthorized();
-
-        $this->json('PUT', route('api.dns-providers.update', $dnsProvider), [])
-            ->assertUnauthorized();
-
-        $this->json('DELETE', route('api.dns-providers.destroy', $dnsProvider))
-            ->assertUnauthorized();
-    }
-
-    public function test_api_insufficient_scopes_denies_access(): void
-    {
-        Sanctum::actingAs($this->user, ['read']); // Only read scope
-
-        $data = [
-            'provider' => Cloudflare::id(),
-            'name' => 'test',
-            'token' => 'fake-token',
-        ];
-
-        $this->json('POST', route('api.dns-providers.create'), $data)
-            ->assertForbidden();
-    }
-
-    public function test_api_cannot_manipulate_user_id_on_creation(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'success' => true,
-                'result' => ['id' => 'test-user-id'],
-            ], 200),
-        ]);
-
-        $data = [
-            'provider' => Cloudflare::id(),
-            'name' => 'test',
-            'token' => 'fake-token',
-            'user_id' => $otherUser->id,
-        ];
-
-        $this->json('POST', route('api.dns-providers.create'), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'provider' => Cloudflare::id(),
-                'name' => 'test',
-            ]);
-
-        $this->assertDatabaseHas('dns_providers', [
-            'name' => 'test',
-            'provider' => Cloudflare::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->assertDatabaseMissing('dns_providers', [
-            'name' => 'test',
-            'provider' => Cloudflare::id(),
-            'user_id' => $otherUser->id,
-        ]);
-    }
-
-    public function test_api_user_can_only_see_own_dns_providers_in_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-
-        $ownDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'name' => 'own-dns-provider',
-        ]);
-
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'name' => 'other-dns-provider',
-        ]);
-
-        $this->json('GET', route('api.dns-providers'))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'id' => $ownDnsProvider->id,
-                'provider' => $ownDnsProvider->provider,
-            ])
-            ->assertJsonMissing([
-                'id' => $otherDnsProvider->id,
-            ]);
-    }
-
-    public function test_dns_provider_creation_requires_name(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $data = [
-            'provider' => Cloudflare::id(),
-            'token' => 'fake-token',
-        ];
-
-        $this->json('POST', route('api.dns-providers.create'), $data)
-            ->assertJsonValidationErrorFor('name');
-    }
-
-    public function test_dns_provider_creation_requires_valid_provider(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $data = [
-            'name' => 'Test Provider',
-            'provider' => 'invalid-provider',
-            'token' => 'fake-token',
-        ];
-
-        $this->json('POST', route('api.dns-providers.create'), $data)
-            ->assertJsonValidationErrorFor('provider');
-    }
-
-    public function test_dns_provider_creation_validates_credentials(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $data = [
-            'name' => 'Test Cloudflare',
-            'provider' => Cloudflare::id(),
-            // Missing required 'token' field
-        ];
-
-        $this->json('POST', route('api.dns-providers.create'), $data)
-            ->assertJsonValidationErrors(['token']);
-    }
-
-    public function test_dns_provider_update_requires_name(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $data = [];
-
-        $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
-            ->assertJsonValidationErrorFor('name');
-    }
-
-    public function test_dns_provider_creation_with_global_flag(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'success' => true,
-                'result' => ['id' => 'test-user-id'],
-            ], 200),
-        ]);
-
-        $data = [
-            'name' => 'Global Cloudflare',
-            'provider' => Cloudflare::id(),
-            'token' => 'fake-token',
-            'global' => true,
-        ];
-
-        $this->json('POST', route('api.dns-providers.create'), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'provider' => Cloudflare::id(),
-                'name' => 'Global Cloudflare',
-                'project_id' => null,
-            ]);
-    }
-
-    public function test_dns_provider_creation_without_global_flag(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'success' => true,
-                'result' => ['id' => 'test-user-id'],
-            ], 200),
-        ]);
-
-        $data = [
-            'name' => 'Project Cloudflare',
-            'provider' => Cloudflare::id(),
-            'token' => 'fake-token',
-        ];
-
-        $this->json('POST', route('api.dns-providers.create'), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'provider' => Cloudflare::id(),
-                'name' => 'Project Cloudflare',
-                'project_id' => $this->user->current_project_id,
-            ]);
-    }
-
-    public function test_dns_providers_are_filtered_by_project(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        // Create DNS provider for current project
-        $projectDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        // Create global DNS provider (no project)
-        $globalDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => null,
-        ]);
-
-        // Create DNS provider for different project
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-        $otherProjectDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherUser->current_project_id,
-        ]);
-
-        $response = $this->json('GET', route('api.dns-providers'))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'id' => $projectDnsProvider->id,
-            ])
-            ->assertJsonFragment([
-                'id' => $globalDnsProvider->id,
-            ])
-            ->assertJsonMissing([
-                'id' => $otherProjectDnsProvider->id,
-            ]);
-    }
-
-    public function test_dns_provider_creation_fails_with_invalid_credentials(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        Http::fake([
-            '*' => Http::response([], 401),
-        ]);
-
-        $data = [
-            'name' => 'Test Cloudflare',
-            'provider' => Cloudflare::id(),
-            'token' => 'invalid-token',
-        ];
-
-        $this->json('POST', route('api.dns-providers.create'), $data)
-            ->assertJsonValidationErrorFor('provider');
-    }
-
-    public function test_dns_provider_creation_ignores_user_id_manipulation(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'success' => true,
-                'result' => ['id' => 'test-user-id'],
-            ], 200),
-        ]);
-
-        $data = [
-            'name' => 'Test Provider',
-            'provider' => Cloudflare::id(),
-            'token' => 'fake-token',
-            'user_id' => $otherUser->id, // Attempt to set different user
-        ];
-
-        $this->json('POST', route('api.dns-providers.create'), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'provider' => Cloudflare::id(),
-                'name' => 'Test Provider',
-            ]);
-
-        $this->assertDatabaseHas('dns_providers', [
-            'user_id' => $this->user->id, // Should be set to authenticated user
-            'name' => 'Test Provider',
-        ]);
-
-        $this->assertDatabaseMissing('dns_providers', [
-            'user_id' => $otherUser->id,
-        ]);
-    }
-
-    public function test_dns_provider_update_ignores_user_id_manipulation(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $data = [
-            'name' => 'Updated Name',
-            'user_id' => $otherUser->id, // Attempt to change user
-        ];
-
-        $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => 'Updated Name',
-            ]);
-
-        $dnsProvider->refresh();
-        $this->assertEquals('Updated Name', $dnsProvider->name);
-        $this->assertEquals($this->user->id, $dnsProvider->user_id); // Should remain unchanged
-    }
-
-    public function test_dns_provider_update_ignores_provider_manipulation(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Cloudflare::id(),
-        ]);
-
-        $data = [
-            'name' => 'Updated Name',
-            'provider' => 'different-provider', // Attempt to change provider
-        ];
-
-        $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => 'Updated Name',
-                'provider' => Cloudflare::id(), // Should remain unchanged
-            ]);
-
-        $dnsProvider->refresh();
-        $this->assertEquals('Updated Name', $dnsProvider->name);
-        $this->assertEquals(Cloudflare::id(), $dnsProvider->provider); // Should remain unchanged
-    }
-
-    public function test_dns_provider_update_keeps_credentials_when_empty(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'credentials' => ['token' => 'original-token'],
-        ]);
-
-        $data = [
-            'name' => 'Updated Name',
-        ];
-
-        $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => 'Updated Name',
-            ]);
-
-        $dnsProvider->refresh();
-        $this->assertEquals('Updated Name', $dnsProvider->name);
-        $this->assertEquals(['token' => 'original-token'], $dnsProvider->credentials);
-    }
-
-    public function test_dns_provider_update_changes_credentials_when_provided(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'credentials' => ['token' => 'original-token'],
-        ]);
-
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'success' => true,
-                'result' => [],
-            ], 200),
-        ]);
-
-        $data = [
-            'name' => 'Updated Name',
-            'token' => 'new-token',
-        ];
-
-        $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => 'Updated Name',
-            ]);
-
-        $dnsProvider->refresh();
-        $this->assertEquals('Updated Name', $dnsProvider->name);
-        $this->assertEquals(['token' => 'new-token'], $dnsProvider->credentials);
-    }
-
-    public function test_dns_provider_update_rejects_invalid_credentials(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'credentials' => ['token' => 'original-token'],
-        ]);
-
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'success' => false,
-                'errors' => [['message' => 'Invalid token']],
-            ], 401),
-        ]);
-
-        $data = [
-            'name' => 'Updated Name',
-            'token' => 'bad-token',
-        ];
-
-        $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
-            ->assertUnprocessable();
-
-        $dnsProvider->refresh();
-        $this->assertEquals(['token' => 'original-token'], $dnsProvider->credentials);
-    }
-
-    public function test_dns_provider_update_ignores_connected_manipulation(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
             'connected' => true,
         ]);
+})->with('data');
 
-        $data = [
-            'name' => 'Updated Name',
-            'connected' => false, // Attempt to change connected status
-        ];
+test('cannot connect to provider', function (string $provider, array $input) {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => 'Updated Name',
-                'connected' => true, // Should remain unchanged
-            ]);
+    Http::fake([
+        '*' => Http::response([], 401),
+    ]);
 
-        $dnsProvider->refresh();
-        $this->assertEquals('Updated Name', $dnsProvider->name);
-        $this->assertTrue($dnsProvider->connected); // Should remain unchanged
-    }
+    $data = array_merge([
+        'name' => 'Test DNS Provider',
+        'provider' => $provider,
+    ], $input);
 
-    public function test_dns_provider_update_ignores_project_id_manipulation(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    $this->json('POST', route('api.dns-providers.create'), $data)
+        ->assertJsonValidationErrorFor('provider');
+})->with('data');
 
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
+test('see dns providers list', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var DNSProvider $dnsProvider */
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $this->json('GET', route('api.dns-providers'))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'id' => $dnsProvider->id,
+            'provider' => $dnsProvider->provider,
+            'name' => $dnsProvider->name,
+        ]);
+});
+
+test('show specific dns provider', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var DNSProvider $dnsProvider */
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $this->json('GET', route('api.dns-providers.show', $dnsProvider))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'id' => $dnsProvider->id,
+            'provider' => $dnsProvider->provider,
+            'name' => $dnsProvider->name,
+            'connected' => $dnsProvider->connected,
+        ]);
+});
+
+test('delete dns provider', function (string $provider, array $input) {
+    unset($input);
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var DNSProvider $dnsProvider */
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => $provider,
+    ]);
+
+    $this->json('DELETE', route('api.dns-providers.destroy', $dnsProvider))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'message' => 'DNS provider deleted successfully',
+        ]);
+})->with('data');
+
+test('update dns provider', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var DNSProvider $dnsProvider */
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $data = [
+        'name' => 'Updated DNS Provider Name',
+    ];
+
+    $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'id' => $dnsProvider->id,
+            'name' => 'Updated DNS Provider Name',
         ]);
 
-        $data = [
+    $dnsProvider->refresh();
+    expect($dnsProvider->name)->toEqual('Updated DNS Provider Name');
+});
+
+test('api user cannot access other users dns provider', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    $this->json('GET', route('api.dns-providers.show', $dnsProvider))
+        ->assertForbidden();
+});
+
+test('api user cannot update other users dns provider', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    $this->json('PUT', route('api.dns-providers.update', $dnsProvider), [
+        'name' => 'hacked',
+    ])
+        ->assertForbidden();
+});
+
+test('api user cannot delete other users dns provider', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    $this->json('DELETE', route('api.dns-providers.destroy', $dnsProvider))
+        ->assertForbidden();
+});
+
+test('api guest cannot access dns providers', function () {
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->json('GET', route('api.dns-providers'))
+        ->assertUnauthorized();
+
+    $this->json('POST', route('api.dns-providers.create'), [])
+        ->assertUnauthorized();
+
+    $this->json('GET', route('api.dns-providers.show', $dnsProvider))
+        ->assertUnauthorized();
+
+    $this->json('PUT', route('api.dns-providers.update', $dnsProvider), [])
+        ->assertUnauthorized();
+
+    $this->json('DELETE', route('api.dns-providers.destroy', $dnsProvider))
+        ->assertUnauthorized();
+});
+
+test('api insufficient scopes denies access', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    // Only read scope
+    $data = [
+        'provider' => Cloudflare::id(),
+        'name' => 'test',
+        'token' => 'fake-token',
+    ];
+
+    $this->json('POST', route('api.dns-providers.create'), $data)
+        ->assertForbidden();
+});
+
+test('api cannot manipulate user id on creation', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'success' => true,
+            'result' => ['id' => 'test-user-id'],
+        ], 200),
+    ]);
+
+    $data = [
+        'provider' => Cloudflare::id(),
+        'name' => 'test',
+        'token' => 'fake-token',
+        'user_id' => $otherUser->id,
+    ];
+
+    $this->json('POST', route('api.dns-providers.create'), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'provider' => Cloudflare::id(),
+            'name' => 'test',
+        ]);
+
+    $this->assertDatabaseHas('dns_providers', [
+        'name' => 'test',
+        'provider' => Cloudflare::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->assertDatabaseMissing('dns_providers', [
+        'name' => 'test',
+        'provider' => Cloudflare::id(),
+        'user_id' => $otherUser->id,
+    ]);
+});
+
+test('api user can only see own dns providers in list', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+
+    $ownDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'name' => 'own-dns-provider',
+    ]);
+
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'name' => 'other-dns-provider',
+    ]);
+
+    $this->json('GET', route('api.dns-providers'))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'id' => $ownDnsProvider->id,
+            'provider' => $ownDnsProvider->provider,
+        ])
+        ->assertJsonMissing([
+            'id' => $otherDnsProvider->id,
+        ]);
+});
+
+test('dns provider creation requires name', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $data = [
+        'provider' => Cloudflare::id(),
+        'token' => 'fake-token',
+    ];
+
+    $this->json('POST', route('api.dns-providers.create'), $data)
+        ->assertJsonValidationErrorFor('name');
+});
+
+test('dns provider creation requires valid provider', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $data = [
+        'name' => 'Test Provider',
+        'provider' => 'invalid-provider',
+        'token' => 'fake-token',
+    ];
+
+    $this->json('POST', route('api.dns-providers.create'), $data)
+        ->assertJsonValidationErrorFor('provider');
+});
+
+test('dns provider creation validates credentials', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $data = [
+        'name' => 'Test Cloudflare',
+        'provider' => Cloudflare::id(),
+        // Missing required 'token' field
+    ];
+
+    $this->json('POST', route('api.dns-providers.create'), $data)
+        ->assertJsonValidationErrors(['token']);
+});
+
+test('dns provider update requires name', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $data = [];
+
+    $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
+        ->assertJsonValidationErrorFor('name');
+});
+
+test('dns provider creation with global flag', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'success' => true,
+            'result' => ['id' => 'test-user-id'],
+        ], 200),
+    ]);
+
+    $data = [
+        'name' => 'Global Cloudflare',
+        'provider' => Cloudflare::id(),
+        'token' => 'fake-token',
+        'global' => true,
+    ];
+
+    $this->json('POST', route('api.dns-providers.create'), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'provider' => Cloudflare::id(),
+            'name' => 'Global Cloudflare',
+            'project_id' => null,
+        ]);
+});
+
+test('dns provider creation without global flag', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'success' => true,
+            'result' => ['id' => 'test-user-id'],
+        ], 200),
+    ]);
+
+    $data = [
+        'name' => 'Project Cloudflare',
+        'provider' => Cloudflare::id(),
+        'token' => 'fake-token',
+    ];
+
+    $this->json('POST', route('api.dns-providers.create'), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'provider' => Cloudflare::id(),
+            'name' => 'Project Cloudflare',
+            'project_id' => $this->user->current_project_id,
+        ]);
+});
+
+test('dns providers are filtered by project', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    // Create DNS provider for current project
+    $projectDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    // Create global DNS provider (no project)
+    $globalDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => null,
+    ]);
+
+    // Create DNS provider for different project
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+    $otherProjectDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherUser->current_project_id,
+    ]);
+
+    $response = $this->json('GET', route('api.dns-providers'))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'id' => $projectDnsProvider->id,
+        ])
+        ->assertJsonFragment([
+            'id' => $globalDnsProvider->id,
+        ])
+        ->assertJsonMissing([
+            'id' => $otherProjectDnsProvider->id,
+        ]);
+});
+
+test('dns provider creation fails with invalid credentials', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    Http::fake([
+        '*' => Http::response([], 401),
+    ]);
+
+    $data = [
+        'name' => 'Test Cloudflare',
+        'provider' => Cloudflare::id(),
+        'token' => 'invalid-token',
+    ];
+
+    $this->json('POST', route('api.dns-providers.create'), $data)
+        ->assertJsonValidationErrorFor('provider');
+});
+
+test('dns provider creation ignores user id manipulation', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'success' => true,
+            'result' => ['id' => 'test-user-id'],
+        ], 200),
+    ]);
+
+    $data = [
+        'name' => 'Test Provider',
+        'provider' => Cloudflare::id(),
+        'token' => 'fake-token',
+        'user_id' => $otherUser->id, // Attempt to set different user
+    ];
+
+    $this->json('POST', route('api.dns-providers.create'), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'provider' => Cloudflare::id(),
+            'name' => 'Test Provider',
+        ]);
+
+    $this->assertDatabaseHas('dns_providers', [
+        'user_id' => $this->user->id, // Should be set to authenticated user
+        'name' => 'Test Provider',
+    ]);
+
+    $this->assertDatabaseMissing('dns_providers', [
+        'user_id' => $otherUser->id,
+    ]);
+});
+
+test('dns provider update ignores user id manipulation', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $data = [
+        'name' => 'Updated Name',
+        'user_id' => $otherUser->id, // Attempt to change user
+    ];
+
+    $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'name' => 'Updated Name',
-            'project_id' => 999, // Attempt to change project
-        ];
+        ]);
 
-        $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => 'Updated Name',
-                'project_id' => $this->user->current_project_id, // Should remain unchanged
-            ]);
+    $dnsProvider->refresh();
+    expect($dnsProvider->name)->toEqual('Updated Name');
+    expect($dnsProvider->user_id)->toEqual($this->user->id);
+    // Should remain unchanged
+});
 
-        $dnsProvider->refresh();
-        $this->assertEquals('Updated Name', $dnsProvider->name);
-        $this->assertEquals($this->user->current_project_id, $dnsProvider->project_id); // Should remain unchanged
-    }
+test('dns provider update ignores provider manipulation', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    /**
-     * @return array<array<int, mixed>>
-     */
-    public static function data(): array
-    {
-        return [
-            [Cloudflare::id(), ['token' => 'test-token']],
-            [Cloudflare::id(), ['token' => 'test-token', 'global' => true]],
-        ];
-    }
-}
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Cloudflare::id(),
+    ]);
+
+    $data = [
+        'name' => 'Updated Name',
+        'provider' => 'different-provider', // Attempt to change provider
+    ];
+
+    $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'name' => 'Updated Name',
+            'provider' => Cloudflare::id(), // Should remain unchanged
+        ]);
+
+    $dnsProvider->refresh();
+    expect($dnsProvider->name)->toEqual('Updated Name');
+    expect($dnsProvider->provider)->toEqual(Cloudflare::id());
+    // Should remain unchanged
+});
+
+test('dns provider update keeps credentials when empty', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'credentials' => ['token' => 'original-token'],
+    ]);
+
+    $data = [
+        'name' => 'Updated Name',
+    ];
+
+    $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'name' => 'Updated Name',
+        ]);
+
+    $dnsProvider->refresh();
+    expect($dnsProvider->name)->toEqual('Updated Name');
+    expect($dnsProvider->credentials)->toEqual(['token' => 'original-token']);
+});
+
+test('dns provider update changes credentials when provided', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'credentials' => ['token' => 'original-token'],
+    ]);
+
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'success' => true,
+            'result' => [],
+        ], 200),
+    ]);
+
+    $data = [
+        'name' => 'Updated Name',
+        'token' => 'new-token',
+    ];
+
+    $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'name' => 'Updated Name',
+        ]);
+
+    $dnsProvider->refresh();
+    expect($dnsProvider->name)->toEqual('Updated Name');
+    expect($dnsProvider->credentials)->toEqual(['token' => 'new-token']);
+});
+
+test('dns provider update rejects invalid credentials', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'credentials' => ['token' => 'original-token'],
+    ]);
+
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'success' => false,
+            'errors' => [['message' => 'Invalid token']],
+        ], 401),
+    ]);
+
+    $data = [
+        'name' => 'Updated Name',
+        'token' => 'bad-token',
+    ];
+
+    $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
+        ->assertUnprocessable();
+
+    $dnsProvider->refresh();
+    expect($dnsProvider->credentials)->toEqual(['token' => 'original-token']);
+});
+
+test('dns provider update ignores connected manipulation', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'connected' => true,
+    ]);
+
+    $data = [
+        'name' => 'Updated Name',
+        'connected' => false, // Attempt to change connected status
+    ];
+
+    $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'name' => 'Updated Name',
+            'connected' => true, // Should remain unchanged
+        ]);
+
+    $dnsProvider->refresh();
+    expect($dnsProvider->name)->toEqual('Updated Name');
+    expect($dnsProvider->connected)->toBeTrue();
+    // Should remain unchanged
+});
+
+test('dns provider update ignores project id manipulation', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $data = [
+        'name' => 'Updated Name',
+        'project_id' => 999, // Attempt to change project
+    ];
+
+    $this->json('PUT', route('api.dns-providers.update', $dnsProvider), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'name' => 'Updated Name',
+            'project_id' => $this->user->current_project_id, // Should remain unchanged
+        ]);
+
+    $dnsProvider->refresh();
+    expect($dnsProvider->name)->toEqual('Updated Name');
+    expect($dnsProvider->project_id)->toEqual($this->user->current_project_id);
+    // Should remain unchanged
+});
+
+/**
+ * @return array<array<int, mixed>>
+ */
+dataset('data', function () {
+    return [
+        [Cloudflare::id(), ['token' => 'test-token']],
+        [Cloudflare::id(), ['token' => 'test-token', 'global' => true]],
+    ];
+});

--- a/tests/Feature/API/DNSProvidersTest.php
+++ b/tests/Feature/API/DNSProvidersTest.php
@@ -86,9 +86,7 @@ test('show specific dns provider', function () {
         ]);
 });
 
-test('delete dns provider', function (string $provider, array $input) {
-    unset($input);
-
+test('delete dns provider', function (string $provider) {
     Sanctum::actingAs($this->user, ['read', 'write']);
 
     /** @var DNSProvider $dnsProvider */
@@ -632,19 +630,15 @@ test('dns provider update ignores project id manipulation', function () {
         ->assertSuccessful()
         ->assertJsonFragment([
             'name' => 'Updated Name',
-            'project_id' => $this->user->current_project_id, // Should remain unchanged
+            'project_id' => $this->user->current_project_id,
         ]);
 
     $dnsProvider->refresh();
     expect($dnsProvider->name)->toEqual('Updated Name');
     expect($dnsProvider->project_id)->toEqual($this->user->current_project_id);
-    // Should remain unchanged
 });
 
-/**
- * @return array<array<int, mixed>>
- */
-dataset('data', function () {
+dataset('data', /** @return array<int, array{0: string, 1: array<string, mixed>}> */ function (): array {
     return [
         [Cloudflare::id(), ['token' => 'test-token']],
         [Cloudflare::id(), ['token' => 'test-token', 'global' => true]],

--- a/tests/Feature/API/DNSRecordTest.php
+++ b/tests/Feature/API/DNSRecordTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Models\DNSProvider;
 use App\Models\DNSRecord;
 use App\Models\Domain;
@@ -9,813 +7,782 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 
-class DNSRecordTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    protected User $otherUser;
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->user->ensureHasDefaultProject();
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+    $this->otherUser = User::factory()->create();
+    $this->otherUser->ensureHasDefaultProject();
+});
 
-        $this->user = User::factory()->create();
-        $this->user->ensureHasDefaultProject();
+test('authenticated user can list dns records for domain', function () {
+    Sanctum::actingAs($this->user, ['read']);
 
-        $this->otherUser = User::factory()->create();
-        $this->otherUser->ensureHasDefaultProject();
-    }
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-    public function test_authenticated_user_can_list_dns_records_for_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
+    $record1 = DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+    ]);
+
+    $record2 = DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'CNAME',
+        'name' => 'mail',
+        'content' => 'example.com',
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records");
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            '*' => [
+                'id',
+                'type',
+                'name',
+                'formatted_name',
+                'content',
+                'ttl',
+
+                'proxied',
+                'domain_id',
+                'created_at',
+                'updated_at',
+            ],
+        ])
+        ->assertJsonFragment([
+            'id' => $record1->id,
+            'type' => 'A',
+            'name' => 'www',
+        ])
+        ->assertJsonFragment([
+            'id' => $record2->id,
+            'type' => 'CNAME',
+            'name' => 'mail',
         ]);
+});
 
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+test('user cannot list dns records for other users domain', function () {
+    Sanctum::actingAs($this->user, ['read']);
 
-        $record1 = DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $this->otherUser->current_project_id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $this->otherUser->current_project_id,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->otherUser->current_project_id}/domains/{$otherDomain->id}/records");
+
+    $response->assertForbidden();
+});
+
+test('authenticated user can create dns record', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+        'provider_domain_id' => 'test-domain-id',
+    ]);
+
+    // Mock the DNS provider API call
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'result' => [
+                'id' => 'test-record-id',
+                'type' => 'A',
+                'name' => 'www',
+                'content' => '192.168.1.1',
+                'ttl' => 300,
+                'proxied' => false,
+            ],
+            'success' => true,
+        ], 200),
+    ]);
+
+    $recordData = [
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+        'ttl' => 300,
+        'proxied' => false,
+    ];
+
+    $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records", $recordData);
+
+    $response->assertCreated()
+        ->assertJsonStructure([
+            'id',
+            'type',
+            'name',
+            'formatted_name',
+            'content',
+            'ttl',
+
+            'proxied',
+            'domain_id',
+            'created_at',
+            'updated_at',
+        ])
+        ->assertJsonFragment([
             'type' => 'A',
             'name' => 'www',
             'content' => '192.168.1.1',
         ]);
 
-        $record2 = DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'CNAME',
-            'name' => 'mail',
-            'content' => 'example.com',
+    $this->assertDatabaseHas('dns_records', [
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+    ]);
+});
+
+test('user cannot create dns record for other users domain', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $this->otherUser->current_project_id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $this->otherUser->current_project_id,
+    ]);
+
+    $recordData = [
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+    ];
+
+    $response = $this->postJson("/api/projects/{$this->otherUser->current_project_id}/domains/{$otherDomain->id}/records", $recordData);
+
+    $response->assertForbidden();
+});
+
+test('user without write ability cannot create dns record', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $recordData = [
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+    ];
+
+    $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records", $recordData);
+
+    $response->assertForbidden();
+});
+
+test('authenticated user can view dns record', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $record = DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/{$record->id}");
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'id',
+            'type',
+            'name',
+            'formatted_name',
+            'content',
+            'ttl',
+
+            'proxied',
+            'domain_id',
+            'created_at',
+            'updated_at',
+        ])
+        ->assertJsonFragment([
+            'id' => $record->id,
+            'type' => 'A',
+            'name' => 'www',
         ]);
+});
 
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records");
+test('user cannot view dns record from other users domain', function () {
+    Sanctum::actingAs($this->user, ['read']);
 
-        $response->assertOk()
-            ->assertJsonStructure([
-                '*' => [
-                    'id',
-                    'type',
-                    'name',
-                    'formatted_name',
-                    'content',
-                    'ttl',
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $this->otherUser->current_project_id,
+    ]);
 
-                    'proxied',
-                    'domain_id',
-                    'created_at',
-                    'updated_at',
-                ],
-            ])
-            ->assertJsonFragment([
-                'id' => $record1->id,
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $this->otherUser->current_project_id,
+    ]);
+
+    $otherRecord = DNSRecord::factory()->create([
+        'domain_id' => $otherDomain->id,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->otherUser->current_project_id}/domains/{$otherDomain->id}/records/{$otherRecord->id}");
+
+    $response->assertForbidden();
+});
+
+test('user cannot view dns record that does not belong to domain', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $record = DNSRecord::factory()->create([
+        'domain_id' => $otherDomain->id,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/{$record->id}");
+
+    $response->assertNotFound();
+});
+
+test('authenticated user can update dns record', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+        'provider_domain_id' => 'test-domain-id',
+    ]);
+
+    $record = DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+        'provider_record_id' => 'test-record-id',
+    ]);
+
+    // Mock the DNS provider API call
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'result' => [
+                'id' => 'test-record-id',
                 'type' => 'A',
                 'name' => 'www',
-            ])
-            ->assertJsonFragment([
-                'id' => $record2->id,
-                'type' => 'CNAME',
-                'name' => 'mail',
-            ]);
-    }
+                'content' => '192.168.1.2',
+                'ttl' => 600,
+                'proxied' => false,
+            ],
+            'success' => true,
+        ], 200),
+    ]);
 
-    public function test_user_cannot_list_dns_records_for_other_users_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+    $updateData = [
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.2',
+        'ttl' => 600,
+    ];
 
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $this->otherUser->current_project_id,
+    $response = $this->patchJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/{$record->id}", $updateData);
+
+    $response->assertOk()
+        ->assertJsonFragment([
+            'content' => '192.168.1.2',
+            'ttl' => 600,
         ]);
 
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $this->otherUser->current_project_id,
-        ]);
+    $this->assertDatabaseHas('dns_records', [
+        'id' => $record->id,
+        'content' => '192.168.1.2',
+        'ttl' => 600,
+    ]);
+});
 
-        $response = $this->getJson("/api/projects/{$this->otherUser->current_project_id}/domains/{$otherDomain->id}/records");
+test('user cannot update dns record from other users domain', function () {
+    Sanctum::actingAs($this->user, ['write']);
 
-        $response->assertForbidden();
-    }
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $this->otherUser->current_project_id,
+    ]);
 
-    public function test_authenticated_user_can_create_dns_record(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $this->otherUser->current_project_id,
+    ]);
 
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    $otherRecord = DNSRecord::factory()->create([
+        'domain_id' => $otherDomain->id,
+    ]);
 
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-            'provider_domain_id' => 'test-domain-id',
-        ]);
+    $updateData = ['content' => '192.168.1.2'];
 
-        // Mock the DNS provider API call
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'result' => [
-                    'id' => 'test-record-id',
+    $response = $this->patchJson("/api/projects/{$this->otherUser->current_project_id}/domains/{$otherDomain->id}/records/{$otherRecord->id}", $updateData);
+
+    $response->assertForbidden();
+});
+
+test('user cannot update dns record that does not belong to domain', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $record = DNSRecord::factory()->create([
+        'domain_id' => $otherDomain->id,
+    ]);
+
+    $updateData = ['content' => '192.168.1.2'];
+
+    $response = $this->patchJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/{$record->id}", $updateData);
+
+    $response->assertNotFound();
+});
+
+test('authenticated user can delete dns record', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $record = DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+    ]);
+
+    $response = $this->deleteJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/{$record->id}");
+
+    $response->assertOk()
+        ->assertJsonFragment(['message' => 'DNS record deleted successfully']);
+
+    $this->assertDatabaseMissing('dns_records', ['id' => $record->id]);
+});
+
+test('user cannot delete dns record from other users domain', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $this->otherUser->current_project_id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $this->otherUser->current_project_id,
+    ]);
+
+    $otherRecord = DNSRecord::factory()->create([
+        'domain_id' => $otherDomain->id,
+    ]);
+
+    $response = $this->deleteJson("/api/projects/{$this->otherUser->current_project_id}/domains/{$otherDomain->id}/records/{$otherRecord->id}");
+
+    $response->assertForbidden();
+
+    $this->assertDatabaseHas('dns_records', ['id' => $otherRecord->id]);
+});
+
+test('user cannot delete dns record that does not belong to domain', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $record = DNSRecord::factory()->create([
+        'domain_id' => $otherDomain->id,
+    ]);
+
+    $response = $this->deleteJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/{$record->id}");
+
+    $response->assertNotFound();
+
+    $this->assertDatabaseHas('dns_records', ['id' => $record->id]);
+});
+
+test('user without write ability cannot delete dns record', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $record = DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+    ]);
+
+    $response = $this->deleteJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/{$record->id}");
+
+    $response->assertForbidden();
+});
+
+test('dns record not found returns 404', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/999999");
+
+    $response->assertNotFound();
+});
+
+test('dns records are ordered by type and name', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    // Create records in random order
+    DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'CNAME',
+        'name' => 'zebra',
+    ]);
+
+    DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'alpha',
+    ]);
+
+    DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'beta',
+    ]);
+
+    DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'CNAME',
+        'name' => 'alpha',
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records");
+
+    $response->assertOk();
+
+    $records = $response->json();
+    expect($records)->toHaveCount(4);
+
+    // Should be ordered by type first (A before CNAME), then by name
+    expect($records[0]['type'])->toEqual('A');
+    expect($records[0]['name'])->toEqual('alpha');
+    expect($records[1]['type'])->toEqual('A');
+    expect($records[1]['name'])->toEqual('beta');
+    expect($records[2]['type'])->toEqual('CNAME');
+    expect($records[2]['name'])->toEqual('alpha');
+    expect($records[3]['type'])->toEqual('CNAME');
+    expect($records[3]['name'])->toEqual('zebra');
+});
+
+test('user cannot access dns records from other projects', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    // Create a second project for a different user
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+    $otherProject = $otherUser->currentProject;
+
+    // Create DNS provider for the other project
+    $otherProjectDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    // Create domain in the other project
+    $otherProjectDomain = Domain::factory()->create([
+        'user_id' => $otherUser->id,
+        'dns_provider_id' => $otherProjectDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    // Create DNS record for the other project domain
+    $otherProjectRecord = DNSRecord::factory()->create([
+        'domain_id' => $otherProjectDomain->id,
+    ]);
+
+    // Should not be able to access DNS records from other project
+    $response = $this->getJson("/api/projects/{$otherProject->id}/domains/{$otherProjectDomain->id}/records");
+
+    $response->assertForbidden();
+
+    // Should not be able to access specific DNS record from other project
+    $response = $this->getJson("/api/projects/{$otherProject->id}/domains/{$otherProjectDomain->id}/records/{$otherProjectRecord->id}");
+
+    $response->assertForbidden();
+});
+
+test('authenticated user can sync dns records', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+        'provider_domain_id' => 'test-domain-id',
+    ]);
+
+    // Create an existing record that will be replaced
+    DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'old',
+        'content' => '192.168.1.1',
+    ]);
+
+    // Mock the DNS provider API call to return records
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'result' => [
+                [
+                    'id' => 'record-1',
                     'type' => 'A',
                     'name' => 'www',
                     'content' => '192.168.1.1',
                     'ttl' => 300,
                     'proxied' => false,
+                    'created_on' => '2023-01-01T00:00:00Z',
+                    'modified_on' => '2023-01-01T00:00:00Z',
                 ],
-                'success' => true,
-            ], 200),
-        ]);
-
-        $recordData = [
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.1',
-            'ttl' => 300,
-            'proxied' => false,
-        ];
-
-        $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records", $recordData);
-
-        $response->assertCreated()
-            ->assertJsonStructure([
-                'id',
-                'type',
-                'name',
-                'formatted_name',
-                'content',
-                'ttl',
-
-                'proxied',
-                'domain_id',
-                'created_at',
-                'updated_at',
-            ])
-            ->assertJsonFragment([
-                'type' => 'A',
-                'name' => 'www',
-                'content' => '192.168.1.1',
-            ]);
-
-        $this->assertDatabaseHas('dns_records', [
-            'domain_id' => $domain->id,
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.1',
-        ]);
-    }
-
-    public function test_user_cannot_create_dns_record_for_other_users_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $this->otherUser->current_project_id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $this->otherUser->current_project_id,
-        ]);
-
-        $recordData = [
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.1',
-        ];
-
-        $response = $this->postJson("/api/projects/{$this->otherUser->current_project_id}/domains/{$otherDomain->id}/records", $recordData);
-
-        $response->assertForbidden();
-    }
-
-    public function test_user_without_write_ability_cannot_create_dns_record(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $recordData = [
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.1',
-        ];
-
-        $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records", $recordData);
-
-        $response->assertForbidden();
-    }
-
-    public function test_authenticated_user_can_view_dns_record(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $record = DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.1',
-        ]);
-
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/{$record->id}");
-
-        $response->assertOk()
-            ->assertJsonStructure([
-                'id',
-                'type',
-                'name',
-                'formatted_name',
-                'content',
-                'ttl',
-
-                'proxied',
-                'domain_id',
-                'created_at',
-                'updated_at',
-            ])
-            ->assertJsonFragment([
-                'id' => $record->id,
-                'type' => 'A',
-                'name' => 'www',
-            ]);
-    }
-
-    public function test_user_cannot_view_dns_record_from_other_users_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $this->otherUser->current_project_id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $this->otherUser->current_project_id,
-        ]);
-
-        $otherRecord = DNSRecord::factory()->create([
-            'domain_id' => $otherDomain->id,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$this->otherUser->current_project_id}/domains/{$otherDomain->id}/records/{$otherRecord->id}");
-
-        $response->assertForbidden();
-    }
-
-    public function test_user_cannot_view_dns_record_that_does_not_belong_to_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $record = DNSRecord::factory()->create([
-            'domain_id' => $otherDomain->id,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/{$record->id}");
-
-        $response->assertNotFound();
-    }
-
-    public function test_authenticated_user_can_update_dns_record(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-            'provider_domain_id' => 'test-domain-id',
-        ]);
-
-        $record = DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.1',
-            'provider_record_id' => 'test-record-id',
-        ]);
-
-        // Mock the DNS provider API call
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'result' => [
-                    'id' => 'test-record-id',
-                    'type' => 'A',
-                    'name' => 'www',
-                    'content' => '192.168.1.2',
+                [
+                    'id' => 'record-2',
+                    'type' => 'CNAME',
+                    'name' => 'mail',
+                    'content' => 'example.com',
                     'ttl' => 600,
                     'proxied' => false,
+                    'created_on' => '2023-01-01T00:00:00Z',
+                    'modified_on' => '2023-01-01T00:00:00Z',
                 ],
-                'success' => true,
-            ], 200),
-        ]);
-
-        $updateData = [
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.2',
-            'ttl' => 600,
-        ];
-
-        $response = $this->patchJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/{$record->id}", $updateData);
-
-        $response->assertOk()
-            ->assertJsonFragment([
-                'content' => '192.168.1.2',
-                'ttl' => 600,
-            ]);
-
-        $this->assertDatabaseHas('dns_records', [
-            'id' => $record->id,
-            'content' => '192.168.1.2',
-            'ttl' => 600,
-        ]);
-    }
-
-    public function test_user_cannot_update_dns_record_from_other_users_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $this->otherUser->current_project_id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $this->otherUser->current_project_id,
-        ]);
-
-        $otherRecord = DNSRecord::factory()->create([
-            'domain_id' => $otherDomain->id,
-        ]);
-
-        $updateData = ['content' => '192.168.1.2'];
-
-        $response = $this->patchJson("/api/projects/{$this->otherUser->current_project_id}/domains/{$otherDomain->id}/records/{$otherRecord->id}", $updateData);
-
-        $response->assertForbidden();
-    }
-
-    public function test_user_cannot_update_dns_record_that_does_not_belong_to_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $record = DNSRecord::factory()->create([
-            'domain_id' => $otherDomain->id,
-        ]);
-
-        $updateData = ['content' => '192.168.1.2'];
-
-        $response = $this->patchJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/{$record->id}", $updateData);
-
-        $response->assertNotFound();
-    }
-
-    public function test_authenticated_user_can_delete_dns_record(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $record = DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-        ]);
-
-        $response = $this->deleteJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/{$record->id}");
-
-        $response->assertOk()
-            ->assertJsonFragment(['message' => 'DNS record deleted successfully']);
-
-        $this->assertDatabaseMissing('dns_records', ['id' => $record->id]);
-    }
-
-    public function test_user_cannot_delete_dns_record_from_other_users_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $this->otherUser->current_project_id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $this->otherUser->current_project_id,
-        ]);
-
-        $otherRecord = DNSRecord::factory()->create([
-            'domain_id' => $otherDomain->id,
-        ]);
-
-        $response = $this->deleteJson("/api/projects/{$this->otherUser->current_project_id}/domains/{$otherDomain->id}/records/{$otherRecord->id}");
-
-        $response->assertForbidden();
-
-        $this->assertDatabaseHas('dns_records', ['id' => $otherRecord->id]);
-    }
-
-    public function test_user_cannot_delete_dns_record_that_does_not_belong_to_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $record = DNSRecord::factory()->create([
-            'domain_id' => $otherDomain->id,
-        ]);
-
-        $response = $this->deleteJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/{$record->id}");
-
-        $response->assertNotFound();
-
-        $this->assertDatabaseHas('dns_records', ['id' => $record->id]);
-    }
-
-    public function test_user_without_write_ability_cannot_delete_dns_record(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $record = DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-        ]);
-
-        $response = $this->deleteJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/{$record->id}");
-
-        $response->assertForbidden();
-    }
-
-    public function test_dns_record_not_found_returns_404(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/999999");
-
-        $response->assertNotFound();
-    }
-
-    public function test_dns_records_are_ordered_by_type_and_name(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        // Create records in random order
-        DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'CNAME',
-            'name' => 'zebra',
-        ]);
-
-        DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'A',
-            'name' => 'alpha',
-        ]);
-
-        DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'A',
-            'name' => 'beta',
-        ]);
-
-        DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'CNAME',
-            'name' => 'alpha',
-        ]);
-
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records");
-
-        $response->assertOk();
-
-        $records = $response->json();
-        $this->assertCount(4, $records);
-
-        // Should be ordered by type first (A before CNAME), then by name
-        $this->assertEquals('A', $records[0]['type']);
-        $this->assertEquals('alpha', $records[0]['name']);
-        $this->assertEquals('A', $records[1]['type']);
-        $this->assertEquals('beta', $records[1]['name']);
-        $this->assertEquals('CNAME', $records[2]['type']);
-        $this->assertEquals('alpha', $records[2]['name']);
-        $this->assertEquals('CNAME', $records[3]['type']);
-        $this->assertEquals('zebra', $records[3]['name']);
-    }
-
-    public function test_user_cannot_access_dns_records_from_other_projects(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        // Create a second project for a different user
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-        $otherProject = $otherUser->currentProject;
-
-        // Create DNS provider for the other project
-        $otherProjectDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        // Create domain in the other project
-        $otherProjectDomain = Domain::factory()->create([
-            'user_id' => $otherUser->id,
-            'dns_provider_id' => $otherProjectDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        // Create DNS record for the other project domain
-        $otherProjectRecord = DNSRecord::factory()->create([
-            'domain_id' => $otherProjectDomain->id,
-        ]);
-
-        // Should not be able to access DNS records from other project
-        $response = $this->getJson("/api/projects/{$otherProject->id}/domains/{$otherProjectDomain->id}/records");
-
-        $response->assertForbidden();
-
-        // Should not be able to access specific DNS record from other project
-        $response = $this->getJson("/api/projects/{$otherProject->id}/domains/{$otherProjectDomain->id}/records/{$otherProjectRecord->id}");
-
-        $response->assertForbidden();
-    }
-
-    public function test_authenticated_user_can_sync_dns_records(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-            'provider_domain_id' => 'test-domain-id',
-        ]);
-
-        // Create an existing record that will be replaced
-        DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'A',
-            'name' => 'old',
-            'content' => '192.168.1.1',
-        ]);
-
-        // Mock the DNS provider API call to return records
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'result' => [
-                    [
-                        'id' => 'record-1',
-                        'type' => 'A',
-                        'name' => 'www',
-                        'content' => '192.168.1.1',
-                        'ttl' => 300,
-                        'proxied' => false,
-                        'created_on' => '2023-01-01T00:00:00Z',
-                        'modified_on' => '2023-01-01T00:00:00Z',
-                    ],
-                    [
-                        'id' => 'record-2',
-                        'type' => 'CNAME',
-                        'name' => 'mail',
-                        'content' => 'example.com',
-                        'ttl' => 600,
-                        'proxied' => false,
-                        'created_on' => '2023-01-01T00:00:00Z',
-                        'modified_on' => '2023-01-01T00:00:00Z',
-                    ],
-                ],
-                'success' => true,
-            ], 200),
-        ]);
-
-        $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/sync");
-
-        $response->assertOk()
-            ->assertJsonFragment(['message' => 'DNS records synced successfully']);
-
-        // Check that old record was deleted and new records were created
-        $this->assertDatabaseMissing('dns_records', [
-            'domain_id' => $domain->id,
-            'name' => 'old',
-        ]);
-
-        $this->assertDatabaseHas('dns_records', [
-            'domain_id' => $domain->id,
-            'provider_record_id' => 'record-1',
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.1',
-        ]);
-
-        $this->assertDatabaseHas('dns_records', [
-            'domain_id' => $domain->id,
-            'provider_record_id' => 'record-2',
-            'type' => 'CNAME',
-            'name' => 'mail',
-            'content' => 'example.com',
-        ]);
-    }
-
-    public function test_sync_dns_records_returns_error_when_provider_fails(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-            'provider_domain_id' => 'test-domain-id',
-        ]);
-
-        // Mock the DNS provider API call to throw an exception
-        Http::fake(function () {
-            throw new \RuntimeException('Domain is not opted in to API access.');
-        });
-
-        $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/sync");
-
-        $response->assertStatus(422);
-        $this->assertStringContainsString('Failed to sync DNS records', $response->json('message'));
-    }
-
-    public function test_user_cannot_sync_dns_records_for_other_users_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $this->otherUser->current_project_id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $this->otherUser->current_project_id,
-        ]);
-
-        $response = $this->postJson("/api/projects/{$this->otherUser->current_project_id}/domains/{$otherDomain->id}/records/sync");
-
-        $response->assertForbidden();
-    }
-
-    public function test_user_without_write_ability_cannot_sync_dns_records(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/sync");
-
-        $response->assertForbidden();
-    }
-}
+            ],
+            'success' => true,
+        ], 200),
+    ]);
+
+    $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/sync");
+
+    $response->assertOk()
+        ->assertJsonFragment(['message' => 'DNS records synced successfully']);
+
+    // Check that old record was deleted and new records were created
+    $this->assertDatabaseMissing('dns_records', [
+        'domain_id' => $domain->id,
+        'name' => 'old',
+    ]);
+
+    $this->assertDatabaseHas('dns_records', [
+        'domain_id' => $domain->id,
+        'provider_record_id' => 'record-1',
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+    ]);
+
+    $this->assertDatabaseHas('dns_records', [
+        'domain_id' => $domain->id,
+        'provider_record_id' => 'record-2',
+        'type' => 'CNAME',
+        'name' => 'mail',
+        'content' => 'example.com',
+    ]);
+});
+
+test('sync dns records returns error when provider fails', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+        'provider_domain_id' => 'test-domain-id',
+    ]);
+
+    // Mock the DNS provider API call to throw an exception
+    Http::fake(function () {
+        throw new RuntimeException('Domain is not opted in to API access.');
+    });
+
+    $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/sync");
+
+    $response->assertStatus(422);
+    $this->assertStringContainsString('Failed to sync DNS records', $response->json('message'));
+});
+
+test('user cannot sync dns records for other users domain', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $this->otherUser->current_project_id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $this->otherUser->current_project_id,
+    ]);
+
+    $response = $this->postJson("/api/projects/{$this->otherUser->current_project_id}/domains/{$otherDomain->id}/records/sync");
+
+    $response->assertForbidden();
+});
+
+test('user without write ability cannot sync dns records', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}/records/sync");
+
+    $response->assertForbidden();
+});

--- a/tests/Feature/API/DatabaseTest.php
+++ b/tests/Feature/API/DatabaseTest.php
@@ -1,95 +1,85 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\DatabaseStatus;
 use App\Facades\SSH;
 use App\Models\Database;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 
-class DatabaseTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_database(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('create database', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->json('POST', route('api.projects.servers.databases.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
+    $this->json('POST', route('api.projects.servers.databases.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'name' => 'database',
+        'charset' => 'utf8mb4',
+        'collation' => 'utf8mb4_unicode_ci',
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'name' => 'database',
-            'charset' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => 'database',
-                'status' => DatabaseStatus::READY,
-            ]);
-    }
-
-    public function test_show_database(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Database $database */
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
+            'status' => DatabaseStatus::READY,
         ]);
+});
 
-        $this->json('GET', route('api.projects.servers.databases.show', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'database' => $database,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => $database->name,
-            ]);
-    }
+test('show database', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_see_databases_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    /** @var Database $database */
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
 
-        /** @var Database $database */
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
+    $this->json('GET', route('api.projects.servers.databases.show', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'database' => $database,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'name' => $database->name,
         ]);
+});
 
-        $this->json('GET', route('api.projects.servers.databases', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => $database->name,
-            ]);
-    }
+test('see databases list', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_delete_database(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    /** @var Database $database */
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
 
-        SSH::fake();
-
-        /** @var Database $database */
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
+    $this->json('GET', route('api.projects.servers.databases', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'name' => $database->name,
         ]);
+});
 
-        $this->json('DELETE', route('api.projects.servers.databases.delete', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'database' => $database,
-        ]))
-            ->assertSuccessful()
-            ->assertNoContent();
-    }
-}
+test('delete database', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    SSH::fake();
+
+    /** @var Database $database */
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $this->json('DELETE', route('api.projects.servers.databases.delete', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'database' => $database,
+    ]))
+        ->assertSuccessful()
+        ->assertNoContent();
+});

--- a/tests/Feature/API/DatabaseUserTest.php
+++ b/tests/Feature/API/DatabaseUserTest.php
@@ -1,146 +1,134 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\DatabaseUserStatus;
 use App\Facades\SSH;
 use App\Models\Database;
 use App\Models\DatabaseUser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 
-class DatabaseUserTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_database_user(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('create database user', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->json('POST', route('api.projects.servers.database-users.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
+    $this->json('POST', route('api.projects.servers.database-users.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'username' => 'user',
+        'password' => 'password',
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'username' => 'user',
-            'password' => 'password',
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'username' => 'user',
-                'status' => DatabaseUserStatus::READY,
-            ]);
-    }
+            'status' => DatabaseUserStatus::READY,
+        ]);
+});
 
-    public function test_create_database_user_with_remote(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('create database user with remote', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->json('POST', route('api.projects.servers.database-users.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
+    $this->json('POST', route('api.projects.servers.database-users.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'username' => 'user',
+        'password' => 'password',
+        'host' => '%',
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'username' => 'user',
-            'password' => 'password',
             'host' => '%',
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'username' => 'user',
-                'host' => '%',
-                'status' => DatabaseUserStatus::READY,
-            ]);
-    }
-
-    public function test_see_database_users_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var DatabaseUser $databaseUser */
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
+            'status' => DatabaseUserStatus::READY,
         ]);
+});
 
-        $this->json('GET', route('api.projects.servers.database-users', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'username' => $databaseUser->username,
-            ]);
-    }
+test('see database users list', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_show_database_user(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    /** @var DatabaseUser $databaseUser */
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+    ]);
 
-        /** @var DatabaseUser $databaseUser */
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
+    $this->json('GET', route('api.projects.servers.database-users', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'username' => $databaseUser->username,
         ]);
+});
 
-        $this->json('GET', route('api.projects.servers.database-users.show', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'databaseUser' => $databaseUser,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'username' => $databaseUser->username,
-            ]);
-    }
+test('show database user', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_link_database(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    /** @var DatabaseUser $databaseUser */
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+    ]);
 
-        SSH::fake();
-
-        /** @var Database $database */
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
+    $this->json('GET', route('api.projects.servers.database-users.show', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'databaseUser' => $databaseUser,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'username' => $databaseUser->username,
         ]);
+});
 
-        /** @var DatabaseUser $databaseUser */
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-        ]);
+test('link database', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('POST', route('api.projects.servers.database-users.link', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'databaseUser' => $databaseUser,
-        ]), [
+    SSH::fake();
+
+    /** @var Database $database */
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    /** @var DatabaseUser $databaseUser */
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $this->json('POST', route('api.projects.servers.database-users.link', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'databaseUser' => $databaseUser,
+    ]), [
+        'databases' => [$database->name],
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'username' => $databaseUser->username,
             'databases' => [$database->name],
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'username' => $databaseUser->username,
-                'databases' => [$database->name],
-            ]);
-    }
-
-    public function test_delete_database_user(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        SSH::fake();
-
-        /** @var DatabaseUser $databaseUser */
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
         ]);
+});
 
-        $this->json('DELETE', route('api.projects.servers.database-users.delete', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'databaseUser' => $databaseUser,
-        ]))
-            ->assertNoContent();
-    }
-}
+test('delete database user', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    SSH::fake();
+
+    /** @var DatabaseUser $databaseUser */
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $this->json('DELETE', route('api.projects.servers.database-users.delete', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'databaseUser' => $databaseUser,
+    ]))
+        ->assertNoContent();
+});

--- a/tests/Feature/API/DeploymentsTest.php
+++ b/tests/Feature/API/DeploymentsTest.php
@@ -9,9 +9,7 @@ use Illuminate\Support\Facades\Http;
 use Laravel\Sanctum\Sanctum;
 use Tests\Traits\PrepareLoadBalancer;
 
-uses(PrepareLoadBalancer::class);
-
-uses(RefreshDatabase::class);
+uses(PrepareLoadBalancer::class, RefreshDatabase::class);
 
 beforeEach(function () {
     $this->prepare();

--- a/tests/Feature/API/DeploymentsTest.php
+++ b/tests/Feature/API/DeploymentsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\DeploymentStatus;
 use App\Facades\SSH;
 use App\Models\Deployment;
@@ -9,107 +7,98 @@ use App\Models\Site;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 use Tests\Traits\PrepareLoadBalancer;
 
-class DeploymentsTest extends TestCase
-{
-    use PrepareLoadBalancer;
-    use RefreshDatabase;
+uses(PrepareLoadBalancer::class);
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+uses(RefreshDatabase::class);
 
-        $this->prepare();
-    }
+beforeEach(function () {
+    $this->prepare();
+});
 
-    public function test_see_deployments_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+test('see deployments list', function () {
+    Sanctum::actingAs($this->user, ['read']);
 
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        $this->json('GET', route('api.projects.servers.sites.deployments', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]))
-            ->assertSuccessful();
-    }
+    $this->json('GET', route('api.projects.servers.sites.deployments', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]))
+        ->assertSuccessful();
+});
 
-    public function test_see_deployment(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+test('see deployment', function () {
+    Sanctum::actingAs($this->user, ['read']);
 
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        /** @var Deployment $deployment */
-        $deployment = Deployment::factory()->create([
-            'site_id' => $site->id,
-            'deployment_script_id' => $site->deploymentScript?->id,
-            'status' => DeploymentStatus::FINISHED,
-        ]);
+    /** @var Deployment $deployment */
+    $deployment = Deployment::factory()->create([
+        'site_id' => $site->id,
+        'deployment_script_id' => $site->deploymentScript?->id,
+        'status' => DeploymentStatus::FINISHED,
+    ]);
 
-        $this->json('GET', route('api.projects.servers.sites.deployments.show', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-            'deployment' => $deployment,
-        ]))
-            ->assertSuccessful();
-    }
+    $this->json('GET', route('api.projects.servers.sites.deployments.show', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+        'deployment' => $deployment,
+    ]))
+        ->assertSuccessful();
+});
 
-    public function test_deploy_site(): void
-    {
-        SSH::fake();
+test('deploy site', function () {
+    SSH::fake();
 
-        Http::fake([
-            'https://api.github.com/repos/*' => Http::response([
+    Http::fake([
+        'https://api.github.com/repos/*' => Http::response([
+            'commit' => [
+                'sha' => 'abc123',
                 'commit' => [
-                    'sha' => 'abc123',
-                    'commit' => [
-                        'message' => 'Test commit',
-                        'author' => [
-                            'name' => 'Test Author',
-                            'email' => 'test@example.com',
-                            'date' => now()->toIso8601String(),
-                        ],
+                    'message' => 'Test commit',
+                    'author' => [
+                        'name' => 'Test Author',
+                        'email' => 'test@example.com',
+                        'date' => now()->toIso8601String(),
                     ],
                 ],
-            ], 200),
+            ],
+        ], 200),
+    ]);
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+    $site->deploymentScript?->update([
+        'content' => 'ls -la',
+    ]);
+
+    $this->json('POST', route('api.projects.servers.sites.deploy', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonStructure([
+            'id',
+            'status',
         ]);
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-        $site->deploymentScript?->update([
-            'content' => 'ls -la',
-        ]);
-
-        $this->json('POST', route('api.projects.servers.sites.deploy', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonStructure([
-                'id',
-                'status',
-            ]);
-
-        $this->assertDatabaseHas('deployments', [
-            'site_id' => $site->id,
-            'status' => DeploymentStatus::FINISHED,
-        ]);
-    }
-}
+    $this->assertDatabaseHas('deployments', [
+        'site_id' => $site->id,
+        'status' => DeploymentStatus::FINISHED,
+    ]);
+});

--- a/tests/Feature/API/DomainsTest.php
+++ b/tests/Feature/API/DomainsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Models\DNSProvider;
 use App\Models\Domain;
 use App\Models\Project;
@@ -9,176 +7,218 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 
-class DomainsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    protected User $otherUser;
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->user->ensureHasDefaultProject();
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+    $this->otherUser = User::factory()->create();
+    $this->otherUser->ensureHasDefaultProject();
+});
 
-        $this->user = User::factory()->create();
-        $this->user->ensureHasDefaultProject();
+test('authenticated user can list domains', function () {
+    Sanctum::actingAs($this->user, ['read']);
 
-        $this->otherUser = User::factory()->create();
-        $this->otherUser->ensureHasDefaultProject();
-    }
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-    public function test_authenticated_user_can_list_domains(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains");
 
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains");
-
-        $response->assertOk()
-            ->assertJsonStructure([
-                'data' => [
-                    '*' => [
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'domain',
+                    'dns_provider_id',
+                    'metadata',
+                    'dns_provider' => [
                         'id',
-                        'domain',
-                        'dns_provider_id',
-                        'metadata',
-                        'dns_provider' => [
-                            'id',
-                            'name',
-                            'provider',
-                            'connected',
-                            'project_id',
-                            'global',
-                        ],
-                        'created_at',
-                        'updated_at',
+                        'name',
+                        'provider',
+                        'connected',
+                        'project_id',
+                        'global',
                     ],
+                    'created_at',
+                    'updated_at',
                 ],
-                'links',
-                'meta',
-            ])
-            ->assertJsonFragment([
-                'id' => $domain->id,
-                'domain' => $domain->domain,
-            ]);
-    }
-
-    public function test_unauthenticated_user_cannot_list_domains(): void
-    {
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains");
-
-        $response->assertUnauthorized();
-    }
-
-    public function test_user_without_read_ability_cannot_list_domains(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains");
-
-        $response->assertForbidden();
-    }
-
-    public function test_user_can_see_all_domains_in_their_project(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        // Create domain for current user in their project
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
+            ],
+            'links',
+            'meta',
+        ])
+        ->assertJsonFragment([
+            'id' => $domain->id,
+            'domain' => $domain->domain,
         ]);
+});
 
-        $userDomain = Domain::factory()->create([
-            'user_id' => $this->user->id,
+test('unauthenticated user cannot list domains', function () {
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains");
+
+    $response->assertUnauthorized();
+});
+
+test('user without read ability cannot list domains', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains");
+
+    $response->assertForbidden();
+});
+
+test('user can see all domains in their project', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    // Create domain for current user in their project
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $userDomain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    // Create domain for other user in the SAME project
+    $otherUserDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    // Create domain for other user in a DIFFERENT project
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $otherProjectDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains");
+
+    $response->assertOk();
+
+    // Should see both domains from the same project, regardless of who created them
+    $response->assertJsonFragment(['id' => $userDomain->id]);
+    $response->assertJsonFragment(['id' => $otherUserDomain->id]);
+
+    // Should NOT see domains from other projects
+    $response->assertJsonMissing(['id' => $otherProjectDomain->id]);
+});
+
+test('user can access domains created by other users in same project', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    // Create a DNS provider for the current user's project
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    // Create a domain for another user in the same project
+    $otherUserDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    // User should be able to view the domain created by another user in the same project
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$otherUserDomain->id}");
+
+    $response->assertOk()
+        ->assertJsonFragment([
+            'id' => $otherUserDomain->id,
+            'domain' => $otherUserDomain->domain,
+        ]);
+});
+
+test('authenticated user can create domain', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    // Mock the DNS provider API calls (getDomain + getRecords)
+    Http::fake([
+        'api.cloudflare.com/client/v4/zones/test-domain-id/dns_records*' => Http::response([
+            'result' => [],
+            'success' => true,
+        ], 200),
+        'api.cloudflare.com/*' => Http::response([
+            'result' => [
+                'id' => 'test-domain-id',
+                'name' => 'example.com',
+                'status' => 'active',
+                'created_on' => '2023-01-01T00:00:00Z',
+                'modified_on' => '2023-01-01T00:00:00Z',
+            ],
+            'success' => true,
+        ], 200),
+    ]);
+
+    $domainData = [
+        'dns_provider_id' => $dnsProvider->id,
+        'provider_domain_id' => 'test-domain-id',
+    ];
+
+    $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains", $domainData);
+
+    $response->assertCreated()
+        ->assertJsonStructure([
+            'id',
+            'domain',
+            'dns_provider_id',
+            'metadata',
+            'dns_provider',
+            'created_at',
+            'updated_at',
+        ])
+        ->assertJsonFragment([
             'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
         ]);
 
-        // Create domain for other user in the SAME project
-        $otherUserDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    $this->assertDatabaseHas('domains', [
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'provider_domain_id' => 'test-domain-id',
+    ]);
+});
 
-        // Create domain for other user in a DIFFERENT project
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
+test('create domain fails when record sync fails', function () {
+    Sanctum::actingAs($this->user, ['write']);
 
-        $otherProjectDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains");
+    $callCount = 0;
 
-        $response->assertOk();
-        // Should see both domains from the same project, regardless of who created them
-        $response->assertJsonFragment(['id' => $userDomain->id]);
-        $response->assertJsonFragment(['id' => $otherUserDomain->id]);
-        // Should NOT see domains from other projects
-        $response->assertJsonMissing(['id' => $otherProjectDomain->id]);
-    }
-
-    public function test_user_can_access_domains_created_by_other_users_in_same_project(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        // Create a DNS provider for the current user's project
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        // Create a domain for another user in the same project
-        $otherUserDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        // User should be able to view the domain created by another user in the same project
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$otherUserDomain->id}");
-
-        $response->assertOk()
-            ->assertJsonFragment([
-                'id' => $otherUserDomain->id,
-                'domain' => $otherUserDomain->domain,
-            ]);
-    }
-
-    public function test_authenticated_user_can_create_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        // Mock the DNS provider API calls (getDomain + getRecords)
-        Http::fake([
-            'api.cloudflare.com/client/v4/zones/test-domain-id/dns_records*' => Http::response([
-                'result' => [],
-                'success' => true,
-            ], 200),
-            'api.cloudflare.com/*' => Http::response([
+    // First call (getDomain) succeeds, subsequent calls throw
+    Http::fake(function () use (&$callCount) {
+        $callCount++;
+        if ($callCount === 1) {
+            return Http::response([
                 'result' => [
                     'id' => 'test-domain-id',
                     'name' => 'example.com',
@@ -187,422 +227,352 @@ class DomainsTest extends TestCase
                     'modified_on' => '2023-01-01T00:00:00Z',
                 ],
                 'success' => true,
-            ], 200),
+            ], 200);
+        }
+
+        throw new RuntimeException('Domain is not opted in to API access.');
+    });
+
+    $domainData = [
+        'dns_provider_id' => $dnsProvider->id,
+        'provider_domain_id' => 'test-domain-id',
+    ];
+
+    $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains", $domainData);
+
+    $response->assertUnprocessable()
+        ->assertJsonValidationErrors('domain');
+
+    // Domain should not have been persisted due to transaction rollback
+    $this->assertDatabaseMissing('domains', [
+        'provider_domain_id' => 'test-domain-id',
+    ]);
+});
+
+test('user cannot create domain with dns provider from other project', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    // Create a different project for the other user
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $domainData = [
+        'dns_provider_id' => $otherDnsProvider->id,
+        'provider_domain_id' => 'test-domain-id',
+    ];
+
+    $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains", $domainData);
+
+    $response->assertForbidden();
+});
+
+test('user without write ability cannot create domain', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domainData = [
+        'dns_provider_id' => $dnsProvider->id,
+        'provider_domain_id' => 'test-domain-id',
+    ];
+
+    $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains", $domainData);
+
+    $response->assertForbidden();
+});
+
+test('authenticated user can view domain', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}");
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'id',
+            'domain',
+            'dns_provider_id',
+            'metadata',
+            'dns_provider',
+            'created_at',
+            'updated_at',
+        ])
+        ->assertJsonFragment([
+            'id' => $domain->id,
+            'domain' => $domain->domain,
+        ]);
+});
+
+test('user cannot view domains from other projects', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    // Create a different project for the other user
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$otherProject->id}/domains/{$otherDomain->id}");
+
+    $response->assertForbidden();
+});
+
+test('authenticated user can delete domain', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $response = $this->deleteJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}");
+
+    $response->assertOk()
+        ->assertJsonFragment(['message' => 'Domain removed successfully']);
+
+    $this->assertDatabaseMissing('domains', ['id' => $domain->id]);
+});
+
+test('user cannot delete domains from other projects', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    // Create a different project for the other user
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $response = $this->deleteJson("/api/projects/{$otherProject->id}/domains/{$otherDomain->id}");
+
+    $response->assertForbidden();
+
+    $this->assertDatabaseHas('domains', ['id' => $otherDomain->id]);
+});
+
+test('user without write ability cannot delete domain', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $response = $this->deleteJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}");
+
+    $response->assertForbidden();
+});
+
+test('authenticated user can get available domains from dns provider', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$dnsProvider->id}/available");
+
+    $response->assertNotFound();
+});
+
+test('user cannot get available domains from dns provider in other project', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    // Create a different project for the other user
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$otherProject->id}/domains/{$otherDnsProvider->id}/available");
+
+    $response->assertNotFound();
+});
+
+test('domain not found returns 404', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/999999");
+
+    $response->assertNotFound();
+});
+
+test('dns provider not found returns 404', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/999999/available");
+
+    $response->assertNotFound();
+});
+
+test('domain pagination works correctly', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    // Create 30 domains to test pagination
+    Domain::factory()->count(30)->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains");
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data',
+            'links',
+            'meta',
         ]);
 
-        $domainData = [
-            'dns_provider_id' => $dnsProvider->id,
-            'provider_domain_id' => 'test-domain-id',
-        ];
-
-        $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains", $domainData);
-
-        $response->assertCreated()
-            ->assertJsonStructure([
-                'id',
-                'domain',
-                'dns_provider_id',
-                'metadata',
-                'dns_provider',
-                'created_at',
-                'updated_at',
-            ])
-            ->assertJsonFragment([
-                'dns_provider_id' => $dnsProvider->id,
-            ]);
-
-        $this->assertDatabaseHas('domains', [
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'provider_domain_id' => 'test-domain-id',
-        ]);
-    }
-
-    public function test_create_domain_fails_when_record_sync_fails(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $callCount = 0;
-
-        // First call (getDomain) succeeds, subsequent calls throw
-        Http::fake(function () use (&$callCount) {
-            $callCount++;
-            if ($callCount === 1) {
-                return Http::response([
-                    'result' => [
-                        'id' => 'test-domain-id',
-                        'name' => 'example.com',
-                        'status' => 'active',
-                        'created_on' => '2023-01-01T00:00:00Z',
-                        'modified_on' => '2023-01-01T00:00:00Z',
-                    ],
-                    'success' => true,
-                ], 200);
-            }
-
-            throw new \RuntimeException('Domain is not opted in to API access.');
-        });
-
-        $domainData = [
-            'dns_provider_id' => $dnsProvider->id,
-            'provider_domain_id' => 'test-domain-id',
-        ];
-
-        $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains", $domainData);
-
-        $response->assertUnprocessable()
-            ->assertJsonValidationErrors('domain');
-
-        // Domain should not have been persisted due to transaction rollback
-        $this->assertDatabaseMissing('domains', [
-            'provider_domain_id' => 'test-domain-id',
-        ]);
-    }
-
-    public function test_user_cannot_create_domain_with_dns_provider_from_other_project(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        // Create a different project for the other user
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $domainData = [
-            'dns_provider_id' => $otherDnsProvider->id,
-            'provider_domain_id' => 'test-domain-id',
-        ];
-
-        $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains", $domainData);
-
-        $response->assertForbidden();
-    }
-
-    public function test_user_without_write_ability_cannot_create_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domainData = [
-            'dns_provider_id' => $dnsProvider->id,
-            'provider_domain_id' => 'test-domain-id',
-        ];
-
-        $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains", $domainData);
-
-        $response->assertForbidden();
-    }
-
-    public function test_authenticated_user_can_view_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}");
-
-        $response->assertOk()
-            ->assertJsonStructure([
-                'id',
-                'domain',
-                'dns_provider_id',
-                'metadata',
-                'dns_provider',
-                'created_at',
-                'updated_at',
-            ])
-            ->assertJsonFragment([
-                'id' => $domain->id,
-                'domain' => $domain->domain,
-            ]);
-    }
-
-    public function test_user_cannot_view_domains_from_other_projects(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        // Create a different project for the other user
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$otherProject->id}/domains/{$otherDomain->id}");
-
-        $response->assertForbidden();
-    }
-
-    public function test_authenticated_user_can_delete_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $response = $this->deleteJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}");
-
-        $response->assertOk()
-            ->assertJsonFragment(['message' => 'Domain removed successfully']);
-
-        $this->assertDatabaseMissing('domains', ['id' => $domain->id]);
-    }
-
-    public function test_user_cannot_delete_domains_from_other_projects(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        // Create a different project for the other user
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $response = $this->deleteJson("/api/projects/{$otherProject->id}/domains/{$otherDomain->id}");
-
-        $response->assertForbidden();
-
-        $this->assertDatabaseHas('domains', ['id' => $otherDomain->id]);
-    }
-
-    public function test_user_without_write_ability_cannot_delete_domain(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $response = $this->deleteJson("/api/projects/{$this->user->current_project_id}/domains/{$domain->id}");
-
-        $response->assertForbidden();
-    }
-
-    public function test_authenticated_user_can_get_available_domains_from_dns_provider(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/{$dnsProvider->id}/available");
-
-        $response->assertNotFound();
-    }
-
-    public function test_user_cannot_get_available_domains_from_dns_provider_in_other_project(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        // Create a different project for the other user
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$otherProject->id}/domains/{$otherDnsProvider->id}/available");
-
-        $response->assertNotFound();
-    }
-
-    public function test_domain_not_found_returns_404(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/999999");
-
-        $response->assertNotFound();
-    }
-
-    public function test_dns_provider_not_found_returns_404(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains/999999/available");
-
-        $response->assertNotFound();
-    }
-
-    public function test_domain_pagination_works_correctly(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        // Create 30 domains to test pagination
-        Domain::factory()->count(30)->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains");
-
-        $response->assertOk()
-            ->assertJsonStructure([
-                'data',
-                'links',
-                'meta',
-            ]);
-
-        // Should have 25 items per page (as defined in controller)
-        $this->assertCount(25, $response->json('data'));
-    }
-
-    public function test_user_cannot_access_domains_from_other_projects(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        // Create a second project for a different user
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-        $otherProject = $otherUser->currentProject;
-
-        // Create DNS provider for the other project
-        $otherProjectDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        // Create domain in the other project
-        $otherProjectDomain = Domain::factory()->create([
-            'user_id' => $otherUser->id,
-            'dns_provider_id' => $otherProjectDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        // Create domain in current project (before switching)
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $currentProjectDomain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        // Should only see domains from current project
-        $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains");
-
-        $response->assertOk();
-        $response->assertJsonMissing(['id' => $otherProjectDomain->id]);
-        $response->assertJsonFragment(['id' => $currentProjectDomain->id]); // Only domains from current project
-
-        // Should not be able to access domain from other project
-        $response = $this->getJson("/api/projects/{$otherProject->id}/domains/{$otherProjectDomain->id}");
-
-        $response->assertForbidden();
-    }
-
-    public function test_user_cannot_create_domain_in_other_project(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        // Create a second project for a different user
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-        $otherProject = $otherUser->currentProject;
-
-        // Create DNS provider for the other project
-        $otherProjectDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        // Try to create domain with DNS provider from other project
-        $domainData = [
-            'dns_provider_id' => $otherProjectDnsProvider->id,
-            'provider_domain_id' => 'test-domain-id',
-        ];
-
-        $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains", $domainData);
-
-        $response->assertForbidden();
-    }
-
-    public function test_user_cannot_delete_domain_from_other_project(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        // Create a second project for a different user
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-        $otherProject = $otherUser->currentProject;
-
-        // Create DNS provider for the other project
-        $otherProjectDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        // Create domain in the other project
-        $otherProjectDomain = Domain::factory()->create([
-            'user_id' => $otherUser->id,
-            'dns_provider_id' => $otherProjectDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        // Try to delete domain from other project
-        $response = $this->deleteJson("/api/projects/{$otherProject->id}/domains/{$otherProjectDomain->id}");
-
-        $response->assertForbidden();
-
-        $this->assertDatabaseHas('domains', ['id' => $otherProjectDomain->id]);
-    }
-}
+    // Should have 25 items per page (as defined in controller)
+    expect($response->json('data'))->toHaveCount(25);
+});
+
+test('user cannot access domains from other projects', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    // Create a second project for a different user
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+    $otherProject = $otherUser->currentProject;
+
+    // Create DNS provider for the other project
+    $otherProjectDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    // Create domain in the other project
+    $otherProjectDomain = Domain::factory()->create([
+        'user_id' => $otherUser->id,
+        'dns_provider_id' => $otherProjectDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    // Create domain in current project (before switching)
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $currentProjectDomain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    // Should only see domains from current project
+    $response = $this->getJson("/api/projects/{$this->user->current_project_id}/domains");
+
+    $response->assertOk();
+    $response->assertJsonMissing(['id' => $otherProjectDomain->id]);
+    $response->assertJsonFragment(['id' => $currentProjectDomain->id]);
+
+    // Only domains from current project
+    // Should not be able to access domain from other project
+    $response = $this->getJson("/api/projects/{$otherProject->id}/domains/{$otherProjectDomain->id}");
+
+    $response->assertForbidden();
+});
+
+test('user cannot create domain in other project', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    // Create a second project for a different user
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+    $otherProject = $otherUser->currentProject;
+
+    // Create DNS provider for the other project
+    $otherProjectDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    // Try to create domain with DNS provider from other project
+    $domainData = [
+        'dns_provider_id' => $otherProjectDnsProvider->id,
+        'provider_domain_id' => 'test-domain-id',
+    ];
+
+    $response = $this->postJson("/api/projects/{$this->user->current_project_id}/domains", $domainData);
+
+    $response->assertForbidden();
+});
+
+test('user cannot delete domain from other project', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    // Create a second project for a different user
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+    $otherProject = $otherUser->currentProject;
+
+    // Create DNS provider for the other project
+    $otherProjectDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    // Create domain in the other project
+    $otherProjectDomain = Domain::factory()->create([
+        'user_id' => $otherUser->id,
+        'dns_provider_id' => $otherProjectDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    // Try to delete domain from other project
+    $response = $this->deleteJson("/api/projects/{$otherProject->id}/domains/{$otherProjectDomain->id}");
+
+    $response->assertForbidden();
+
+    $this->assertDatabaseHas('domains', ['id' => $otherProjectDomain->id]);
+});

--- a/tests/Feature/API/FirewallTest.php
+++ b/tests/Feature/API/FirewallTest.php
@@ -1,238 +1,219 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\FirewallRuleStatus;
 use App\Facades\SSH;
 use App\Models\FirewallRule;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class FirewallTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_firewall_rule(): void
-    {
-        SSH::fake();
+test('create firewall rule', function () {
+    SSH::fake();
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('POST', route('api.projects.servers.firewall-rules.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
-            'name' => 'Test',
-            'type' => 'allow',
-            'protocol' => 'tcp',
+    $this->json('POST', route('api.projects.servers.firewall-rules.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'name' => 'Test',
+        'type' => 'allow',
+        'protocol' => 'tcp',
+        'port' => '1234',
+        'source' => '0.0.0.0',
+        'mask' => '1',
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'port' => '1234',
-            'source' => '0.0.0.0',
-            'mask' => '1',
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'port' => '1234',
-                'status' => FirewallRuleStatus::CREATING,
-            ]);
-    }
+            'status' => FirewallRuleStatus::CREATING,
+        ]);
+});
 
-    public function test_create_firewall_rule_with_integer_port_input(): void
-    {
-        SSH::fake();
+test('create firewall rule with integer port input', function () {
+    SSH::fake();
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('POST', route('api.projects.servers.firewall-rules.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
-            'name' => 'IntPort',
-            'type' => 'allow',
-            'protocol' => 'tcp',
-            'port' => 1234,
-            'source' => null,
-            'mask' => null,
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'port' => '1234',
-            ]);
-    }
+    $this->json('POST', route('api.projects.servers.firewall-rules.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'name' => 'IntPort',
+        'type' => 'allow',
+        'protocol' => 'tcp',
+        'port' => 1234,
+        'source' => null,
+        'mask' => null,
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'port' => '1234',
+        ]);
+});
 
-    public function test_create_firewall_rule_with_port_range(): void
-    {
-        SSH::fake();
+test('create firewall rule with port range', function () {
+    SSH::fake();
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('POST', route('api.projects.servers.firewall-rules.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
-            'name' => 'RangeAPI',
-            'type' => 'allow',
-            'protocol' => 'tcp',
+    $this->json('POST', route('api.projects.servers.firewall-rules.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'name' => 'RangeAPI',
+        'type' => 'allow',
+        'protocol' => 'tcp',
+        'port' => '3000:3010',
+        'source' => null,
+        'mask' => null,
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'port' => '3000:3010',
-            'source' => null,
-            'mask' => null,
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'port' => '3000:3010',
-            ]);
-    }
-
-    public function test_edit_firewall_rule(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $rule = FirewallRule::factory()->create([
-            'server_id' => $this->server->id,
-            'port' => '1234',
         ]);
+});
 
-        $this->json('PUT', route('api.projects.servers.firewall-rules.edit', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'firewallRule' => $rule,
-        ]), [
-            'name' => 'Test',
-            'type' => 'allow',
-            'protocol' => 'tcp',
+test('edit firewall rule', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $rule = FirewallRule::factory()->create([
+        'server_id' => $this->server->id,
+        'port' => '1234',
+    ]);
+
+    $this->json('PUT', route('api.projects.servers.firewall-rules.edit', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'firewallRule' => $rule,
+    ]), [
+        'name' => 'Test',
+        'type' => 'allow',
+        'protocol' => 'tcp',
+        'port' => '55',
+        'source' => null,
+        'mask' => null,
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'port' => '55',
-            'source' => null,
-            'mask' => null,
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'port' => '55',
-                'status' => FirewallRuleStatus::UPDATING,
-            ]);
-    }
-
-    public function test_see_firewall_rules(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var FirewallRule $rule */
-        $rule = FirewallRule::factory()->create([
-            'server_id' => $this->server->id,
+            'status' => FirewallRuleStatus::UPDATING,
         ]);
+});
 
-        $this->json('GET', route('api.projects.servers.firewall-rules', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'source' => $rule->source,
-                'port' => $rule->port,
-            ]);
-    }
+test('see firewall rules', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_delete_firewall_rule(): void
-    {
-        SSH::fake();
+    /** @var FirewallRule $rule */
+    $rule = FirewallRule::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var FirewallRule $rule */
-        $rule = FirewallRule::factory()->create([
-            'server_id' => $this->server->id,
+    $this->json('GET', route('api.projects.servers.firewall-rules', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'source' => $rule->source,
+            'port' => $rule->port,
         ]);
+});
 
-        $this->json('DELETE', route('api.projects.servers.firewall-rules.delete', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'firewallRule' => $rule,
-        ]))
-            ->assertNoContent();
-    }
+test('delete firewall rule', function () {
+    SSH::fake();
 
-    #[DataProvider('nonScalarPortProvider')]
-    public function test_rejects_non_string_or_int_port_input(mixed $port): void
-    {
-        SSH::fake();
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    /** @var FirewallRule $rule */
+    $rule = FirewallRule::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        $this->json('POST', route('api.projects.servers.firewall-rules.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
-            'name' => 'BadType',
-            'type' => 'allow',
-            'protocol' => 'tcp',
-            'port' => $port,
-            'source' => null,
-            'mask' => null,
-        ])
-            ->assertStatus(422)
-            ->assertJsonValidationErrors(['port']);
-    }
+    $this->json('DELETE', route('api.projects.servers.firewall-rules.delete', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'firewallRule' => $rule,
+    ]))
+        ->assertNoContent();
+});
 
-    /**
-     * @return array<string, array<int, mixed>>
-     */
-    public static function nonScalarPortProvider(): array
-    {
-        return [
-            'true boolean' => [true],
-            'false boolean' => [false],
-            'float' => [22.5],
-            'array' => [[22]],
-            'null' => [null],
-        ];
-    }
+test('rejects non string or int port input', function (mixed $port) {
+    SSH::fake();
 
-    #[DataProvider('invalidPortProvider')]
-    public function test_rejects_invalid_port_input(string $port): void
-    {
-        SSH::fake();
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    $this->json('POST', route('api.projects.servers.firewall-rules.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'name' => 'BadType',
+        'type' => 'allow',
+        'protocol' => 'tcp',
+        'port' => $port,
+        'source' => null,
+        'mask' => null,
+    ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['port']);
+})->with('nonScalarPortProvider');
 
-        $this->json('POST', route('api.projects.servers.firewall-rules.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
-            'name' => 'BadPort',
-            'type' => 'allow',
-            'protocol' => 'tcp',
-            'port' => $port,
-            'source' => null,
-            'mask' => null,
-        ])
-            ->assertStatus(422)
-            ->assertJsonValidationErrors(['port']);
-    }
+/**
+ * @return array<string, array<int, mixed>>
+ */
+dataset('nonScalarPortProvider', function () {
+    return [
+        'true boolean' => [true],
+        'false boolean' => [false],
+        'float' => [22.5],
+        'array' => [[22]],
+        'null' => [null],
+    ];
+});
 
-    /**
-     * @return array<string, array<int, string>>
-     */
-    public static function invalidPortProvider(): array
-    {
-        return [
-            'zero' => ['0'],
-            'above max' => ['65536'],
-            'far above max' => ['99999'],
-            'both above max' => ['100000:200000'],
-            'second side above max' => ['1000:65536'],
-            'reversed range' => ['5000:4000'],
-            'equal range' => ['3000:3000'],
-            'non-numeric' => ['abc'],
-            'trailing colon' => ['3000:'],
-            'leading colon' => [':3010'],
-            'leading zero' => ['01234'],
-            'negative' => ['-22'],
-            'decimal' => ['22.5'],
-            'whitespace inside' => ['3000 : 3010'],
-            'three parts' => ['1000:2000:3000'],
-            'empty' => [''],
-        ];
-    }
-}
+test('rejects invalid port input', function (string $port) {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $this->json('POST', route('api.projects.servers.firewall-rules.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'name' => 'BadPort',
+        'type' => 'allow',
+        'protocol' => 'tcp',
+        'port' => $port,
+        'source' => null,
+        'mask' => null,
+    ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['port']);
+})->with('invalidPortProvider');
+
+/**
+ * @return array<string, array<int, string>>
+ */
+dataset('invalidPortProvider', function () {
+    return [
+        'zero' => ['0'],
+        'above max' => ['65536'],
+        'far above max' => ['99999'],
+        'both above max' => ['100000:200000'],
+        'second side above max' => ['1000:65536'],
+        'reversed range' => ['5000:4000'],
+        'equal range' => ['3000:3000'],
+        'non-numeric' => ['abc'],
+        'trailing colon' => ['3000:'],
+        'leading colon' => [':3010'],
+        'leading zero' => ['01234'],
+        'negative' => ['-22'],
+        'decimal' => ['22.5'],
+        'whitespace inside' => ['3000 : 3010'],
+        'three parts' => ['1000:2000:3000'],
+        'empty' => [''],
+    ];
+});

--- a/tests/Feature/API/ProjectsTest.php
+++ b/tests/Feature/API/ProjectsTest.php
@@ -1,99 +1,88 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\UserRole;
 use App\Models\Project;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 
-class ProjectsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_project(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('create project', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('POST', '/api/projects', [
-            'name' => 'test',
-        ])
-            ->assertSuccessful();
+    $this->json('POST', '/api/projects', [
+        'name' => 'test',
+    ])
+        ->assertSuccessful();
 
-        $this->assertDatabaseHas('projects', [
-            'name' => 'test',
+    $this->assertDatabaseHas('projects', [
+        'name' => 'test',
+    ]);
+});
+
+test('see projects list', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Project $project */
+    $project = Project::factory()->create();
+    $project->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
+
+    $this->json('GET', '/api/projects')
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'name' => $project->name,
         ]);
-    }
+});
 
-    public function test_see_projects_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('delete project', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        /** @var Project $project */
-        $project = Project::factory()->create();
-        $project->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
+    /** @var Project $project */
+    $project = Project::factory()->create();
+    $project->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::OWNER,
+    ]);
 
-        $this->json('GET', '/api/projects')
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => $project->name,
-            ]);
-    }
+    $this->json('DELETE', '/api/projects/'.$project->id)
+        ->assertSuccessful();
 
-    public function test_delete_project(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    $this->assertDatabaseMissing('projects', [
+        'id' => $project->id,
+    ]);
+});
 
-        /** @var Project $project */
-        $project = Project::factory()->create();
-        $project->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::OWNER,
-        ]);
+test('edit project', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('DELETE', '/api/projects/'.$project->id)
-            ->assertSuccessful();
+    /** @var Project $project */
+    $project = Project::factory()->create();
+    $project->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
 
-        $this->assertDatabaseMissing('projects', [
-            'id' => $project->id,
-        ]);
-    }
+    $this->json('PUT', "/api/projects/{$project->id}", [
+        'name' => 'new-name',
+    ])
+        ->assertSuccessful();
 
-    public function test_edit_project(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    $this->assertDatabaseHas('projects', [
+        'id' => $project->id,
+        'name' => 'new-name',
+    ]);
+});
 
-        /** @var Project $project */
-        $project = Project::factory()->create();
-        $project->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
+test('cannot delete last project', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('PUT', "/api/projects/{$project->id}", [
-            'name' => 'new-name',
-        ])
-            ->assertSuccessful();
+    $this->json('DELETE', "/api/projects/{$this->user->currentProject->id}")
+        ->assertJsonValidationErrorFor('name');
 
-        $this->assertDatabaseHas('projects', [
-            'id' => $project->id,
-            'name' => 'new-name',
-        ]);
-    }
-
-    public function test_cannot_delete_last_project(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $this->json('DELETE', "/api/projects/{$this->user->currentProject->id}")
-            ->assertJsonValidationErrorFor('name');
-
-        $this->assertDatabaseHas('projects', [
-            'id' => $this->user->currentProject->id,
-        ]);
-    }
-}
+    $this->assertDatabaseHas('projects', [
+        'id' => $this->user->currentProject->id,
+    ]);
+});

--- a/tests/Feature/API/RedirectsTest.php
+++ b/tests/Feature/API/RedirectsTest.php
@@ -1,108 +1,98 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\RedirectStatus;
 use App\Facades\SSH;
 use App\Models\Redirect;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 
-class RedirectsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_redirect(): void
-    {
-        SSH::fake();
+test('create redirect', function () {
+    SSH::fake();
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('POST', route('api.projects.servers.sites.redirects.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
+    $this->json('POST', route('api.projects.servers.sites.redirects.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'from' => 'testing/path',
+        'to' => 'https://example.com',
+        'mode' => 301,
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'from' => 'testing/path',
             'to' => 'https://example.com',
             'mode' => 301,
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'from' => 'testing/path',
-                'to' => 'https://example.com',
-                'mode' => 301,
-                'status' => RedirectStatus::READY,
-            ]);
-    }
+            'status' => RedirectStatus::READY,
+        ]);
+});
 
-    public function test_update_redirect(): void
-    {
-        SSH::fake();
+test('update redirect', function () {
+    SSH::fake();
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('PUT', route('api.projects.servers.sites.redirects.update', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $this->site,
-            'redirect' => $this->redirect->id,
-        ]), [
+    $this->json('PUT', route('api.projects.servers.sites.redirects.update', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $this->site,
+        'redirect' => $this->redirect->id,
+    ]), [
+        'from' => 'updated/path',
+        'to' => 'https://updated.example.com',
+        'mode' => 302,
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'id' => $this->redirect->id,
             'from' => 'updated/path',
             'to' => 'https://updated.example.com',
             'mode' => 302,
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'id' => $this->redirect->id,
-                'from' => 'updated/path',
-                'to' => 'https://updated.example.com',
-                'mode' => 302,
-                'status' => RedirectStatus::READY,
-            ]);
-    }
-
-    public function test_see_redirects_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        /** @var Redirect $redirect */
-        $redirect = Redirect::factory()->create([
-            'site_id' => $this->site->id,
+            'status' => RedirectStatus::READY,
         ]);
+});
 
-        $this->json('GET', route('api.projects.servers.sites.redirects.index', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'from' => $redirect->from,
-                'to' => $redirect->to,
-                'mode' => $redirect->mode,
-                'status' => $redirect->status,
-            ]);
-    }
+test('see redirects list', function () {
+    Sanctum::actingAs($this->user, ['read']);
 
-    public function test_delete_redirect(): void
-    {
-        SSH::fake();
+    /** @var Redirect $redirect */
+    $redirect = Redirect::factory()->create([
+        'site_id' => $this->site->id,
+    ]);
 
-        Sanctum::actingAs($this->user, ['write']);
-
-        $this->json('DELETE', route('api.projects.servers.sites.redirects.delete', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $this->site,
-            'redirect' => $this->redirect->id,
-        ]))
-            ->assertSuccessful()
-            ->assertNoContent();
-
-        $this->assertDatabaseMissing('redirects', [
-            'id' => $this->redirect->id,
+    $this->json('GET', route('api.projects.servers.sites.redirects.index', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'from' => $redirect->from,
+            'to' => $redirect->to,
+            'mode' => $redirect->mode,
+            'status' => $redirect->status,
         ]);
-    }
-}
+});
+
+test('delete redirect', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['write']);
+
+    $this->json('DELETE', route('api.projects.servers.sites.redirects.delete', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $this->site,
+        'redirect' => $this->redirect->id,
+    ]))
+        ->assertSuccessful()
+        ->assertNoContent();
+
+    $this->assertDatabaseMissing('redirects', [
+        'id' => $this->redirect->id,
+    ]);
+});

--- a/tests/Feature/API/ServerProvidersTest.php
+++ b/tests/Feature/API/ServerProvidersTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Models\ServerProvider;
 use App\Models\User;
 use App\ServerProviders\DigitalOcean;
@@ -11,541 +9,499 @@ use App\ServerProviders\Vultr;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Laravel\Sanctum\Sanctum;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class ServerProvidersTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    /**
-     * @param  array<string, mixed>  $input
-     */
-    #[DataProvider('data')]
-    public function test_connect_provider(string $provider, array $input): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('connect provider', function (string $provider, array $input) {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        Http::fake();
+    Http::fake();
 
-        $data = array_merge(
-            [
-                'provider' => $provider,
-                'name' => 'profile',
-            ],
-            $input
-        );
-        $this->json('POST', route('api.projects.server-providers.create', [
-            'project' => $this->user->current_project_id,
-        ]), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'provider' => $provider,
-                'name' => 'profile',
-                'project_id' => isset($input['global']) ? null : $this->user->current_project_id,
-            ]);
-    }
-
-    /**
-     * @param  array<string, mixed>  $input
-     */
-    #[DataProvider('data')]
-    public function test_cannot_connect_to_provider(string $provider, array $input): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        Http::fake([
-            '*' => Http::response([], 401),
-        ]);
-
-        $data = array_merge(
-            [
-                'provider' => $provider,
-                'name' => 'profile',
-            ],
-            $input
-        );
-        $this->json('POST', route('api.projects.server-providers.create', [
-            'project' => $this->user->current_project_id,
-        ]), $data)
-            ->assertJsonValidationErrorFor('provider');
-    }
-
-    public function test_see_providers_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var ServerProvider $provider */
-        $provider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->json('GET', route('api.projects.server-providers', [
-            'project' => $this->user->current_project_id,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'id' => $provider->id,
-                'provider' => $provider->provider,
-            ]);
-    }
-
-    #[DataProvider('data')]
-    public function test_delete_provider(string $provider, array $input): void
-    {
-        unset($input);
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var ServerProvider $provider */
-        $provider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
+    $data = array_merge(
+        [
             'provider' => $provider,
-        ]);
-
-        $this->json('DELETE', route('api.projects.server-providers.delete', [
-            'project' => $this->user->current_project_id,
-            'serverProvider' => $provider->id,
-        ]))
-            ->assertNoContent();
-    }
-
-    #[DataProvider('data')]
-    public function test_cannot_delete_provider(string $provider, array $input): void
-    {
-        unset($input);
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var ServerProvider $provider */
-        $provider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
+            'name' => 'profile',
+        ],
+        $input
+    );
+    $this->json('POST', route('api.projects.server-providers.create', [
+        'project' => $this->user->current_project_id,
+    ]), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'provider' => $provider,
+            'name' => 'profile',
+            'project_id' => isset($input['global']) ? null : $this->user->current_project_id,
         ]);
+})->with('data');
 
-        $this->server->update([
-            'provider_id' => $provider->id,
+test('cannot connect to provider', function (string $provider, array $input) {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    Http::fake([
+        '*' => Http::response([], 401),
+    ]);
+
+    $data = array_merge(
+        [
+            'provider' => $provider,
+            'name' => 'profile',
+        ],
+        $input
+    );
+    $this->json('POST', route('api.projects.server-providers.create', [
+        'project' => $this->user->current_project_id,
+    ]), $data)
+        ->assertJsonValidationErrorFor('provider');
+})->with('data');
+
+test('see providers list', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var ServerProvider $provider */
+    $provider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->json('GET', route('api.projects.server-providers', [
+        'project' => $this->user->current_project_id,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'id' => $provider->id,
+            'provider' => $provider->provider,
         ]);
+});
 
-        $this->json('DELETE', route('api.projects.server-providers.delete', [
-            'project' => $this->user->current_project_id,
-            'serverProvider' => $provider->id,
-        ]))
-            ->assertJsonValidationErrors([
-                'provider' => 'This server provider is being used by a server.',
-            ]);
-    }
+test('delete provider', function (string $provider, array $input) {
+    unset($input);
 
-    public function test_api_user_cannot_access_other_users_server_provider(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $otherUser = User::factory()->create();
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $otherUser->id,
+    /** @var ServerProvider $provider */
+    $provider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => $provider,
+    ]);
+
+    $this->json('DELETE', route('api.projects.server-providers.delete', [
+        'project' => $this->user->current_project_id,
+        'serverProvider' => $provider->id,
+    ]))
+        ->assertNoContent();
+})->with('data');
+
+test('cannot delete provider', function (string $provider, array $input) {
+    unset($input);
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var ServerProvider $provider */
+    $provider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => $provider,
+    ]);
+
+    $this->server->update([
+        'provider_id' => $provider->id,
+    ]);
+
+    $this->json('DELETE', route('api.projects.server-providers.delete', [
+        'project' => $this->user->current_project_id,
+        'serverProvider' => $provider->id,
+    ]))
+        ->assertJsonValidationErrors([
+            'provider' => 'This server provider is being used by a server.',
         ]);
+})->with('data');
 
-        $this->json('GET', route('api.projects.server-providers.show', [
-            'project' => $this->user->current_project_id,
-            'serverProvider' => $serverProvider->id,
-        ]))
-            ->assertForbidden();
-    }
+test('api user cannot access other users server provider', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_api_user_cannot_update_other_users_server_provider(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    $otherUser = User::factory()->create();
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
 
-        $otherUser = User::factory()->create();
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
+    $this->json('GET', route('api.projects.server-providers.show', [
+        'project' => $this->user->current_project_id,
+        'serverProvider' => $serverProvider->id,
+    ]))
+        ->assertForbidden();
+});
 
-        $this->json('PUT', route('api.projects.server-providers.update', [
-            'project' => $this->user->current_project_id,
-            'serverProvider' => $serverProvider->id,
-        ]), [
-            'name' => 'hacked',
+test('api user cannot update other users server provider', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    $this->json('PUT', route('api.projects.server-providers.update', [
+        'project' => $this->user->current_project_id,
+        'serverProvider' => $serverProvider->id,
+    ]), [
+        'name' => 'hacked',
+    ])
+        ->assertForbidden();
+});
+
+test('api user cannot delete other users server provider', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    $this->json('DELETE', route('api.projects.server-providers.delete', [
+        'project' => $this->user->current_project_id,
+        'serverProvider' => $serverProvider->id,
+    ]))
+        ->assertForbidden();
+});
+
+test('api guest cannot access server providers', function () {
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->json('GET', route('api.projects.server-providers', [
+        'project' => $this->user->current_project_id,
+    ]))
+        ->assertUnauthorized();
+
+    $this->json('POST', route('api.projects.server-providers.create', [
+        'project' => $this->user->current_project_id,
+    ]), [])
+        ->assertUnauthorized();
+
+    $this->json('DELETE', route('api.projects.server-providers.delete', [
+        'project' => $this->user->current_project_id,
+        'serverProvider' => $serverProvider->id,
+    ]))
+        ->assertUnauthorized();
+});
+
+test('api insufficient scopes denies access', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    // Only read scope
+    $data = [
+        'provider' => DigitalOcean::id(),
+        'name' => 'test',
+        'token' => 'fake-token',
+    ];
+
+    $this->json('POST', route('api.projects.server-providers.create', [
+        'project' => $this->user->current_project_id,
+    ]), $data)
+        ->assertForbidden();
+});
+
+test('api cannot manipulate user id on creation', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+
+    Http::fake();
+
+    $data = [
+        'provider' => DigitalOcean::id(),
+        'name' => 'test',
+        'token' => 'fake-token',
+        'user_id' => $otherUser->id,
+    ];
+
+    $this->json('POST', route('api.projects.server-providers.create', [
+        'project' => $this->user->current_project_id,
+    ]), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'provider' => DigitalOcean::id(),
+            'name' => 'test',
+            'user_id' => $this->user->id,
         ])
-            ->assertForbidden();
-    }
-
-    public function test_api_user_cannot_delete_other_users_server_provider(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-        $serverProvider = ServerProvider::factory()->create([
+        ->assertJsonMissing([
             'user_id' => $otherUser->id,
         ]);
+});
 
-        $this->json('DELETE', route('api.projects.server-providers.delete', [
-            'project' => $this->user->current_project_id,
-            'serverProvider' => $serverProvider->id,
-        ]))
-            ->assertForbidden();
-    }
+test('api user can only see own server providers in list', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_api_guest_cannot_access_server_providers(): void
-    {
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
+    $otherUser = User::factory()->create();
+
+    $ownProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'profile' => 'own-provider',
+    ]);
+
+    $otherProvider = ServerProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'profile' => 'other-provider',
+    ]);
+
+    $response = $this->json('GET', route('api.projects.server-providers', [
+        'project' => $this->user->current_project_id,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'id' => $ownProvider->id,
+            'provider' => $ownProvider->provider,
+        ])
+        ->assertJsonMissing([
+            'id' => $otherProvider->id,
         ]);
+});
 
-        $this->json('GET', route('api.projects.server-providers', [
-            'project' => $this->user->current_project_id,
-        ]))
-            ->assertUnauthorized();
+test('get regions', function (string $provider, array $input) {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('POST', route('api.projects.server-providers.create', [
-            'project' => $this->user->current_project_id,
-        ]), [])
-            ->assertUnauthorized();
+    // Mock the provider's regions method
+    Http::fake([
+        '*' => Http::response([
+            ['id' => 'nyc1', 'name' => 'New York 1', 'country' => 'US', 'available' => true],
+            ['id' => 'sfo1', 'name' => 'San Francisco 1', 'country' => 'US', 'available' => true],
+        ], 200),
+    ]);
 
-        $this->json('DELETE', route('api.projects.server-providers.delete', [
-            'project' => $this->user->current_project_id,
-            'serverProvider' => $serverProvider->id,
-        ]))
-            ->assertUnauthorized();
-    }
+    /** @var ServerProvider $serverProvider */
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'provider' => $provider,
+        'credentials' => $input,
+    ]);
 
-    public function test_api_insufficient_scopes_denies_access(): void
-    {
-        Sanctum::actingAs($this->user, ['read']); // Only read scope
-
-        $data = [
-            'provider' => DigitalOcean::id(),
-            'name' => 'test',
-            'token' => 'fake-token',
-        ];
-
-        $this->json('POST', route('api.projects.server-providers.create', [
-            'project' => $this->user->current_project_id,
-        ]), $data)
-            ->assertForbidden();
-    }
-
-    public function test_api_cannot_manipulate_user_id_on_creation(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-
-        Http::fake();
-
-        $data = [
-            'provider' => DigitalOcean::id(),
-            'name' => 'test',
-            'token' => 'fake-token',
-            'user_id' => $otherUser->id,
-        ];
-
-        $this->json('POST', route('api.projects.server-providers.create', [
-            'project' => $this->user->current_project_id,
-        ]), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'provider' => DigitalOcean::id(),
-                'name' => 'test',
-                'user_id' => $this->user->id,
-            ])
-            ->assertJsonMissing([
-                'user_id' => $otherUser->id,
-            ]);
-    }
-
-    public function test_api_user_can_only_see_own_server_providers_in_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-
-        $ownProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'profile' => 'own-provider',
+    $this->json('GET', route('api.projects.server-providers.regions', [
+        'project' => $this->user->current_project_id,
+        'serverProvider' => $serverProvider->id,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonStructure([
+            '*' => [
+                'id',
+                'name',
+                'country',
+                'available',
+            ],
         ]);
+})->with('data');
 
-        $otherProvider = ServerProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'profile' => 'other-provider',
+test('get plans', function (string $provider, array $input) {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    // Mock the provider's plans method
+    Http::fake([
+        '*' => Http::response([
+            [
+                'id' => 's-1vcpu-1gb',
+                'name' => 'Basic',
+                'memory' => 1024,
+                'vcpus' => 1,
+                'disk' => 25,
+                'price_monthly' => 5.0,
+                'price_hourly' => 0.007,
+                'available' => true,
+            ],
+            [
+                'id' => 's-1vcpu-2gb',
+                'name' => 'Standard',
+                'memory' => 2048,
+                'vcpus' => 1,
+                'disk' => 50,
+                'price_monthly' => 10.0,
+                'price_hourly' => 0.014,
+                'available' => true,
+            ],
+        ], 200),
+    ]);
+
+    /** @var ServerProvider $serverProvider */
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'provider' => $provider,
+        'credentials' => $input,
+    ]);
+
+    $this->json('GET', route('api.projects.server-providers.plans', [
+        'project' => $this->user->current_project_id,
+        'serverProvider' => $serverProvider->id,
+        'region' => 'nyc1',
+    ]))
+        ->assertSuccessful()
+        ->assertJsonStructure([
+            '*' => [
+                'id',
+                'name',
+                'memory',
+                'vcpus',
+                'disk',
+                'price_monthly',
+                'price_hourly',
+                'available',
+            ],
         ]);
+})->with('data');
 
-        $response = $this->json('GET', route('api.projects.server-providers', [
-            'project' => $this->user->current_project_id,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'id' => $ownProvider->id,
-                'provider' => $ownProvider->provider,
-            ])
-            ->assertJsonMissing([
-                'id' => $otherProvider->id,
-            ]);
-    }
+test('hetzner plans endpoint returns flat available only', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    /**
-     * @param  array<string, mixed>  $input
-     */
-    #[DataProvider('data')]
-    public function test_get_regions(string $provider, array $input): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        // Mock the provider's regions method
-        Http::fake([
-            '*' => Http::response([
-                ['id' => 'nyc1', 'name' => 'New York 1', 'country' => 'US', 'available' => true],
-                ['id' => 'sfo1', 'name' => 'San Francisco 1', 'country' => 'US', 'available' => true],
-            ], 200),
-        ]);
-
-        /** @var ServerProvider $serverProvider */
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'provider' => $provider,
-            'credentials' => $input,
-        ]);
-
-        $this->json('GET', route('api.projects.server-providers.regions', [
-            'project' => $this->user->current_project_id,
-            'serverProvider' => $serverProvider->id,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonStructure([
-                '*' => [
-                    'id',
-                    'name',
-                    'country',
-                    'available',
-                ],
-            ]);
-    }
-
-    /**
-     * @param  array<string, mixed>  $input
-     */
-    #[DataProvider('data')]
-    public function test_get_plans(string $provider, array $input): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        // Mock the provider's plans method
-        Http::fake([
-            '*' => Http::response([
+    Http::fake([
+        '*' => Http::response([
+            'server_types' => [
                 [
-                    'id' => 's-1vcpu-1gb',
-                    'name' => 'Basic',
-                    'memory' => 1024,
-                    'vcpus' => 1,
-                    'disk' => 25,
-                    'price_monthly' => 5.0,
-                    'price_hourly' => 0.007,
-                    'available' => true,
-                ],
-                [
-                    'id' => 's-1vcpu-2gb',
-                    'name' => 'Standard',
-                    'memory' => 2048,
-                    'vcpus' => 1,
-                    'disk' => 50,
-                    'price_monthly' => 10.0,
-                    'price_hourly' => 0.014,
-                    'available' => true,
-                ],
-            ], 200),
-        ]);
-
-        /** @var ServerProvider $serverProvider */
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'provider' => $provider,
-            'credentials' => $input,
-        ]);
-
-        $this->json('GET', route('api.projects.server-providers.plans', [
-            'project' => $this->user->current_project_id,
-            'serverProvider' => $serverProvider->id,
-            'region' => 'nyc1',
-        ]))
-            ->assertSuccessful()
-            ->assertJsonStructure([
-                '*' => [
-                    'id',
-                    'name',
-                    'memory',
-                    'vcpus',
-                    'disk',
-                    'price_monthly',
-                    'price_hourly',
-                    'available',
-                ],
-            ]);
-    }
-
-    public function test_hetzner_plans_endpoint_returns_flat_available_only(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        Http::fake([
-            '*' => Http::response([
-                'server_types' => [
-                    [
-                        'name' => 'ccx13', 'cores' => 2, 'memory' => 8, 'disk' => 80,
-                        'prices' => [['location' => 'fsn1', 'price_monthly' => ['net' => '18.4900000000']]],
-                        'locations' => [
-                            ['name' => 'fsn1', 'available' => true, 'deprecation' => null],
-                        ],
-                    ],
-                    [
-                        'name' => 'cax11', 'cores' => 2, 'memory' => 4, 'disk' => 40,
-                        'prices' => [['location' => 'fsn1', 'price_monthly' => ['net' => '5.4900000000']]],
-                        'locations' => [
-                            ['name' => 'fsn1', 'available' => false, 'deprecation' => null],
-                        ],
+                    'name' => 'ccx13', 'cores' => 2, 'memory' => 8, 'disk' => 80,
+                    'prices' => [['location' => 'fsn1', 'price_monthly' => ['net' => '18.4900000000']]],
+                    'locations' => [
+                        ['name' => 'fsn1', 'available' => true, 'deprecation' => null],
                     ],
                 ],
-            ], 200),
-        ]);
-
-        /** @var ServerProvider $serverProvider */
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'provider' => Hetzner::id(),
-            'credentials' => ['token' => 'token'],
-        ]);
-
-        $plans = $this->json('GET', route('api.projects.server-providers.plans', [
-            'project' => $this->user->current_project_id,
-            'serverProvider' => $serverProvider->id,
-            'region' => 'fsn1',
-        ]))
-            ->assertSuccessful()
-            ->json();
-
-        $this->assertArrayHasKey('ccx13', $plans);
-        $this->assertArrayNotHasKey('cax11', $plans);
-        $this->assertIsString($plans['ccx13']);
-    }
-
-    public function test_cannot_access_regions_without_authentication(): void
-    {
-        /** @var ServerProvider $serverProvider */
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $this->json('GET', route('api.projects.server-providers.regions', [
-            'project' => $this->user->current_project_id,
-            'serverProvider' => $serverProvider->id,
-        ]))
-            ->assertUnauthorized();
-    }
-
-    public function test_cannot_access_plans_without_authentication(): void
-    {
-        /** @var ServerProvider $serverProvider */
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $this->json('GET', route('api.projects.server-providers.plans', [
-            'project' => $this->user->current_project_id,
-            'serverProvider' => $serverProvider->id,
-            'region' => 'nyc1',
-        ]))
-            ->assertUnauthorized();
-    }
-
-    public function test_cannot_access_other_users_server_provider_regions(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var User $otherUser */
-        $otherUser = User::factory()->create();
-
-        /** @var ServerProvider $serverProvider */
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherUser->current_project_id,
-        ]);
-
-        $this->json('GET', route('api.projects.server-providers.regions', [
-            'project' => $this->user->current_project_id,
-            'serverProvider' => $serverProvider->id,
-        ]))
-            ->assertForbidden();
-    }
-
-    public function test_cannot_access_other_users_server_provider_plans(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var User $otherUser */
-        $otherUser = User::factory()->create();
-
-        /** @var ServerProvider $serverProvider */
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherUser->current_project_id,
-        ]);
-
-        $this->json('GET', route('api.projects.server-providers.plans', [
-            'project' => $this->user->current_project_id,
-            'serverProvider' => $serverProvider->id,
-            'region' => 'nyc1',
-        ]))
-            ->assertForbidden();
-    }
-
-    /**
-     * @return array<array<int, mixed>>
-     */
-    public static function data(): array
-    {
-        return [
-            // [
-            //     ServerProvider::AWS,
-            //     [
-            //         'key' => 'key',
-            //         'secret' => 'secret',
-            //     ],
-            // ],
-            [
-                Linode::id(),
                 [
-                    'token' => 'token',
+                    'name' => 'cax11', 'cores' => 2, 'memory' => 4, 'disk' => 40,
+                    'prices' => [['location' => 'fsn1', 'price_monthly' => ['net' => '5.4900000000']]],
+                    'locations' => [
+                        ['name' => 'fsn1', 'available' => false, 'deprecation' => null],
+                    ],
                 ],
             ],
+        ], 200),
+    ]);
+
+    /** @var ServerProvider $serverProvider */
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'provider' => Hetzner::id(),
+        'credentials' => ['token' => 'token'],
+    ]);
+
+    $plans = $this->json('GET', route('api.projects.server-providers.plans', [
+        'project' => $this->user->current_project_id,
+        'serverProvider' => $serverProvider->id,
+        'region' => 'fsn1',
+    ]))
+        ->assertSuccessful()
+        ->json();
+
+    expect($plans)->toHaveKey('ccx13');
+    $this->assertArrayNotHasKey('cax11', $plans);
+    expect($plans['ccx13'])->toBeString();
+});
+
+test('cannot access regions without authentication', function () {
+    /** @var ServerProvider $serverProvider */
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $this->json('GET', route('api.projects.server-providers.regions', [
+        'project' => $this->user->current_project_id,
+        'serverProvider' => $serverProvider->id,
+    ]))
+        ->assertUnauthorized();
+});
+
+test('cannot access plans without authentication', function () {
+    /** @var ServerProvider $serverProvider */
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $this->json('GET', route('api.projects.server-providers.plans', [
+        'project' => $this->user->current_project_id,
+        'serverProvider' => $serverProvider->id,
+        'region' => 'nyc1',
+    ]))
+        ->assertUnauthorized();
+});
+
+test('cannot access other users server provider regions', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var User $otherUser */
+    $otherUser = User::factory()->create();
+
+    /** @var ServerProvider $serverProvider */
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherUser->current_project_id,
+    ]);
+
+    $this->json('GET', route('api.projects.server-providers.regions', [
+        'project' => $this->user->current_project_id,
+        'serverProvider' => $serverProvider->id,
+    ]))
+        ->assertForbidden();
+});
+
+test('cannot access other users server provider plans', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var User $otherUser */
+    $otherUser = User::factory()->create();
+
+    /** @var ServerProvider $serverProvider */
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherUser->current_project_id,
+    ]);
+
+    $this->json('GET', route('api.projects.server-providers.plans', [
+        'project' => $this->user->current_project_id,
+        'serverProvider' => $serverProvider->id,
+        'region' => 'nyc1',
+    ]))
+        ->assertForbidden();
+});
+
+/**
+ * @return array<array<int, mixed>>
+ */
+dataset('data', function () {
+    return [
+        // [
+        //     ServerProvider::AWS,
+        //     [
+        //         'key' => 'key',
+        //         'secret' => 'secret',
+        //     ],
+        // ],
+        [
+            Linode::id(),
             [
-                Linode::id(),
-                [
-                    'token' => 'token',
-                    'global' => 1,
-                ],
+                'token' => 'token',
             ],
+        ],
+        [
+            Linode::id(),
             [
-                DigitalOcean::id(),
-                [
-                    'token' => 'token',
-                ],
+                'token' => 'token',
+                'global' => 1,
             ],
+        ],
+        [
+            DigitalOcean::id(),
             [
-                Vultr::id(),
-                [
-                    'token' => 'token',
-                ],
+                'token' => 'token',
             ],
+        ],
+        [
+            Vultr::id(),
             [
-                Hetzner::id(),
-                [
-                    'token' => 'token',
-                ],
+                'token' => 'token',
             ],
-        ];
-    }
-}
+        ],
+        [
+            Hetzner::id(),
+            [
+                'token' => 'token',
+            ],
+        ],
+    ];
+});

--- a/tests/Feature/API/ServerSshKeysTest.php
+++ b/tests/Feature/API/ServerSshKeysTest.php
@@ -1,170 +1,158 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\SshKeyStatus;
 use App\Facades\SSH;
 use App\Models\SshKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 
-class ServerSshKeysTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_see_server_keys()
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('see server keys', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $sshKey = SshKey::factory()->create([
-            'user_id' => $this->user->id,
+    $sshKey = SshKey::factory()->create([
+        'user_id' => $this->user->id,
+        'name' => 'My first key',
+        'public_key' => 'public-key-content',
+    ]);
+
+    $this->server->sshKeys()->attach($sshKey, [
+        'status' => SshKeyStatus::ADDED,
+        'user' => $this->server->getSshUser(),
+    ]);
+
+    $this->json('GET', route('api.projects.servers.ssh-keys', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'name' => 'My first key',
-            'public_key' => 'public-key-content',
         ]);
+});
 
-        $this->server->sshKeys()->attach($sshKey, [
-            'status' => SshKeyStatus::ADDED,
-            'user' => $this->server->getSshUser(),
-        ]);
+test('add new ssh key', function () {
+    SSH::fake();
 
-        $this->json('GET', route('api.projects.servers.ssh-keys', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => 'My first key',
-            ]);
-    }
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_add_new_ssh_key()
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $this->json('POST', route('api.projects.servers.ssh-keys.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
+    $this->json('POST', route('api.projects.servers.ssh-keys.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'name' => 'My first key',
+        'public_key' => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC3CCnyBbpCgOJ0AWUSfBZ+mYAsYzcQDegPkBx1kyE0bXT1yX4+6uYx1Jh6NxWgLyaU0BaP4nsClrK1u5FojQHd8J7ycc0N3H8B+v2NPzj1Q6bFnl40saastONVm+d4edbCg9BowGAafLcf9ALsognqqOWQbK/QOpAhg25IAe47eiY3IjDGMHlsvaZkMtkDhT4t1mK8ZLjxw5vjyVYgINJefR981bIxMFrXy+0xBCsYOZxMIoAJsgCkrAGlI4kQHKv0SQVccSyTE1eziIZa5b3QUlXj8ogxMfK/EOD7Aoqinw652k4S5CwFs/LLmjWcFqCKDM6CSggWpB78DZ729O6zFvQS9V99/9SsSV7Qc5ML7B0DKzJ/tbHkaAE8xdZnQnZFVUegUMtUmjvngMaGlYsxkAZrUKsFRoh7xfXVkDyRBaBSslRNe8LFsXw9f7Q+3jdZ5vhGhmp+TBXTlgxApwR023411+ABE9y0doCx8illya3m2olEiiMZkRclgqsWFSk=',
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'name' => 'My first key',
-            'public_key' => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC3CCnyBbpCgOJ0AWUSfBZ+mYAsYzcQDegPkBx1kyE0bXT1yX4+6uYx1Jh6NxWgLyaU0BaP4nsClrK1u5FojQHd8J7ycc0N3H8B+v2NPzj1Q6bFnl40saastONVm+d4edbCg9BowGAafLcf9ALsognqqOWQbK/QOpAhg25IAe47eiY3IjDGMHlsvaZkMtkDhT4t1mK8ZLjxw5vjyVYgINJefR981bIxMFrXy+0xBCsYOZxMIoAJsgCkrAGlI4kQHKv0SQVccSyTE1eziIZa5b3QUlXj8ogxMfK/EOD7Aoqinw652k4S5CwFs/LLmjWcFqCKDM6CSggWpB78DZ729O6zFvQS9V99/9SsSV7Qc5ML7B0DKzJ/tbHkaAE8xdZnQnZFVUegUMtUmjvngMaGlYsxkAZrUKsFRoh7xfXVkDyRBaBSslRNe8LFsXw9f7Q+3jdZ5vhGhmp+TBXTlgxApwR023411+ABE9y0doCx8illya3m2olEiiMZkRclgqsWFSk=',
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => 'My first key',
-            ]);
-    }
+        ]);
+});
 
-    public function test_add_existing_key()
-    {
-        SSH::fake();
+test('add existing key', function () {
+    SSH::fake();
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        /** @var SshKey $sshKey */
-        $sshKey = SshKey::factory()->create([
-            'user_id' => $this->user->id,
+    /** @var SshKey $sshKey */
+    $sshKey = SshKey::factory()->create([
+        'user_id' => $this->user->id,
+        'name' => 'My first key',
+        'public_key' => 'public-key-content',
+    ]);
+
+    $this->json('POST', route('api.projects.servers.ssh-keys.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'key_id' => $sshKey->id,
+        'user' => $this->server->getSshUser(),
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'name' => 'My first key',
-            'public_key' => 'public-key-content',
         ]);
+});
 
-        $this->json('POST', route('api.projects.servers.ssh-keys.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
-            'key_id' => $sshKey->id,
-            'user' => $this->server->getSshUser(),
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => 'My first key',
-            ]);
-    }
+test('add key to specific user', function () {
+    SSH::fake();
 
-    public function test_add_key_to_specific_user()
-    {
-        SSH::fake();
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    /** @var SshKey $sshKey */
+    $sshKey = SshKey::factory()->create([
+        'user_id' => $this->user->id,
+        'name' => 'My first key',
+        'public_key' => 'public-key-content',
+    ]);
 
-        /** @var SshKey $sshKey */
-        $sshKey = SshKey::factory()->create([
-            'user_id' => $this->user->id,
+    $targetUser = 'root';
+
+    $this->json('POST', route('api.projects.servers.ssh-keys.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'key_id' => $sshKey->id,
+        'user' => $targetUser,
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'name' => 'My first key',
-            'public_key' => 'public-key-content',
         ]);
 
-        $targetUser = 'root';
+    $this->assertDatabaseHas('server_ssh_keys', [
+        'server_id' => $this->server->id,
+        'ssh_key_id' => $sshKey->id,
+        'user' => $targetUser,
+    ]);
+});
 
-        $this->json('POST', route('api.projects.servers.ssh-keys.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
-            'key_id' => $sshKey->id,
-            'user' => $targetUser,
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => 'My first key',
-            ]);
+test('add key to invalid user fails', function () {
+    SSH::fake();
 
-        $this->assertDatabaseHas('server_ssh_keys', [
-            'server_id' => $this->server->id,
-            'ssh_key_id' => $sshKey->id,
-            'user' => $targetUser,
-        ]);
-    }
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_add_key_to_invalid_user_fails()
-    {
-        SSH::fake();
+    /** @var SshKey $sshKey */
+    $sshKey = SshKey::factory()->create([
+        'user_id' => $this->user->id,
+        'name' => 'My first key',
+        'public_key' => 'public-key-content',
+    ]);
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    $this->json('POST', route('api.projects.servers.ssh-keys.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'key_id' => $sshKey->id,
+        'user' => 'invalid-user',
+    ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['user']);
+});
 
-        /** @var SshKey $sshKey */
-        $sshKey = SshKey::factory()->create([
-            'user_id' => $this->user->id,
-            'name' => 'My first key',
-            'public_key' => 'public-key-content',
-        ]);
+test('delete ssh key', function () {
+    SSH::fake();
 
-        $this->json('POST', route('api.projects.servers.ssh-keys.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
-            'key_id' => $sshKey->id,
-            'user' => 'invalid-user',
-        ])
-            ->assertStatus(422)
-            ->assertJsonValidationErrors(['user']);
-    }
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_delete_ssh_key()
-    {
-        SSH::fake();
+    /** @var SshKey $sshKey */
+    $sshKey = SshKey::factory()->create([
+        'user_id' => $this->user->id,
+        'name' => 'My first key',
+        'public_key' => 'public-key-content',
+    ]);
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    $this->server->sshKeys()->attach($sshKey, [
+        'status' => SshKeyStatus::ADDED,
+        'user' => $this->server->getSshUser(),
+    ]);
 
-        /** @var SshKey $sshKey */
-        $sshKey = SshKey::factory()->create([
-            'user_id' => $this->user->id,
-            'name' => 'My first key',
-            'public_key' => 'public-key-content',
-        ]);
-
-        $this->server->sshKeys()->attach($sshKey, [
-            'status' => SshKeyStatus::ADDED,
-            'user' => $this->server->getSshUser(),
-        ]);
-
-        $this->json('DELETE', route('api.projects.servers.ssh-keys.delete', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'sshKey' => $sshKey,
-        ]))
-            ->assertSuccessful()
-            ->assertNoContent();
-    }
-}
+    $this->json('DELETE', route('api.projects.servers.ssh-keys.delete', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'sshKey' => $sshKey,
+    ]))
+        ->assertSuccessful()
+        ->assertNoContent();
+});

--- a/tests/Feature/API/ServerTest.php
+++ b/tests/Feature/API/ServerTest.php
@@ -1,103 +1,92 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\OperatingSystem;
 use App\Facades\SSH;
 use App\ServerProviders\Custom;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 
-class ServerTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_get_servers(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('get servers', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('GET', route('api.projects.servers', [
-            'project' => $this->user->current_project_id,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => $this->server->name,
-            ]);
-    }
+    $this->json('GET', route('api.projects.servers', [
+        'project' => $this->user->current_project_id,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'name' => $this->server->name,
+        ]);
+});
 
-    public function test_get_server(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('get server', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('GET', route('api.projects.servers.show', [
-            'project' => $this->user->current_project_id,
-            'server' => $this->server,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => $this->server->name,
-            ]);
-    }
+    $this->json('GET', route('api.projects.servers.show', [
+        'project' => $this->user->current_project_id,
+        'server' => $this->server,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'name' => $this->server->name,
+        ]);
+});
 
-    public function test_create_server(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('create server', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        SSH::fake('user_not_found'); // fake output for vito user check and service installations
+    SSH::fake('user_not_found');
 
-        $this->json('POST', route('api.projects.servers.create', [
-            'project' => $this->user->current_project_id,
-        ]), [
-            'provider' => Custom::id(),
+    // fake output for vito user check and service installations
+    $this->json('POST', route('api.projects.servers.create', [
+        'project' => $this->user->current_project_id,
+    ]), [
+        'provider' => Custom::id(),
+        'name' => 'test',
+        'ip' => '1.1.1.1',
+        'port' => '22',
+        'os' => OperatingSystem::UBUNTU22->value,
+        'services' => [],
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'name' => 'test',
-            'ip' => '1.1.1.1',
-            'port' => '22',
-            'os' => OperatingSystem::UBUNTU22->value,
-            'services' => [],
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => 'test',
-            ]);
-    }
+        ]);
+});
 
-    public function test_delete_server(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('delete server', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->json('DELETE', route('api.projects.servers.delete', [
-            'project' => $this->server->project_id,
-            'server' => $this->server->id,
-        ]))
-            ->assertNoContent();
-    }
+    $this->json('DELETE', route('api.projects.servers.delete', [
+        'project' => $this->server->project_id,
+        'server' => $this->server->id,
+    ]))
+        ->assertNoContent();
+});
 
-    public function test_reboot_server(): void
-    {
-        SSH::fake();
+test('reboot server', function () {
+    SSH::fake();
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('POST', route('api.projects.servers.reboot', [
-            'project' => $this->server->project_id,
-            'server' => $this->server->id,
-        ]))
-            ->assertNoContent();
-    }
+    $this->json('POST', route('api.projects.servers.reboot', [
+        'project' => $this->server->project_id,
+        'server' => $this->server->id,
+    ]))
+        ->assertNoContent();
+});
 
-    public function test_upgrade_server(): void
-    {
-        SSH::fake('Available updates:0');
+test('upgrade server', function () {
+    SSH::fake('Available updates:0');
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('POST', route('api.projects.servers.upgrade', [
-            'project' => $this->server->project_id,
-            'server' => $this->server->id,
-        ]))
-            ->assertNoContent();
-    }
-}
+    $this->json('POST', route('api.projects.servers.upgrade', [
+        'project' => $this->server->project_id,
+        'server' => $this->server->id,
+    ]))
+        ->assertNoContent();
+});

--- a/tests/Feature/API/ServicesTest.php
+++ b/tests/Feature/API/ServicesTest.php
@@ -1,158 +1,143 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\ServiceStatus;
 use App\Facades\SSH;
 use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class ServicesTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_services_list_redacts_type_data_secret(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('services list redacts type data secret', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'vito-agent',
-            'type' => 'monitoring',
-            'type_data' => [
-                'url' => 'https://vito.test/agent-endpoint',
-                'secret' => 'agent-secret',
-                'data_retention' => 7,
-            ],
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
+    Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'vito-agent',
+        'type' => 'monitoring',
+        'type_data' => [
+            'url' => 'https://vito.test/agent-endpoint',
+            'secret' => 'agent-secret',
+            'data_retention' => 7,
+        ],
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+
+    $this->json('GET', route('api.projects.servers.services', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment(['url' => 'https://vito.test/agent-endpoint'])
+        ->assertJsonMissing(['secret' => 'agent-secret']);
+});
+
+test('see services list', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $this->json('GET', route('api.projects.servers.services', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'name' => 'mysql',
+        ])
+        ->assertJsonFragment([
+            'name' => 'nginx',
+        ])
+        ->assertJsonFragment([
+            'name' => 'php',
+        ])
+        ->assertJsonFragment([
+            'name' => 'supervisor',
+        ])
+        ->assertJsonFragment([
+            'name' => 'redis',
+        ])
+        ->assertJsonFragment([
+            'name' => 'ufw',
         ]);
+});
 
-        $this->json('GET', route('api.projects.servers.services', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment(['url' => 'https://vito.test/agent-endpoint'])
-            ->assertJsonMissing(['secret' => 'agent-secret']);
-    }
+test('show service', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+    $service = $this->server->services()->firstOrFail();
 
-    public function test_see_services_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $this->json('GET', route('api.projects.servers.services', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => 'mysql',
-            ])
-            ->assertJsonFragment([
-                'name' => 'nginx',
-            ])
-            ->assertJsonFragment([
-                'name' => 'php',
-            ])
-            ->assertJsonFragment([
-                'name' => 'supervisor',
-            ])
-            ->assertJsonFragment([
-                'name' => 'redis',
-            ])
-            ->assertJsonFragment([
-                'name' => 'ufw',
-            ]);
-    }
-
-    public function test_show_service(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-        $service = $this->server->services()->firstOrFail();
-
-        $this->json('GET', route('api.projects.servers.services.show', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'service' => $service,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'name' => $service->name,
-            ]);
-    }
-
-    #[DataProvider('data')]
-    public function test_manage_service(string $action): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $service = $this->server->services()->firstOrFail();
-        $service->status = ServiceStatus::STOPPED;
-        $service->save();
-
-        SSH::fake('Active: active');
-
-        $this->json('POST', route('api.projects.servers.services.'.$action, [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'service' => $service,
-        ]))
-            ->assertSuccessful()
-            ->assertNoContent();
-    }
-
-    public function test_uninstall_service(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $service = $this->server->services()->where('type', 'process_manager')->firstOrFail();
-
-        SSH::fake();
-
-        $this->json('DELETE', route('api.projects.servers.services.uninstall', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'service' => $service,
-        ]))
-            ->assertSuccessful()
-            ->assertNoContent();
-
-        $this->assertDatabaseMissing('services', [
-            'id' => $service->id,
+    $this->json('GET', route('api.projects.servers.services.show', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'service' => $service,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'name' => $service->name,
         ]);
-    }
+});
 
-    public function test_cannot_uninstall_service_because_it_is_being_used(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('manage service', function (string $action) {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $service = $this->server->services()->where('type', 'webserver')->firstOrFail();
+    $service = $this->server->services()->firstOrFail();
+    $service->status = ServiceStatus::STOPPED;
+    $service->save();
 
-        SSH::fake();
+    SSH::fake('Active: active');
 
-        $this->json('DELETE', route('api.projects.servers.services.uninstall', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'service' => $service,
-        ]))
-            ->assertJsonValidationErrorFor('service');
-    }
+    $this->json('POST', route('api.projects.servers.services.'.$action, [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'service' => $service,
+    ]))
+        ->assertSuccessful()
+        ->assertNoContent();
+})->with('data');
 
-    /**
-     * @return array<array<string>>
-     */
-    public static function data(): array
-    {
-        return [
-            ['start'],
-            ['stop'],
-            ['restart'],
-            ['enable'],
-            ['disable'],
-        ];
-    }
-}
+test('uninstall service', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $service = $this->server->services()->where('type', 'process_manager')->firstOrFail();
+
+    SSH::fake();
+
+    $this->json('DELETE', route('api.projects.servers.services.uninstall', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'service' => $service,
+    ]))
+        ->assertSuccessful()
+        ->assertNoContent();
+
+    $this->assertDatabaseMissing('services', [
+        'id' => $service->id,
+    ]);
+});
+
+test('cannot uninstall service because it is being used', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $service = $this->server->services()->where('type', 'webserver')->firstOrFail();
+
+    SSH::fake();
+
+    $this->json('DELETE', route('api.projects.servers.services.uninstall', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'service' => $service,
+    ]))
+        ->assertJsonValidationErrorFor('service');
+});
+
+/**
+ * @return array<array<string>>
+ */
+dataset('data', function () {
+    return [
+        ['start'],
+        ['stop'],
+        ['restart'],
+        ['enable'],
+        ['disable'],
+    ];
+});

--- a/tests/Feature/API/SiteCronjobTest.php
+++ b/tests/Feature/API/SiteCronjobTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\CronjobStatus;
 use App\Facades\SSH;
 use App\Models\CronJob;
@@ -9,245 +7,233 @@ use App\Models\Server;
 use App\Models\Site;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 
-class SiteCronjobTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_see_site_cronjobs_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+test('see site cronjobs list', function () {
+    Sanctum::actingAs($this->user, ['read']);
 
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        $this->json('GET', route('api.projects.servers.sites.cron-jobs', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]))
-            ->assertSuccessful();
-    }
+    $this->json('GET', route('api.projects.servers.sites.cron-jobs', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]))
+        ->assertSuccessful();
+});
 
-    public function test_see_site_cronjob(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+test('see site cronjob', function () {
+    Sanctum::actingAs($this->user, ['read']);
 
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $site->id,
-        ]);
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $site->id,
+    ]);
 
-        $this->json('GET', route('api.projects.servers.sites.cron-jobs.show', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-            'cronJob' => $cronjob,
-        ]))
-            ->assertSuccessful();
-    }
+    $this->json('GET', route('api.projects.servers.sites.cron-jobs.show', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+        'cronJob' => $cronjob,
+    ]))
+        ->assertSuccessful();
+});
 
-    public function test_create_site_cronjob(): void
-    {
-        SSH::fake();
+test('create site cronjob', function () {
+    SSH::fake();
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        $this->json('POST', route('api.projects.servers.sites.cron-jobs.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]), [
-            'command' => 'ls -la',
-            'user' => 'vito',
-            'frequency' => '* * * * *',
-            'name' => 'My Site Cronjob',
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'command' => 'ls -la',
-                'user' => 'vito',
-                'frequency' => '* * * * *',
-                'status' => CronjobStatus::READY,
-                'site_id' => $site->id,
-            ]);
-
-        $this->assertDatabaseHas('cron_jobs', [
-            'server_id' => $this->server->id,
-            'site_id' => $site->id,
+    $this->json('POST', route('api.projects.servers.sites.cron-jobs.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]), [
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+        'name' => 'My Site Cronjob',
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'command' => 'ls -la',
             'user' => 'vito',
             'frequency' => '* * * * *',
             'status' => CronjobStatus::READY,
-            'name' => 'My Site Cronjob',
-        ]);
-    }
-
-    public function test_create_site_cronjob_for_isolated_user(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'example',
+            'site_id' => $site->id,
         ]);
 
-        $this->json('POST', route('api.projects.servers.sites.cron-jobs.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]), [
+    $this->assertDatabaseHas('cron_jobs', [
+        'server_id' => $this->server->id,
+        'site_id' => $site->id,
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+        'status' => CronjobStatus::READY,
+        'name' => 'My Site Cronjob',
+    ]);
+});
+
+test('create site cronjob for isolated user', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'example',
+    ]);
+
+    $this->json('POST', route('api.projects.servers.sites.cron-jobs.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]), [
+        'command' => 'ls -la',
+        'user' => 'example',
+        'frequency' => '* * * * *',
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'command' => 'ls -la',
             'user' => 'example',
             'frequency' => '* * * * *',
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'command' => 'ls -la',
-                'user' => 'example',
-                'frequency' => '* * * * *',
-                'status' => CronjobStatus::READY,
-                'site_id' => $site->id,
-            ]);
-
-        $this->assertDatabaseHas('cron_jobs', [
-            'server_id' => $this->server->id,
-            'site_id' => $site->id,
-            'user' => 'example',
-        ]);
-    }
-
-    public function test_cannot_create_site_cronjob_for_non_existing_user(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->json('POST', route('api.projects.servers.sites.cron-jobs.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]), [
-            'command' => 'ls -la',
-            'user' => 'nonexistent',
-            'frequency' => '* * * * *',
-        ])
-            ->assertStatus(422);
-
-        $this->assertDatabaseMissing('cron_jobs', [
-            'server_id' => $this->server->id,
-            'site_id' => $site->id,
-            'user' => 'nonexistent',
-        ]);
-    }
-
-    public function test_delete_site_cronjob(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
+            'status' => CronjobStatus::READY,
             'site_id' => $site->id,
         ]);
 
-        $this->json('DELETE', route('api.projects.servers.sites.cron-jobs.delete', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-            'cronJob' => $cronjob,
-        ]))
-            ->assertStatus(204);
+    $this->assertDatabaseHas('cron_jobs', [
+        'server_id' => $this->server->id,
+        'site_id' => $site->id,
+        'user' => 'example',
+    ]);
+});
 
-        $this->assertDatabaseMissing('cron_jobs', [
-            'id' => $cronjob->id,
-        ]);
-    }
+test('cannot create site cronjob for non existing user', function () {
+    SSH::fake();
 
-    public function test_cannot_access_cronjob_from_different_site(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        /** @var Site $site1 */
-        $site1 = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        /** @var Site $site2 */
-        $site2 = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+    $this->json('POST', route('api.projects.servers.sites.cron-jobs.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]), [
+        'command' => 'ls -la',
+        'user' => 'nonexistent',
+        'frequency' => '* * * * *',
+    ])
+        ->assertStatus(422);
 
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $site1->id,
-        ]);
+    $this->assertDatabaseMissing('cron_jobs', [
+        'server_id' => $this->server->id,
+        'site_id' => $site->id,
+        'user' => 'nonexistent',
+    ]);
+});
 
-        $this->json('GET', route('api.projects.servers.sites.cron-jobs.show', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site2,
-            'cronJob' => $cronjob,
-        ]))
-            ->assertStatus(404);
-    }
+test('delete site cronjob', function () {
+    SSH::fake();
 
-    public function test_cannot_access_cronjob_from_different_server(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $site->id,
-        ]);
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $site->id,
+    ]);
 
-        // Create another server and try to access the cronjob through it
-        $otherServer = Server::factory()->create([
-            'project_id' => $this->server->project->id,
-        ]);
+    $this->json('DELETE', route('api.projects.servers.sites.cron-jobs.delete', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+        'cronJob' => $cronjob,
+    ]))
+        ->assertStatus(204);
 
-        $this->json('GET', route('api.projects.servers.sites.cron-jobs.show', [
-            'project' => $this->server->project,
-            'server' => $otherServer,
-            'site' => $site,
-            'cronJob' => $cronjob,
-        ]))
-            ->assertStatus(403);
-    }
-}
+    $this->assertDatabaseMissing('cron_jobs', [
+        'id' => $cronjob->id,
+    ]);
+});
+
+test('cannot access cronjob from different site', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    /** @var Site $site1 */
+    $site1 = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    /** @var Site $site2 */
+    $site2 = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $site1->id,
+    ]);
+
+    $this->json('GET', route('api.projects.servers.sites.cron-jobs.show', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site2,
+        'cronJob' => $cronjob,
+    ]))
+        ->assertStatus(404);
+});
+
+test('cannot access cronjob from different server', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $site->id,
+    ]);
+
+    // Create another server and try to access the cronjob through it
+    $otherServer = Server::factory()->create([
+        'project_id' => $this->server->project->id,
+    ]);
+
+    $this->json('GET', route('api.projects.servers.sites.cron-jobs.show', [
+        'project' => $this->server->project,
+        'server' => $otherServer,
+        'site' => $site,
+        'cronJob' => $cronjob,
+    ]))
+        ->assertStatus(403);
+});

--- a/tests/Feature/API/SitesTest.php
+++ b/tests/Feature/API/SitesTest.php
@@ -367,7 +367,6 @@ test('show env unauthorized', function () {
 
     Sanctum::actingAs($this->user, []);
 
-    // no abilities
     /** @var Site $site */
     $site = Site::factory()->create([
         'server_id' => $this->server->id,

--- a/tests/Feature/API/SitesTest.php
+++ b/tests/Feature/API/SitesTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\DeploymentStatus;
 use App\Enums\LoadBalancerMethod;
 use App\Facades\SSH;
@@ -14,429 +12,404 @@ use App\SourceControlProviders\Github;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Laravel\Sanctum\Sanctum;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 use Tests\Traits\PrepareLoadBalancer;
 
-class SitesTest extends TestCase
-{
-    use PrepareLoadBalancer;
-    use RefreshDatabase;
+uses(PrepareLoadBalancer::class);
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+uses(RefreshDatabase::class);
 
-        $this->prepare();
-    }
+beforeEach(function () {
+    $this->prepare();
+});
 
-    /**
-     * @param  array<string, mixed>  $inputs
-     */
-    #[DataProvider('create_data')]
-    public function test_create_site(array $inputs): void
-    {
-        SSH::fake();
+test('create site', function (array $inputs) {
+    SSH::fake();
 
-        Http::fake([
-            'https://api.github.com/repos/*' => Http::response([
-            ], 201),
-        ]);
+    Http::fake([
+        'https://api.github.com/repos/*' => Http::response([
+        ], 201),
+    ]);
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        if (isset($inputs['database']) && isset($inputs['database_user'])) {
-            /** @var Database $database */
-            $database = Database::factory()->create([
-                'server_id' => $this->server->id,
-            ]);
-            /** @var DatabaseUser $databaseUser */
-            $databaseUser = DatabaseUser::factory()->create([
-                'server_id' => $this->server->id,
-            ]);
-            $inputs['database'] = $database->id;
-            $inputs['database_user'] = $databaseUser->id;
-        }
-
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Github::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $inputs['source_control'] = $sourceControl->id;
-
-        $this->json('POST', route('api.projects.servers.sites.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), $inputs)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'domain' => $inputs['domain'],
-                'user' => $inputs['user'],
-                'path' => '/home/'.$inputs['user'].'/'.$inputs['domain'],
-            ]);
-    }
-
-    public function test_see_sites_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
+    if (isset($inputs['database']) && isset($inputs['database_user'])) {
+        /** @var Database $database */
+        $database = Database::factory()->create([
             'server_id' => $this->server->id,
         ]);
-
-        $this->json('GET', route('api.projects.servers.sites', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'domain' => $site->domain,
-            ]);
-    }
-
-    public function test_see_site(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
+        /** @var DatabaseUser $databaseUser */
+        $databaseUser = DatabaseUser::factory()->create([
             'server_id' => $this->server->id,
         ]);
-
-        $this->json('GET', route('api.projects.servers.sites.show', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'domain' => $site->domain,
-            ]);
+        $inputs['database'] = $database->id;
+        $inputs['database_user'] = $databaseUser->id;
     }
 
-    public function test_delete_site(): void
-    {
-        SSH::fake();
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    $inputs['source_control'] = $sourceControl->id;
 
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
+    $this->json('POST', route('api.projects.servers.sites.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), $inputs)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'domain' => $inputs['domain'],
+            'user' => $inputs['user'],
+            'path' => '/home/'.$inputs['user'].'/'.$inputs['domain'],
         ]);
+})->with('create_data');
 
-        $this->json('DELETE', route('api.projects.servers.sites.delete', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]))
-            ->assertSuccessful()
-            ->assertNoContent();
-    }
+test('see sites list', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_update_web_directory(): void
-    {
-        SSH::fake();
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
+    $this->json('GET', route('api.projects.servers.sites', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'domain' => $site->domain,
         ]);
+});
 
-        $this->json('PUT', route('api.projects.servers.sites.web-directory', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]), [
+test('see site', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->json('GET', route('api.projects.servers.sites.show', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'domain' => $site->domain,
+        ]);
+});
+
+test('delete site', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->json('DELETE', route('api.projects.servers.sites.delete', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]))
+        ->assertSuccessful()
+        ->assertNoContent();
+});
+
+test('update web directory', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->json('PUT', route('api.projects.servers.sites.web-directory', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]), [
+        'web_directory' => 'public',
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'web_directory' => 'public',
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'web_directory' => 'public',
-            ]);
-    }
+        ]);
+});
 
-    public function test_update_load_balancer(): void
-    {
-        SSH::fake();
+test('update load balancer', function () {
+    SSH::fake();
 
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $servers = Server::query()->where('id', '!=', $this->server->id)->get();
-        $this->assertEquals(2, $servers->count());
+    $servers = Server::query()->where('id', '!=', $this->server->id)->get();
+    expect($servers->count())->toEqual(2);
 
-        $this->json('POST', route('api.projects.servers.sites.load-balancer', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'method' => LoadBalancerMethod::ROUND_ROBIN,
-            'servers' => [
-                [
-                    'ip' => $servers[0]->local_ip,
-                    'port' => 80,
-                    'weight' => 1,
-                    'backup' => false,
+    $this->json('POST', route('api.projects.servers.sites.load-balancer', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'method' => LoadBalancerMethod::ROUND_ROBIN,
+        'servers' => [
+            [
+                'ip' => $servers[0]->local_ip,
+                'port' => 80,
+                'weight' => 1,
+                'backup' => false,
+            ],
+            [
+                'ip' => $servers[1]->local_ip,
+                'port' => 80,
+                'weight' => 1,
+                'backup' => false,
+            ],
+        ],
+    ])
+        ->assertSuccessful();
+
+    $this->assertDatabaseHas('load_balancer_servers', [
+        'load_balancer_id' => $this->site->id,
+        'ip' => $servers[0]->local_ip,
+        'port' => 80,
+        'weight' => 1,
+        'backup' => false,
+    ]);
+    $this->assertDatabaseHas('load_balancer_servers', [
+        'load_balancer_id' => $this->site->id,
+        'ip' => $servers[1]->local_ip,
+        'port' => 80,
+        'weight' => 1,
+        'backup' => false,
+    ]);
+});
+
+test('deploy site', function () {
+    SSH::fake();
+
+    Http::fake([
+        'https://api.github.com/repos/*' => Http::response([
+            'commit' => [
+                'sha' => 'abc123',
+                'commit' => [
+                    'message' => 'Test commit',
+                    'author' => [
+                        'name' => 'Test Author',
+                        'email' => 'test@example.com',
+                        'date' => now()->toIso8601String(),
+                    ],
                 ],
-                [
-                    'ip' => $servers[1]->local_ip,
-                    'port' => 80,
-                    'weight' => 1,
-                    'backup' => false,
+            ],
+        ], 200),
+    ]);
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+    $site->deploymentScript?->update([
+        'content' => 'ls -la',
+    ]);
+
+    $this->json('POST', route('api.projects.servers.sites.deploy', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonStructure([
+            'id',
+            'status',
+        ]);
+
+    $this->assertDatabaseHas('deployments', [
+        'site_id' => $site->id,
+        'status' => DeploymentStatus::FINISHED,
+    ]);
+});
+
+test('update deployment script', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $scriptContent = "git pull\ncomposer install\nphp artisan migrate";
+
+    $this->json('PUT', route('api.projects.servers.sites.deployment-script', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]), [
+        'script' => $scriptContent,
+    ])
+        ->assertSuccessful()
+        ->assertNoContent();
+
+    $this->assertDatabaseHas('deployment_scripts', [
+        'site_id' => $site->id,
+        'content' => $scriptContent,
+    ]);
+});
+
+test('update deployment script without content', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->json('PUT', route('api.projects.servers.sites.deployment-script', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]), [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['script']);
+});
+
+test('show deployment script', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $scriptContent = "git pull\ncomposer install";
+
+    $site->deploymentScript->update([
+        'content' => $scriptContent,
+    ]);
+
+    $this->json('GET', route('api.projects.servers.sites.deployment-script.show', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonPath('script', $scriptContent);
+});
+
+test('show env', function () {
+    $envContent = "APP_NAME=Laravel\nAPP_ENV=production";
+    SSH::fake($envContent);
+
+    Sanctum::actingAs($this->user, ['read']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $site->update(['env_variables' => ['DB_PASSWORD']]);
+
+    $this->json('GET', route('api.projects.servers.sites.env.show', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonStructure([
+            'data' => [
+                'variables' => [
+                    '*' => ['key', 'value', 'is_secret'],
                 ],
             ],
         ])
-            ->assertSuccessful();
+        ->assertJsonMissingPath('data.env');
+});
 
-        $this->assertDatabaseHas('load_balancer_servers', [
-            'load_balancer_id' => $this->site->id,
-            'ip' => $servers[0]->local_ip,
-            'port' => 80,
-            'weight' => 1,
-            'backup' => false,
+test('show env with write token', function () {
+    $envContent = "APP_NAME=Laravel\nDB_PASSWORD=supersecret";
+    SSH::fake($envContent);
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $site->update(['env_variables' => ['DB_PASSWORD']]);
+
+    $response = $this->json('GET', route('api.projects.servers.sites.env.show', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]))->assertSuccessful();
+
+    expect($response->json('data.env'))->toEqual($envContent);
+
+    $secret = collect($response->json('data.variables'))->firstWhere('key', 'DB_PASSWORD');
+    expect($secret['is_secret'])->toBeTrue();
+    expect($secret['value'])->toEqual('supersecret');
+});
+
+test('show env unauthorized', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, []);
+
+    // no abilities
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->json('GET', route('api.projects.servers.sites.env.show', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]))
+        ->assertForbidden();
+});
+
+test('update env', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $envContent = "APP_NAME=Laravel\nAPP_ENV=production";
+
+    $this->json('PUT', route('api.projects.servers.sites.env', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]), [
+        'env' => $envContent,
+        'path' => '/home/vito/some-path/.env',
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'domain' => $site->domain,
         ]);
-        $this->assertDatabaseHas('load_balancer_servers', [
-            'load_balancer_id' => $this->site->id,
-            'ip' => $servers[1]->local_ip,
-            'port' => 80,
-            'weight' => 1,
-            'backup' => false,
-        ]);
-    }
+});
 
-    public function test_deploy_site(): void
-    {
-        SSH::fake();
-
-        Http::fake([
-            'https://api.github.com/repos/*' => Http::response([
-                'commit' => [
-                    'sha' => 'abc123',
-                    'commit' => [
-                        'message' => 'Test commit',
-                        'author' => [
-                            'name' => 'Test Author',
-                            'email' => 'test@example.com',
-                            'date' => now()->toIso8601String(),
-                        ],
-                    ],
-                ],
-            ], 200),
-        ]);
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-        $site->deploymentScript?->update([
-            'content' => 'ls -la',
-        ]);
-
-        $this->json('POST', route('api.projects.servers.sites.deploy', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonStructure([
-                'id',
-                'status',
-            ]);
-
-        $this->assertDatabaseHas('deployments', [
-            'site_id' => $site->id,
-            'status' => DeploymentStatus::FINISHED,
-        ]);
-    }
-
-    public function test_update_deployment_script(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $scriptContent = "git pull\ncomposer install\nphp artisan migrate";
-
-        $this->json('PUT', route('api.projects.servers.sites.deployment-script', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]), [
-            'script' => $scriptContent,
-        ])
-            ->assertSuccessful()
-            ->assertNoContent();
-
-        $this->assertDatabaseHas('deployment_scripts', [
-            'site_id' => $site->id,
-            'content' => $scriptContent,
-        ]);
-    }
-
-    public function test_update_deployment_script_without_content(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->json('PUT', route('api.projects.servers.sites.deployment-script', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]), [])
-            ->assertStatus(422)
-            ->assertJsonValidationErrors(['script']);
-    }
-
-    public function test_show_deployment_script(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $scriptContent = "git pull\ncomposer install";
-
-        $site->deploymentScript->update([
-            'content' => $scriptContent,
-        ]);
-
-        $this->json('GET', route('api.projects.servers.sites.deployment-script.show', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonPath('script', $scriptContent);
-    }
-
-    public function test_show_env(): void
-    {
-        $envContent = "APP_NAME=Laravel\nAPP_ENV=production";
-        SSH::fake($envContent);
-
-        Sanctum::actingAs($this->user, ['read']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $site->update(['env_variables' => ['DB_PASSWORD']]);
-
-        $this->json('GET', route('api.projects.servers.sites.env.show', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonStructure([
-                'data' => [
-                    'variables' => [
-                        '*' => ['key', 'value', 'is_secret'],
-                    ],
-                ],
-            ])
-            ->assertJsonMissingPath('data.env');
-    }
-
-    public function test_show_env_with_write_token(): void
-    {
-        $envContent = "APP_NAME=Laravel\nDB_PASSWORD=supersecret";
-        SSH::fake($envContent);
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $site->update(['env_variables' => ['DB_PASSWORD']]);
-
-        $response = $this->json('GET', route('api.projects.servers.sites.env.show', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]))->assertSuccessful();
-
-        $this->assertEquals($envContent, $response->json('data.env'));
-
-        $secret = collect($response->json('data.variables'))->firstWhere('key', 'DB_PASSWORD');
-        $this->assertTrue($secret['is_secret']);
-        $this->assertEquals('supersecret', $secret['value']);
-    }
-
-    public function test_show_env_unauthorized(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, []); // no abilities
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->json('GET', route('api.projects.servers.sites.env.show', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]))
-            ->assertForbidden();
-    }
-
-    public function test_update_env(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $envContent = "APP_NAME=Laravel\nAPP_ENV=production";
-
-        $this->json('PUT', route('api.projects.servers.sites.env', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]), [
-            'env' => $envContent,
-            'path' => '/home/vito/some-path/.env',
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'domain' => $site->domain,
-            ]);
-    }
-
-    /**
-     * @return array<array<array<string, mixed>>>
-     */
-    public static function create_data(): array
-    {
-        return \Tests\Feature\SitesTest::create_data();
-    }
-}
+/**
+ * @return array<array<array<string, mixed>>>
+ */
+dataset('create_data', function () {
+    return vitoPestSiteCreateData();
+});

--- a/tests/Feature/API/SourceControlsTest.php
+++ b/tests/Feature/API/SourceControlsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Models\SourceControl;
 use App\Models\User;
 use App\SourceControlProviders\Bitbucket;
@@ -10,325 +8,290 @@ use App\SourceControlProviders\Gitlab;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Laravel\Sanctum\Sanctum;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class SourceControlsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    /**
-     * @param  array<string, mixed>  $input
-     */
-    #[DataProvider('data')]
-    public function test_connect_provider(string $provider, array $input): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('connect provider', function (string $provider, array $input) {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        Http::fake();
+    Http::fake();
 
-        $input = array_merge([
+    $input = array_merge([
+        'name' => 'test',
+        'provider' => $provider,
+    ], $input);
+
+    $this->json('POST', route('api.projects.source-controls.create', [
+        'project' => $this->user->current_project_id,
+    ]), $input)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'provider' => $provider,
             'name' => 'test',
+        ]);
+})->with('data');
+
+test('delete provider', function (string $provider, array $input) {
+    unset($input);
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => $provider,
+        'profile' => 'test',
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->json('DELETE', route('api.projects.source-controls.delete', [
+        'project' => $this->user->current_project_id,
+        'sourceControl' => $sourceControl->id,
+    ]))
+        ->assertSuccessful()
+        ->assertNoContent();
+})->with('data');
+
+test('cannot delete provider', function (string $provider, array $input) {
+    unset($input);
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => $provider,
+        'profile' => 'test',
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->site->update([
+        'source_control_id' => $sourceControl->id,
+    ]);
+
+    $this->json('DELETE', route('api.projects.source-controls.delete', [
+        'project' => $this->user->current_project_id,
+        'sourceControl' => $sourceControl->id,
+    ]))
+        ->assertStatus(422)
+        ->assertJsonFragment([
+            'message' => 'This source control is being used by a site.',
+        ]);
+
+    $this->assertNotSoftDeleted('source_controls', [
+        'id' => $sourceControl->id,
+    ]);
+})->with('data');
+
+test('edit source control', function (string $provider, array $input) {
+    Http::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => $provider,
+        'profile' => 'old-name',
+        'url' => $input['url'] ?? null,
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->json('PUT', route('api.projects.source-controls.update', [
+        'project' => $this->user->current_project_id,
+        'sourceControl' => $sourceControl->id,
+    ]), array_merge([
+        'name' => 'new-name',
+    ], $input))
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'provider' => $provider,
-        ], $input);
-
-        $this->json('POST', route('api.projects.source-controls.create', [
-            'project' => $this->user->current_project_id,
-        ]), $input)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'provider' => $provider,
-                'name' => 'test',
-            ]);
-    }
-
-    /**
-     * @dataProvider data
-     */
-    #[DataProvider('data')]
-    public function test_delete_provider(string $provider, array $input): void
-    {
-        unset($input);
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => $provider,
-            'profile' => 'test',
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->json('DELETE', route('api.projects.source-controls.delete', [
-            'project' => $this->user->current_project_id,
-            'sourceControl' => $sourceControl->id,
-        ]))
-            ->assertSuccessful()
-            ->assertNoContent();
-    }
-
-    /**
-     * @dataProvider data
-     */
-    #[DataProvider('data')]
-    public function test_cannot_delete_provider(string $provider, array $input): void
-    {
-        unset($input);
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => $provider,
-            'profile' => 'test',
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->site->update([
-            'source_control_id' => $sourceControl->id,
-        ]);
-
-        $this->json('DELETE', route('api.projects.source-controls.delete', [
-            'project' => $this->user->current_project_id,
-            'sourceControl' => $sourceControl->id,
-        ]))
-            ->assertStatus(422)
-            ->assertJsonFragment([
-                'message' => 'This source control is being used by a site.',
-            ]);
-
-        $this->assertNotSoftDeleted('source_controls', [
-            'id' => $sourceControl->id,
-        ]);
-    }
-
-    /**
-     * @dataProvider data
-     *
-     * @param  array<string, mixed>  $input
-     */
-    #[DataProvider('data')]
-    public function test_edit_source_control(string $provider, array $input): void
-    {
-        Http::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => $provider,
-            'profile' => 'old-name',
-            'url' => $input['url'] ?? null,
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->json('PUT', route('api.projects.source-controls.update', [
-            'project' => $this->user->current_project_id,
-            'sourceControl' => $sourceControl->id,
-        ]), array_merge([
             'name' => 'new-name',
-        ], $input))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'provider' => $provider,
-                'name' => 'new-name',
-            ]);
-
-        $sourceControl->refresh();
-
-        $this->assertEquals('new-name', $sourceControl->profile);
-        if (isset($input['url'])) {
-            $this->assertEquals($input['url'], $sourceControl->url);
-        }
-    }
-
-    public function test_api_user_cannot_access_other_users_source_control(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-        $sourceControl = SourceControl::factory()->create([
-            'user_id' => $otherUser->id,
         ]);
 
-        $this->json('GET', route('api.projects.source-controls.show', [
-            'project' => $this->user->current_project_id,
-            'sourceControl' => $sourceControl->id,
-        ]))
-            ->assertForbidden();
+    $sourceControl->refresh();
+
+    expect($sourceControl->profile)->toEqual('new-name');
+    if (isset($input['url'])) {
+        expect($sourceControl->url)->toEqual($input['url']);
     }
+})->with('data');
 
-    public function test_api_user_cannot_update_other_users_source_control(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('api user cannot access other users source control', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $otherUser = User::factory()->create();
-        $sourceControl = SourceControl::factory()->create([
-            'user_id' => $otherUser->id,
+    $otherUser = User::factory()->create();
+    $sourceControl = SourceControl::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    $this->json('GET', route('api.projects.source-controls.show', [
+        'project' => $this->user->current_project_id,
+        'sourceControl' => $sourceControl->id,
+    ]))
+        ->assertForbidden();
+});
+
+test('api user cannot update other users source control', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+    $sourceControl = SourceControl::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    Http::fake();
+
+    $this->json('PUT', route('api.projects.source-controls.update', [
+        'project' => $this->user->current_project_id,
+        'sourceControl' => $sourceControl->id,
+    ]), [
+        'name' => 'hacked',
+        'token' => 'hacked-token',
+    ])
+        ->assertForbidden();
+});
+
+test('api user cannot delete other users source control', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+    $sourceControl = SourceControl::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    $this->json('DELETE', route('api.projects.source-controls.delete', [
+        'project' => $this->user->current_project_id,
+        'sourceControl' => $sourceControl->id,
+    ]))
+        ->assertForbidden();
+});
+
+test('api guest cannot access source controls', function () {
+    $sourceControl = SourceControl::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->json('GET', route('api.projects.source-controls', [
+        'project' => $this->user->current_project_id,
+    ]))
+        ->assertUnauthorized();
+
+    $this->json('POST', route('api.projects.source-controls.create', [
+        'project' => $this->user->current_project_id,
+    ]), [])
+        ->assertUnauthorized();
+
+    $this->json('DELETE', route('api.projects.source-controls.delete', [
+        'project' => $this->user->current_project_id,
+        'sourceControl' => $sourceControl->id,
+    ]))
+        ->assertUnauthorized();
+});
+
+test('api insufficient scopes denies access', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    // Only read scope
+    $data = [
+        'provider' => Github::id(),
+        'name' => 'test',
+        'token' => 'fake-token',
+    ];
+
+    $this->json('POST', route('api.projects.source-controls.create', [
+        'project' => $this->user->current_project_id,
+    ]), $data)
+        ->assertForbidden();
+});
+
+test('api cannot manipulate user id on creation', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+
+    Http::fake();
+
+    $data = [
+        'provider' => Github::id(),
+        'name' => 'test',
+        'token' => 'fake-token',
+        'user_id' => $otherUser->id,
+    ];
+
+    $this->json('POST', route('api.projects.source-controls.create', [
+        'project' => $this->user->current_project_id,
+    ]), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'provider' => Github::id(),
+            'name' => 'test',
         ]);
 
-        Http::fake();
+    $this->assertDatabaseHas('source_controls', [
+        'profile' => 'test',
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
 
-        $this->json('PUT', route('api.projects.source-controls.update', [
-            'project' => $this->user->current_project_id,
-            'sourceControl' => $sourceControl->id,
-        ]), [
-            'name' => 'hacked',
-            'token' => 'hacked-token',
+    $this->assertDatabaseMissing('source_controls', [
+        'profile' => 'test',
+        'provider' => Github::id(),
+        'user_id' => $otherUser->id,
+    ]);
+});
+
+test('api user can only see own source controls in list', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+
+    $ownSourceControl = SourceControl::factory()->create([
+        'user_id' => $this->user->id,
+        'profile' => 'own-source-control',
+    ]);
+
+    $otherSourceControl = SourceControl::factory()->create([
+        'user_id' => $otherUser->id,
+        'profile' => 'other-source-control',
+    ]);
+
+    $this->json('GET', route('api.projects.source-controls', [
+        'project' => $this->user->current_project_id,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'id' => $ownSourceControl->id,
+            'provider' => $ownSourceControl->provider,
         ])
-            ->assertForbidden();
-    }
-
-    public function test_api_user_cannot_delete_other_users_source_control(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-        $sourceControl = SourceControl::factory()->create([
-            'user_id' => $otherUser->id,
+        ->assertJsonMissing([
+            'id' => $otherSourceControl->id,
         ]);
+});
 
-        $this->json('DELETE', route('api.projects.source-controls.delete', [
-            'project' => $this->user->current_project_id,
-            'sourceControl' => $sourceControl->id,
-        ]))
-            ->assertForbidden();
-    }
+test('api soft deleted source control cannot be accessed', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_api_guest_cannot_access_source_controls(): void
-    {
-        $sourceControl = SourceControl::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $otherUser = User::factory()->create();
+    $sourceControl = SourceControl::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
 
-        $this->json('GET', route('api.projects.source-controls', [
-            'project' => $this->user->current_project_id,
-        ]))
-            ->assertUnauthorized();
+    $sourceControl->delete();
 
-        $this->json('POST', route('api.projects.source-controls.create', [
-            'project' => $this->user->current_project_id,
-        ]), [])
-            ->assertUnauthorized();
+    $this->json('GET', route('api.projects.source-controls.show', [
+        'project' => $this->user->current_project_id,
+        'sourceControl' => $sourceControl->id,
+    ]))
+        ->assertNotFound();
+});
 
-        $this->json('DELETE', route('api.projects.source-controls.delete', [
-            'project' => $this->user->current_project_id,
-            'sourceControl' => $sourceControl->id,
-        ]))
-            ->assertUnauthorized();
-    }
-
-    public function test_api_insufficient_scopes_denies_access(): void
-    {
-        Sanctum::actingAs($this->user, ['read']); // Only read scope
-
-        $data = [
-            'provider' => Github::id(),
-            'name' => 'test',
-            'token' => 'fake-token',
-        ];
-
-        $this->json('POST', route('api.projects.source-controls.create', [
-            'project' => $this->user->current_project_id,
-        ]), $data)
-            ->assertForbidden();
-    }
-
-    public function test_api_cannot_manipulate_user_id_on_creation(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-
-        Http::fake();
-
-        $data = [
-            'provider' => Github::id(),
-            'name' => 'test',
-            'token' => 'fake-token',
-            'user_id' => $otherUser->id,
-        ];
-
-        $this->json('POST', route('api.projects.source-controls.create', [
-            'project' => $this->user->current_project_id,
-        ]), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'provider' => Github::id(),
-                'name' => 'test',
-            ]);
-
-        $this->assertDatabaseHas('source_controls', [
-            'profile' => 'test',
-            'provider' => Github::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->assertDatabaseMissing('source_controls', [
-            'profile' => 'test',
-            'provider' => Github::id(),
-            'user_id' => $otherUser->id,
-        ]);
-    }
-
-    public function test_api_user_can_only_see_own_source_controls_in_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-
-        $ownSourceControl = SourceControl::factory()->create([
-            'user_id' => $this->user->id,
-            'profile' => 'own-source-control',
-        ]);
-
-        $otherSourceControl = SourceControl::factory()->create([
-            'user_id' => $otherUser->id,
-            'profile' => 'other-source-control',
-        ]);
-
-        $this->json('GET', route('api.projects.source-controls', [
-            'project' => $this->user->current_project_id,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'id' => $ownSourceControl->id,
-                'provider' => $ownSourceControl->provider,
-            ])
-            ->assertJsonMissing([
-                'id' => $otherSourceControl->id,
-            ]);
-    }
-
-    public function test_api_soft_deleted_source_control_cannot_be_accessed(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-        $sourceControl = SourceControl::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
-
-        $sourceControl->delete();
-
-        $this->json('GET', route('api.projects.source-controls.show', [
-            'project' => $this->user->current_project_id,
-            'sourceControl' => $sourceControl->id,
-        ]))
-            ->assertNotFound();
-    }
-
-    /**
-     * @return array<array<int, mixed>>
-     */
-    public static function data(): array
-    {
-        return [
-            [Github::id(), ['token' => 'test']],
-            [Github::id(), ['token' => 'test', 'global' => '1']],
-            [Gitlab::id(), ['token' => 'test']],
-            [Gitlab::id(), ['token' => 'test', 'url' => 'https://git.example.com/']],
-            [Bitbucket::id(), ['username' => 'test', 'password' => 'test']],
-        ];
-    }
-}
+/**
+ * @return array<array<int, mixed>>
+ */
+dataset('data', function () {
+    return [
+        [Github::id(), ['token' => 'test']],
+        [Github::id(), ['token' => 'test', 'global' => '1']],
+        [Gitlab::id(), ['token' => 'test']],
+        [Gitlab::id(), ['token' => 'test', 'url' => 'https://git.example.com/']],
+        [Bitbucket::id(), ['username' => 'test', 'password' => 'test']],
+    ];
+});

--- a/tests/Feature/API/StorageProvidersTest.php
+++ b/tests/Feature/API/StorageProvidersTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Facades\FTP;
 use App\Facades\SFTP;
 use App\Models\Backup;
@@ -13,339 +11,320 @@ use App\StorageProviders\Local;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Laravel\Sanctum\Sanctum;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class StorageProvidersTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    /**
-     * @param  array<string, mixed>  $input
-     */
-    #[DataProvider('createData')]
-    public function test_create(array $input): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('create', function (array $input) {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        if ($input['provider'] === Dropbox::id()) {
-            Http::fake([
-                '*oauth2/token' => Http::response([
-                    'access_token' => 'fresh-access',
-                    'expires_in' => 14400,
-                ]),
-                '*' => Http::response([], 200),
-            ]);
-        }
-
-        if ($input['provider'] === \App\StorageProviders\FTP::id()) {
-            FTP::fake();
-        }
-
-        if ($input['provider'] === \App\StorageProviders\SFTP::id()) {
-            SFTP::fake();
-        }
-
-        $this->json('POST', route('api.projects.storage-providers.create', [
-            'project' => $this->user->current_project_id,
-        ]), $input)
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'provider' => $input['provider'],
-                'name' => $input['name'],
-            ]);
+    if ($input['provider'] === Dropbox::id()) {
+        Http::fake([
+            '*oauth2/token' => Http::response([
+                'access_token' => 'fresh-access',
+                'expires_in' => 14400,
+            ]),
+            '*' => Http::response([], 200),
+        ]);
     }
 
-    public function test_see_providers_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var StorageProviderModel $provider */
-        $provider = StorageProviderModel::factory()->dropbox()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->json('GET', route('api.projects.storage-providers', [
-            'project' => $this->user->current_project_id,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'provider' => $provider->provider,
-                'name' => $provider->profile,
-            ]);
+    if ($input['provider'] === App\StorageProviders\FTP::id()) {
+        FTP::fake();
     }
 
-    public function test_delete_provider(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var StorageProviderModel $provider */
-        $provider = StorageProviderModel::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->json('DELETE', route('api.projects.storage-providers.delete', [
-            'project' => $this->user->current_project_id,
-            'storageProvider' => $provider->id,
-        ]))
-            ->assertSuccessful()
-            ->assertNoContent();
+    if ($input['provider'] === App\StorageProviders\SFTP::id()) {
+        SFTP::fake();
     }
 
-    public function test_cannot_delete_provider(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    $this->json('POST', route('api.projects.storage-providers.create', [
+        'project' => $this->user->current_project_id,
+    ]), $input)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'provider' => $input['provider'],
+            'name' => $input['name'],
+        ]);
+})->with('createData');
 
-        /** @var Database $database */
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
+test('see providers list', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var StorageProviderModel $provider */
+    $provider = StorageProviderModel::factory()->dropbox()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->json('GET', route('api.projects.storage-providers', [
+        'project' => $this->user->current_project_id,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'provider' => $provider->provider,
+            'name' => $provider->profile,
+        ]);
+});
+
+test('delete provider', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var StorageProviderModel $provider */
+    $provider = StorageProviderModel::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->json('DELETE', route('api.projects.storage-providers.delete', [
+        'project' => $this->user->current_project_id,
+        'storageProvider' => $provider->id,
+    ]))
+        ->assertSuccessful()
+        ->assertNoContent();
+});
+
+test('cannot delete provider', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Database $database */
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    /** @var StorageProviderModel $provider */
+    $provider = StorageProviderModel::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Backup::factory()->create([
+        'server_id' => $this->server->id,
+        'database_id' => $database->id,
+        'storage_id' => $provider->id,
+    ]);
+
+    $this->json('DELETE', route('api.projects.storage-providers.delete', [
+        'project' => $this->user->current_project_id,
+        'storageProvider' => $provider->id,
+    ]))
+        ->assertJsonValidationErrorFor('provider');
+});
+
+test('api user cannot update other users storage provider', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+    $storageProvider = StorageProviderModel::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    $this->json('PUT', route('api.projects.storage-providers.update', [
+        'project' => $this->user->current_project_id,
+        'storageProvider' => $storageProvider->id,
+    ]), [
+        'name' => 'hacked',
+    ])
+        ->assertForbidden();
+});
+
+test('api user cannot delete other users storage provider', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+    $storageProvider = StorageProviderModel::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    $this->json('DELETE', route('api.projects.storage-providers.delete', [
+        'project' => $this->user->current_project_id,
+        'storageProvider' => $storageProvider->id,
+    ]))
+        ->assertForbidden();
+});
+
+test('api guest cannot access storage providers', function () {
+    $storageProvider = StorageProviderModel::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->json('GET', route('api.projects.storage-providers', [
+        'project' => $this->user->current_project_id,
+    ]))
+        ->assertUnauthorized();
+
+    $this->json('POST', route('api.projects.storage-providers.create', [
+        'project' => $this->user->current_project_id,
+    ]), [])
+        ->assertUnauthorized();
+
+    $this->json('DELETE', route('api.projects.storage-providers.delete', [
+        'project' => $this->user->current_project_id,
+        'storageProvider' => $storageProvider->id,
+    ]))
+        ->assertUnauthorized();
+});
+
+test('api insufficient scopes denies access', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    // Only read scope
+    $data = [
+        'provider' => Local::id(),
+        'name' => 'test',
+        'path' => '/home/test',
+    ];
+
+    $this->json('POST', route('api.projects.storage-providers.create', [
+        'project' => $this->user->current_project_id,
+    ]), $data)
+        ->assertForbidden();
+});
+
+test('api cannot manipulate user id on creation', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+
+    $data = [
+        'provider' => Local::id(),
+        'name' => 'test',
+        'path' => '/home/test',
+        'user_id' => $otherUser->id,
+    ];
+
+    $this->json('POST', route('api.projects.storage-providers.create', [
+        'project' => $this->user->current_project_id,
+    ]), $data)
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'provider' => Local::id(),
+            'name' => 'test',
         ]);
 
-        /** @var StorageProviderModel $provider */
-        $provider = StorageProviderModel::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $this->assertDatabaseHas('storage_providers', [
+        'profile' => 'test',
+        'provider' => Local::id(),
+        'user_id' => $this->user->id,
+    ]);
 
-        Backup::factory()->create([
-            'server_id' => $this->server->id,
-            'database_id' => $database->id,
-            'storage_id' => $provider->id,
-        ]);
+    $this->assertDatabaseMissing('storage_providers', [
+        'profile' => 'test',
+        'provider' => Local::id(),
+        'user_id' => $otherUser->id,
+    ]);
+});
 
-        $this->json('DELETE', route('api.projects.storage-providers.delete', [
-            'project' => $this->user->current_project_id,
-            'storageProvider' => $provider->id,
-        ]))
-            ->assertJsonValidationErrorFor('provider');
-    }
+test('api user can only see own storage providers in list', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_api_user_cannot_update_other_users_storage_provider(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    $otherUser = User::factory()->create();
 
-        $otherUser = User::factory()->create();
-        $storageProvider = StorageProviderModel::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
+    $ownProvider = StorageProviderModel::factory()->create([
+        'user_id' => $this->user->id,
+        'profile' => 'own-provider',
+    ]);
 
-        $this->json('PUT', route('api.projects.storage-providers.update', [
-            'project' => $this->user->current_project_id,
-            'storageProvider' => $storageProvider->id,
-        ]), [
-            'name' => 'hacked',
+    $otherProvider = StorageProviderModel::factory()->create([
+        'user_id' => $otherUser->id,
+        'profile' => 'other-provider',
+    ]);
+
+    $this->json('GET', route('api.projects.storage-providers', [
+        'project' => $this->user->current_project_id,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'id' => $ownProvider->id,
+            'provider' => $ownProvider->provider,
         ])
-            ->assertForbidden();
-    }
-
-    public function test_api_user_cannot_delete_other_users_storage_provider(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-        $storageProvider = StorageProviderModel::factory()->create([
-            'user_id' => $otherUser->id,
+        ->assertJsonMissing([
+            'id' => $otherProvider->id,
         ]);
+});
 
-        $this->json('DELETE', route('api.projects.storage-providers.delete', [
-            'project' => $this->user->current_project_id,
-            'storageProvider' => $storageProvider->id,
-        ]))
-            ->assertForbidden();
-    }
-
-    public function test_api_guest_cannot_access_storage_providers(): void
-    {
-        $storageProvider = StorageProviderModel::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->json('GET', route('api.projects.storage-providers', [
-            'project' => $this->user->current_project_id,
-        ]))
-            ->assertUnauthorized();
-
-        $this->json('POST', route('api.projects.storage-providers.create', [
-            'project' => $this->user->current_project_id,
-        ]), [])
-            ->assertUnauthorized();
-
-        $this->json('DELETE', route('api.projects.storage-providers.delete', [
-            'project' => $this->user->current_project_id,
-            'storageProvider' => $storageProvider->id,
-        ]))
-            ->assertUnauthorized();
-    }
-
-    public function test_api_insufficient_scopes_denies_access(): void
-    {
-        Sanctum::actingAs($this->user, ['read']); // Only read scope
-
-        $data = [
-            'provider' => Local::id(),
-            'name' => 'test',
-            'path' => '/home/test',
-        ];
-
-        $this->json('POST', route('api.projects.storage-providers.create', [
-            'project' => $this->user->current_project_id,
-        ]), $data)
-            ->assertForbidden();
-    }
-
-    public function test_api_cannot_manipulate_user_id_on_creation(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-
-        $data = [
-            'provider' => Local::id(),
-            'name' => 'test',
-            'path' => '/home/test',
-            'user_id' => $otherUser->id,
-        ];
-
-        $this->json('POST', route('api.projects.storage-providers.create', [
-            'project' => $this->user->current_project_id,
-        ]), $data)
-            ->assertSuccessful()
-            ->assertJsonFragment([
+/**
+ * @return array<int, array<int, array<string, mixed>>>
+ */
+dataset('createData', function () {
+    return [
+        [
+            [
                 'provider' => Local::id(),
-                'name' => 'test',
-            ]);
-
-        $this->assertDatabaseHas('storage_providers', [
-            'profile' => 'test',
-            'provider' => Local::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->assertDatabaseMissing('storage_providers', [
-            'profile' => 'test',
-            'provider' => Local::id(),
-            'user_id' => $otherUser->id,
-        ]);
-    }
-
-    public function test_api_user_can_only_see_own_storage_providers_in_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-
-        $ownProvider = StorageProviderModel::factory()->create([
-            'user_id' => $this->user->id,
-            'profile' => 'own-provider',
-        ]);
-
-        $otherProvider = StorageProviderModel::factory()->create([
-            'user_id' => $otherUser->id,
-            'profile' => 'other-provider',
-        ]);
-
-        $this->json('GET', route('api.projects.storage-providers', [
-            'project' => $this->user->current_project_id,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'id' => $ownProvider->id,
-                'provider' => $ownProvider->provider,
-            ])
-            ->assertJsonMissing([
-                'id' => $otherProvider->id,
-            ]);
-    }
-
-    /**
-     * @return array<int, array<int, array<string, mixed>>>
-     */
-    public static function createData(): array
-    {
-        return [
-            [
-                [
-                    'provider' => Local::id(),
-                    'name' => 'local-test',
-                    'path' => '/home/vito/backups',
-                ],
+                'name' => 'local-test',
+                'path' => '/home/vito/backups',
             ],
+        ],
+        [
             [
-                [
-                    'provider' => Local::id(),
-                    'name' => 'local-test',
-                    'path' => '/home/vito/backups',
-                    'global' => 1,
-                ],
+                'provider' => Local::id(),
+                'name' => 'local-test',
+                'path' => '/home/vito/backups',
+                'global' => 1,
             ],
+        ],
+        [
             [
-                [
-                    'provider' => \App\StorageProviders\FTP::id(),
-                    'name' => 'ftp-test',
-                    'host' => '1.2.3.4',
-                    'port' => '22',
-                    'path' => '/home/vito',
-                    'username' => 'username',
-                    'password' => 'password',
-                    'ssl' => 1,
-                    'passive' => 1,
-                ],
+                'provider' => App\StorageProviders\FTP::id(),
+                'name' => 'ftp-test',
+                'host' => '1.2.3.4',
+                'port' => '22',
+                'path' => '/home/vito',
+                'username' => 'username',
+                'password' => 'password',
+                'ssl' => 1,
+                'passive' => 1,
             ],
+        ],
+        [
             [
-                [
-                    'provider' => \App\StorageProviders\FTP::id(),
-                    'name' => 'ftp-test',
-                    'host' => '1.2.3.4',
-                    'port' => '22',
-                    'path' => '/home/vito',
-                    'username' => 'username',
-                    'password' => 'password',
-                    'ssl' => 1,
-                    'passive' => 1,
-                    'global' => 1,
-                ],
+                'provider' => App\StorageProviders\FTP::id(),
+                'name' => 'ftp-test',
+                'host' => '1.2.3.4',
+                'port' => '22',
+                'path' => '/home/vito',
+                'username' => 'username',
+                'password' => 'password',
+                'ssl' => 1,
+                'passive' => 1,
+                'global' => 1,
             ],
+        ],
+        [
             [
-                [
-                    'provider' => Dropbox::id(),
-                    'name' => 'dropbox-test',
-                    'app_key' => 'app-key',
-                    'app_secret' => 'app-secret',
-                    'refresh_token' => 'refresh-token',
-                ],
+                'provider' => Dropbox::id(),
+                'name' => 'dropbox-test',
+                'app_key' => 'app-key',
+                'app_secret' => 'app-secret',
+                'refresh_token' => 'refresh-token',
             ],
+        ],
+        [
             [
-                [
-                    'provider' => Dropbox::id(),
-                    'name' => 'dropbox-test',
-                    'app_key' => 'app-key',
-                    'app_secret' => 'app-secret',
-                    'refresh_token' => 'refresh-token',
-                    'global' => 1,
-                ],
+                'provider' => Dropbox::id(),
+                'name' => 'dropbox-test',
+                'app_key' => 'app-key',
+                'app_secret' => 'app-secret',
+                'refresh_token' => 'refresh-token',
+                'global' => 1,
             ],
+        ],
+        [
             [
-                [
-                    'provider' => \App\StorageProviders\SFTP::id(),
-                    'name' => 'sftp-test',
-                    'host' => '1.2.3.4',
-                    'port' => '22',
-                    'path' => '/home/vito',
-                    'username' => 'username',
-                    'password' => 'password',
-                ],
+                'provider' => App\StorageProviders\SFTP::id(),
+                'name' => 'sftp-test',
+                'host' => '1.2.3.4',
+                'port' => '22',
+                'path' => '/home/vito',
+                'username' => 'username',
+                'password' => 'password',
             ],
+        ],
+        [
             [
-                [
-                    'provider' => \App\StorageProviders\SFTP::id(),
-                    'name' => 'sftp-test',
-                    'host' => '1.2.3.4',
-                    'port' => '22',
-                    'path' => '/home/vito',
-                    'username' => 'username',
-                    'password' => 'password',
-                    'global' => 1,
-                ],
+                'provider' => App\StorageProviders\SFTP::id(),
+                'name' => 'sftp-test',
+                'host' => '1.2.3.4',
+                'port' => '22',
+                'path' => '/home/vito',
+                'username' => 'username',
+                'password' => 'password',
+                'global' => 1,
             ],
-        ];
-    }
-}
+        ],
+    ];
+});

--- a/tests/Feature/API/WorkersTest.php
+++ b/tests/Feature/API/WorkersTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\WorkerStatus;
 use App\Facades\SSH;
 use App\Jobs\Worker\RestartAllJob;
@@ -11,477 +9,454 @@ use App\Models\Worker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 
-class WorkersTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_see_server_workers_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+test('see server workers list', function () {
+    Sanctum::actingAs($this->user, ['read']);
 
-        $this->json('GET', route('api.projects.servers.workers', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]))
-            ->assertSuccessful();
-    }
+    $this->json('GET', route('api.projects.servers.workers', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]))
+        ->assertSuccessful();
+});
 
-    public function test_see_site_workers_list(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+test('see site workers list', function () {
+    Sanctum::actingAs($this->user, ['read']);
 
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->json('GET', route('api.projects.servers.sites.workers', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]))
+        ->assertSuccessful();
+});
+
+test('see server worker', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $this->json('GET', route('api.projects.servers.workers.show', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'worker' => $worker,
+    ]))
+        ->assertSuccessful();
+});
+
+test('see site worker', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server,
+        'site_id' => $site->id,
+    ]);
+
+    $this->json('GET', route('api.projects.servers.sites.workers.show', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+        'worker' => $worker,
+    ]))
+        ->assertSuccessful();
+});
+
+test('create server worker', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $this->json('POST', route('api.projects.servers.workers.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]), [
+        'name' => 'Test Worker',
+        'command' => 'php artisan worker:work',
+        'user' => 'vito',
+        'auto_start' => true,
+        'auto_restart' => true,
+        'numprocs' => 1,
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'status' => WorkerStatus::CREATING,
         ]);
 
-        $this->json('GET', route('api.projects.servers.sites.workers', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]))
-            ->assertSuccessful();
-    }
+    $this->assertDatabaseHas('workers', [
+        'status' => WorkerStatus::RUNNING,
+        'name' => 'Test Worker',
+    ]);
+});
 
-    public function test_see_server_worker(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+test('create site worker', function () {
+    SSH::fake();
 
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server,
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->json('POST', route('api.projects.servers.workers.create', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+    ]), [
+        'name' => 'Test Worker',
+        'command' => 'php artisan worker:work',
+        'user' => 'vito',
+        'auto_start' => true,
+        'auto_restart' => true,
+        'numprocs' => 1,
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'status' => WorkerStatus::CREATING,
         ]);
 
-        $this->json('GET', route('api.projects.servers.workers.show', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'worker' => $worker,
-        ]))
-            ->assertSuccessful();
-    }
+    $this->assertDatabaseHas('workers', [
+        'site_id' => $site->id,
+        'status' => WorkerStatus::RUNNING,
+        'name' => 'Test Worker',
+    ]);
+});
 
-    public function test_see_site_worker(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+test('update server worker', function () {
+    SSH::fake();
 
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server,
+        'numprocs' => 1,
+    ]);
+
+    $this->json('PUT', route('api.projects.servers.workers.update', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'worker' => $worker,
+    ]), [
+        'name' => $worker->name,
+        'command' => $worker->command,
+        'user' => $worker->user,
+        'auto_start' => $worker->auto_start,
+        'auto_restart' => $worker->auto_restart,
+        'numprocs' => 2,
+    ])
+        ->assertSuccessful();
+
+    $this->assertDatabaseHas('workers', [
+        'numprocs' => 2,
+    ]);
+});
+
+test('update site worker', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server,
+        'site_id' => $site->id,
+        'numprocs' => 1,
+    ]);
+
+    $this->json('PUT', route('api.projects.servers.workers.update', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'worker' => $worker,
+        'site' => $site,
+    ]), [
+        'name' => $worker->name,
+        'command' => $worker->command,
+        'user' => $worker->user,
+        'auto_start' => $worker->auto_start,
+        'auto_restart' => $worker->auto_restart,
+        'numprocs' => 2,
+    ])
+        ->assertSuccessful();
+
+    $this->assertDatabaseHas('workers', [
+        'site_id' => $site->id,
+        'numprocs' => 2,
+    ]);
+});
+
+test('start worker', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $this->json('POST', route('api.projects.servers.workers.start', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'worker' => $worker,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'status' => WorkerStatus::STARTING,
         ]);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server,
-            'site_id' => $site->id,
-        ]);
-
-        $this->json('GET', route('api.projects.servers.sites.workers.show', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-            'worker' => $worker,
-        ]))
-            ->assertSuccessful();
-    }
-
-    public function test_create_server_worker(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $this->json('POST', route('api.projects.servers.workers.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]), [
-            'name' => 'Test Worker',
-            'command' => 'php artisan worker:work',
-            'user' => 'vito',
-            'auto_start' => true,
-            'auto_restart' => true,
-            'numprocs' => 1,
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'status' => WorkerStatus::CREATING,
-            ]);
-
-        $this->assertDatabaseHas('workers', [
-            'status' => WorkerStatus::RUNNING,
-            'name' => 'Test Worker',
-        ]);
-    }
-
-    public function test_create_site_worker(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->json('POST', route('api.projects.servers.workers.create', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-        ]), [
-            'name' => 'Test Worker',
-            'command' => 'php artisan worker:work',
-            'user' => 'vito',
-            'auto_start' => true,
-            'auto_restart' => true,
-            'numprocs' => 1,
-        ])
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'status' => WorkerStatus::CREATING,
-            ]);
-
-        $this->assertDatabaseHas('workers', [
-            'site_id' => $site->id,
-            'status' => WorkerStatus::RUNNING,
-            'name' => 'Test Worker',
-        ]);
-    }
-
-    public function test_update_server_worker(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server,
-            'numprocs' => 1,
-        ]);
-
-        $this->json('PUT', route('api.projects.servers.workers.update', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'worker' => $worker,
-        ]), [
-            'name' => $worker->name,
-            'command' => $worker->command,
-            'user' => $worker->user,
-            'auto_start' => $worker->auto_start,
-            'auto_restart' => $worker->auto_restart,
-            'numprocs' => 2,
-        ])
-            ->assertSuccessful();
-
-        $this->assertDatabaseHas('workers', [
-            'numprocs' => 2,
-        ]);
-    }
-
-    public function test_update_site_worker(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server,
-            'site_id' => $site->id,
-            'numprocs' => 1,
-        ]);
-
-        $this->json('PUT', route('api.projects.servers.workers.update', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'worker' => $worker,
-            'site' => $site,
-        ]), [
-            'name' => $worker->name,
-            'command' => $worker->command,
-            'user' => $worker->user,
-            'auto_start' => $worker->auto_start,
-            'auto_restart' => $worker->auto_restart,
-            'numprocs' => 2,
-        ])
-            ->assertSuccessful();
-
-        $this->assertDatabaseHas('workers', [
-            'site_id' => $site->id,
-            'numprocs' => 2,
-        ]);
-    }
-
-    public function test_start_worker(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $this->json('POST', route('api.projects.servers.workers.start', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'worker' => $worker,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'status' => WorkerStatus::STARTING,
-            ]);
-    }
-
-    public function test_restart_worker(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $this->json('POST', route('api.projects.servers.workers.restart', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'worker' => $worker,
-        ]))
-            ->assertSuccessful()
-            ->assertJsonFragment([
-                'status' => WorkerStatus::RESTARTING,
-            ]);
-    }
-
-    public function test_delete_server_worker(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $this->json('DELETE', route('api.projects.servers.workers.delete', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'worker' => $worker,
-        ]))
-            ->assertSuccessful()
-            ->assertNoContent();
-    }
-
-    public function test_see_worker_logs(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read']);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $this->json('GET', route('api.projects.servers.workers.logs', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'worker' => $worker,
-        ]))
-            ->assertSuccessful()
-            ->assertExactJson(['logs' => 'fake output']);
-    }
-
-    public function test_delete_site_worker(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server,
-            'site_id' => $site->id,
-        ]);
-
-        $this->json('DELETE', route('api.projects.servers.workers.delete', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-            'worker' => $worker,
-        ]))
-            ->assertSuccessful()
-            ->assertNoContent();
-    }
-
-    public function test_cannot_update_site_bootstrap_worker(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server,
-            'site_id' => $site->id,
-            'numprocs' => 1,
-        ]);
-
-        $site->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
-
-        $this->json('PUT', route('api.projects.servers.workers.update', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-            'worker' => $worker,
-        ]), [
-            'name' => 'renamed',
-            'command' => 'renamed command',
-            'user' => $worker->user,
-            'auto_start' => $worker->auto_start,
-            'auto_restart' => $worker->auto_restart,
-            'numprocs' => 2,
-        ])
-            ->assertStatus(422)
-            ->assertJsonValidationErrors(['name']);
-
-        $this->assertDatabaseMissing('workers', [
-            'id' => $worker->id,
-            'command' => 'renamed command',
-        ]);
-    }
-
-    public function test_cannot_delete_site_bootstrap_worker(): void
-    {
-        SSH::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server,
-            'site_id' => $site->id,
-        ]);
-
-        $site->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
-
-        $this->json('DELETE', route('api.projects.servers.workers.delete', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $site,
-            'worker' => $worker,
-        ]))
-            ->assertStatus(422)
-            ->assertJsonValidationErrors(['name']);
-
-        $this->assertDatabaseHas('workers', ['id' => $worker->id]);
-    }
-
-    public function test_resync_workers(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => WorkerStatus::FAILED,
-        ]);
-
-        SSH::fake("{$worker->id}:{$worker->id}_00   RUNNING   pid 100, uptime 0:00:05");
-
-        $this->json('POST', route('api.projects.servers.workers.resync', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]))
-            ->assertSuccessful()
-            ->assertExactJson(['synced' => 1]);
-
-        $this->assertDatabaseHas('workers', [
-            'id' => $worker->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-    }
-
-    public function test_restart_all_workers(): void
-    {
-        Queue::fake();
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        $this->json('POST', route('api.projects.servers.workers.restart-all', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]))
-            ->assertStatus(202);
-
-        $this->assertDatabaseHas('workers', [
-            'id' => $worker->id,
+});
+
+test('restart worker', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $this->json('POST', route('api.projects.servers.workers.restart', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'worker' => $worker,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonFragment([
             'status' => WorkerStatus::RESTARTING,
         ]);
+});
 
-        Queue::assertPushed(RestartAllJob::class);
-    }
+test('delete server worker', function () {
+    SSH::fake();
 
-    public function test_cannot_resync_workers_without_write_ability(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $this->json('POST', route('api.projects.servers.workers.resync', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-        ]))
-            ->assertForbidden();
-    }
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server,
+    ]);
 
-    public function test_cannot_resync_workers_for_site_on_another_server(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    $this->json('DELETE', route('api.projects.servers.workers.delete', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'worker' => $worker,
+    ]))
+        ->assertSuccessful()
+        ->assertNoContent();
+});
 
-        /** @var Server $otherServer */
-        $otherServer = Server::factory()->create(['user_id' => 1]);
+test('see worker logs', function () {
+    SSH::fake();
 
-        /** @var Site $otherSite */
-        $otherSite = Site::factory()->create([
-            'server_id' => $otherServer->id,
-        ]);
+    Sanctum::actingAs($this->user, ['read']);
 
-        $this->json('POST', route('api.projects.servers.workers.resync', [
-            'project' => $this->server->project,
-            'server' => $this->server,
-            'site' => $otherSite,
-        ]))
-            ->assertNotFound();
-    }
-}
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $this->json('GET', route('api.projects.servers.workers.logs', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'worker' => $worker,
+    ]))
+        ->assertSuccessful()
+        ->assertExactJson(['logs' => 'fake output']);
+});
+
+test('delete site worker', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server,
+        'site_id' => $site->id,
+    ]);
+
+    $this->json('DELETE', route('api.projects.servers.workers.delete', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+        'worker' => $worker,
+    ]))
+        ->assertSuccessful()
+        ->assertNoContent();
+});
+
+test('cannot update site bootstrap worker', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server,
+        'site_id' => $site->id,
+        'numprocs' => 1,
+    ]);
+
+    $site->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
+
+    $this->json('PUT', route('api.projects.servers.workers.update', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+        'worker' => $worker,
+    ]), [
+        'name' => 'renamed',
+        'command' => 'renamed command',
+        'user' => $worker->user,
+        'auto_start' => $worker->auto_start,
+        'auto_restart' => $worker->auto_restart,
+        'numprocs' => 2,
+    ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['name']);
+
+    $this->assertDatabaseMissing('workers', [
+        'id' => $worker->id,
+        'command' => 'renamed command',
+    ]);
+});
+
+test('cannot delete site bootstrap worker', function () {
+    SSH::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server,
+        'site_id' => $site->id,
+    ]);
+
+    $site->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
+
+    $this->json('DELETE', route('api.projects.servers.workers.delete', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $site,
+        'worker' => $worker,
+    ]))
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['name']);
+
+    $this->assertDatabaseHas('workers', ['id' => $worker->id]);
+});
+
+test('resync workers', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => WorkerStatus::FAILED,
+    ]);
+
+    SSH::fake("{$worker->id}:{$worker->id}_00   RUNNING   pid 100, uptime 0:00:05");
+
+    $this->json('POST', route('api.projects.servers.workers.resync', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]))
+        ->assertSuccessful()
+        ->assertExactJson(['synced' => 1]);
+
+    $this->assertDatabaseHas('workers', [
+        'id' => $worker->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+});
+
+test('restart all workers', function () {
+    Queue::fake();
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    $this->json('POST', route('api.projects.servers.workers.restart-all', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]))
+        ->assertStatus(202);
+
+    $this->assertDatabaseHas('workers', [
+        'id' => $worker->id,
+        'status' => WorkerStatus::RESTARTING,
+    ]);
+
+    Queue::assertPushed(RestartAllJob::class);
+});
+
+test('cannot resync workers without write ability', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $this->json('POST', route('api.projects.servers.workers.resync', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+    ]))
+        ->assertForbidden();
+});
+
+test('cannot resync workers for site on another server', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    /** @var Server $otherServer */
+    $otherServer = Server::factory()->create(['user_id' => 1]);
+
+    /** @var Site $otherSite */
+    $otherSite = Site::factory()->create([
+        'server_id' => $otherServer->id,
+    ]);
+
+    $this->json('POST', route('api.projects.servers.workers.resync', [
+        'project' => $this->server->project,
+        'server' => $this->server,
+        'site' => $otherSite,
+    ]))
+        ->assertNotFound();
+});

--- a/tests/Feature/API/WorkflowRunTest.php
+++ b/tests/Feature/API/WorkflowRunTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Actions\Workflow\RunWorkflow;
 use App\Enums\UserRole;
 use App\Enums\WorkflowRunStatus;
@@ -13,365 +11,331 @@ use App\Models\WorkflowRun;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Sanctum\Sanctum;
-use Mockery;
-use Tests\TestCase;
 
-class WorkflowRunTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    protected User $user;
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->project = Project::factory()->create();
+    $this->project->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::OWNER,
+    ]);
+    $this->workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->project->id,
+        'name' => 'Test Workflow',
+    ]);
+    $this->workflowRun = WorkflowRun::factory()->create([
+        'workflow_id' => $this->workflow->id,
+        'user_id' => $this->user->id,
+        'status' => WorkflowRunStatus::COMPLETED,
+        'current_node_label' => 'Test Node',
+        'current_node_id' => 'node-1',
+    ]);
+});
 
-    protected Project $project;
+test('can list workflow runs', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    protected Workflow $workflow;
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs");
 
-    protected WorkflowRun $workflowRun;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->user = User::factory()->create();
-        $this->project = Project::factory()->create();
-        $this->project->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::OWNER,
-        ]);
-        $this->workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->project->id,
-            'name' => 'Test Workflow',
-        ]);
-        $this->workflowRun = WorkflowRun::factory()->create([
-            'workflow_id' => $this->workflow->id,
-            'user_id' => $this->user->id,
-            'status' => WorkflowRunStatus::COMPLETED,
-            'current_node_label' => 'Test Node',
-            'current_node_id' => 'node-1',
-        ]);
-
-    }
-
-    public function test_can_list_workflow_runs(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs");
-
-        $response->assertSuccessful()
-            ->assertJsonStructure([
-                'data' => [
-                    '*' => [
-                        'id',
-                        'workflow_id',
-                        'status',
-                        'status_color',
-                        'current_node_label',
-                        'current_node_id',
-                        'created_at',
-                        'updated_at',
-                    ],
+    $response->assertSuccessful()
+        ->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'workflow_id',
+                    'status',
+                    'status_color',
+                    'current_node_label',
+                    'current_node_id',
+                    'created_at',
+                    'updated_at',
                 ],
-                'links',
-                'meta',
-            ]);
+            ],
+            'links',
+            'meta',
+        ]);
 
-        $this->assertCount(1, $response->json('data'));
-        $this->assertEquals($this->workflowRun->id, $response->json('data.0.id'));
-    }
+    expect($response->json('data'))->toHaveCount(1);
+    expect($response->json('data.0.id'))->toEqual($this->workflowRun->id);
+});
 
-    public function test_can_run_workflow(): void
-    {
-        SSH::fake();
-        Sanctum::actingAs($this->user, ['read', 'write']);
+test('can run workflow', function () {
+    SSH::fake();
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        // Create a workflow with proper nodes and edges
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->project->id,
-            'name' => 'Test Workflow',
-            'payload' => [
-                'nodes' => [
-                    [
-                        'id' => 'node-1',
-                        'data' => [
-                            'action' => [
-                                'label' => 'Deploy Application',
-                                'handler' => 'App\\WorkflowActions\\Deploy\\DeployApplication',
-                                'outputs' => [
-                                    'deployment_id' => 'The ID of the deployment',
-                                ],
-                                'inputs' => [
-                                    'branch' => 'main',
-                                ],
-                                'starting' => true,
+    // Create a workflow with proper nodes and edges
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->project->id,
+        'name' => 'Test Workflow',
+        'payload' => [
+            'nodes' => [
+                [
+                    'id' => 'node-1',
+                    'data' => [
+                        'action' => [
+                            'label' => 'Deploy Application',
+                            'handler' => 'App\\WorkflowActions\\Deploy\\DeployApplication',
+                            'outputs' => [
+                                'deployment_id' => 'The ID of the deployment',
                             ],
+                            'inputs' => [
+                                'branch' => 'main',
+                            ],
+                            'starting' => true,
                         ],
                     ],
                 ],
-                'edges' => [],
+            ],
+            'edges' => [],
+        ],
+    ]);
+
+    $mockRunWorkflow = Mockery::mock(RunWorkflow::class);
+    $mockRunWorkflow->shouldReceive('run')
+        ->once()
+        ->with(Mockery::on(function ($user) {
+            return $user instanceof User && $user->id === $this->user->id;
+        }), Mockery::on(function ($wf) use ($workflow) {
+            return $wf instanceof Workflow && $wf->id === $workflow->id;
+        }), ['branch' => 'main'])
+        ->andReturn($this->workflowRun);
+
+    $this->app->instance(RunWorkflow::class, $mockRunWorkflow);
+
+    $response = $this->postJson("/api/projects/{$this->project->id}/workflows/{$workflow->id}/runs", [
+        'branch' => 'main',
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonStructure([
+            'id',
+            'workflow_id',
+            'status',
+            'status_color',
+            'current_node_label',
+            'current_node_id',
+            'created_at',
+            'updated_at',
+        ]);
+
+    expect($response->json('id'))->toEqual($this->workflowRun->id);
+});
+
+test('can get single workflow run', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs/{$this->workflowRun->id}");
+
+    $response->assertSuccessful()
+        ->assertJsonStructure([
+            'id',
+            'workflow_id',
+            'status',
+            'status_color',
+            'current_node_label',
+            'current_node_id',
+            'created_at',
+            'updated_at',
+        ]);
+
+    expect($response->json('id'))->toEqual($this->workflowRun->id);
+});
+
+test('can get workflow run logs', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    // Mock the log content
+    Storage::fake('server-logs');
+    $logContent = "Test log content\nWith multiple lines";
+    $this->workflowRun->log($logContent);
+
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs/{$this->workflowRun->id}/log");
+
+    $response->assertSuccessful()
+        ->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+
+    $this->assertStringContainsString('Test log content', $response->getContent());
+});
+
+test('returns empty log when no log file exists', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs/{$this->workflowRun->id}/log");
+
+    $response->assertSuccessful()
+        ->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+
+    $this->assertStringContainsString("Log file doesn't exist or is empty!", $response->getContent());
+});
+
+test('cannot access workflow run from different workflow', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherWorkflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->project->id,
+        'name' => 'Other Workflow',
+    ]);
+    $otherWorkflowRun = WorkflowRun::factory()->create([
+        'workflow_id' => $otherWorkflow->id,
+        'user_id' => $this->user->id,
+        'status' => WorkflowRunStatus::RUNNING,
+        'verbose' => true,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs/{$otherWorkflowRun->id}");
+
+    $response->assertNotFound();
+});
+
+test('cannot access workflow run from different project', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherProject = Project::factory()->create();
+    $otherProject->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::OWNER,
+    ]);
+    $otherWorkflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $otherProject->id,
+    ]);
+    $otherWorkflowRun = WorkflowRun::factory()->create([
+        'workflow_id' => $otherWorkflow->id,
+        'user_id' => $this->user->id,
+        'status' => WorkflowRunStatus::RUNNING,
+        'verbose' => true,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs/{$otherWorkflowRun->id}");
+
+    $response->assertNotFound();
+});
+
+test('cannot access workflow run from different user', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+    $otherProject = Project::factory()->create();
+    $otherProject->users()->create([
+        'user_id' => $otherUser->id,
+        'role' => UserRole::OWNER,
+    ]);
+    $otherWorkflow = Workflow::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+    $otherWorkflowRun = WorkflowRun::factory()->create([
+        'workflow_id' => $otherWorkflow->id,
+        'user_id' => $otherUser->id,
+        'status' => WorkflowRunStatus::RUNNING,
+        'verbose' => true,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$otherProject->id}/workflows/{$otherWorkflow->id}/runs/{$otherWorkflowRun->id}");
+
+    $response->assertForbidden();
+});
+
+test('cannot access nonexistent project', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $response = $this->getJson("/api/projects/999/workflows/{$this->workflow->id}/runs");
+
+    $response->assertNotFound();
+});
+
+test('cannot access nonexistent workflow', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows/999/runs");
+
+    $response->assertNotFound();
+});
+
+test('cannot access nonexistent workflow run', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs/999");
+
+    $response->assertNotFound();
+});
+
+test('requires authentication', function () {
+    // Create a fresh test case without authentication
+    $this->refreshDatabase();
+
+    $user = User::factory()->create();
+    $project = Project::factory()->create();
+    $project->users()->create([
+        'user_id' => $user->id,
+        'role' => UserRole::OWNER,
+    ]);
+    $workflow = Workflow::factory()->create([
+        'user_id' => $user->id,
+        'project_id' => $project->id,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$project->id}/workflows/{$workflow->id}/runs");
+
+    $response->assertUnauthorized();
+});
+
+test('requires read ability for listing', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs");
+
+    $response->assertForbidden();
+});
+
+test('requires write ability for running', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $response = $this->postJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs", [
+        'branch' => 'main',
+    ]);
+
+    $response->assertForbidden();
+});
+
+test('pagination works correctly', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    // Create additional workflow runs
+    WorkflowRun::factory()->count(30)->create([
+        'workflow_id' => $this->workflow->id,
+        'user_id' => $this->user->id,
+        'status' => WorkflowRunStatus::RUNNING,
+        'verbose' => true,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs");
+
+    $response->assertSuccessful()
+        ->assertJsonStructure([
+            'data',
+            'links' => [
+                'first',
+                'prev',
+                'next',
+            ],
+            'meta' => [
+                'current_page',
+                'from',
+                'per_page',
+                'to',
             ],
         ]);
 
-        $mockRunWorkflow = Mockery::mock(RunWorkflow::class);
-        $mockRunWorkflow->shouldReceive('run')
-            ->once()
-            ->with(Mockery::on(function ($user) {
-                return $user instanceof User && $user->id === $this->user->id;
-            }), Mockery::on(function ($wf) use ($workflow) {
-                return $wf instanceof Workflow && $wf->id === $workflow->id;
-            }), ['branch' => 'main'])
-            ->andReturn($this->workflowRun);
+    // Should have pagination links since we have more than 25 workflow runs
+    expect($response->json('links.next'))->not->toBeNull();
+});
 
-        $this->app->instance(RunWorkflow::class, $mockRunWorkflow);
-
-        $response = $this->postJson("/api/projects/{$this->project->id}/workflows/{$workflow->id}/runs", [
-            'branch' => 'main',
-        ]);
-
-        $response->assertCreated()
-            ->assertJsonStructure([
-                'id',
-                'workflow_id',
-                'status',
-                'status_color',
-                'current_node_label',
-                'current_node_id',
-                'created_at',
-                'updated_at',
-            ]);
-
-        $this->assertEquals($this->workflowRun->id, $response->json('id'));
-    }
-
-    public function test_can_get_single_workflow_run(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs/{$this->workflowRun->id}");
-
-        $response->assertSuccessful()
-            ->assertJsonStructure([
-                'id',
-                'workflow_id',
-                'status',
-                'status_color',
-                'current_node_label',
-                'current_node_id',
-                'created_at',
-                'updated_at',
-            ]);
-
-        $this->assertEquals($this->workflowRun->id, $response->json('id'));
-    }
-
-    public function test_can_get_workflow_run_logs(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        // Mock the log content
-        Storage::fake('server-logs');
-        $logContent = "Test log content\nWith multiple lines";
-        $this->workflowRun->log($logContent);
-
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs/{$this->workflowRun->id}/log");
-
-        $response->assertSuccessful()
-            ->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
-
-        $this->assertStringContainsString('Test log content', $response->getContent());
-    }
-
-    public function test_returns_empty_log_when_no_log_file_exists(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs/{$this->workflowRun->id}/log");
-
-        $response->assertSuccessful()
-            ->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
-
-        $this->assertStringContainsString("Log file doesn't exist or is empty!", $response->getContent());
-    }
-
-    public function test_cannot_access_workflow_run_from_different_workflow(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherWorkflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->project->id,
-            'name' => 'Other Workflow',
-        ]);
-        $otherWorkflowRun = WorkflowRun::factory()->create([
-            'workflow_id' => $otherWorkflow->id,
-            'user_id' => $this->user->id,
-            'status' => WorkflowRunStatus::RUNNING,
-            'verbose' => true,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs/{$otherWorkflowRun->id}");
-
-        $response->assertNotFound();
-    }
-
-    public function test_cannot_access_workflow_run_from_different_project(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherProject = Project::factory()->create();
-        $otherProject->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::OWNER,
-        ]);
-        $otherWorkflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $otherProject->id,
-        ]);
-        $otherWorkflowRun = WorkflowRun::factory()->create([
-            'workflow_id' => $otherWorkflow->id,
-            'user_id' => $this->user->id,
-            'status' => WorkflowRunStatus::RUNNING,
-            'verbose' => true,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs/{$otherWorkflowRun->id}");
-
-        $response->assertNotFound();
-    }
-
-    public function test_cannot_access_workflow_run_from_different_user(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherUser = User::factory()->create();
-        $otherProject = Project::factory()->create();
-        $otherProject->users()->create([
-            'user_id' => $otherUser->id,
-            'role' => UserRole::OWNER,
-        ]);
-        $otherWorkflow = Workflow::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-        $otherWorkflowRun = WorkflowRun::factory()->create([
-            'workflow_id' => $otherWorkflow->id,
-            'user_id' => $otherUser->id,
-            'status' => WorkflowRunStatus::RUNNING,
-            'verbose' => true,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$otherProject->id}/workflows/{$otherWorkflow->id}/runs/{$otherWorkflowRun->id}");
-
-        $response->assertForbidden();
-    }
-
-    public function test_cannot_access_nonexistent_project(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $response = $this->getJson("/api/projects/999/workflows/{$this->workflow->id}/runs");
-
-        $response->assertNotFound();
-    }
-
-    public function test_cannot_access_nonexistent_workflow(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows/999/runs");
-
-        $response->assertNotFound();
-    }
-
-    public function test_cannot_access_nonexistent_workflow_run(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs/999");
-
-        $response->assertNotFound();
-    }
-
-    public function test_requires_authentication(): void
-    {
-        // Create a fresh test case without authentication
-        $this->refreshDatabase();
-
-        $user = User::factory()->create();
-        $project = Project::factory()->create();
-        $project->users()->create([
-            'user_id' => $user->id,
-            'role' => UserRole::OWNER,
-        ]);
-        $workflow = Workflow::factory()->create([
-            'user_id' => $user->id,
-            'project_id' => $project->id,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$project->id}/workflows/{$workflow->id}/runs");
-
-        $response->assertUnauthorized();
-    }
-
-    public function test_requires_read_ability_for_listing(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
-
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs");
-
-        $response->assertForbidden();
-    }
-
-    public function test_requires_write_ability_for_running(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
-
-        $response = $this->postJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs", [
-            'branch' => 'main',
-        ]);
-
-        $response->assertForbidden();
-    }
-
-    public function test_pagination_works_correctly(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        // Create additional workflow runs
-        WorkflowRun::factory()->count(30)->create([
-            'workflow_id' => $this->workflow->id,
-            'user_id' => $this->user->id,
-            'status' => WorkflowRunStatus::RUNNING,
-            'verbose' => true,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}/runs");
-
-        $response->assertSuccessful()
-            ->assertJsonStructure([
-                'data',
-                'links' => [
-                    'first',
-                    'prev',
-                    'next',
-                ],
-                'meta' => [
-                    'current_page',
-                    'from',
-                    'per_page',
-                    'to',
-                ],
-            ]);
-
-        // Should have pagination links since we have more than 25 workflow runs
-        $this->assertNotNull($response->json('links.next'));
-    }
-
-    protected function tearDown(): void
-    {
-        Mockery::close();
-        parent::tearDown();
-    }
-}
+afterEach(function () {
+    Mockery::close();
+});

--- a/tests/Feature/API/WorkflowRunTest.php
+++ b/tests/Feature/API/WorkflowRunTest.php
@@ -335,7 +335,3 @@ test('pagination works correctly', function () {
     // Should have pagination links since we have more than 25 workflow runs
     expect($response->json('links.next'))->not->toBeNull();
 });
-
-afterEach(function () {
-    Mockery::close();
-});

--- a/tests/Feature/API/WorkflowTest.php
+++ b/tests/Feature/API/WorkflowTest.php
@@ -1,227 +1,201 @@
 <?php
 
-namespace Tests\Feature\API;
-
 use App\Enums\UserRole;
 use App\Models\Project;
 use App\Models\User;
 use App\Models\Workflow;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 
-class WorkflowTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    protected User $user;
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->project = Project::factory()->create();
+    $this->project->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::OWNER,
+    ]);
+    $this->workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->project->id,
+        'name' => 'Test Workflow',
+    ]);
+});
 
-    protected Project $project;
+test('can list workflows', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    protected Workflow $workflow;
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows");
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->user = User::factory()->create();
-        $this->project = Project::factory()->create();
-        $this->project->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::OWNER,
-        ]);
-        $this->workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->project->id,
-            'name' => 'Test Workflow',
-        ]);
-    }
-
-    public function test_can_list_workflows(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows");
-
-        $response->assertSuccessful()
-            ->assertJsonStructure([
-                'data' => [
-                    '*' => [
-                        'id',
-                        'project_id',
-                        'user_id',
-                        'name',
-                        'nodes',
-                        'edges',
-                        'run_inputs',
-                        'created_at',
-                        'updated_at',
-                    ],
+    $response->assertSuccessful()
+        ->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'project_id',
+                    'user_id',
+                    'name',
+                    'nodes',
+                    'edges',
+                    'run_inputs',
+                    'created_at',
+                    'updated_at',
                 ],
-                'links',
-                'meta',
-            ]);
-
-        $this->assertCount(1, $response->json('data'));
-        $this->assertEquals($this->workflow->id, $response->json('data.0.id'));
-    }
-
-    public function test_can_get_single_workflow(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}");
-
-        $response->assertSuccessful()
-            ->assertJsonStructure([
-                'id',
-                'project_id',
-                'user_id',
-                'name',
-                'nodes',
-                'edges',
-                'run_inputs',
-                'created_at',
-                'updated_at',
-            ]);
-
-        $this->assertEquals($this->workflow->id, $response->json('id'));
-        $this->assertEquals('Test Workflow', $response->json('name'));
-    }
-
-    public function test_can_delete_workflow(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $response = $this->deleteJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}");
-
-        $response->assertNoContent();
-
-        $this->assertSoftDeleted('workflows', [
-            'id' => $this->workflow->id,
-        ]);
-    }
-
-    public function test_cannot_access_workflow_from_different_project(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $otherProject = Project::factory()->create();
-        $otherProject->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::OWNER,
-        ]);
-        $otherWorkflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $otherProject->id,
+            ],
+            'links',
+            'meta',
         ]);
 
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$otherWorkflow->id}");
+    expect($response->json('data'))->toHaveCount(1);
+    expect($response->json('data.0.id'))->toEqual($this->workflow->id);
+});
 
-        $response->assertNotFound();
-    }
+test('can get single workflow', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_cannot_access_workflow_from_different_user(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}");
 
-        $otherUser = User::factory()->create();
-        $otherProject = Project::factory()->create();
-        $otherProject->users()->create([
-            'user_id' => $otherUser->id,
-            'role' => UserRole::OWNER,
-        ]);
-        $otherWorkflow = Workflow::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $response = $this->getJson("/api/projects/{$otherProject->id}/workflows/{$otherWorkflow->id}");
-
-        $response->assertForbidden();
-    }
-
-    public function test_cannot_access_nonexistent_project(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $response = $this->getJson("/api/projects/999/workflows/{$this->workflow->id}");
-
-        $response->assertNotFound();
-    }
-
-    public function test_cannot_access_nonexistent_workflow(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows/999");
-
-        $response->assertNotFound();
-    }
-
-    public function test_requires_authentication(): void
-    {
-        // Create a fresh test case without authentication
-        $this->refreshDatabase();
-
-        $user = User::factory()->create();
-        $project = Project::factory()->create();
-        $project->users()->create([
-            'user_id' => $user->id,
-            'role' => UserRole::OWNER,
+    $response->assertSuccessful()
+        ->assertJsonStructure([
+            'id',
+            'project_id',
+            'user_id',
+            'name',
+            'nodes',
+            'edges',
+            'run_inputs',
+            'created_at',
+            'updated_at',
         ]);
 
-        $response = $this->getJson("/api/projects/{$project->id}/workflows");
+    expect($response->json('id'))->toEqual($this->workflow->id);
+    expect($response->json('name'))->toEqual('Test Workflow');
+});
 
-        $response->assertUnauthorized();
-    }
+test('can delete workflow', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-    public function test_requires_read_ability_for_listing(): void
-    {
-        Sanctum::actingAs($this->user, ['write']);
+    $response = $this->deleteJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}");
 
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows");
+    $response->assertNoContent();
 
-        $response->assertForbidden();
-    }
+    $this->assertSoftDeleted('workflows', [
+        'id' => $this->workflow->id,
+    ]);
+});
 
-    public function test_requires_write_ability_for_deleting(): void
-    {
-        Sanctum::actingAs($this->user, ['read']);
+test('cannot access workflow from different project', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
 
-        $response = $this->deleteJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}");
+    $otherProject = Project::factory()->create();
+    $otherProject->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::OWNER,
+    ]);
+    $otherWorkflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $otherProject->id,
+    ]);
 
-        $response->assertForbidden();
-    }
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows/{$otherWorkflow->id}");
 
-    public function test_pagination_works_correctly(): void
-    {
-        Sanctum::actingAs($this->user, ['read', 'write']);
+    $response->assertNotFound();
+});
 
-        // Create additional workflows
-        Workflow::factory()->count(30)->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->project->id,
+test('cannot access workflow from different user', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $otherUser = User::factory()->create();
+    $otherProject = Project::factory()->create();
+    $otherProject->users()->create([
+        'user_id' => $otherUser->id,
+        'role' => UserRole::OWNER,
+    ]);
+    $otherWorkflow = Workflow::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$otherProject->id}/workflows/{$otherWorkflow->id}");
+
+    $response->assertForbidden();
+});
+
+test('cannot access nonexistent project', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $response = $this->getJson("/api/projects/999/workflows/{$this->workflow->id}");
+
+    $response->assertNotFound();
+});
+
+test('cannot access nonexistent workflow', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows/999");
+
+    $response->assertNotFound();
+});
+
+test('requires authentication', function () {
+    // Create a fresh test case without authentication
+    $this->refreshDatabase();
+
+    $user = User::factory()->create();
+    $project = Project::factory()->create();
+    $project->users()->create([
+        'user_id' => $user->id,
+        'role' => UserRole::OWNER,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$project->id}/workflows");
+
+    $response->assertUnauthorized();
+});
+
+test('requires read ability for listing', function () {
+    Sanctum::actingAs($this->user, ['write']);
+
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows");
+
+    $response->assertForbidden();
+});
+
+test('requires write ability for deleting', function () {
+    Sanctum::actingAs($this->user, ['read']);
+
+    $response = $this->deleteJson("/api/projects/{$this->project->id}/workflows/{$this->workflow->id}");
+
+    $response->assertForbidden();
+});
+
+test('pagination works correctly', function () {
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    // Create additional workflows
+    Workflow::factory()->count(30)->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->project->id,
+    ]);
+
+    $response = $this->getJson("/api/projects/{$this->project->id}/workflows");
+
+    $response->assertSuccessful()
+        ->assertJsonStructure([
+            'data',
+            'links' => [
+                'first',
+                'prev',
+                'next',
+            ],
+            'meta' => [
+                'current_page',
+                'from',
+                'per_page',
+                'to',
+            ],
         ]);
 
-        $response = $this->getJson("/api/projects/{$this->project->id}/workflows");
-
-        $response->assertSuccessful()
-            ->assertJsonStructure([
-                'data',
-                'links' => [
-                    'first',
-                    'prev',
-                    'next',
-                ],
-                'meta' => [
-                    'current_page',
-                    'from',
-                    'per_page',
-                    'to',
-                ],
-            ]);
-
-        $this->assertNotNull($response->json('links.next'));
-    }
-}
+    expect($response->json('links.next'))->not->toBeNull();
+});

--- a/tests/Feature/AfterDeployHookTest.php
+++ b/tests/Feature/AfterDeployHookTest.php
@@ -126,16 +126,10 @@ test('after deploy refuses to adopt user worker with custom command', function (
         'status' => WorkerStatus::RUNNING,
     ]);
 
-    // bootstrapWorker() should return null (command doesn't match a known
-    // default) so afterDeploy() attempts to create a new worker. Worker
-    // name uniqueness then surfaces the conflict — the user must rename
-    // their custom worker before deploy can succeed.
     $type = $this->proxiedSite->type();
-
-    $this->expectException(ValidationException::class);
 
     $type->afterDeploy(Deployment::factory()->create([
         'site_id' => $this->proxiedSite->id,
         'status' => DeploymentStatus::DEPLOYING,
     ]));
-});
+})->throws(ValidationException::class);

--- a/tests/Feature/AfterDeployHookTest.php
+++ b/tests/Feature/AfterDeployHookTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\DeploymentStatus;
 use App\Enums\WorkerStatus;
 use App\Facades\SSH;
@@ -11,147 +9,133 @@ use App\Models\Worker;
 use App\SiteTypes\NodeSite;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Validation\ValidationException;
-use Tests\TestCase;
 
-class AfterDeployHookTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    private Site $proxiedSite;
+beforeEach(function () {
+    $this->proxiedSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'isolated-foo',
+        'path' => '/home/isolated-foo/app.test',
+        'type' => NodeSite::id(),
+        'port' => 3000,
+        'type_data' => [
+            'node_version' => '22',
+            'package_manager' => 'npm',
+            'start_command' => 'npm start',
+        ],
+    ]);
+});
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+test('after deploy creates worker when none exists', function () {
+    SSH::fake();
 
-        $this->proxiedSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'isolated-foo',
-            'path' => '/home/isolated-foo/app.test',
-            'type' => NodeSite::id(),
-            'port' => 3000,
-            'type_data' => [
-                'node_version' => '22',
-                'package_manager' => 'npm',
-                'start_command' => 'npm start',
-            ],
-        ]);
-    }
+    $type = $this->proxiedSite->type();
+    $type->afterDeploy(Deployment::factory()->create([
+        'site_id' => $this->proxiedSite->id,
+        'status' => DeploymentStatus::DEPLOYING,
+    ]));
 
-    public function test_after_deploy_creates_worker_when_none_exists(): void
-    {
-        SSH::fake();
+    $worker = $this->proxiedSite->workers()->where('name', 'app')->first();
+    expect($worker)->not->toBeNull();
+    expect($worker->command)->toBe('npm start');
 
-        $type = $this->proxiedSite->type();
-        $type->afterDeploy(Deployment::factory()->create([
-            'site_id' => $this->proxiedSite->id,
-            'status' => DeploymentStatus::DEPLOYING,
-        ]));
+    $this->proxiedSite->refresh();
+    expect($this->proxiedSite->type_data['bootstrap_worker_id'])->toBe($worker->id);
+});
 
-        $worker = $this->proxiedSite->workers()->where('name', 'app')->first();
-        $this->assertNotNull($worker);
-        $this->assertSame('npm start', $worker->command);
+test('after deploy copies site worker environment to worker', function () {
+    SSH::fake();
 
-        $this->proxiedSite->refresh();
-        $this->assertSame($worker->id, $this->proxiedSite->type_data['bootstrap_worker_id']);
-    }
+    $this->proxiedSite->worker_environment = [
+        ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+        ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
+    ];
+    $this->proxiedSite->save();
 
-    public function test_after_deploy_copies_site_worker_environment_to_worker(): void
-    {
-        SSH::fake();
+    $type = $this->proxiedSite->type();
+    $type->afterDeploy(Deployment::factory()->create([
+        'site_id' => $this->proxiedSite->id,
+        'status' => DeploymentStatus::DEPLOYING,
+    ]));
 
-        $this->proxiedSite->worker_environment = [
-            ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-            ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
-        ];
-        $this->proxiedSite->save();
+    $worker = $this->proxiedSite->workers()->where('name', 'app')->first();
+    expect($worker)->not->toBeNull();
+    expect($worker->environment)->toEqual([
+        ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+        ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
+    ]);
+    expect($worker->effectiveEnvironment()['NODE_ENV'])->toBe('production');
+    expect($worker->effectiveEnvironment()['API_KEY'])->toBe('secret-value');
+});
 
-        $type = $this->proxiedSite->type();
-        $type->afterDeploy(Deployment::factory()->create([
-            'site_id' => $this->proxiedSite->id,
-            'status' => DeploymentStatus::DEPLOYING,
-        ]));
+test('after deploy is idempotent when worker already recorded', function () {
+    SSH::fake();
 
-        $worker = $this->proxiedSite->workers()->where('name', 'app')->first();
-        $this->assertNotNull($worker);
-        $this->assertEquals([
-            ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-            ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
-        ], $worker->environment);
-        $this->assertSame('production', $worker->effectiveEnvironment()['NODE_ENV']);
-        $this->assertSame('secret-value', $worker->effectiveEnvironment()['API_KEY']);
-    }
+    $existing = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->proxiedSite->id,
+        'user' => 'isolated-foo',
+        'name' => 'app',
+        'command' => 'npm start',
+        'status' => WorkerStatus::RUNNING,
+    ]);
+    $this->proxiedSite->jsonUpdate('type_data', 'bootstrap_worker_id', $existing->id);
 
-    public function test_after_deploy_is_idempotent_when_worker_already_recorded(): void
-    {
-        SSH::fake();
+    $type = $this->proxiedSite->type();
+    $type->afterDeploy(Deployment::factory()->create([
+        'site_id' => $this->proxiedSite->id,
+        'status' => DeploymentStatus::DEPLOYING,
+    ]));
 
-        $existing = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->proxiedSite->id,
-            'user' => 'isolated-foo',
-            'name' => 'app',
-            'command' => 'npm start',
-            'status' => WorkerStatus::RUNNING,
-        ]);
-        $this->proxiedSite->jsonUpdate('type_data', 'bootstrap_worker_id', $existing->id);
+    expect($this->proxiedSite->workers()->where('name', 'app')->count())->toBe(1);
+});
 
-        $type = $this->proxiedSite->type();
-        $type->afterDeploy(Deployment::factory()->create([
-            'site_id' => $this->proxiedSite->id,
-            'status' => DeploymentStatus::DEPLOYING,
-        ]));
+test('after deploy backfills by known default command', function () {
+    SSH::fake();
 
-        $this->assertSame(1, $this->proxiedSite->workers()->where('name', 'app')->count());
-    }
+    $existing = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->proxiedSite->id,
+        'user' => 'isolated-foo',
+        'name' => 'app',
+        'command' => 'npm start',
+        'status' => WorkerStatus::RUNNING,
+    ]);
 
-    public function test_after_deploy_backfills_by_known_default_command(): void
-    {
-        SSH::fake();
+    $type = $this->proxiedSite->type();
+    $type->afterDeploy(Deployment::factory()->create([
+        'site_id' => $this->proxiedSite->id,
+        'status' => DeploymentStatus::DEPLOYING,
+    ]));
 
-        $existing = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->proxiedSite->id,
-            'user' => 'isolated-foo',
-            'name' => 'app',
-            'command' => 'npm start',
-            'status' => WorkerStatus::RUNNING,
-        ]);
+    $this->proxiedSite->refresh();
+    expect($this->proxiedSite->type_data['bootstrap_worker_id'])->toBe($existing->id);
+    expect($this->proxiedSite->workers()->where('name', 'app')->count())->toBe(1);
+});
 
-        $type = $this->proxiedSite->type();
-        $type->afterDeploy(Deployment::factory()->create([
-            'site_id' => $this->proxiedSite->id,
-            'status' => DeploymentStatus::DEPLOYING,
-        ]));
+test('after deploy refuses to adopt user worker with custom command', function () {
+    SSH::fake();
 
-        $this->proxiedSite->refresh();
-        $this->assertSame($existing->id, $this->proxiedSite->type_data['bootstrap_worker_id']);
-        $this->assertSame(1, $this->proxiedSite->workers()->where('name', 'app')->count());
-    }
+    Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->proxiedSite->id,
+        'user' => 'isolated-foo',
+        'name' => 'app',
+        'command' => 'node custom-server.js',
+        'status' => WorkerStatus::RUNNING,
+    ]);
 
-    public function test_after_deploy_refuses_to_adopt_user_worker_with_custom_command(): void
-    {
-        SSH::fake();
+    // bootstrapWorker() should return null (command doesn't match a known
+    // default) so afterDeploy() attempts to create a new worker. Worker
+    // name uniqueness then surfaces the conflict — the user must rename
+    // their custom worker before deploy can succeed.
+    $type = $this->proxiedSite->type();
 
-        Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->proxiedSite->id,
-            'user' => 'isolated-foo',
-            'name' => 'app',
-            'command' => 'node custom-server.js',
-            'status' => WorkerStatus::RUNNING,
-        ]);
+    $this->expectException(ValidationException::class);
 
-        // bootstrapWorker() should return null (command doesn't match a known
-        // default) so afterDeploy() attempts to create a new worker. Worker
-        // name uniqueness then surfaces the conflict — the user must rename
-        // their custom worker before deploy can succeed.
-        $type = $this->proxiedSite->type();
-
-        $this->expectException(ValidationException::class);
-
-        $type->afterDeploy(Deployment::factory()->create([
-            'site_id' => $this->proxiedSite->id,
-            'status' => DeploymentStatus::DEPLOYING,
-        ]));
-    }
-}
+    $type->afterDeploy(Deployment::factory()->create([
+        'site_id' => $this->proxiedSite->id,
+        'status' => DeploymentStatus::DEPLOYING,
+    ]));
+});

--- a/tests/Feature/ApiDocsTest.php
+++ b/tests/Feature/ApiDocsTest.php
@@ -1,40 +1,32 @@
 <?php
 
-namespace Tests\Feature;
-
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class ApiDocsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_api_docs_endpoint_returns_html_documentation(): void
-    {
-        $response = $this->get('/api/docs');
+test('api docs endpoint returns html documentation', function () {
+    $response = $this->get('/api/docs');
 
-        $response->assertSuccessful();
+    $response->assertSuccessful();
 
-        // For BinaryFileResponse, we can't easily get the content in tests
-        // but we can verify the response is successful and has correct headers
-        $this->assertEquals(200, $response->getStatusCode());
-    }
+    // For BinaryFileResponse, we can't easily get the content in tests
+    // but we can verify the response is successful and has correct headers
+    expect($response->getStatusCode())->toEqual(200);
+});
 
-    public function test_api_yaml_endpoint_returns_valid_yaml_specification(): void
-    {
-        $response = $this->get('/api.yaml');
+test('api yaml endpoint returns valid yaml specification', function () {
+    $response = $this->get('/api.yaml');
 
-        $response->assertSuccessful();
-        $response->assertHeader('content-type', 'text/yaml; charset=UTF-8');
-        $response->assertHeader('cache-control', 'must-revalidate, no-cache, no-store, private');
-        $response->assertHeader('pragma', 'no-cache');
-        $response->assertHeader('expires', '0');
+    $response->assertSuccessful();
+    $response->assertHeader('content-type', 'text/yaml; charset=UTF-8');
+    $response->assertHeader('cache-control', 'must-revalidate, no-cache, no-store, private');
+    $response->assertHeader('pragma', 'no-cache');
+    $response->assertHeader('expires', '0');
 
-        // Verify the response contains valid YAML structure
-        $yamlContent = $response->getContent();
-        $this->assertStringContainsString('openapi: 3.0.0', $yamlContent);
-        $this->assertStringContainsString("title: 'VitoDeploy API'", $yamlContent);
-        $this->assertStringContainsString('version: 1.0.0', $yamlContent);
-        $this->assertStringContainsString("description: 'Complete API documentation for VitoDeploy - Free and Self-Hosted server management tool'", $yamlContent);
-    }
-}
+    // Verify the response contains valid YAML structure
+    $yamlContent = $response->getContent();
+    $this->assertStringContainsString('openapi: 3.0.0', $yamlContent);
+    $this->assertStringContainsString("title: 'VitoDeploy API'", $yamlContent);
+    $this->assertStringContainsString('version: 1.0.0', $yamlContent);
+    $this->assertStringContainsString("description: 'Complete API documentation for VitoDeploy - Free and Self-Hosted server management tool'", $yamlContent);
+});

--- a/tests/Feature/ApiDocsTest.php
+++ b/tests/Feature/ApiDocsTest.php
@@ -8,10 +8,6 @@ test('api docs endpoint returns html documentation', function () {
     $response = $this->get('/api/docs');
 
     $response->assertSuccessful();
-
-    // For BinaryFileResponse, we can't easily get the content in tests
-    // but we can verify the response is successful and has correct headers
-    expect($response->getStatusCode())->toEqual(200);
 });
 
 test('api yaml endpoint returns valid yaml specification', function () {
@@ -23,7 +19,6 @@ test('api yaml endpoint returns valid yaml specification', function () {
     $response->assertHeader('pragma', 'no-cache');
     $response->assertHeader('expires', '0');
 
-    // Verify the response contains valid YAML structure
     $yamlContent = $response->getContent();
     $this->assertStringContainsString('openapi: 3.0.0', $yamlContent);
     $this->assertStringContainsString("title: 'VitoDeploy API'", $yamlContent);

--- a/tests/Feature/ApiKeyTest.php
+++ b/tests/Feature/ApiKeyTest.php
@@ -1,186 +1,164 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\UserRole;
 use App\Models\Project;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class ApiKeyTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_api_key_with_read_permission(): void
-    {
-        $this->actingAs($this->user)
-            ->post(route('api-keys.store'), [
-                'name' => 'test-key',
-                'permission' => 'read',
-            ])
-            ->assertSessionHas('success');
-
-        $this->assertDatabaseHas('personal_access_tokens', [
+test('create api key with read permission', function () {
+    $this->actingAs($this->user)
+        ->post(route('api-keys.store'), [
             'name' => 'test-key',
-            'tokenable_id' => $this->user->id,
-        ]);
-    }
+            'permission' => 'read',
+        ])
+        ->assertSessionHas('success');
 
-    public function test_create_api_key_with_write_permission(): void
-    {
-        $this->actingAs($this->user)
-            ->post(route('api-keys.store'), [
-                'name' => 'test-key',
-                'permission' => 'write',
-            ])
-            ->assertSessionHas('success');
+    $this->assertDatabaseHas('personal_access_tokens', [
+        'name' => 'test-key',
+        'tokenable_id' => $this->user->id,
+    ]);
+});
 
-        $token = $this->user->tokens()->where('name', 'test-key')->first();
-        $this->assertContains('read', $token->abilities);
-        $this->assertContains('write', $token->abilities);
-    }
+test('create api key with write permission', function () {
+    $this->actingAs($this->user)
+        ->post(route('api-keys.store'), [
+            'name' => 'test-key',
+            'permission' => 'write',
+        ])
+        ->assertSessionHas('success');
 
-    public function test_create_api_key_with_project_scope(): void
-    {
-        $this->actingAs($this->user)
-            ->post(route('api-keys.store'), [
-                'name' => 'scoped-key',
-                'permission' => 'read',
-                'projects' => [$this->user->current_project_id],
-            ])
-            ->assertSessionHas('success');
+    $token = $this->user->tokens()->where('name', 'test-key')->first();
+    expect($token->abilities)->toContain('read');
+    expect($token->abilities)->toContain('write');
+});
 
-        $token = $this->user->tokens()->where('name', 'scoped-key')->first();
-        $this->assertContains('read', $token->abilities);
-        $this->assertContains('project:'.$this->user->current_project_id, $token->abilities);
-    }
+test('create api key with project scope', function () {
+    $this->actingAs($this->user)
+        ->post(route('api-keys.store'), [
+            'name' => 'scoped-key',
+            'permission' => 'read',
+            'projects' => [$this->user->current_project_id],
+        ])
+        ->assertSessionHas('success');
 
-    public function test_create_api_key_without_project_scope(): void
-    {
-        $this->actingAs($this->user)
-            ->post(route('api-keys.store'), [
-                'name' => 'full-access-key',
-                'permission' => 'write',
-            ])
-            ->assertSessionHas('success');
+    $token = $this->user->tokens()->where('name', 'scoped-key')->first();
+    expect($token->abilities)->toContain('read');
+    expect($token->abilities)->toContain('project:'.$this->user->current_project_id);
+});
 
-        $token = $this->user->tokens()->where('name', 'full-access-key')->first();
-        $this->assertContains('read', $token->abilities);
-        $this->assertContains('write', $token->abilities);
-        $this->assertEmpty(
-            collect($token->abilities)->filter(fn ($a) => str_starts_with($a, 'project:'))->all()
-        );
-    }
+test('create api key without project scope', function () {
+    $this->actingAs($this->user)
+        ->post(route('api-keys.store'), [
+            'name' => 'full-access-key',
+            'permission' => 'write',
+        ])
+        ->assertSessionHas('success');
 
-    public function test_create_api_key_with_multiple_projects(): void
-    {
-        /** @var Project $project2 */
-        $project2 = Project::factory()->create();
-        $project2->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
+    $token = $this->user->tokens()->where('name', 'full-access-key')->first();
+    expect($token->abilities)->toContain('read');
+    expect($token->abilities)->toContain('write');
+    expect(collect($token->abilities)->filter(fn ($a) => str_starts_with($a, 'project:'))->all())->toBeEmpty();
+});
 
-        $this->actingAs($this->user)
-            ->post(route('api-keys.store'), [
-                'name' => 'multi-project-key',
-                'permission' => 'write',
-                'projects' => [$this->user->current_project_id, $project2->id],
-            ])
-            ->assertSessionHas('success');
+test('create api key with multiple projects', function () {
+    /** @var Project $project2 */
+    $project2 = Project::factory()->create();
+    $project2->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
 
-        $token = $this->user->tokens()->where('name', 'multi-project-key')->first();
-        $this->assertContains('project:'.$this->user->current_project_id, $token->abilities);
-        $this->assertContains('project:'.$project2->id, $token->abilities);
-    }
+    $this->actingAs($this->user)
+        ->post(route('api-keys.store'), [
+            'name' => 'multi-project-key',
+            'permission' => 'write',
+            'projects' => [$this->user->current_project_id, $project2->id],
+        ])
+        ->assertSessionHas('success');
 
-    public function test_cannot_create_api_key_with_invalid_project(): void
-    {
-        $this->actingAs($this->user)
-            ->post(route('api-keys.store'), [
-                'name' => 'bad-key',
-                'permission' => 'read',
-                'projects' => [999999],
-            ])
-            ->assertSessionHasErrors('projects.0');
-    }
+    $token = $this->user->tokens()->where('name', 'multi-project-key')->first();
+    expect($token->abilities)->toContain('project:'.$this->user->current_project_id);
+    expect($token->abilities)->toContain('project:'.$project2->id);
+});
 
-    public function test_cannot_create_api_key_with_project_user_does_not_belong_to(): void
-    {
-        /** @var Project $otherProject */
-        $otherProject = Project::factory()->create();
+test('cannot create api key with invalid project', function () {
+    $this->actingAs($this->user)
+        ->post(route('api-keys.store'), [
+            'name' => 'bad-key',
+            'permission' => 'read',
+            'projects' => [999999],
+        ])
+        ->assertSessionHasErrors('projects.0');
+});
 
-        $this->actingAs($this->user)
-            ->post(route('api-keys.store'), [
-                'name' => 'bad-key',
-                'permission' => 'read',
-                'projects' => [$otherProject->id],
-            ])
-            ->assertSessionHasErrors('projects.0');
-    }
+test('cannot create api key with project user does not belong to', function () {
+    /** @var Project $otherProject */
+    $otherProject = Project::factory()->create();
 
-    public function test_delete_api_key(): void
-    {
-        $token = $this->user->createToken('delete-me', ['read']);
+    $this->actingAs($this->user)
+        ->post(route('api-keys.store'), [
+            'name' => 'bad-key',
+            'permission' => 'read',
+            'projects' => [$otherProject->id],
+        ])
+        ->assertSessionHasErrors('projects.0');
+});
 
-        $this->actingAs($this->user)
-            ->delete(route('api-keys.destroy', $token->accessToken->id))
-            ->assertSessionHas('success');
+test('delete api key', function () {
+    $token = $this->user->createToken('delete-me', ['read']);
 
-        $this->assertDatabaseMissing('personal_access_tokens', [
-            'id' => $token->accessToken->id,
-        ]);
-    }
+    $this->actingAs($this->user)
+        ->delete(route('api-keys.destroy', $token->accessToken->id))
+        ->assertSessionHas('success');
 
-    public function test_index_returns_api_keys(): void
-    {
-        $this->user->createToken('test-key', ['read', 'project:'.$this->user->current_project_id]);
+    $this->assertDatabaseMissing('personal_access_tokens', [
+        'id' => $token->accessToken->id,
+    ]);
+});
 
-        $this->actingAs($this->user)
-            ->get(route('api-keys'))
-            ->assertSuccessful();
-    }
+test('index returns api keys', function () {
+    $this->user->createToken('test-key', ['read', 'project:'.$this->user->current_project_id]);
 
-    public function test_index_returns_project_ids_and_filtered_permissions(): void
-    {
-        $this->user->createToken('scoped-key', ['read', 'write', 'project:'.$this->user->current_project_id]);
+    $this->actingAs($this->user)
+        ->get(route('api-keys'))
+        ->assertSuccessful();
+});
 
-        $response = $this->actingAs($this->user)
-            ->get(route('api-keys'))
-            ->assertSuccessful();
+test('index returns project ids and filtered permissions', function () {
+    $this->user->createToken('scoped-key', ['read', 'write', 'project:'.$this->user->current_project_id]);
 
-        $apiKeys = $response->original->getData()['page']['props']['apiKeys']['data'];
-        $key = collect($apiKeys)->firstWhere('name', 'scoped-key');
+    $response = $this->actingAs($this->user)
+        ->get(route('api-keys'))
+        ->assertSuccessful();
 
-        $this->assertNotNull($key);
-        $this->assertEquals(['read', 'write'], $key['permissions']);
-        $this->assertEquals([$this->user->current_project_id], $key['project_ids']);
-    }
+    $apiKeys = $response->original->getData()['page']['props']['apiKeys']['data'];
+    $key = collect($apiKeys)->firstWhere('name', 'scoped-key');
 
-    public function test_create_api_key_with_empty_projects_array(): void
-    {
-        $this->actingAs($this->user)
-            ->post(route('api-keys.store'), [
-                'name' => 'empty-projects-key',
-                'permission' => 'read',
-                'projects' => [],
-            ])
-            ->assertSessionHas('success');
+    expect($key)->not->toBeNull();
+    expect($key['permissions'])->toEqual(['read', 'write']);
+    expect($key['project_ids'])->toEqual([$this->user->current_project_id]);
+});
 
-        $token = $this->user->tokens()->where('name', 'empty-projects-key')->first();
-        $this->assertContains('read', $token->abilities);
-        $this->assertEmpty(
-            collect($token->abilities)->filter(fn ($a) => str_starts_with($a, 'project:'))->all()
-        );
-    }
+test('create api key with empty projects array', function () {
+    $this->actingAs($this->user)
+        ->post(route('api-keys.store'), [
+            'name' => 'empty-projects-key',
+            'permission' => 'read',
+            'projects' => [],
+        ])
+        ->assertSessionHas('success');
 
-    public function test_cannot_create_api_key_with_invalid_permission(): void
-    {
-        $this->actingAs($this->user)
-            ->post(route('api-keys.store'), [
-                'name' => 'bad-key',
-                'permission' => 'admin',
-            ])
-            ->assertSessionHasErrors('permission');
-    }
-}
+    $token = $this->user->tokens()->where('name', 'empty-projects-key')->first();
+    expect($token->abilities)->toContain('read');
+    expect(collect($token->abilities)->filter(fn ($a) => str_starts_with($a, 'project:'))->all())->toBeEmpty();
+});
+
+test('cannot create api key with invalid permission', function () {
+    $this->actingAs($this->user)
+        ->post(route('api-keys.store'), [
+            'name' => 'bad-key',
+            'permission' => 'admin',
+        ])
+        ->assertSessionHasErrors('permission');
+});

--- a/tests/Feature/ApplicationTest.php
+++ b/tests/Feature/ApplicationTest.php
@@ -934,9 +934,6 @@ test('git hook deployment invalid secret', function () {
     ]);
 });
 
-/**
- * @return array<array<int, mixed>>
- */
 dataset('hookData', function () {
     return [
         [
@@ -1235,9 +1232,6 @@ test('read only member can read the default env path', function () {
     ]))->assertOk();
 });
 
-/**
- * @return array<string, array<int, string>>
- */
 dataset('rejectedEnvPathProvider', function () {
     return [
         'absolute path outside the site' => ['/etc/passwd'],

--- a/tests/Feature/ApplicationTest.php
+++ b/tests/Feature/ApplicationTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\Site\UpdateEnv;
 use App\Enums\DeploymentStatus;
 use App\Enums\UserRole;
@@ -15,1597 +13,1519 @@ use App\Models\Worker;
 use App\Notifications\DeploymentCompleted;
 use App\SiteTypes\Blank;
 use App\SiteTypes\NodeSite;
-use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Validation\ValidationException;
 use Inertia\Testing\AssertableInertia;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class ApplicationTest extends TestCase
+uses(RefreshDatabase::class);
+
+test('visit application', function () {
+    $this->actingAs($this->user);
+
+    $this->get(route('application', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('application/index'));
+});
+
+test('application page passes null worker for non proxied site', function () {
+    $this->actingAs($this->user);
+
+    $this->get(route('application', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('application/index')
+            ->where('worker', null)
+        );
+});
+
+test('application page passes bootstrap worker for proxied site', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    /** @var Site $proxied */
+    $proxied = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'type' => NodeSite::id(),
+    ]);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $proxied->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    $proxied->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
+
+    $this->get(route('application', [
+        'server' => $this->server,
+        'site' => $proxied,
+    ]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('application/index')
+            ->where('worker.id', $worker->id)
+            ->where('worker.is_site_bootstrap', true)
+        );
+});
+
+test('update deployment script', function () {
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-deployment-script', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'deploymentScript' => $this->site->deploymentScript,
+    ]), [
+        'script' => 'some script',
+        'restart_workers' => true,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('deployment_scripts', [
+        'site_id' => $this->site->id,
+        'name' => 'default',
+        'content' => 'some script',
+    ]);
+
+    $deploymentScript = $this->site->refresh()->deploymentScript;
+    expect($deploymentScript->shouldRestartWorkers())->toBeTrue();
+});
+
+test('deploy classic', function () {
+    SSH::fake('fake output');
+    Http::fake([
+        'github.com/*' => Http::response([
+            'sha' => '123',
+            'commit' => [
+                'message' => 'test commit message',
+                'name' => 'test commit name',
+                'email' => 'test@example.com',
+                'url' => 'https://github.com/commit-url',
+            ],
+        ]),
+    ]);
+    Notification::fake();
+
+    $this->site->deploymentScript->update([
+        'content' => 'git pull',
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('application.deploy', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('deployments', [
+        'site_id' => $this->site->id,
+        'status' => DeploymentStatus::FINISHED,
+    ]);
+
+    SSH::assertExecutedContains('cd /home/vito/'.$this->site->domain);
+    SSH::assertExecutedContains('git pull');
+
+    Notification::assertSentTo($this->notificationChannel, DeploymentCompleted::class);
+});
+
+test('deploy broadcasts deployment created', function () {
+    vitoPestFeatureApplicationTestAssertBroadcastsDeploymentCreated(function (): void {
+        $this->site->deploymentScript->update([
+            'content' => 'git pull',
+        ]);
+    });
+});
+
+test('deploy modern broadcasts deployment created', function () {
+    vitoPestFeatureApplicationTestAssertBroadcastsDeploymentCreated(function (): void {
+        $this->site->update([
+            'type_data' => [
+                'modern_deployment' => true,
+                'modern_deployment_history' => 10,
+                'modern_deployment_shared_resources' => ['.env'],
+            ],
+        ]);
+        $this->site->ensureDeploymentScriptsExist();
+        $this->site->refresh();
+    });
+});
+
+function vitoPestFeatureApplicationTestAssertBroadcastsDeploymentCreated(callable $siteSetup): void
 {
-    use RefreshDatabase;
+    SSH::fake('fake output');
+    Http::fake([
+        'github.com/*' => Http::response([
+            'sha' => '123',
+            'commit' => [
+                'message' => 'test commit message',
+                'name' => 'test commit name',
+                'email' => 'test@example.com',
+                'url' => 'https://github.com/commit-url',
+            ],
+        ]),
+    ]);
+    Notification::fake();
+    Event::fake([SocketEvent::class]);
 
-    public function test_visit_application(): void
-    {
-        $this->actingAs($this->user);
+    $siteSetup();
 
-        $this->get(route('application', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('application/index'));
-    }
+    test()->actingAs(test()->user);
 
-    public function test_application_page_passes_null_worker_for_non_proxied_site(): void
-    {
-        $this->actingAs($this->user);
+    test()->post(route('application.deploy', [
+        'server' => test()->server,
+        'site' => test()->site,
+    ]))
+        ->assertSessionDoesntHaveErrors();
 
-        $this->get(route('application', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('application/index')
-                ->where('worker', null)
-            );
-    }
+    Event::assertDispatched(
+        SocketEvent::class,
+        fn (SocketEvent $event) => $event->data->type === 'deployment.created'
+            && $event->data->data['site_id'] === test()->site->id
+            && $event->data->projectId === test()->server->project_id,
+    );
+}
 
-    public function test_application_page_passes_bootstrap_worker_for_proxied_site(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
+test('deploy reverse proxy without port and start command shows error', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
 
-        /** @var Site $proxied */
-        $proxied = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'type' => NodeSite::id(),
-        ]);
+    /** @var Site $proxied */
+    $proxied = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'type' => Blank::id(),
+        'port' => null,
+        'type_data' => [],
+    ]);
 
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $proxied->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        $proxied->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
-
-        $this->get(route('application', [
+    $this->withHeader('X-Inertia', 'true')
+        ->post(route('application.deploy', [
             'server' => $this->server,
             'site' => $proxied,
-        ]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('application/index')
-                ->where('worker.id', $worker->id)
-                ->where('worker.is_site_bootstrap', true)
-            );
-    }
+        ]))->assertSessionHas('error');
 
-    public function test_update_deployment_script(): void
-    {
-        $this->actingAs($this->user);
+    $this->assertDatabaseMissing('deployments', [
+        'site_id' => $proxied->id,
+    ]);
+});
 
-        $this->put(route('application.update-deployment-script', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'deploymentScript' => $this->site->deploymentScript,
-        ]), [
-            'script' => 'some script',
-            'restart_workers' => true,
-        ])
-            ->assertSessionDoesntHaveErrors();
+test('deploy reverse proxy with port and start command is allowed', function () {
+    SSH::fake('fake output');
+    Notification::fake();
+    $this->actingAs($this->user);
 
-        $this->assertDatabaseHas('deployment_scripts', [
-            'site_id' => $this->site->id,
-            'name' => 'default',
-            'content' => 'some script',
-        ]);
+    /** @var Site $proxied */
+    $proxied = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'type' => Blank::id(),
+        'port' => 3000,
+        'type_data' => ['start_command' => 'node app.js'],
+    ]);
 
-        $deploymentScript = $this->site->refresh()->deploymentScript;
-        $this->assertTrue($deploymentScript->shouldRestartWorkers());
-    }
+    $proxied->deploymentScript->update(['content' => 'echo deploy']);
 
-    /**
-     * @throws Exception
-     */
-    public function test_deploy_classic(): void
-    {
-        SSH::fake('fake output');
-        Http::fake([
-            'github.com/*' => Http::response([
-                'sha' => '123',
-                'commit' => [
-                    'message' => 'test commit message',
-                    'name' => 'test commit name',
-                    'email' => 'test@example.com',
-                    'url' => 'https://github.com/commit-url',
-                ],
-            ]),
-        ]);
-        Notification::fake();
+    $this->post(route('application.deploy', [
+        'server' => $this->server,
+        'site' => $proxied,
+    ]))->assertSessionDoesntHaveErrors();
 
-        $this->site->deploymentScript->update([
-            'content' => 'git pull',
-        ]);
+    $this->assertDatabaseHas('deployments', [
+        'site_id' => $proxied->id,
+    ]);
+});
 
-        $this->actingAs($this->user);
+test('deploy modern', function () {
+    SSH::fake('fake output');
+    Http::fake([
+        'github.com/*' => Http::response([
+            'sha' => '123',
+            'commit' => [
+                'message' => 'test commit message',
+                'name' => 'test commit name',
+                'email' => 'test@example.com',
+                'url' => 'https://github.com/commit-url',
+            ],
+        ]),
+    ]);
+    Notification::fake();
 
-        $this->post(route('application.deploy', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))
-            ->assertSessionDoesntHaveErrors();
+    $this->site->update([
+        'type_data' => [
+            'modern_deployment' => true,
+            'modern_deployment_history' => 10,
+            'modern_deployment_shared_resources' => ['.env'],
+        ],
+    ]);
+    $this->site->ensureDeploymentScriptsExist();
+    $this->site->refresh();
 
-        $this->assertDatabaseHas('deployments', [
-            'site_id' => $this->site->id,
-            'status' => DeploymentStatus::FINISHED,
-        ]);
+    $this->site->buildScript->update([
+        'content' => 'composer install',
+    ]);
 
-        SSH::assertExecutedContains('cd /home/vito/'.$this->site->domain);
-        SSH::assertExecutedContains('git pull');
+    $this->site->preFlightScript->update([
+        'content' => 'php artisan migrate --force',
+    ]);
 
-        Notification::assertSentTo($this->notificationChannel, DeploymentCompleted::class);
-    }
+    $this->actingAs($this->user);
 
-    public function test_deploy_broadcasts_deployment_created(): void
-    {
-        $this->assertBroadcastsDeploymentCreated(function (): void {
-            $this->site->deploymentScript->update([
-                'content' => 'git pull',
-            ]);
-        });
-    }
+    $this->post(route('application.deploy', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))
+        ->assertSessionDoesntHaveErrors();
 
-    public function test_deploy_modern_broadcasts_deployment_created(): void
-    {
-        $this->assertBroadcastsDeploymentCreated(function (): void {
-            $this->site->update([
-                'type_data' => [
-                    'modern_deployment' => true,
-                    'modern_deployment_history' => 10,
-                    'modern_deployment_shared_resources' => ['.env'],
-                ],
-            ]);
-            $this->site->ensureDeploymentScriptsExist();
-            $this->site->refresh();
-        });
-    }
+    $this->assertDatabaseHas('deployments', [
+        'site_id' => $this->site->id,
+        'status' => DeploymentStatus::FINISHED,
+    ]);
 
-    private function assertBroadcastsDeploymentCreated(callable $siteSetup): void
-    {
-        SSH::fake('fake output');
-        Http::fake([
-            'github.com/*' => Http::response([
-                'sha' => '123',
-                'commit' => [
-                    'message' => 'test commit message',
-                    'name' => 'test commit name',
-                    'email' => 'test@example.com',
-                    'url' => 'https://github.com/commit-url',
-                ],
-            ]),
-        ]);
-        Notification::fake();
-        Event::fake([SocketEvent::class]);
+    /** @var Deployment $lastDeployment */
+    $lastDeployment = $this->site->deployments()->latest()->first();
 
-        $siteSetup();
+    expect($lastDeployment->release)->not->toBeNull();
 
-        $this->actingAs($this->user);
+    SSH::assertExecutedContains('composer install');
 
-        $this->post(route('application.deploy', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))
-            ->assertSessionDoesntHaveErrors();
+    Notification::assertSentTo($this->notificationChannel, DeploymentCompleted::class);
+});
 
-        Event::assertDispatched(
-            SocketEvent::class,
-            fn (SocketEvent $event) => $event->data->type === 'deployment.created'
-                && $event->data->data['site_id'] === $this->site->id
-                && $event->data->projectId === $this->server->project_id,
-        );
-    }
+test('rollback', function () {
+    SSH::fake('fake output');
+    Notification::fake();
 
-    public function test_deploy_reverse_proxy_without_port_and_start_command_shows_error(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
+    $this->site->update([
+        'type_data' => [
+            'modern_deployment' => true,
+            'modern_deployment_history' => 10,
+            'modern_deployment_shared_resources' => ['.env'],
+        ],
+    ]);
 
-        /** @var Site $proxied */
-        $proxied = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'type' => Blank::id(),
-            'port' => null,
-            'type_data' => [],
-        ]);
+    $this->actingAs($this->user);
 
-        $this->withHeader('X-Inertia', 'true')
-            ->post(route('application.deploy', [
-                'server' => $this->server,
-                'site' => $proxied,
-            ]))->assertSessionHas('error');
+    Deployment::factory()->create([
+        'site_id' => $this->site->id,
+        'status' => DeploymentStatus::FINISHED,
+        'active' => true,
+        'release' => '20250901000000',
+    ]);
 
+    /** @var Deployment $oldRelease */
+    $oldRelease = Deployment::factory()->create([
+        'site_id' => $this->site->id,
+        'status' => DeploymentStatus::FINISHED,
+        'active' => false,
+        'release' => '20240901000000',
+    ]);
+
+    $this->post(route('application.rollback', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'deployment' => $oldRelease->id,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('deployments', [
+        'id' => $oldRelease->id,
+        'site_id' => $this->site->id,
+        'status' => DeploymentStatus::FINISHED,
+        'active' => true,
+    ]);
+
+    SSH::assertExecutedContains('ln -sfn');
+});
+
+test('enable auto deployment', function () {
+    Http::fake([
+        'github.com/*' => Http::response([
+            'id' => '123',
+        ], 201),
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('application.enable-auto-deployment', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+
+    expect($this->site->isAutoDeployment())->toBeTrue();
+});
+
+test('delete release', function () {
+    SSH::fake('fake output');
+
+    $this->site->update([
+        'type_data' => [
+            'modern_deployment' => true,
+            'modern_deployment_history' => 10,
+            'modern_deployment_shared_resources' => ['.env'],
+        ],
+    ]);
+
+    $this->actingAs($this->user);
+
+    Deployment::factory()->create([
+        'site_id' => $this->site->id,
+        'status' => DeploymentStatus::FINISHED,
+        'active' => true,
+        'release' => '20250901000000',
+    ]);
+
+    /** @var Deployment $oldRelease */
+    $oldRelease = Deployment::factory()->create([
+        'site_id' => $this->site->id,
+        'status' => DeploymentStatus::FINISHED,
+        'active' => false,
+        'release' => '20240901000000',
+    ]);
+
+    $this->delete(route('application.deployments.destroy', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'deployment' => $oldRelease->id,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseMissing('deployments', [
+        'id' => $oldRelease->id,
+    ]);
+
+    SSH::assertExecutedContains('rm -rf '.$this->site->basePath().'/releases/20240901000000');
+});
+
+test('disable auto deployment', function () {
+    Http::fake([
+        'api.github.com/repos/organization/repository' => Http::response([
+            'id' => '123',
+        ], 200),
+        'api.github.com/repos/organization/repository/hooks/*' => Http::response([], 204),
+    ]);
+
+    $this->actingAs($this->user);
+
+    GitHook::factory()->create([
+        'site_id' => $this->site->id,
+        'source_control_id' => $this->site->source_control_id,
+    ]);
+
+    $this->post(route('application.disable-auto-deployment', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+
+    expect($this->site->isAutoDeployment())->toBeFalse();
+});
+
+test('disable auto deployment even if hook destroy fails', function () {
+    Http::fake([
+        'api.github.com/repos/organization/repository' => Http::response([
+            'id' => '123',
+        ], 200),
+        'api.github.com/repos/organization/repository/hooks/*' => Http::response([], 404),
+    ]);
+
+    $this->actingAs($this->user);
+
+    GitHook::factory()->create([
+        'site_id' => $this->site->id,
+        'source_control_id' => $this->site->source_control_id,
+    ]);
+
+    $this->post(route('application.disable-auto-deployment', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+
+    expect($this->site->isAutoDeployment())->toBeFalse();
+});
+
+test('update env file', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'env' => 'APP_ENV="production"',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+
+    expect(data_get($this->site->type_data, 'env_path'))->toEqual($this->site->path.'/.env');
+});
+
+test('update env file with path', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'env' => 'APP_ENV="production"',
+        'path' => $this->site->path.'/some-path/.env',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+
+    expect(data_get($this->site->type_data, 'env_path'))->toEqual($this->site->path.'/some-path/.env');
+});
+
+test('update env blocks path outside site directory', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'env' => 'APP_ENV="production"',
+        'path' => '/home/vito/other-site/.env',
+    ])
+        ->assertSessionHasErrors('path');
+});
+
+test('update env allows stored env path outside site directory', function () {
+    SSH::fake();
+
+    $this->site->update([
+        'type_data' => array_merge($this->site->type_data ?? [], [
+            'env_path' => '/home/vito/other-site/.env',
+        ]),
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'env' => 'APP_ENV="production"',
+        'path' => '/home/vito/other-site/.env',
+    ])
+        ->assertSessionDoesntHaveErrors();
+});
+
+test('update env blocks path traversal', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'env' => 'APP_ENV="production"',
+        'path' => $this->site->path.'/../../etc/passwd',
+    ])
+        ->assertSessionHasErrors('path');
+});
+
+test('update env file with variables', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'variables' => [
+            ['key' => 'APP_ENV', 'value' => 'production'],
+            ['key' => 'APP_DEBUG', 'value' => 'false'],
+            ['key' => 'DB_PASSWORD', 'value' => 'secret123'],
+        ],
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+
+    expect(data_get($this->site->type_data, 'env_path'))->toEqual($this->site->path.'/.env');
+});
+
+test('get env returns variables', function () {
+    SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=secret');
+
+    $this->actingAs($this->user);
+
+    $response = $this->get(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]));
+
+    $response->assertOk();
+    $response->assertJsonStructure([
+        'env',
+        'variables' => [
+            '*' => ['key', 'value', 'is_secret'],
+        ],
+    ]);
+});
+
+test('only secret keys are stored in db', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'variables' => [
+            ['key' => 'APP_NAME', 'value' => 'TestApp', 'is_secret' => false],
+            ['key' => 'DB_PASSWORD', 'value' => 'supersecret123', 'is_secret' => true],
+        ],
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+
+    expect($this->site->env_variables)->toEqual(['DB_PASSWORD']);
+});
+
+test('secret values are masked for read only members', function () {
+    SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=supersecret123');
+
+    vitoPestFeatureApplicationTestMakeUserReadOnly();
+
+    $this->actingAs($this->user);
+
+    $this->site->update(['env_variables' => ['DB_PASSWORD']]);
+
+    $response = $this->get(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]));
+
+    $response->assertOk();
+    $response->assertJsonMissingPath('env');
+    expect($response->json('can_edit'))->toBeFalse();
+
+    $data = $response->json('variables');
+
+    $secretVar = collect($data)->firstWhere('key', 'DB_PASSWORD');
+    expect($secretVar['is_secret'])->toBeTrue();
+    expect($secretVar['value'])->toEqual('');
+
+    $normalVar = collect($data)->firstWhere('key', 'APP_NAME');
+    expect($normalVar['is_secret'])->toBeFalse();
+    expect($normalVar['value'])->toEqual('TestApp');
+});
+
+test('secret values are revealed for writers', function () {
+    $env = 'APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=supersecret123';
+
+    SSH::fake($env);
+
+    $this->actingAs($this->user);
+
+    $this->site->update(['env_variables' => ['DB_PASSWORD']]);
+
+    $response = $this->get(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]));
+
+    $response->assertOk();
+    expect($response->json('can_edit'))->toBeTrue();
+    expect($response->json('env'))->toEqual($env);
+
+    $secretVar = collect($response->json('variables'))->firstWhere('key', 'DB_PASSWORD');
+    expect($secretVar['is_secret'])->toBeTrue();
+    expect($secretVar['value'])->toEqual('supersecret123');
+});
+
+test('secret classification survives legacy db shape', function () {
+    SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=supersecret123');
+
+    vitoPestFeatureApplicationTestMakeUserReadOnly();
+
+    $this->actingAs($this->user);
+
+    $this->site->update([
+        'env_variables' => [
+            ['key' => 'APP_NAME', 'value' => 'TestApp', 'is_secret' => false],
+            ['key' => 'DB_PASSWORD', 'value' => 'supersecret123', 'is_secret' => true],
+        ],
+    ]);
+
+    $response = $this->get(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]));
+
+    $response->assertOk();
+    $secretVar = collect($response->json('variables'))->firstWhere('key', 'DB_PASSWORD');
+    expect($secretVar['is_secret'])->toBeTrue();
+    expect($secretVar['value'])->toEqual('');
+});
+
+test('secret value preserved on server when submitted empty', function () {
+    $ssh = SSH::fake('DB_PASSWORD=original_secret');
+
+    $this->actingAs($this->user);
+
+    $this->site->update(['env_variables' => ['DB_PASSWORD']]);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'variables' => [
+            ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
+        ],
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertStringContainsString('DB_PASSWORD=original_secret', $ssh->getUploadedContent());
+});
+
+test('secret value reflects live server file when changed out of band', function () {
+    $ssh = SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=rotated_secret');
+
+    $this->actingAs($this->user);
+
+    $this->site->update(['env_variables' => ['DB_PASSWORD']]);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'variables' => [
+            ['key' => 'APP_NAME', 'value' => 'ChangedApp', 'is_secret' => false],
+            ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
+        ],
+    ])->assertSessionDoesntHaveErrors();
+
+    $uploaded = $ssh->getUploadedContent();
+    $this->assertStringContainsString('DB_PASSWORD=rotated_secret', $uploaded);
+    $this->assertStringContainsString('APP_NAME=ChangedApp', $uploaded);
+});
+
+test('stored secret cannot be wiped by marking it non secret', function () {
+    $ssh = SSH::fake('DB_PASSWORD=original_secret');
+
+    $this->actingAs($this->user);
+
+    $this->site->update(['env_variables' => ['DB_PASSWORD']]);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'variables' => [
+            ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => false],
+        ],
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertStringContainsString('DB_PASSWORD=original_secret', $ssh->getUploadedContent());
+
+    $this->site->refresh();
+    expect($this->site->env_variables)->toEqual(['DB_PASSWORD']);
+});
+
+test('secret can be dropped to non secret with new value', function () {
+    $ssh = SSH::fake('DB_PASSWORD=original_secret');
+
+    $this->actingAs($this->user);
+
+    $this->site->update(['env_variables' => ['DB_PASSWORD']]);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'variables' => [
+            ['key' => 'DB_PASSWORD', 'value' => 'now_plain', 'is_secret' => false],
+        ],
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertStringContainsString('DB_PASSWORD=now_plain', $ssh->getUploadedContent());
+
+    $this->site->refresh();
+    expect($this->site->env_variables)->toEqual([]);
+});
+
+test('pattern secrets masked for site never saved through vito', function () {
+    SSH::fake('APP_NAME=TestApp'.PHP_EOL.'APP_KEY=base64:supersecret');
+
+    vitoPestFeatureApplicationTestMakeUserReadOnly();
+
+    $this->actingAs($this->user);
+
+    expect($this->site->env_variables)->toBeNull();
+
+    $response = $this->get(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]));
+
+    $response->assertOk();
+    $secretVar = collect($response->json('variables'))->firstWhere('key', 'APP_KEY');
+    expect($secretVar['is_secret'])->toBeTrue();
+    expect($secretVar['value'])->toEqual('');
+});
+
+test('raw env path writes content verbatim without restoring secrets', function () {
+    $ssh = SSH::fake('DB_PASSWORD=original_secret');
+
+    $this->actingAs($this->user);
+
+    $this->site->update(['env_variables' => ['DB_PASSWORD']]);
+
+    $raw = '# leading comment'.PHP_EOL.'APP_NAME=Raw'.PHP_EOL.PHP_EOL.'DB_PASSWORD=';
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'env' => $raw,
+    ])->assertSessionDoesntHaveErrors();
+
+    $uploaded = $ssh->getUploadedContent();
+    expect($uploaded)->toBe($raw);
+    $this->assertStringNotContainsString('DB_PASSWORD=original_secret', $uploaded);
+});
+
+test('update env aborts when live file cannot be read', function () {
+    SSH::fake('');
+
+    $this->actingAs($this->user);
+
+    $this->site->update(['env_variables' => ['DB_PASSWORD']]);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'variables' => [
+            ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
+        ],
+    ])->assertSessionHasErrors('variables');
+});
+
+test('parse env endpoint', function () {
+    $this->actingAs($this->user);
+
+    $envContent = "APP_NAME=TestApp\nDB_PASSWORD=secret123\nAPP_DEBUG=true";
+
+    $response = $this->post(route('application.parse-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'content' => $envContent,
+    ]);
+
+    $response->assertOk();
+    $response->assertJsonStructure([
+        'variables' => [
+            '*' => ['key', 'value', 'is_secret'],
+        ],
+    ]);
+
+    $variables = $response->json('variables');
+    expect($variables)->toHaveCount(3);
+
+    // Check that DB_PASSWORD is detected as secret
+    $passwordVar = collect($variables)->firstWhere('key', 'DB_PASSWORD');
+    expect($passwordVar['is_secret'])->toBeTrue();
+
+    // Check that APP_NAME is not secret
+    $nameVar = collect($variables)->firstWhere('key', 'APP_NAME');
+    expect($nameVar['is_secret'])->toBeFalse();
+});
+
+test('git hook deployment', function (string $provider, array $webhook, string $url, array $payload, bool $skip) {
+    SSH::fake();
+    Http::fake([
+        $url => Http::response($payload),
+    ]);
+
+    $this->site->update([
+        'branch' => 'main',
+    ]);
+    $this->site->sourceControl->update([
+        'provider' => $provider,
+    ]);
+
+    GitHook::factory()->create([
+        'site_id' => $this->site->id,
+        'source_control_id' => $this->site->source_control_id,
+        'secret' => 'secret',
+        'events' => ['push'],
+        'actions' => ['deploy'],
+    ]);
+
+    $this->site->deploymentScript->update([
+        'content' => 'git pull',
+    ]);
+
+    $this->post(route('api.git-hooks', [
+        'secret' => 'secret',
+    ]), $webhook)->assertSessionDoesntHaveErrors();
+
+    if ($skip) {
         $this->assertDatabaseMissing('deployments', [
-            'site_id' => $proxied->id,
-        ]);
-    }
-
-    public function test_deploy_reverse_proxy_with_port_and_start_command_is_allowed(): void
-    {
-        SSH::fake('fake output');
-        Notification::fake();
-        $this->actingAs($this->user);
-
-        /** @var Site $proxied */
-        $proxied = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'type' => Blank::id(),
-            'port' => 3000,
-            'type_data' => ['start_command' => 'node app.js'],
-        ]);
-
-        $proxied->deploymentScript->update(['content' => 'echo deploy']);
-
-        $this->post(route('application.deploy', [
-            'server' => $this->server,
-            'site' => $proxied,
-        ]))->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('deployments', [
-            'site_id' => $proxied->id,
-        ]);
-    }
-
-    public function test_deploy_modern(): void
-    {
-        SSH::fake('fake output');
-        Http::fake([
-            'github.com/*' => Http::response([
-                'sha' => '123',
-                'commit' => [
-                    'message' => 'test commit message',
-                    'name' => 'test commit name',
-                    'email' => 'test@example.com',
-                    'url' => 'https://github.com/commit-url',
-                ],
-            ]),
-        ]);
-        Notification::fake();
-
-        $this->site->update([
-            'type_data' => [
-                'modern_deployment' => true,
-                'modern_deployment_history' => 10,
-                'modern_deployment_shared_resources' => ['.env'],
-            ],
-        ]);
-        $this->site->ensureDeploymentScriptsExist();
-        $this->site->refresh();
-
-        $this->site->buildScript->update([
-            'content' => 'composer install',
-        ]);
-
-        $this->site->preFlightScript->update([
-            'content' => 'php artisan migrate --force',
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('application.deploy', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('deployments', [
-            'site_id' => $this->site->id,
-            'status' => DeploymentStatus::FINISHED,
-        ]);
-
-        /** @var Deployment $lastDeployment */
-        $lastDeployment = $this->site->deployments()->latest()->first();
-
-        $this->assertNotNull($lastDeployment->release);
-
-        SSH::assertExecutedContains('composer install');
-
-        Notification::assertSentTo($this->notificationChannel, DeploymentCompleted::class);
-    }
-
-    public function test_rollback(): void
-    {
-        SSH::fake('fake output');
-        Notification::fake();
-
-        $this->site->update([
-            'type_data' => [
-                'modern_deployment' => true,
-                'modern_deployment_history' => 10,
-                'modern_deployment_shared_resources' => ['.env'],
-            ],
-        ]);
-
-        $this->actingAs($this->user);
-
-        Deployment::factory()->create([
-            'site_id' => $this->site->id,
-            'status' => DeploymentStatus::FINISHED,
-            'active' => true,
-            'release' => '20250901000000',
-        ]);
-
-        /** @var Deployment $oldRelease */
-        $oldRelease = Deployment::factory()->create([
-            'site_id' => $this->site->id,
-            'status' => DeploymentStatus::FINISHED,
-            'active' => false,
-            'release' => '20240901000000',
-        ]);
-
-        $this->post(route('application.rollback', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'deployment' => $oldRelease->id,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('deployments', [
-            'id' => $oldRelease->id,
-            'site_id' => $this->site->id,
-            'status' => DeploymentStatus::FINISHED,
-            'active' => true,
-        ]);
-
-        SSH::assertExecutedContains('ln -sfn');
-    }
-
-    public function test_enable_auto_deployment(): void
-    {
-        Http::fake([
-            'github.com/*' => Http::response([
-                'id' => '123',
-            ], 201),
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('application.enable-auto-deployment', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))->assertSessionDoesntHaveErrors();
-
-        $this->site->refresh();
-
-        $this->assertTrue($this->site->isAutoDeployment());
-    }
-
-    public function test_delete_release(): void
-    {
-        SSH::fake('fake output');
-
-        $this->site->update([
-            'type_data' => [
-                'modern_deployment' => true,
-                'modern_deployment_history' => 10,
-                'modern_deployment_shared_resources' => ['.env'],
-            ],
-        ]);
-
-        $this->actingAs($this->user);
-
-        Deployment::factory()->create([
-            'site_id' => $this->site->id,
-            'status' => DeploymentStatus::FINISHED,
-            'active' => true,
-            'release' => '20250901000000',
-        ]);
-
-        /** @var Deployment $oldRelease */
-        $oldRelease = Deployment::factory()->create([
-            'site_id' => $this->site->id,
-            'status' => DeploymentStatus::FINISHED,
-            'active' => false,
-            'release' => '20240901000000',
-        ]);
-
-        $this->delete(route('application.deployments.destroy', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'deployment' => $oldRelease->id,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('deployments', [
-            'id' => $oldRelease->id,
-        ]);
-
-        SSH::assertExecutedContains('rm -rf '.$this->site->basePath().'/releases/20240901000000');
-    }
-
-    public function test_disable_auto_deployment(): void
-    {
-        Http::fake([
-            'api.github.com/repos/organization/repository' => Http::response([
-                'id' => '123',
-            ], 200),
-            'api.github.com/repos/organization/repository/hooks/*' => Http::response([], 204),
-        ]);
-
-        $this->actingAs($this->user);
-
-        GitHook::factory()->create([
-            'site_id' => $this->site->id,
-            'source_control_id' => $this->site->source_control_id,
-        ]);
-
-        $this->post(route('application.disable-auto-deployment', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))->assertSessionDoesntHaveErrors();
-
-        $this->site->refresh();
-
-        $this->assertFalse($this->site->isAutoDeployment());
-    }
-
-    public function test_disable_auto_deployment_even_if_hook_destroy_fails(): void
-    {
-        Http::fake([
-            'api.github.com/repos/organization/repository' => Http::response([
-                'id' => '123',
-            ], 200),
-            'api.github.com/repos/organization/repository/hooks/*' => Http::response([], 404),
-        ]);
-
-        $this->actingAs($this->user);
-
-        GitHook::factory()->create([
-            'site_id' => $this->site->id,
-            'source_control_id' => $this->site->source_control_id,
-        ]);
-
-        $this->post(route('application.disable-auto-deployment', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))->assertSessionDoesntHaveErrors();
-
-        $this->site->refresh();
-
-        $this->assertFalse($this->site->isAutoDeployment());
-    }
-
-    public function test_update_env_file(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'env' => 'APP_ENV="production"',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->site->refresh();
-
-        $this->assertEquals($this->site->path.'/.env', data_get($this->site->type_data, 'env_path'));
-    }
-
-    public function test_update_env_file_with_path(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'env' => 'APP_ENV="production"',
-            'path' => $this->site->path.'/some-path/.env',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->site->refresh();
-
-        $this->assertEquals($this->site->path.'/some-path/.env', data_get($this->site->type_data, 'env_path'));
-    }
-
-    public function test_update_env_blocks_path_outside_site_directory(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'env' => 'APP_ENV="production"',
-            'path' => '/home/vito/other-site/.env',
-        ])
-            ->assertSessionHasErrors('path');
-    }
-
-    public function test_update_env_allows_stored_env_path_outside_site_directory(): void
-    {
-        SSH::fake();
-
-        $this->site->update([
-            'type_data' => array_merge($this->site->type_data ?? [], [
-                'env_path' => '/home/vito/other-site/.env',
-            ]),
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'env' => 'APP_ENV="production"',
-            'path' => '/home/vito/other-site/.env',
-        ])
-            ->assertSessionDoesntHaveErrors();
-    }
-
-    public function test_update_env_blocks_path_traversal(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'env' => 'APP_ENV="production"',
-            'path' => $this->site->path.'/../../etc/passwd',
-        ])
-            ->assertSessionHasErrors('path');
-    }
-
-    public function test_update_env_file_with_variables(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'variables' => [
-                ['key' => 'APP_ENV', 'value' => 'production'],
-                ['key' => 'APP_DEBUG', 'value' => 'false'],
-                ['key' => 'DB_PASSWORD', 'value' => 'secret123'],
-            ],
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->site->refresh();
-
-        $this->assertEquals($this->site->path.'/.env', data_get($this->site->type_data, 'env_path'));
-    }
-
-    public function test_get_env_returns_variables(): void
-    {
-        SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=secret');
-
-        $this->actingAs($this->user);
-
-        $response = $this->get(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]));
-
-        $response->assertOk();
-        $response->assertJsonStructure([
-            'env',
-            'variables' => [
-                '*' => ['key', 'value', 'is_secret'],
-            ],
-        ]);
-    }
-
-    public function test_only_secret_keys_are_stored_in_db(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'variables' => [
-                ['key' => 'APP_NAME', 'value' => 'TestApp', 'is_secret' => false],
-                ['key' => 'DB_PASSWORD', 'value' => 'supersecret123', 'is_secret' => true],
-            ],
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->site->refresh();
-
-        $this->assertEquals(['DB_PASSWORD'], $this->site->env_variables);
-    }
-
-    public function test_secret_values_are_masked_for_read_only_members(): void
-    {
-        SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=supersecret123');
-
-        $this->makeUserReadOnly();
-
-        $this->actingAs($this->user);
-
-        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
-
-        $response = $this->get(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]));
-
-        $response->assertOk();
-        $response->assertJsonMissingPath('env');
-        $this->assertFalse($response->json('can_edit'));
-
-        $data = $response->json('variables');
-
-        $secretVar = collect($data)->firstWhere('key', 'DB_PASSWORD');
-        $this->assertTrue($secretVar['is_secret']);
-        $this->assertEquals('', $secretVar['value']);
-
-        $normalVar = collect($data)->firstWhere('key', 'APP_NAME');
-        $this->assertFalse($normalVar['is_secret']);
-        $this->assertEquals('TestApp', $normalVar['value']);
-    }
-
-    public function test_secret_values_are_revealed_for_writers(): void
-    {
-        $env = 'APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=supersecret123';
-
-        SSH::fake($env);
-
-        $this->actingAs($this->user);
-
-        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
-
-        $response = $this->get(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]));
-
-        $response->assertOk();
-        $this->assertTrue($response->json('can_edit'));
-        $this->assertEquals($env, $response->json('env'));
-
-        $secretVar = collect($response->json('variables'))->firstWhere('key', 'DB_PASSWORD');
-        $this->assertTrue($secretVar['is_secret']);
-        $this->assertEquals('supersecret123', $secretVar['value']);
-    }
-
-    public function test_secret_classification_survives_legacy_db_shape(): void
-    {
-        SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=supersecret123');
-
-        $this->makeUserReadOnly();
-
-        $this->actingAs($this->user);
-
-        $this->site->update([
-            'env_variables' => [
-                ['key' => 'APP_NAME', 'value' => 'TestApp', 'is_secret' => false],
-                ['key' => 'DB_PASSWORD', 'value' => 'supersecret123', 'is_secret' => true],
-            ],
-        ]);
-
-        $response = $this->get(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]));
-
-        $response->assertOk();
-        $secretVar = collect($response->json('variables'))->firstWhere('key', 'DB_PASSWORD');
-        $this->assertTrue($secretVar['is_secret']);
-        $this->assertEquals('', $secretVar['value']);
-    }
-
-    public function test_secret_value_preserved_on_server_when_submitted_empty(): void
-    {
-        $ssh = SSH::fake('DB_PASSWORD=original_secret');
-
-        $this->actingAs($this->user);
-
-        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'variables' => [
-                ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
-            ],
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertStringContainsString('DB_PASSWORD=original_secret', $ssh->getUploadedContent());
-    }
-
-    public function test_secret_value_reflects_live_server_file_when_changed_out_of_band(): void
-    {
-        $ssh = SSH::fake('APP_NAME=TestApp'.PHP_EOL.'DB_PASSWORD=rotated_secret');
-
-        $this->actingAs($this->user);
-
-        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'variables' => [
-                ['key' => 'APP_NAME', 'value' => 'ChangedApp', 'is_secret' => false],
-                ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
-            ],
-        ])->assertSessionDoesntHaveErrors();
-
-        $uploaded = $ssh->getUploadedContent();
-        $this->assertStringContainsString('DB_PASSWORD=rotated_secret', $uploaded);
-        $this->assertStringContainsString('APP_NAME=ChangedApp', $uploaded);
-    }
-
-    public function test_stored_secret_cannot_be_wiped_by_marking_it_non_secret(): void
-    {
-        $ssh = SSH::fake('DB_PASSWORD=original_secret');
-
-        $this->actingAs($this->user);
-
-        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'variables' => [
-                ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => false],
-            ],
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertStringContainsString('DB_PASSWORD=original_secret', $ssh->getUploadedContent());
-
-        $this->site->refresh();
-        $this->assertEquals(['DB_PASSWORD'], $this->site->env_variables);
-    }
-
-    public function test_secret_can_be_dropped_to_non_secret_with_new_value(): void
-    {
-        $ssh = SSH::fake('DB_PASSWORD=original_secret');
-
-        $this->actingAs($this->user);
-
-        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'variables' => [
-                ['key' => 'DB_PASSWORD', 'value' => 'now_plain', 'is_secret' => false],
-            ],
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertStringContainsString('DB_PASSWORD=now_plain', $ssh->getUploadedContent());
-
-        $this->site->refresh();
-        $this->assertEquals([], $this->site->env_variables);
-    }
-
-    public function test_pattern_secrets_masked_for_site_never_saved_through_vito(): void
-    {
-        SSH::fake('APP_NAME=TestApp'.PHP_EOL.'APP_KEY=base64:supersecret');
-
-        $this->makeUserReadOnly();
-
-        $this->actingAs($this->user);
-
-        $this->assertNull($this->site->env_variables);
-
-        $response = $this->get(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]));
-
-        $response->assertOk();
-        $secretVar = collect($response->json('variables'))->firstWhere('key', 'APP_KEY');
-        $this->assertTrue($secretVar['is_secret']);
-        $this->assertEquals('', $secretVar['value']);
-    }
-
-    public function test_raw_env_path_writes_content_verbatim_without_restoring_secrets(): void
-    {
-        $ssh = SSH::fake('DB_PASSWORD=original_secret');
-
-        $this->actingAs($this->user);
-
-        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
-
-        $raw = '# leading comment'.PHP_EOL.'APP_NAME=Raw'.PHP_EOL.PHP_EOL.'DB_PASSWORD=';
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'env' => $raw,
-        ])->assertSessionDoesntHaveErrors();
-
-        $uploaded = $ssh->getUploadedContent();
-        $this->assertSame($raw, $uploaded);
-        $this->assertStringNotContainsString('DB_PASSWORD=original_secret', $uploaded);
-    }
-
-    public function test_update_env_aborts_when_live_file_cannot_be_read(): void
-    {
-        SSH::fake('');
-
-        $this->actingAs($this->user);
-
-        $this->site->update(['env_variables' => ['DB_PASSWORD']]);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'variables' => [
-                ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
-            ],
-        ])->assertSessionHasErrors('variables');
-    }
-
-    public function test_parse_env_endpoint(): void
-    {
-        $this->actingAs($this->user);
-
-        $envContent = "APP_NAME=TestApp\nDB_PASSWORD=secret123\nAPP_DEBUG=true";
-
-        $response = $this->post(route('application.parse-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'content' => $envContent,
-        ]);
-
-        $response->assertOk();
-        $response->assertJsonStructure([
-            'variables' => [
-                '*' => ['key', 'value', 'is_secret'],
-            ],
-        ]);
-
-        $variables = $response->json('variables');
-        $this->assertCount(3, $variables);
-
-        // Check that DB_PASSWORD is detected as secret
-        $passwordVar = collect($variables)->firstWhere('key', 'DB_PASSWORD');
-        $this->assertTrue($passwordVar['is_secret']);
-
-        // Check that APP_NAME is not secret
-        $nameVar = collect($variables)->firstWhere('key', 'APP_NAME');
-        $this->assertFalse($nameVar['is_secret']);
-    }
-
-    /**
-     * @param  array<string, mixed>  $webhook
-     * @param  array<string, mixed>  $payload
-     */
-    #[DataProvider('hookData')]
-    public function test_git_hook_deployment(string $provider, array $webhook, string $url, array $payload, bool $skip): void
-    {
-        SSH::fake();
-        Http::fake([
-            $url => Http::response($payload),
-        ]);
-
-        $this->site->update([
-            'branch' => 'main',
-        ]);
-        $this->site->sourceControl->update([
-            'provider' => $provider,
-        ]);
-
-        GitHook::factory()->create([
-            'site_id' => $this->site->id,
-            'source_control_id' => $this->site->source_control_id,
-            'secret' => 'secret',
-            'events' => ['push'],
-            'actions' => ['deploy'],
-        ]);
-
-        $this->site->deploymentScript->update([
-            'content' => 'git pull',
-        ]);
-
-        $this->post(route('api.git-hooks', [
-            'secret' => 'secret',
-        ]), $webhook)->assertSessionDoesntHaveErrors();
-
-        if ($skip) {
-            $this->assertDatabaseMissing('deployments', [
-                'site_id' => $this->site->id,
-                'deployment_script_id' => $this->site->deploymentScript->id,
-                'status' => DeploymentStatus::FINISHED,
-            ]);
-
-            return;
-        }
-
-        $this->assertDatabaseHas('deployments', [
             'site_id' => $this->site->id,
             'deployment_script_id' => $this->site->deploymentScript->id,
             'status' => DeploymentStatus::FINISHED,
         ]);
 
-        $deployment = $this->site->deployments()->first();
-        $this->assertEquals('saeed', $deployment->commit_data['name']);
-        $this->assertEquals('saeed@vitodeploy.com', $deployment->commit_data['email']);
+        return;
     }
 
-    public function test_git_hook_deployment_invalid_secret(): void
-    {
-        SSH::fake();
-        Http::fake();
+    $this->assertDatabaseHas('deployments', [
+        'site_id' => $this->site->id,
+        'deployment_script_id' => $this->site->deploymentScript->id,
+        'status' => DeploymentStatus::FINISHED,
+    ]);
 
-        GitHook::factory()->create([
-            'site_id' => $this->site->id,
-            'source_control_id' => $this->site->source_control_id,
-            'secret' => 'secret',
-            'events' => ['push'],
-            'actions' => ['deploy'],
-        ]);
+    $deployment = $this->site->deployments()->first();
+    expect($deployment->commit_data['name'])->toEqual('saeed');
+    expect($deployment->commit_data['email'])->toEqual('saeed@vitodeploy.com');
+})->with('hookData');
 
-        $this->site->deploymentScript->update([
-            'content' => 'git pull',
-        ]);
+test('git hook deployment invalid secret', function () {
+    SSH::fake();
+    Http::fake();
 
-        $this->post(route('api.git-hooks'), [
-            'secret' => 'invalid-secret',
-        ])->assertNotFound();
+    GitHook::factory()->create([
+        'site_id' => $this->site->id,
+        'source_control_id' => $this->site->source_control_id,
+        'secret' => 'secret',
+        'events' => ['push'],
+        'actions' => ['deploy'],
+    ]);
 
-        $this->assertDatabaseMissing('deployments', [
-            'site_id' => $this->site->id,
-            'deployment_script_id' => $this->site->deploymentScript->id,
-            'status' => DeploymentStatus::FINISHED,
-        ]);
-    }
+    $this->site->deploymentScript->update([
+        'content' => 'git pull',
+    ]);
 
-    /**
-     * @return array<array<int, mixed>>
-     */
-    public static function hookData(): array
-    {
-        return [
-            [
-                'github',
-                [
-                    'ref' => 'refs/heads/main',
-                ],
-                'github.com/*',
-                [
-                    'sha' => '123',
-                    'commit' => [
-                        'committer' => [
-                            'name' => 'saeed',
-                            'email' => 'saeed@vitodeploy.com',
-                        ],
-                        'message' => 'test commit message',
-                        'url' => 'https://github.com',
-                    ],
-                ],
-                false,
-            ],
-            [
-                'github',
-                [
-                    'ref' => 'refs/heads/other-branch',
-                ],
-                'github.com/*',
-                [
-                    'sha' => '123',
-                    'commit' => [
-                        'committer' => [
-                            'name' => 'saeed',
-                            'email' => 'saeed@vitodeploy.com',
-                        ],
-                        'message' => 'test commit message',
-                        'url' => 'https://github.com',
-                    ],
-                ],
-                true,
-            ],
-            [
-                'gitlab',
-                [
-                    'ref' => 'main',
-                ],
-                'gitlab.com/*',
-                [
-                    [
-                        'id' => '123',
-                        'committer_name' => 'saeed',
-                        'committer_email' => 'saeed@vitodeploy.com',
-                        'title' => 'test',
-                        'web_url' => 'https://gitlab.com',
-                    ],
-                ],
-                false,
-            ],
-            [
-                'gitlab',
-                [
-                    'ref' => 'other-branch',
-                ],
-                'gitlab.com/*',
-                [
-                    [
-                        'id' => '123',
-                        'committer_name' => 'saeed',
-                        'committer_email' => 'saeed@vitodeploy.com',
-                        'title' => 'test',
-                        'web_url' => 'https://gitlab.com',
-                    ],
-                ],
-                true,
-            ],
-            [
-                'bitbucket',
-                [
-                    'push' => [
-                        'changes' => [
-                            [
-                                'new' => [
-                                    'name' => 'main',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-                'bitbucket.org/*',
-                [
-                    'values' => [
-                        [
-                            'hash' => '123',
-                            'author' => [
-                                'raw' => 'saeed <saeed@vitodeploy.com>',
-                            ],
-                            'message' => 'test',
-                            'links' => [
-                                'html' => [
-                                    'href' => 'https://bitbucket.org',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-                false,
-            ],
-            [
-                'bitbucket',
-                [
-                    'push' => [
-                        'changes' => [
-                            [
-                                'new' => [
-                                    'name' => 'other-branch',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-                'bitbucket.org/*',
-                [
-                    'values' => [
-                        [
-                            'hash' => '123',
-                            'author' => [
-                                'raw' => 'saeed <saeed@vitodeploy.com>',
-                            ],
-                            'message' => 'test',
-                            'links' => [
-                                'html' => [
-                                    'href' => 'https://bitbucket.org',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-                true,
-            ],
-        ];
-    }
+    $this->post(route('api.git-hooks'), [
+        'secret' => 'invalid-secret',
+    ])->assertNotFound();
 
-    public function test_deploy_classic_restarts_only_site_workers(): void
-    {
-        $sshFake = SSH::fake('fake output');
-        Http::fake([
-            'github.com/*' => Http::response([
+    $this->assertDatabaseMissing('deployments', [
+        'site_id' => $this->site->id,
+        'deployment_script_id' => $this->site->deploymentScript->id,
+        'status' => DeploymentStatus::FINISHED,
+    ]);
+});
+
+/**
+ * @return array<array<int, mixed>>
+ */
+dataset('hookData', function () {
+    return [
+        [
+            'github',
+            [
+                'ref' => 'refs/heads/main',
+            ],
+            'github.com/*',
+            [
                 'sha' => '123',
                 'commit' => [
+                    'committer' => [
+                        'name' => 'saeed',
+                        'email' => 'saeed@vitodeploy.com',
+                    ],
                     'message' => 'test commit message',
-                    'name' => 'test commit name',
-                    'email' => 'test@example.com',
-                    'url' => 'https://github.com/commit-url',
+                    'url' => 'https://github.com',
                 ],
-            ]),
-        ]);
-        Notification::fake();
-
-        // Create a worker for the site being deployed
-        $siteWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        // Create another site with workers on the same server
-        $otherSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-        $otherSiteWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $otherSite->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        // Enable restart workers for the deployment script
-        $this->site->deploymentScript->update([
-            'content' => 'git pull',
-            'configs' => ['restart_workers' => true],
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('application.deploy', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        // Verify that only the site worker restart command was executed
-        SSH::assertExecutedContains('supervisorctl restart '.$siteWorker->id.':*');
-
-        // Verify that other site's worker and "restart all" are not executed
-        $this->assertWorkerNotRestarted($otherSiteWorker->id);
-        SSH::assertNotExecutedContains('supervisorctl restart all', 'Should not restart all workers');
-    }
-
-    public function test_deploy_modern_restarts_only_site_workers(): void
-    {
-        $sshFake = SSH::fake('fake output');
-        Http::fake([
-            'github.com/*' => Http::response([
+            ],
+            false,
+        ],
+        [
+            'github',
+            [
+                'ref' => 'refs/heads/other-branch',
+            ],
+            'github.com/*',
+            [
                 'sha' => '123',
                 'commit' => [
+                    'committer' => [
+                        'name' => 'saeed',
+                        'email' => 'saeed@vitodeploy.com',
+                    ],
                     'message' => 'test commit message',
-                    'name' => 'test commit name',
-                    'email' => 'test@example.com',
-                    'url' => 'https://github.com/commit-url',
+                    'url' => 'https://github.com',
                 ],
-            ]),
-        ]);
-        Notification::fake();
-
-        $this->site->update([
-            'type_data' => [
-                'modern_deployment' => true,
-                'modern_deployment_history' => 10,
-                'modern_deployment_shared_resources' => ['.env'],
             ],
-        ]);
-        $this->site->ensureDeploymentScriptsExist();
-        $this->site->refresh();
-
-        // Create a worker for the site being deployed
-        $siteWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        // Create another site with workers on the same server
-        $otherSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-        $otherSiteWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $otherSite->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        // Enable restart workers for the pre-flight script
-        $this->site->preFlightScript->update([
-            'content' => 'php artisan migrate --force',
-            'configs' => ['restart_workers' => true],
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('application.deploy', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        // Verify that only the site worker restart command was executed
-        SSH::assertExecutedContains('supervisorctl restart '.$siteWorker->id.':*');
-
-        // Verify that other site's worker and "restart all" are not executed
-        $this->assertWorkerNotRestarted($otherSiteWorker->id);
-        SSH::assertNotExecutedContains('supervisorctl restart all', 'Should not restart all workers');
-    }
-
-    /**
-     * Assert that the given worker's restart command was not executed via SSH.
-     */
-    private function assertWorkerNotRestarted(int|string $workerId): void
-    {
-        SSH::assertNotExecutedContains(
-            'supervisorctl restart '.$workerId.':*',
-            "Worker {$workerId} should not be restarted"
-        );
-    }
-
-    public function test_read_only_member_cannot_override_env_path(): void
-    {
-        SSH::fake('APP_NAME=TestApp');
-
-        $this->makeUserReadOnly();
-
-        $this->actingAs($this->user);
-
-        $this->get(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'env' => $this->site->path.'/other/.env',
-        ]))->assertForbidden();
-    }
-
-    public function test_read_only_member_can_read_the_default_env_path(): void
-    {
-        SSH::fake('APP_NAME=TestApp');
-
-        $this->makeUserReadOnly();
-
-        $this->actingAs($this->user);
-
-        $this->get(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'env' => $this->site->path.'/.env',
-        ]))->assertOk();
-    }
-
-    /**
-     * @return array<string, array<int, string>>
-     */
-    public static function rejectedEnvPathProvider(): array
-    {
-        return [
-            'absolute path outside the site' => ['/etc/passwd'],
-            'shell metacharacters' => ['/etc/passwd;id'],
-            'export prefix' => ['export /etc/passwd'],
-        ];
-    }
-
-    #[DataProvider('rejectedEnvPathProvider')]
-    public function test_env_path_outside_the_site_is_rejected(string $path): void
-    {
-        SSH::fake('APP_NAME=TestApp');
-
-        $this->actingAs($this->user);
-
-        $this->getJson(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'env' => $path,
-        ]))->assertStatus(422);
-    }
-
-    public function test_env_path_traversal_is_rejected(): void
-    {
-        SSH::fake('APP_NAME=TestApp');
-
-        $this->actingAs($this->user);
-
-        $this->getJson(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'env' => $this->site->path.'/../other/.env',
-        ]))->assertStatus(422);
-    }
-
-    public function test_array_env_param_is_treated_as_no_override(): void
-    {
-        SSH::fake('APP_NAME=TestApp');
-
-        $this->actingAs($this->user);
-
-        $this->get(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]).'?env[]=/etc/passwd')->assertOk();
-    }
-
-    public function test_stored_env_path_outside_the_site_is_still_readable(): void
-    {
-        SSH::fake('APP_NAME=TestApp');
-
-        $this->actingAs($this->user);
-
-        $this->site->jsonUpdate('type_data', 'env_path', '/home/vito/other-site/.env');
-
-        $this->get(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'env' => '/home/vito/other-site/.env',
-        ]))->assertOk();
-    }
-
-    public function test_env_path_within_the_site_is_accepted(): void
-    {
-        SSH::fake('APP_NAME=TestApp');
-
-        $this->actingAs($this->user);
-
-        $this->get(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'env' => $this->site->path.'/nested/.env',
-        ]))->assertOk();
-    }
-
-    public function test_reading_env_does_not_persist_the_overridden_path(): void
-    {
-        SSH::fake('APP_NAME=TestApp');
-
-        $this->actingAs($this->user);
-
-        $this->get(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'env' => $this->site->path.'/nested/.env',
-        ]))->assertOk();
-
-        $this->site->refresh();
-
-        $this->assertNull(data_get($this->site->type_data, 'env_path'));
-    }
-
-    public function test_missing_env_file_still_returns_ok(): void
-    {
-        SSH::fake('');
-
-        $this->actingAs($this->user);
-
-        $response = $this->get(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]));
-
-        $response->assertOk();
-        $this->assertEquals([], $response->json('variables'));
-    }
-
-    public function test_ssh_failure_while_reading_env_surfaces_as_an_error(): void
-    {
-        $ssh = SSH::fake();
-        $ssh->execWillFail();
-
-        $this->actingAs($this->user);
-
-        $this->get(route('application.env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))->assertStatus(500);
-    }
-
-    public function test_update_env_rejects_an_empty_path(): void
-    {
-        SSH::fake();
-
-        $this->expectException(ValidationException::class);
-
-        app(UpdateEnv::class)->update($this->site, ['env' => 'APP_NAME=Test', 'path' => '']);
-    }
-
-    public function test_update_env_rejects_an_array_path(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'env' => 'APP_NAME=Test',
-            'path' => ['x'],
-        ])->assertSessionHasErrors('path');
-    }
-
-    public function test_update_env_rejects_an_empty_variables_array(): void
-    {
-        SSH::fake('APP_NAME=TestApp');
-
-        $this->actingAs($this->user);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'variables' => [],
-        ])->assertSessionHasErrors('variables');
-    }
-
-    public function test_update_env_rejects_an_empty_variables_array_alongside_env(): void
-    {
-        SSH::fake('APP_NAME=TestApp');
-
-        $this->actingAs($this->user);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'env' => '',
-            'variables' => [],
-        ])->assertSessionHasErrors('variables');
-    }
-
-    public function test_update_env_rejects_a_null_env_sent_alongside_variables(): void
-    {
-        SSH::fake('APP_NAME=TestApp');
-
-        $this->actingAs($this->user);
-
-        $this->putJson(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'env' => null,
-            'variables' => null,
-        ])->assertStatus(422);
-    }
-
-    public function test_update_env_rejects_a_submission_with_both_keys(): void
-    {
-        SSH::fake('APP_NAME=TestApp');
-
-        $this->actingAs($this->user);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'env' => 'APP_NAME=Test',
-            'variables' => [
-                ['key' => 'APP_NAME', 'value' => 'Test', 'is_secret' => false],
+            true,
+        ],
+        [
+            'gitlab',
+            [
+                'ref' => 'main',
             ],
-        ])->assertSessionHasErrors('env');
-    }
-
-    public function test_update_env_rejects_a_submission_with_neither_key(): void
-    {
-        SSH::fake('APP_NAME=TestApp');
-
-        $this->actingAs($this->user);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'path' => $this->site->path.'/.env',
-        ])->assertSessionHasErrors('env');
-    }
-
-    public function test_classic_mode_can_blank_the_env_file(): void
-    {
-        $ssh = SSH::fake('APP_NAME=TestApp');
-
-        $this->actingAs($this->user);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'env' => '',
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertEquals('', trim($ssh->getUploadedContent() ?? 'not-empty'));
-    }
-
-    public function test_read_only_member_cannot_update_env(): void
-    {
-        SSH::fake();
-
-        $this->makeUserReadOnly();
-
-        $this->actingAs($this->user);
-
-        $this->put(route('application.update-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'env' => 'APP_NAME=Test',
-        ])->assertForbidden();
-    }
-
-    public function test_parse_env_accepts_empty_content(): void
-    {
-        $this->actingAs($this->user);
-
-        $response = $this->post(route('application.parse-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), ['content' => '']);
-
-        $response->assertOk();
-        $this->assertEquals([], $response->json('variables'));
-    }
-
-    public function test_parse_env_marks_a_commented_file_as_representable(): void
-    {
-        $this->actingAs($this->user);
-
-        $content = '# Application'.PHP_EOL.PHP_EOL.'APP_NAME=TestApp'.PHP_EOL.'MY-KEY=1'.PHP_EOL.'2FA_ENABLED=1'.PHP_EOL."A='single quoted'";
-
-        $this->post(route('application.parse-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), ['content' => $content])->assertOk()->assertJsonPath('representable', true);
-    }
-
-    public function test_stringify_env_serialises_rows(): void
-    {
-        $this->actingAs($this->user);
-
-        $response = $this->post(route('application.stringify-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'variables' => [
-                ['key' => 'APP_NAME', 'value' => 'TestApp'],
-                ['key' => 'APP_DEBUG', 'value' => ''],
+            'gitlab.com/*',
+            [
+                [
+                    'id' => '123',
+                    'committer_name' => 'saeed',
+                    'committer_email' => 'saeed@vitodeploy.com',
+                    'title' => 'test',
+                    'web_url' => 'https://gitlab.com',
+                ],
             ],
-        ]);
+            false,
+        ],
+        [
+            'gitlab',
+            [
+                'ref' => 'other-branch',
+            ],
+            'gitlab.com/*',
+            [
+                [
+                    'id' => '123',
+                    'committer_name' => 'saeed',
+                    'committer_email' => 'saeed@vitodeploy.com',
+                    'title' => 'test',
+                    'web_url' => 'https://gitlab.com',
+                ],
+            ],
+            true,
+        ],
+        [
+            'bitbucket',
+            [
+                'push' => [
+                    'changes' => [
+                        [
+                            'new' => [
+                                'name' => 'main',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'bitbucket.org/*',
+            [
+                'values' => [
+                    [
+                        'hash' => '123',
+                        'author' => [
+                            'raw' => 'saeed <saeed@vitodeploy.com>',
+                        ],
+                        'message' => 'test',
+                        'links' => [
+                            'html' => [
+                                'href' => 'https://bitbucket.org',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            false,
+        ],
+        [
+            'bitbucket',
+            [
+                'push' => [
+                    'changes' => [
+                        [
+                            'new' => [
+                                'name' => 'other-branch',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'bitbucket.org/*',
+            [
+                'values' => [
+                    [
+                        'hash' => '123',
+                        'author' => [
+                            'raw' => 'saeed <saeed@vitodeploy.com>',
+                        ],
+                        'message' => 'test',
+                        'links' => [
+                            'html' => [
+                                'href' => 'https://bitbucket.org',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            true,
+        ],
+    ];
+});
 
-        $response->assertOk();
-        $this->assertEquals('APP_NAME=TestApp'.PHP_EOL.'APP_DEBUG=', $response->json('env'));
-    }
+test('deploy classic restarts only site workers', function () {
+    $sshFake = SSH::fake('fake output');
+    Http::fake([
+        'github.com/*' => Http::response([
+            'sha' => '123',
+            'commit' => [
+                'message' => 'test commit message',
+                'name' => 'test commit name',
+                'email' => 'test@example.com',
+                'url' => 'https://github.com/commit-url',
+            ],
+        ]),
+    ]);
+    Notification::fake();
 
-    public function test_stringify_env_requires_variables(): void
-    {
-        $this->actingAs($this->user);
+    // Create a worker for the site being deployed
+    $siteWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
 
-        $this->post(route('application.stringify-env', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [])->assertSessionHasErrors('variables');
-    }
+    // Create another site with workers on the same server
+    $otherSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+    $otherSiteWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $otherSite->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
 
-    /**
-     * Demote the acting user to the read-only project role.
-     */
-    private function makeUserReadOnly(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::USER,
-        ]);
-    }
+    // Enable restart workers for the deployment script
+    $this->site->deploymentScript->update([
+        'content' => 'git pull',
+        'configs' => ['restart_workers' => true],
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('application.deploy', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    // Verify that only the site worker restart command was executed
+    SSH::assertExecutedContains('supervisorctl restart '.$siteWorker->id.':*');
+
+    // Verify that other site's worker and "restart all" are not executed
+    vitoPestFeatureApplicationTestAssertWorkerNotRestarted($otherSiteWorker->id);
+    SSH::assertNotExecutedContains('supervisorctl restart all', 'Should not restart all workers');
+});
+
+test('deploy modern restarts only site workers', function () {
+    $sshFake = SSH::fake('fake output');
+    Http::fake([
+        'github.com/*' => Http::response([
+            'sha' => '123',
+            'commit' => [
+                'message' => 'test commit message',
+                'name' => 'test commit name',
+                'email' => 'test@example.com',
+                'url' => 'https://github.com/commit-url',
+            ],
+        ]),
+    ]);
+    Notification::fake();
+
+    $this->site->update([
+        'type_data' => [
+            'modern_deployment' => true,
+            'modern_deployment_history' => 10,
+            'modern_deployment_shared_resources' => ['.env'],
+        ],
+    ]);
+    $this->site->ensureDeploymentScriptsExist();
+    $this->site->refresh();
+
+    // Create a worker for the site being deployed
+    $siteWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    // Create another site with workers on the same server
+    $otherSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+    $otherSiteWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $otherSite->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    // Enable restart workers for the pre-flight script
+    $this->site->preFlightScript->update([
+        'content' => 'php artisan migrate --force',
+        'configs' => ['restart_workers' => true],
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('application.deploy', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    // Verify that only the site worker restart command was executed
+    SSH::assertExecutedContains('supervisorctl restart '.$siteWorker->id.':*');
+
+    // Verify that other site's worker and "restart all" are not executed
+    vitoPestFeatureApplicationTestAssertWorkerNotRestarted($otherSiteWorker->id);
+    SSH::assertNotExecutedContains('supervisorctl restart all', 'Should not restart all workers');
+});
+
+/**
+ * Assert that the given worker's restart command was not executed via SSH.
+ */
+function vitoPestFeatureApplicationTestAssertWorkerNotRestarted(int|string $workerId): void
+{
+    SSH::assertNotExecutedContains(
+        'supervisorctl restart '.$workerId.':*',
+        "Worker {$workerId} should not be restarted"
+    );
+}
+
+test('read only member cannot override env path', function () {
+    SSH::fake('APP_NAME=TestApp');
+
+    vitoPestFeatureApplicationTestMakeUserReadOnly();
+
+    $this->actingAs($this->user);
+
+    $this->get(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'env' => $this->site->path.'/other/.env',
+    ]))->assertForbidden();
+});
+
+test('read only member can read the default env path', function () {
+    SSH::fake('APP_NAME=TestApp');
+
+    vitoPestFeatureApplicationTestMakeUserReadOnly();
+
+    $this->actingAs($this->user);
+
+    $this->get(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'env' => $this->site->path.'/.env',
+    ]))->assertOk();
+});
+
+/**
+ * @return array<string, array<int, string>>
+ */
+dataset('rejectedEnvPathProvider', function () {
+    return [
+        'absolute path outside the site' => ['/etc/passwd'],
+        'shell metacharacters' => ['/etc/passwd;id'],
+        'export prefix' => ['export /etc/passwd'],
+    ];
+});
+
+test('env path outside the site is rejected', function (string $path) {
+    SSH::fake('APP_NAME=TestApp');
+
+    $this->actingAs($this->user);
+
+    $this->getJson(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'env' => $path,
+    ]))->assertStatus(422);
+})->with('rejectedEnvPathProvider');
+
+test('env path traversal is rejected', function () {
+    SSH::fake('APP_NAME=TestApp');
+
+    $this->actingAs($this->user);
+
+    $this->getJson(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'env' => $this->site->path.'/../other/.env',
+    ]))->assertStatus(422);
+});
+
+test('array env param is treated as no override', function () {
+    SSH::fake('APP_NAME=TestApp');
+
+    $this->actingAs($this->user);
+
+    $this->get(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]).'?env[]=/etc/passwd')->assertOk();
+});
+
+test('stored env path outside the site is still readable', function () {
+    SSH::fake('APP_NAME=TestApp');
+
+    $this->actingAs($this->user);
+
+    $this->site->jsonUpdate('type_data', 'env_path', '/home/vito/other-site/.env');
+
+    $this->get(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'env' => '/home/vito/other-site/.env',
+    ]))->assertOk();
+});
+
+test('env path within the site is accepted', function () {
+    SSH::fake('APP_NAME=TestApp');
+
+    $this->actingAs($this->user);
+
+    $this->get(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'env' => $this->site->path.'/nested/.env',
+    ]))->assertOk();
+});
+
+test('reading env does not persist the overridden path', function () {
+    SSH::fake('APP_NAME=TestApp');
+
+    $this->actingAs($this->user);
+
+    $this->get(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'env' => $this->site->path.'/nested/.env',
+    ]))->assertOk();
+
+    $this->site->refresh();
+
+    expect(data_get($this->site->type_data, 'env_path'))->toBeNull();
+});
+
+test('missing env file still returns ok', function () {
+    SSH::fake('');
+
+    $this->actingAs($this->user);
+
+    $response = $this->get(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]));
+
+    $response->assertOk();
+    expect($response->json('variables'))->toEqual([]);
+});
+
+test('ssh failure while reading env surfaces as an error', function () {
+    $ssh = SSH::fake();
+    $ssh->execWillFail();
+
+    $this->actingAs($this->user);
+
+    $this->get(route('application.env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))->assertStatus(500);
+});
+
+test('update env rejects an empty path', function () {
+    SSH::fake();
+
+    $this->expectException(ValidationException::class);
+
+    app(UpdateEnv::class)->update($this->site, ['env' => 'APP_NAME=Test', 'path' => '']);
+});
+
+test('update env rejects an array path', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'env' => 'APP_NAME=Test',
+        'path' => ['x'],
+    ])->assertSessionHasErrors('path');
+});
+
+test('update env rejects an empty variables array', function () {
+    SSH::fake('APP_NAME=TestApp');
+
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'variables' => [],
+    ])->assertSessionHasErrors('variables');
+});
+
+test('update env rejects an empty variables array alongside env', function () {
+    SSH::fake('APP_NAME=TestApp');
+
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'env' => '',
+        'variables' => [],
+    ])->assertSessionHasErrors('variables');
+});
+
+test('update env rejects a null env sent alongside variables', function () {
+    SSH::fake('APP_NAME=TestApp');
+
+    $this->actingAs($this->user);
+
+    $this->putJson(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'env' => null,
+        'variables' => null,
+    ])->assertStatus(422);
+});
+
+test('update env rejects a submission with both keys', function () {
+    SSH::fake('APP_NAME=TestApp');
+
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'env' => 'APP_NAME=Test',
+        'variables' => [
+            ['key' => 'APP_NAME', 'value' => 'Test', 'is_secret' => false],
+        ],
+    ])->assertSessionHasErrors('env');
+});
+
+test('update env rejects a submission with neither key', function () {
+    SSH::fake('APP_NAME=TestApp');
+
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'path' => $this->site->path.'/.env',
+    ])->assertSessionHasErrors('env');
+});
+
+test('classic mode can blank the env file', function () {
+    $ssh = SSH::fake('APP_NAME=TestApp');
+
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'env' => '',
+    ])->assertSessionDoesntHaveErrors();
+
+    expect(trim($ssh->getUploadedContent() ?? 'not-empty'))->toEqual('');
+});
+
+test('read only member cannot update env', function () {
+    SSH::fake();
+
+    vitoPestFeatureApplicationTestMakeUserReadOnly();
+
+    $this->actingAs($this->user);
+
+    $this->put(route('application.update-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'env' => 'APP_NAME=Test',
+    ])->assertForbidden();
+});
+
+test('parse env accepts empty content', function () {
+    $this->actingAs($this->user);
+
+    $response = $this->post(route('application.parse-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), ['content' => '']);
+
+    $response->assertOk();
+    expect($response->json('variables'))->toEqual([]);
+});
+
+test('parse env marks a commented file as representable', function () {
+    $this->actingAs($this->user);
+
+    $content = '# Application'.PHP_EOL.PHP_EOL.'APP_NAME=TestApp'.PHP_EOL.'MY-KEY=1'.PHP_EOL.'2FA_ENABLED=1'.PHP_EOL."A='single quoted'";
+
+    $this->post(route('application.parse-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), ['content' => $content])->assertOk()->assertJsonPath('representable', true);
+});
+
+test('stringify env serialises rows', function () {
+    $this->actingAs($this->user);
+
+    $response = $this->post(route('application.stringify-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'variables' => [
+            ['key' => 'APP_NAME', 'value' => 'TestApp'],
+            ['key' => 'APP_DEBUG', 'value' => ''],
+        ],
+    ]);
+
+    $response->assertOk();
+    expect($response->json('env'))->toEqual('APP_NAME=TestApp'.PHP_EOL.'APP_DEBUG=');
+});
+
+test('stringify env requires variables', function () {
+    $this->actingAs($this->user);
+
+    $this->post(route('application.stringify-env', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [])->assertSessionHasErrors('variables');
+});
+
+/**
+ * Demote the acting user to the read-only project role.
+ */
+function vitoPestFeatureApplicationTestMakeUserReadOnly(): void
+{
+    test()->server->project->users()->where('user_id', test()->user->id)->update([
+        'role' => UserRole::USER,
+    ]);
 }

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -1,58 +1,48 @@
 <?php
 
-namespace Tests\Feature\Auth;
-
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class AuthenticationTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_login_screen_can_be_rendered(): void
-    {
-        $response = $this->get(route('login'));
+test('login screen can be rendered', function () {
+    $response = $this->get(route('login'));
 
-        $response->assertStatus(200);
-    }
+    $response->assertStatus(200);
+});
 
-    public function test_users_can_authenticate_using_the_login_screen(): void
-    {
-        /** @var User $user */
-        $user = User::factory()->create();
+test('users can authenticate using the login screen', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
 
-        $response = $this->post(route('login.store'), [
-            'email' => $user->email,
-            'password' => 'password',
-        ]);
+    $response = $this->post(route('login.store'), [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
 
-        $this->assertAuthenticated();
-        $response->assertRedirect(route('servers', absolute: false));
-    }
+    $this->assertAuthenticated();
+    $response->assertRedirect(route('servers', absolute: false));
+});
 
-    public function test_users_can_not_authenticate_with_invalid_password(): void
-    {
-        /** @var User $user */
-        $user = User::factory()->create();
+test('users can not authenticate with invalid password', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
 
-        $this->post(route('login.store'), [
-            'email' => $user->email,
-            'password' => 'wrong-password',
-        ]);
+    $this->post(route('login.store'), [
+        'email' => $user->email,
+        'password' => 'wrong-password',
+    ]);
 
-        $this->assertGuest();
-    }
+    $this->assertGuest();
+});
 
-    public function test_users_can_logout(): void
-    {
-        /** @var User $user */
-        $user = User::factory()->create();
-        $user->ensureHasDefaultProject();
+test('users can logout', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    $user->ensureHasDefaultProject();
 
-        $response = $this->actingAs($user)->post(route('logout'));
+    $response = $this->actingAs($user)->post(route('logout'));
 
-        $this->assertGuest();
-        $response->assertRedirect(route('login'));
-    }
-}
+    $this->assertGuest();
+    $response->assertRedirect(route('login'));
+});

--- a/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -1,50 +1,41 @@
 <?php
 
-namespace Tests\Feature\Auth;
-
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class PasswordConfirmationTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_confirm_password_screen_can_be_rendered(): void
-    {
-        /** @var User $user */
-        $user = User::factory()->create();
-        $user->ensureHasDefaultProject();
+test('confirm password screen can be rendered', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    $user->ensureHasDefaultProject();
 
-        $response = $this->actingAs($user)->get(route('password.confirm'));
+    $response = $this->actingAs($user)->get(route('password.confirm'));
 
-        $response->assertStatus(200);
-    }
+    $response->assertStatus(200);
+});
 
-    public function test_password_can_be_confirmed(): void
-    {
-        /** @var User $user */
-        $user = User::factory()->create();
-        $user->ensureHasDefaultProject();
+test('password can be confirmed', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    $user->ensureHasDefaultProject();
 
-        $response = $this->actingAs($user)->post(route('password.confirm'), [
-            'password' => 'password',
-        ]);
+    $response = $this->actingAs($user)->post(route('password.confirm'), [
+        'password' => 'password',
+    ]);
 
-        $response->assertRedirect();
-        $response->assertSessionDoesntHaveErrors();
-    }
+    $response->assertRedirect();
+    $response->assertSessionDoesntHaveErrors();
+});
 
-    public function test_password_is_not_confirmed_with_invalid_password(): void
-    {
-        /** @var User $user */
-        $user = User::factory()->create();
-        $user->ensureHasDefaultProject();
+test('password is not confirmed with invalid password', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    $user->ensureHasDefaultProject();
 
-        $response = $this->actingAs($user)->post(route('password.confirm'), [
-            'password' => 'wrong-password',
-        ]);
+    $response = $this->actingAs($user)->post(route('password.confirm'), [
+        'password' => 'wrong-password',
+    ]);
 
-        $response->assertSessionHasErrors();
-    }
-}
+    $response->assertSessionHasErrors();
+});

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -1,86 +1,66 @@
 <?php
 
-namespace Tests\Feature\Auth;
-
 use App\Models\User;
-use Exception;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
-use Tests\TestCase;
 
-class PasswordResetTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_reset_password_link_screen_can_be_rendered(): void
-    {
-        $response = $this->get(route('password.email'));
+test('reset password link screen can be rendered', function () {
+    $response = $this->get(route('password.email'));
+
+    $response->assertStatus(200);
+});
+
+test('reset password link can be requested', function () {
+    Notification::fake();
+
+    /** @var User $user */
+    $user = User::factory()->create();
+
+    $this->post(route('password.email'), ['email' => $user->email]);
+
+    Notification::assertSentTo($user, ResetPassword::class);
+});
+
+test('reset password screen can be rendered', function () {
+    Notification::fake();
+
+    /** @var User $user */
+    $user = User::factory()->create();
+
+    $this->post('/forgot-password', ['email' => $user->email]);
+
+    Notification::assertSentTo($user, ResetPassword::class, function ($notification) {
+        $response = $this->get(route('password.reset', ['token' => $notification->token]));
 
         $response->assertStatus(200);
-    }
 
-    /**
-     * @throws Exception
-     */
-    public function test_reset_password_link_can_be_requested(): void
-    {
-        Notification::fake();
+        return true;
+    });
+});
 
-        /** @var User $user */
-        $user = User::factory()->create();
+test('password can be reset with valid token', function () {
+    Notification::fake();
 
-        $this->post(route('password.email'), ['email' => $user->email]);
+    /** @var User $user */
+    $user = User::factory()->create();
 
-        Notification::assertSentTo($user, ResetPassword::class);
-    }
+    $this->post('/forgot-password', ['email' => $user->email]);
 
-    /**
-     * @throws Exception
-     */
-    public function test_reset_password_screen_can_be_rendered(): void
-    {
-        Notification::fake();
+    Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user) {
+        $response = $this->post(route('password.update'), [
+            'token' => $notification->token,
+            'email' => $user->email,
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
 
-        /** @var User $user */
-        $user = User::factory()->create();
+        $response
+            ->assertSessionHasNoErrors()
+            ->assertRedirect(route('login'));
 
-        $this->post('/forgot-password', ['email' => $user->email]);
-
-        Notification::assertSentTo($user, ResetPassword::class, function ($notification) {
-            $response = $this->get(route('password.reset', ['token' => $notification->token]));
-
-            $response->assertStatus(200);
-
-            return true;
-        });
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function test_password_can_be_reset_with_valid_token(): void
-    {
-        Notification::fake();
-
-        /** @var User $user */
-        $user = User::factory()->create();
-
-        $this->post('/forgot-password', ['email' => $user->email]);
-
-        Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user) {
-            $response = $this->post(route('password.update'), [
-                'token' => $notification->token,
-                'email' => $user->email,
-                'password' => 'password',
-                'password_confirmation' => 'password',
-            ]);
-
-            $response
-                ->assertSessionHasNoErrors()
-                ->assertRedirect(route('login'));
-
-            return true;
-        });
-    }
-}
+        return true;
+    });
+});

--- a/tests/Feature/Auth/TwoFactorTest.php
+++ b/tests/Feature/Auth/TwoFactorTest.php
@@ -1,121 +1,100 @@
 <?php
 
-namespace Tests\Feature\Auth;
-
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use PragmaRX\Google2FA\Exceptions\IncompatibleWithGoogleAuthenticatorException;
-use PragmaRX\Google2FA\Exceptions\InvalidCharactersException;
-use PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException;
 use PragmaRX\Google2FA\Google2FA;
-use Tests\TestCase;
 
-class TwoFactorTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    /**
-     * @throws IncompatibleWithGoogleAuthenticatorException
-     * @throws InvalidCharactersException
-     * @throws SecretKeyTooShortException
-     */
-    public function test_user_can_enable_two_factor_authentication(): void
-    {
-        /** @var User $user */
-        $user = User::factory()->create();
-        $user->ensureHasDefaultProject();
+test('user can enable two factor authentication', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    $user->ensureHasDefaultProject();
 
-        $this->actingAs($user);
+    $this->actingAs($user);
 
-        // Enable two-factor authentication
-        $this->post(route('two-factor.enable'))
-            ->assertSessionDoesntHaveErrors();
+    // Enable two-factor authentication
+    $this->post(route('two-factor.enable'))
+        ->assertSessionDoesntHaveErrors();
 
-        $user = $user->refresh();
+    $user = $user->refresh();
 
-        $this->assertNotNull($user->two_factor_secret);
-        $this->assertNull($user->two_factor_confirmed_at);
+    expect($user->two_factor_secret)->not->toBeNull();
+    expect($user->two_factor_confirmed_at)->toBeNull();
 
-        // Generate a valid TOTP code from the secret
-        $google2fa = new Google2FA;
-        $validCode = $google2fa->getCurrentOtp(decrypt($user->two_factor_secret));
+    // Generate a valid TOTP code from the secret
+    $google2fa = new Google2FA;
+    $validCode = $google2fa->getCurrentOtp(decrypt($user->two_factor_secret));
 
-        // Submit the code to confirm 2FA
-        $this->post(route('two-factor.confirm'), [
-            'code' => $validCode,
-        ])->assertSessionDoesntHaveErrors();
+    // Submit the code to confirm 2FA
+    $this->post(route('two-factor.confirm'), [
+        'code' => $validCode,
+    ])->assertSessionDoesntHaveErrors();
 
-        // Assert the user is now confirmed
-        $this->assertNotNull($user->refresh()->two_factor_confirmed_at);
-    }
+    // Assert the user is now confirmed
+    expect($user->refresh()->two_factor_confirmed_at)->not->toBeNull();
+});
 
-    public function test_user_can_disable_two_factor_authentication(): void
-    {
-        /** @var User $user */
-        $user = User::factory()->create();
-        $user->ensureHasDefaultProject();
+test('user can disable two factor authentication', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    $user->ensureHasDefaultProject();
 
-        $this->actingAs($user);
+    $this->actingAs($user);
 
-        // First, enable 2FA
-        $this->post(route('two-factor.enable'))
-            ->assertSessionDoesntHaveErrors();
+    // First, enable 2FA
+    $this->post(route('two-factor.enable'))
+        ->assertSessionDoesntHaveErrors();
 
-        $user = $user->refresh();
+    $user = $user->refresh();
 
-        // Ensure 2FA secret is set
-        $this->assertNotNull($user->two_factor_secret);
+    // Ensure 2FA secret is set
+    expect($user->two_factor_secret)->not->toBeNull();
 
-        // Now disable 2FA
-        $this->delete(route('two-factor.disable'))
-            ->assertSessionDoesntHaveErrors();
+    // Now disable 2FA
+    $this->delete(route('two-factor.disable'))
+        ->assertSessionDoesntHaveErrors();
 
-        $user = $user->refresh();
+    $user = $user->refresh();
 
-        // Ensure 2FA is fully removed
-        $this->assertNull($user->two_factor_secret);
-        $this->assertNull($user->two_factor_confirmed_at);
-        $this->assertEmpty($user->two_factor_recovery_codes ?? []);
-    }
+    // Ensure 2FA is fully removed
+    expect($user->two_factor_secret)->toBeNull();
+    expect($user->two_factor_confirmed_at)->toBeNull();
+    expect($user->two_factor_recovery_codes ?? [])->toBeEmpty();
+});
 
-    /**
-     * @throws IncompatibleWithGoogleAuthenticatorException
-     * @throws InvalidCharactersException
-     * @throws SecretKeyTooShortException
-     */
-    public function test_see_two_factor_challenge(): void
-    {
-        /** @var User $user */
-        $user = User::factory()->create([
-            'password' => bcrypt('password'),
-            'two_factor_secret' => encrypt((new Google2FA)->generateSecretKey()),
-            'two_factor_confirmed_at' => now(),
-        ]);
-        $user->ensureHasDefaultProject();
+test('see two factor challenge', function () {
+    /** @var User $user */
+    $user = User::factory()->create([
+        'password' => bcrypt('password'),
+        'two_factor_secret' => encrypt((new Google2FA)->generateSecretKey()),
+        'two_factor_confirmed_at' => now(),
+    ]);
+    $user->ensureHasDefaultProject();
 
-        $response = $this->post(route('login.store'), [
-            'email' => $user->email,
-            'password' => 'password',
-        ]);
+    $response = $this->post(route('login.store'), [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
 
-        // Should redirect to the two-factor challenge page
-        $response->assertRedirect(route('two-factor.login'));
+    // Should redirect to the two-factor challenge page
+    $response->assertRedirect(route('two-factor.login'));
 
-        // Simulate entering 2FA code
-        $loginId = session('login.id');
-        $this->assertNotNull($loginId);
+    // Simulate entering 2FA code
+    $loginId = session('login.id');
+    expect($loginId)->not->toBeNull();
 
-        $user->refresh();
-        $code = (new Google2FA)->getCurrentOtp(decrypt($user->two_factor_secret));
+    $user->refresh();
+    $code = (new Google2FA)->getCurrentOtp(decrypt($user->two_factor_secret));
 
-        $response = $this->withSession([
-            'login.id' => $loginId,
-        ])->post(route('two-factor.login.store'), [
-            'code' => $code,
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $response = $this->withSession([
+        'login.id' => $loginId,
+    ])->post(route('two-factor.login.store'), [
+        'code' => $code,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $response->assertRedirect(route('servers')); // or your expected redirect route
-        $this->assertAuthenticatedAs($user);
-    }
-}
+    $response->assertRedirect(route('servers'));
+    // or your expected redirect route
+    $this->assertAuthenticatedAs($user);
+});

--- a/tests/Feature/Auth/TwoFactorTest.php
+++ b/tests/Feature/Auth/TwoFactorTest.php
@@ -13,7 +13,6 @@ test('user can enable two factor authentication', function () {
 
     $this->actingAs($user);
 
-    // Enable two-factor authentication
     $this->post(route('two-factor.enable'))
         ->assertSessionDoesntHaveErrors();
 
@@ -22,16 +21,13 @@ test('user can enable two factor authentication', function () {
     expect($user->two_factor_secret)->not->toBeNull();
     expect($user->two_factor_confirmed_at)->toBeNull();
 
-    // Generate a valid TOTP code from the secret
     $google2fa = new Google2FA;
     $validCode = $google2fa->getCurrentOtp(decrypt($user->two_factor_secret));
 
-    // Submit the code to confirm 2FA
     $this->post(route('two-factor.confirm'), [
         'code' => $validCode,
     ])->assertSessionDoesntHaveErrors();
 
-    // Assert the user is now confirmed
     expect($user->refresh()->two_factor_confirmed_at)->not->toBeNull();
 });
 
@@ -42,22 +38,18 @@ test('user can disable two factor authentication', function () {
 
     $this->actingAs($user);
 
-    // First, enable 2FA
     $this->post(route('two-factor.enable'))
         ->assertSessionDoesntHaveErrors();
 
     $user = $user->refresh();
 
-    // Ensure 2FA secret is set
     expect($user->two_factor_secret)->not->toBeNull();
 
-    // Now disable 2FA
     $this->delete(route('two-factor.disable'))
         ->assertSessionDoesntHaveErrors();
 
     $user = $user->refresh();
 
-    // Ensure 2FA is fully removed
     expect($user->two_factor_secret)->toBeNull();
     expect($user->two_factor_confirmed_at)->toBeNull();
     expect($user->two_factor_recovery_codes ?? [])->toBeEmpty();
@@ -77,10 +69,8 @@ test('see two factor challenge', function () {
         'password' => 'password',
     ]);
 
-    // Should redirect to the two-factor challenge page
     $response->assertRedirect(route('two-factor.login'));
 
-    // Simulate entering 2FA code
     $loginId = session('login.id');
     expect($loginId)->not->toBeNull();
 
@@ -95,6 +85,5 @@ test('see two factor challenge', function () {
         ->assertSessionDoesntHaveErrors();
 
     $response->assertRedirect(route('servers'));
-    // or your expected redirect route
     $this->assertAuthenticatedAs($user);
 });

--- a/tests/Feature/BackupTest.php
+++ b/tests/Feature/BackupTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\Backup\ManageBackupFile;
 use App\Actions\Backup\RestoreBackup;
 use App\Actions\Backup\RunBackup;
@@ -19,7 +17,6 @@ use App\Models\Database;
 use App\Models\Project;
 use App\Models\Server;
 use App\Models\StorageProvider;
-use App\Models\User;
 use App\StorageProviders\Local;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
@@ -27,1129 +24,1053 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Testing\TestResponse;
 use Illuminate\Validation\ValidationException;
 use Inertia\Testing\AssertableInertia;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class BackupTest extends TestCase
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Additional setup for file restore tests
+    $this->storageProvider = StorageProvider::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+    $this->backup = Backup::factory()->create([
+        'type' => BackupType::FILE,
+        'server_id' => $this->server->id,
+        'storage_id' => $this->storageProvider->id,
+        'path' => '/home/vito/x.com',
+        'status' => null,
+    ]);
+    $this->backupFile = BackupFile::factory()->create([
+        'backup_id' => $this->backup->id,
+        'status' => BackupFileStatus::CREATED,
+    ]);
+});
+
+test('backup model can have path field', function () {
+    $server = Server::factory()->create();
+    $storage = StorageProvider::factory()->create();
+
+    $backup = Backup::create([
+        'type' => BackupType::FILE,
+        'server_id' => $server->id,
+        'storage_id' => $storage->id,
+        'path' => '/var/www/html',
+        'interval' => '0 0 * * *',
+        'keep_backups' => 5,
+        'status' => null,
+    ]);
+
+    expect($backup)->toBeInstanceOf(Backup::class);
+    expect($backup->type)->toEqual(BackupType::FILE);
+    expect($backup->path)->toEqual('/var/www/html');
+    expect($backup->database_id)->toBeNull();
+    expect($backup->storage_id)->toEqual($storage->id);
+});
+
+test('backup model can have database field', function () {
+    $server = Server::factory()->create();
+    $storage = StorageProvider::factory()->create();
+    $database = $server->databases()->create([
+        'name' => 'test_db',
+        'status' => 'ready',
+    ]);
+
+    $backup = Backup::create([
+        'type' => BackupType::DATABASE,
+        'server_id' => $server->id,
+        'storage_id' => $storage->id,
+        'database_id' => $database->id,
+        'interval' => '0 0 * * *',
+        'keep_backups' => 5,
+        'status' => null,
+    ]);
+
+    expect($backup)->toBeInstanceOf(Backup::class);
+    expect($backup->type)->toEqual(BackupType::DATABASE);
+    expect($backup->database_id)->toEqual($database->id);
+    expect($backup->path)->toBeNull();
+    expect($backup->storage_id)->toEqual($storage->id);
+});
+
+test('create database backup', function (string $db, string $version) {
+    SSH::fake();
+    Http::fake([
+        '*oauth2/token' => Http::response([
+            'access_token' => 'fresh-access',
+            'expires_in' => 14400,
+        ]),
+        '*' => Http::response([], 200),
+    ]);
+
+    vitoPestFeatureBackupTestSetupDatabase($db, $version);
+
+    $this->actingAs($this->user);
+
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $storage = StorageProvider::factory()->dropbox()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->post(route('backups.store', [
+        'server' => $this->server,
+    ]), [
+        'type' => 'database',
+        'database' => $database->id,
+        'storage' => $storage->id,
+        'interval' => '0 * * * *',
+        'keep' => '10',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('backups', [
+        'status' => null,
+    ]);
+
+    $this->assertDatabaseHas('backup_files', [
+        'status' => BackupFileStatus::CREATED,
+    ]);
+})->with('data');
+
+test('create custom interval database backup', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $storage = StorageProvider::factory()->dropbox()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->post(route('backups.store', ['server' => $this->server]), [
+        'type' => 'database',
+        'database' => $database->id,
+        'storage' => $storage->id,
+        'interval' => 'custom',
+        'custom_interval' => '* * * * *',
+        'keep' => '10',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('backups', [
+        'status' => null,
+    ]);
+});
+
+test('see database backups list', function () {
+    $this->actingAs($this->user);
+
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $storage = StorageProvider::factory()->dropbox()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Backup::factory()->create([
+        'server_id' => $this->server->id,
+        'database_id' => $database->id,
+        'storage_id' => $storage->id,
+    ]);
+
+    $this->get(route('backups', ['server' => $this->server]))
+        ->assertSuccessful();
+});
+
+test('update database backup', function () {
+    $this->actingAs($this->user);
+
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $storage = StorageProvider::factory()->dropbox()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $backup = Backup::factory()->create([
+        'server_id' => $this->server->id,
+        'database_id' => $database->id,
+        'storage_id' => $storage->id,
+        'interval' => '0 * * * *',
+        'keep_backups' => 5,
+    ]);
+
+    $this->patch(route('backups.update', [
+        'server' => $this->server,
+        'backup' => $backup,
+    ]), [
+        'interval' => '0 0 * * *',
+        'keep' => 10,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('backups', [
+        'id' => $backup->id,
+        'interval' => '0 0 * * *',
+        'keep_backups' => 10,
+    ]);
+});
+
+test('delete database backup', function (string $db, string $version) {
+    vitoPestFeatureBackupTestSetupDatabase($db, $version);
+
+    $this->actingAs($this->user);
+
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $storage = StorageProvider::factory()->dropbox()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $backup = Backup::factory()->create([
+        'server_id' => $this->server->id,
+        'database_id' => $database->id,
+        'storage_id' => $storage->id,
+    ]);
+
+    $this->delete(route('backups.destroy', ['server' => $this->server, 'backup' => $backup]))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseMissing('backups', [
+        'id' => $backup->id,
+    ]);
+})->with('data');
+
+test('file restore validation requires path', function () {
+    $this->expectException(ValidationException::class);
+    $this->expectExceptionMessage('The path field is required.');
+
+    app(RestoreBackup::class)->restore($this->backupFile, []);
+});
+
+test('file restore validation path must be string', function () {
+    $this->expectException(ValidationException::class);
+    $this->expectExceptionMessage('The path field must be a string.');
+
+    app(RestoreBackup::class)->restore($this->backupFile, [
+        'path' => 123,
+    ]);
+});
+
+test('file restore validation path must not be empty', function () {
+    $this->expectException(ValidationException::class);
+    $this->expectExceptionMessage('The path field is required.');
+
+    app(RestoreBackup::class)->restore($this->backupFile, [
+        'path' => '',
+    ]);
+});
+
+test('file restore sets correct status and restored to', function () {
+    Bus::fake();
+
+    app(RestoreBackup::class)->restore($this->backupFile, [
+        'path' => '/home/vito/restored-x.com',
+        'owner' => 'vito:vito',
+        'permissions' => '755',
+    ]);
+
+    $this->backupFile->refresh();
+
+    expect($this->backupFile->status)->toEqual(BackupFileStatus::RESTORING);
+    expect($this->backupFile->restored_to)->toEqual('/home/vito/restored-x.com');
+});
+
+test('file restore dispatches job', function () {
+    Bus::fake();
+
+    app(RestoreBackup::class)->restore($this->backupFile, [
+        'path' => '/home/vito/restored-x.com',
+        'owner' => 'vito:vito',
+        'permissions' => '755',
+    ]);
+
+    // The job dispatch is tested by checking that the status is set correctly
+    // and the restored_to field is populated
+    $this->backupFile->refresh();
+    expect($this->backupFile->status)->toEqual(BackupFileStatus::RESTORING);
+    expect($this->backupFile->restored_to)->toEqual('/home/vito/restored-x.com');
+});
+
+test('database restore validation requires database', function () {
+    // Create a database backup instead
+    $databaseBackup = Backup::factory()->create([
+        'type' => BackupType::DATABASE,
+        'server_id' => $this->server->id,
+        'storage_id' => $this->storageProvider->id,
+        'database_id' => 1,
+        'status' => null,
+    ]);
+    $databaseBackupFile = BackupFile::factory()->create([
+        'backup_id' => $databaseBackup->id,
+        'status' => BackupFileStatus::CREATED,
+    ]);
+
+    $this->expectException(ValidationException::class);
+    $this->expectExceptionMessage('The database field is required.');
+
+    app(RestoreBackup::class)->restore($databaseBackupFile, []);
+});
+
+test('database restore validation database must exist', function () {
+    // Create a database backup instead
+    $databaseBackup = Backup::factory()->create([
+        'type' => BackupType::DATABASE,
+        'server_id' => $this->server->id,
+        'storage_id' => $this->storageProvider->id,
+        'database_id' => 1,
+        'status' => null,
+    ]);
+    $databaseBackupFile = BackupFile::factory()->create([
+        'backup_id' => $databaseBackup->id,
+        'status' => BackupFileStatus::CREATED,
+    ]);
+
+    $this->expectException(ValidationException::class);
+    $this->expectExceptionMessage('The selected database is invalid.');
+
+    app(RestoreBackup::class)->restore($databaseBackupFile, [
+        'database' => 999, // Non-existent database
+    ]);
+});
+
+test('restore database backup', function (string $db, string $version) {
+    Http::fake([
+        '*oauth2/token' => Http::response([
+            'access_token' => 'fresh-access',
+            'expires_in' => 14400,
+        ]),
+        '*' => Http::response([], 200),
+    ]);
+    SSH::fake();
+
+    vitoPestFeatureBackupTestSetupDatabase($db, $version);
+
+    $this->actingAs($this->user);
+
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $storage = StorageProvider::factory()->dropbox()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $backup = Backup::factory()->create([
+        'server_id' => $this->server->id,
+        'database_id' => $database->id,
+        'storage_id' => $storage->id,
+    ]);
+
+    $backupFile = app(RunBackup::class)->run($backup);
+
+    $this->post(route('backup-files.restore', [
+        'server' => $this->server,
+        'backup' => $backup,
+        'backupFile' => $backupFile,
+    ]), [
+        'database' => $database->id,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('backup_files', [
+        'id' => $backupFile->id,
+        'status' => BackupFileStatus::RESTORED,
+    ]);
+})->with('data');
+
+test('database backup and restore are streamed', function (string $db, string $version) {
+    Http::fake([
+        '*oauth2/token' => Http::response([
+            'access_token' => 'fresh-access',
+            'expires_in' => 14400,
+        ]),
+        '*' => Http::response([], 200),
+    ]);
+    SSH::fake();
+
+    vitoPestFeatureBackupTestSetupDatabase($db, $version);
+
+    $this->actingAs($this->user);
+
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $storage = StorageProvider::factory()->dropbox()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $backup = Backup::factory()->create([
+        'server_id' => $this->server->id,
+        'database_id' => $database->id,
+        'storage_id' => $storage->id,
+    ]);
+
+    $backupFile = app(RunBackup::class)->run($backup);
+
+    SSH::assertExecutedContains('| ');
+    SSH::assertExecutedContains('gzip');
+    SSH::assertNotExecutedContains('unzip');
+
+    $this->post(route('backup-files.restore', [
+        'server' => $this->server,
+        'backup' => $backup,
+        'backupFile' => $backupFile,
+    ]), [
+        'database' => $database->id,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    SSH::assertExecutedContains('gunzip -c');
+})->with('data');
+
+test('database backup captures compressed size', function () {
+    Http::fake();
+    SSH::fake('12345');
+
+    vitoPestFeatureBackupTestSetupDatabase('mysql', '8.4');
+
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $storage = StorageProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Local::id(),
+        'credentials' => ['path' => '/home/vito/backups'],
+    ]);
+
+    $backup = Backup::factory()->create([
+        'server_id' => $this->server->id,
+        'database_id' => $database->id,
+        'storage_id' => $storage->id,
+    ]);
+
+    $backupFile = app(RunBackup::class)->run($backup);
+
+    $this->assertDatabaseHas('backup_files', [
+        'id' => $backupFile->id,
+        'status' => BackupFileStatus::CREATED,
+        'size' => 12345,
+    ]);
+});
+
+test('database backup file uses sql gz extension', function () {
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $storage = StorageProvider::factory()->dropbox()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $backup = Backup::factory()->create([
+        'type' => BackupType::DATABASE,
+        'server_id' => $this->server->id,
+        'database_id' => $database->id,
+        'storage_id' => $storage->id,
+    ]);
+
+    $file = BackupFile::factory()->create([
+        'backup_id' => $backup->id,
+        'name' => 'db-20260101000000',
+    ]);
+
+    expect($file->tempPath())->toEndWith('.sql.gz');
+    expect($file->path())->toEndWith('.sql.gz');
+});
+
+test('file backup file uses tar gz extension', function () {
+    expect($this->backupFile->tempPath())->toEndWith('.tar.gz');
+});
+
+test('can disable backup', function () {
+    $this->actingAs($this->user);
+
+    $backup = Backup::factory()->create([
+        'type' => BackupType::FILE,
+        'server_id' => $this->server->id,
+        'storage_id' => $this->storageProvider->id,
+        'path' => '/home/vito/x.com',
+        'status' => null,
+        'enabled' => true,
+    ]);
+
+    $this->post(route('backups.disable', ['server' => $this->server, 'backup' => $backup]))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('backups', [
+        'id' => $backup->id,
+        'enabled' => false,
+        'status' => null,
+    ]);
+});
+
+test('can enable backup', function () {
+    $this->actingAs($this->user);
+
+    $backup = Backup::factory()->create([
+        'type' => BackupType::FILE,
+        'server_id' => $this->server->id,
+        'storage_id' => $this->storageProvider->id,
+        'path' => '/home/vito/x.com',
+        'status' => null,
+        'enabled' => false,
+    ]);
+
+    $this->post(route('backups.enable', ['server' => $this->server, 'backup' => $backup]))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('backups', [
+        'id' => $backup->id,
+        'enabled' => true,
+        'status' => null,
+    ]);
+});
+
+test('cannot enable a backup being deleted', function () {
+    $this->actingAs($this->user);
+
+    $backup = Backup::factory()->create([
+        'type' => BackupType::FILE,
+        'server_id' => $this->server->id,
+        'storage_id' => $this->storageProvider->id,
+        'path' => '/home/vito/x.com',
+        'status' => BackupStatus::DELETING,
+        'enabled' => false,
+    ]);
+
+    $this->post(route('backups.enable', ['server' => $this->server, 'backup' => $backup]))
+        ->assertSessionHasErrors('backup');
+
+    $this->assertDatabaseHas('backups', [
+        'id' => $backup->id,
+        'enabled' => false,
+        'status' => BackupStatus::DELETING->value,
+    ]);
+});
+
+test('delete orphaned backup file hard deletes without dispatching job', function () {
+    Bus::fake();
+
+    $backup = Backup::factory()->create([
+        'type' => BackupType::DATABASE,
+        'server_id' => 999999,
+        'storage_id' => $this->storageProvider->id,
+        'status' => null,
+    ]);
+    $file = BackupFile::factory()->create([
+        'backup_id' => $backup->id,
+        'status' => BackupFileStatus::CREATED,
+    ]);
+
+    app(ManageBackupFile::class)->delete($file);
+
+    $this->assertDatabaseMissing('backup_files', ['id' => $file->id]);
+    Bus::assertNotDispatched(DeleteFileJob::class);
+});
+
+test('see global backups list scoped to current project', function () {
+    $this->actingAs($this->user);
+
+    $secondServer = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+    ]);
+    $secondBackup = Backup::factory()->create([
+        'type' => BackupType::FILE,
+        'server_id' => $secondServer->id,
+        'storage_id' => $this->storageProvider->id,
+        'path' => '/home/vito/y.com',
+        'status' => null,
+    ]);
+
+    $otherProject = Project::factory()->create();
+    $otherServer = Server::factory()->create([
+        'project_id' => $otherProject->id,
+        'user_id' => $this->user->id,
+    ]);
+    $otherBackup = Backup::factory()->create([
+        'type' => BackupType::FILE,
+        'server_id' => $otherServer->id,
+        'storage_id' => $this->storageProvider->id,
+        'path' => '/home/vito/z.com',
+        'status' => null,
+    ]);
+
+    $this->get(route('backups.all'))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('backups/index')
+            ->where('backups.data', function ($rows) use ($secondBackup, $otherBackup): bool {
+                $ids = collect($rows)->pluck('id');
+
+                return $ids->contains($this->backup->id)
+                    && $ids->contains($secondBackup->id)
+                    && ! $ids->contains($otherBackup->id);
+            })
+        );
+});
+
+test('per server backups list is filtered to server', function () {
+    $this->actingAs($this->user);
+
+    $secondServer = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+    ]);
+    $secondBackup = Backup::factory()->create([
+        'type' => BackupType::FILE,
+        'server_id' => $secondServer->id,
+        'storage_id' => $this->storageProvider->id,
+        'path' => '/home/vito/y.com',
+        'status' => null,
+    ]);
+
+    $this->get(route('backups', ['server' => $secondServer]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('backups/index')
+            ->where('backups.data', function ($rows) use ($secondBackup): bool {
+                $ids = collect($rows)->pluck('id');
+
+                return $ids->contains($secondBackup->id) && ! $ids->contains($this->backup->id);
+            })
+        );
+});
+
+test('backup run captures database engine and version', function () {
+    Http::fake();
+    SSH::fake('8.0.36');
+
+    vitoPestFeatureBackupTestSetupDatabase('mysql', '8.4');
+
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $storage = StorageProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Local::id(),
+        'credentials' => ['path' => '/home/vito/backups'],
+    ]);
+
+    $backup = Backup::factory()->create([
+        'server_id' => $this->server->id,
+        'database_id' => $database->id,
+        'storage_id' => $storage->id,
+    ]);
+
+    $backupFile = app(RunBackup::class)->run($backup);
+
+    $this->assertDatabaseHas('backup_files', [
+        'id' => $backupFile->id,
+        'status' => BackupFileStatus::CREATED,
+        'database_engine' => 'mysql',
+        'database_version' => '8.0.36',
+    ]);
+});
+
+test('backup run succeeds with null version when version query yields nothing', function () {
+    Http::fake();
+    SSH::fake();
+
+    vitoPestFeatureBackupTestSetupDatabase('mysql', '8.4');
+
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $storage = StorageProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Local::id(),
+        'credentials' => ['path' => '/home/vito/backups'],
+    ]);
+
+    $backup = Backup::factory()->create([
+        'server_id' => $this->server->id,
+        'database_id' => $database->id,
+        'storage_id' => $storage->id,
+    ]);
+
+    $backupFile = app(RunBackup::class)->run($backup);
+
+    $this->assertDatabaseHas('backup_files', [
+        'id' => $backupFile->id,
+        'status' => BackupFileStatus::CREATED,
+        'database_engine' => 'mysql',
+        'database_version' => null,
+    ]);
+});
+
+test('restore to database on same server without metadata is allowed', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile();
+    $targetDatabase = Database::factory()->create(['server_id' => $this->server->id]);
+
+    vitoPestFeatureBackupTestPostRestore($backupFile, $targetDatabase)
+        ->assertSessionDoesntHaveErrors();
+
+    Bus::assertDispatched(RestoreDatabaseJob::class);
+});
+
+test('restore to compatible server is allowed', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
+    $targetServer = vitoPestFeatureBackupTestCreateTargetServer('mysql', '8.4');
+    $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
+
+    vitoPestFeatureBackupTestPostRestore($backupFile, $targetDatabase)
+        ->assertSessionDoesntHaveErrors();
+
+    Bus::assertDispatched(RestoreDatabaseJob::class);
+
+    expect($backupFile->refresh()->restored_to)->toEqual("{$targetDatabase->name} ({$targetServer->name})");
+});
+
+test('restore to server with lower version is rejected', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
+    $targetServer = vitoPestFeatureBackupTestCreateTargetServer('mysql', '5.7');
+    $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
+
+    vitoPestFeatureBackupTestPostRestore($backupFile, $targetDatabase)
+        ->assertSessionHasErrors('database');
+
+    Bus::assertNotDispatched(RestoreDatabaseJob::class);
+});
+
+test('restore to server with different engine is rejected', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
+    $targetServer = vitoPestFeatureBackupTestCreateTargetServer('mariadb', '11.4');
+    $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
+
+    vitoPestFeatureBackupTestPostRestore($backupFile, $targetDatabase)
+        ->assertSessionHasErrors('database');
+
+    Bus::assertNotDispatched(RestoreDatabaseJob::class);
+});
+
+test('restore without metadata to another server is rejected', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile();
+    $targetServer = vitoPestFeatureBackupTestCreateTargetServer('mysql', '8.4');
+    $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
+
+    vitoPestFeatureBackupTestPostRestore($backupFile, $targetDatabase)
+        ->assertSessionHasErrors('database');
+
+    Bus::assertNotDispatched(RestoreDatabaseJob::class);
+});
+
+test('restore from local storage to another server is rejected', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $localStorage = StorageProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Local::id(),
+        'credentials' => ['path' => '/home/vito/backups'],
+    ]);
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36'], $localStorage);
+    $targetServer = vitoPestFeatureBackupTestCreateTargetServer('mysql', '8.4');
+    $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
+
+    vitoPestFeatureBackupTestPostRestore($backupFile, $targetDatabase)
+        ->assertSessionHasErrors('database');
+
+    Bus::assertNotDispatched(RestoreDatabaseJob::class);
+});
+
+test('restore to database in another project is rejected', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
+    $otherProject = Project::factory()->create();
+    $targetServer = vitoPestFeatureBackupTestCreateTargetServer('mysql', '8.4', $otherProject->id);
+    $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
+
+    vitoPestFeatureBackupTestPostRestore($backupFile, $targetDatabase)
+        ->assertSessionHasErrors('database');
+
+    Bus::assertNotDispatched(RestoreDatabaseJob::class);
+});
+
+test('restore to not ready server is rejected', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
+    $targetServer = vitoPestFeatureBackupTestCreateTargetServer('mysql', '8.4');
+    $targetServer->update(['status' => ServerStatus::INSTALLING]);
+    $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
+
+    vitoPestFeatureBackupTestPostRestore($backupFile, $targetDatabase)
+        ->assertSessionHasErrors('database');
+
+    Bus::assertNotDispatched(RestoreDatabaseJob::class);
+});
+
+test('restore to not ready database is rejected', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
+    $targetServer = vitoPestFeatureBackupTestCreateTargetServer('mysql', '8.4');
+    $targetDatabase = Database::factory()->create([
+        'server_id' => $targetServer->id,
+        'status' => DatabaseStatus::DELETING,
+    ]);
+
+    vitoPestFeatureBackupTestPostRestore($backupFile, $targetDatabase)
+        ->assertSessionHasErrors('database');
+
+    Bus::assertNotDispatched(RestoreDatabaseJob::class);
+});
+
+test('restore to soft deleted database is rejected', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
+    $targetServer = vitoPestFeatureBackupTestCreateTargetServer('mysql', '8.4');
+    $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
+    $targetDatabase->delete();
+
+    vitoPestFeatureBackupTestPostRestore($backupFile, $targetDatabase)
+        ->assertSessionHasErrors('database');
+
+    Bus::assertNotDispatched(RestoreDatabaseJob::class);
+});
+
+test('restore is rejected when target version cannot be determined', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
+    $targetServer = vitoPestFeatureBackupTestCreateTargetServer('mysql', 'latest');
+    $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
+
+    vitoPestFeatureBackupTestPostRestore($backupFile, $targetDatabase)
+        ->assertSessionHasErrors('database');
+
+    Bus::assertNotDispatched(RestoreDatabaseJob::class);
+});
+
+test('restore allows less precise target version', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.39']);
+    $targetServer = vitoPestFeatureBackupTestCreateTargetServer('mysql', '8.0');
+    $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
+
+    vitoPestFeatureBackupTestPostRestore($backupFile, $targetDatabase)
+        ->assertSessionDoesntHaveErrors();
+
+    Bus::assertDispatched(RestoreDatabaseJob::class);
+});
+
+test('restore with foreign backup file returns 404', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile();
+    $foreignFile = vitoPestFeatureBackupTestDatabaseBackupFile();
+    $targetDatabase = Database::factory()->create(['server_id' => $this->server->id]);
+
+    $this->post(route('backup-files.restore', [
+        'server' => $this->server,
+        'backup' => $backupFile->backup,
+        'backupFile' => $foreignFile,
+    ]), [
+        'database' => $targetDatabase->id,
+    ])->assertNotFound();
+
+    Bus::assertNotDispatched(RestoreDatabaseJob::class);
+});
+
+test('delete with foreign backup file returns 404', function () {
+    $this->actingAs($this->user);
+
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile();
+    $foreignFile = vitoPestFeatureBackupTestDatabaseBackupFile();
+
+    $this->delete(route('backup-files.destroy', [
+        'server' => $this->server,
+        'backup' => $backupFile->backup,
+        'backupFile' => $foreignFile,
+    ]))->assertNotFound();
+
+    $this->assertDatabaseHas('backup_files', [
+        'id' => $foreignFile->id,
+        'status' => BackupFileStatus::CREATED,
+    ]);
+});
+
+test('restore backup on another server', function () {
+    Http::fake([
+        '*oauth2/token' => Http::response([
+            'access_token' => 'fresh-access',
+            'expires_in' => 14400,
+        ]),
+        '*' => Http::response([], 200),
+    ]);
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $backupFile = vitoPestFeatureBackupTestDatabaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
+    $targetServer = vitoPestFeatureBackupTestCreateTargetServer('mysql', '8.4');
+    $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
+
+    vitoPestFeatureBackupTestPostRestore($backupFile, $targetDatabase)
+        ->assertSessionDoesntHaveErrors();
+
+    $backupFile->refresh();
+
+    expect($backupFile->status)->toEqual(BackupFileStatus::RESTORED);
+    expect($backupFile->restored_to)->toEqual("{$targetDatabase->name} ({$targetServer->name})");
+});
+
+test('temp path uses target server ssh user', function () {
+    $targetServer = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'ssh_user' => 'other-user',
+    ]);
+
+    expect($this->backupFile->tempPath())->toStartWith('/home/vito/');
+    expect($this->backupFile->tempPath($targetServer))->toStartWith('/home/other-user/');
+});
+
+test('version gte', function (string $target, string $source, bool $expected) {
+    expect(BackupFile::versionGte($target, $source))->toBe($expected);
+})->with('versionComparisons');
+
+/**
+ * @return array<int, array<int, string|bool>>
+ */
+dataset('versionComparisons', function () {
+    return [
+        ['8.4', '8.0.36', true],
+        ['8.0', '8.0.39', true],
+        ['16', '16.4', true],
+        ['15', '16.1', false],
+        ['5.7', '8.0.36', false],
+        ['10.11.6', '10.11.6', true],
+        ['11.4', '10.11.6', true],
+    ];
+});
+
+test('normalize version', function () {
+    expect(BackupFile::normalizeVersion("8.0.42\n0.24.04"))->toBe('8.0.42');
+    expect(BackupFile::normalizeVersion('16'))->toBe('16');
+    expect(BackupFile::normalizeVersion('10.11.6-MariaDB'))->toBe('10.11.6');
+    expect(BackupFile::normalizeVersion('latest'))->toBeNull();
+    expect(BackupFile::normalizeVersion(''))->toBeNull();
+    expect(BackupFile::normalizeVersion(null))->toBeNull();
+});
+
+/**
+ * @param  array<string, mixed>  $fileAttributes
+ */
+function vitoPestFeatureBackupTestDatabaseBackupFile(array $fileAttributes = [], ?StorageProvider $storage = null): BackupFile
 {
-    use RefreshDatabase;
-
-    protected User $user;
-
-    protected Server $server;
-
-    protected StorageProvider $storageProvider;
-
-    protected Backup $backup;
-
-    protected BackupFile $backupFile;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        // Additional setup for file restore tests
-        $this->storageProvider = StorageProvider::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-        $this->backup = Backup::factory()->create([
-            'type' => BackupType::FILE,
-            'server_id' => $this->server->id,
-            'storage_id' => $this->storageProvider->id,
-            'path' => '/home/vito/x.com',
-            'status' => null,
-        ]);
-        $this->backupFile = BackupFile::factory()->create([
-            'backup_id' => $this->backup->id,
-            'status' => BackupFileStatus::CREATED,
-        ]);
-    }
-
-    public function test_backup_model_can_have_path_field(): void
-    {
-        $server = Server::factory()->create();
-        $storage = StorageProvider::factory()->create();
-
-        $backup = Backup::create([
-            'type' => BackupType::FILE,
-            'server_id' => $server->id,
-            'storage_id' => $storage->id,
-            'path' => '/var/www/html',
-            'interval' => '0 0 * * *',
-            'keep_backups' => 5,
-            'status' => null,
-        ]);
-
-        $this->assertInstanceOf(Backup::class, $backup);
-        $this->assertEquals(BackupType::FILE, $backup->type);
-        $this->assertEquals('/var/www/html', $backup->path);
-        $this->assertNull($backup->database_id);
-        $this->assertEquals($storage->id, $backup->storage_id);
-    }
-
-    public function test_backup_model_can_have_database_field(): void
-    {
-        $server = Server::factory()->create();
-        $storage = StorageProvider::factory()->create();
-        $database = $server->databases()->create([
-            'name' => 'test_db',
-            'status' => 'ready',
-        ]);
-
-        $backup = Backup::create([
-            'type' => BackupType::DATABASE,
-            'server_id' => $server->id,
-            'storage_id' => $storage->id,
-            'database_id' => $database->id,
-            'interval' => '0 0 * * *',
-            'keep_backups' => 5,
-            'status' => null,
-        ]);
-
-        $this->assertInstanceOf(Backup::class, $backup);
-        $this->assertEquals(BackupType::DATABASE, $backup->type);
-        $this->assertEquals($database->id, $backup->database_id);
-        $this->assertNull($backup->path);
-        $this->assertEquals($storage->id, $backup->storage_id);
-    }
-
-    #[DataProvider('data')]
-    public function test_create_database_backup(string $db, string $version): void
-    {
-        SSH::fake();
-        Http::fake([
-            '*oauth2/token' => Http::response([
-                'access_token' => 'fresh-access',
-                'expires_in' => 14400,
-            ]),
-            '*' => Http::response([], 200),
-        ]);
-
-        $this->setupDatabase($db, $version);
-
-        $this->actingAs($this->user);
-
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $storage = StorageProvider::factory()->dropbox()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->post(route('backups.store', [
-            'server' => $this->server,
-        ]), [
-            'type' => 'database',
-            'database' => $database->id,
-            'storage' => $storage->id,
-            'interval' => '0 * * * *',
-            'keep' => '10',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('backups', [
-            'status' => null,
-        ]);
-
-        $this->assertDatabaseHas('backup_files', [
-            'status' => BackupFileStatus::CREATED,
-        ]);
-    }
-
-    public function test_create_custom_interval_database_backup(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $storage = StorageProvider::factory()->dropbox()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->post(route('backups.store', ['server' => $this->server]), [
-            'type' => 'database',
-            'database' => $database->id,
-            'storage' => $storage->id,
-            'interval' => 'custom',
-            'custom_interval' => '* * * * *',
-            'keep' => '10',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('backups', [
-            'status' => null,
-        ]);
-    }
-
-    public function test_see_database_backups_list(): void
-    {
-        $this->actingAs($this->user);
-
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $storage = StorageProvider::factory()->dropbox()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        Backup::factory()->create([
-            'server_id' => $this->server->id,
-            'database_id' => $database->id,
-            'storage_id' => $storage->id,
-        ]);
-
-        $this->get(route('backups', ['server' => $this->server]))
-            ->assertSuccessful();
-    }
-
-    public function test_update_database_backup(): void
-    {
-        $this->actingAs($this->user);
-
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $storage = StorageProvider::factory()->dropbox()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $backup = Backup::factory()->create([
-            'server_id' => $this->server->id,
-            'database_id' => $database->id,
-            'storage_id' => $storage->id,
-            'interval' => '0 * * * *',
-            'keep_backups' => 5,
-        ]);
-
-        $this->patch(route('backups.update', [
-            'server' => $this->server,
-            'backup' => $backup,
-        ]), [
-            'interval' => '0 0 * * *',
-            'keep' => 10,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('backups', [
-            'id' => $backup->id,
-            'interval' => '0 0 * * *',
-            'keep_backups' => 10,
-        ]);
-    }
-
-    #[DataProvider('data')]
-    public function test_delete_database_backup(string $db, string $version): void
-    {
-        $this->setupDatabase($db, $version);
-
-        $this->actingAs($this->user);
-
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $storage = StorageProvider::factory()->dropbox()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $backup = Backup::factory()->create([
-            'server_id' => $this->server->id,
-            'database_id' => $database->id,
-            'storage_id' => $storage->id,
-        ]);
-
-        $this->delete(route('backups.destroy', ['server' => $this->server, 'backup' => $backup]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('backups', [
-            'id' => $backup->id,
-        ]);
-    }
-
-    public function test_file_restore_validation_requires_path(): void
-    {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('The path field is required.');
-
-        app(RestoreBackup::class)->restore($this->backupFile, []);
-    }
-
-    public function test_file_restore_validation_path_must_be_string(): void
-    {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('The path field must be a string.');
-
-        app(RestoreBackup::class)->restore($this->backupFile, [
-            'path' => 123,
-        ]);
-    }
-
-    public function test_file_restore_validation_path_must_not_be_empty(): void
-    {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('The path field is required.');
-
-        app(RestoreBackup::class)->restore($this->backupFile, [
-            'path' => '',
-        ]);
-    }
-
-    public function test_file_restore_sets_correct_status_and_restored_to(): void
-    {
-        Bus::fake();
-
-        app(RestoreBackup::class)->restore($this->backupFile, [
-            'path' => '/home/vito/restored-x.com',
-            'owner' => 'vito:vito',
-            'permissions' => '755',
-        ]);
-
-        $this->backupFile->refresh();
-
-        $this->assertEquals(BackupFileStatus::RESTORING, $this->backupFile->status);
-        $this->assertEquals('/home/vito/restored-x.com', $this->backupFile->restored_to);
-    }
-
-    public function test_file_restore_dispatches_job(): void
-    {
-        Bus::fake();
-
-        app(RestoreBackup::class)->restore($this->backupFile, [
-            'path' => '/home/vito/restored-x.com',
-            'owner' => 'vito:vito',
-            'permissions' => '755',
-        ]);
-
-        // The job dispatch is tested by checking that the status is set correctly
-        // and the restored_to field is populated
-        $this->backupFile->refresh();
-        $this->assertEquals(BackupFileStatus::RESTORING, $this->backupFile->status);
-        $this->assertEquals('/home/vito/restored-x.com', $this->backupFile->restored_to);
-    }
-
-    public function test_database_restore_validation_requires_database(): void
-    {
-        // Create a database backup instead
-        $databaseBackup = Backup::factory()->create([
-            'type' => BackupType::DATABASE,
-            'server_id' => $this->server->id,
-            'storage_id' => $this->storageProvider->id,
-            'database_id' => 1,
-            'status' => null,
-        ]);
-        $databaseBackupFile = BackupFile::factory()->create([
-            'backup_id' => $databaseBackup->id,
-            'status' => BackupFileStatus::CREATED,
-        ]);
-
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('The database field is required.');
-
-        app(RestoreBackup::class)->restore($databaseBackupFile, []);
-    }
-
-    public function test_database_restore_validation_database_must_exist(): void
-    {
-        // Create a database backup instead
-        $databaseBackup = Backup::factory()->create([
-            'type' => BackupType::DATABASE,
-            'server_id' => $this->server->id,
-            'storage_id' => $this->storageProvider->id,
-            'database_id' => 1,
-            'status' => null,
-        ]);
-        $databaseBackupFile = BackupFile::factory()->create([
-            'backup_id' => $databaseBackup->id,
-            'status' => BackupFileStatus::CREATED,
-        ]);
-
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('The selected database is invalid.');
-
-        app(RestoreBackup::class)->restore($databaseBackupFile, [
-            'database' => 999, // Non-existent database
-        ]);
-    }
-
-    #[DataProvider('data')]
-    public function test_restore_database_backup(string $db, string $version): void
-    {
-        Http::fake([
-            '*oauth2/token' => Http::response([
-                'access_token' => 'fresh-access',
-                'expires_in' => 14400,
-            ]),
-            '*' => Http::response([], 200),
-        ]);
-        SSH::fake();
-
-        $this->setupDatabase($db, $version);
-
-        $this->actingAs($this->user);
-
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $storage = StorageProvider::factory()->dropbox()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $backup = Backup::factory()->create([
-            'server_id' => $this->server->id,
-            'database_id' => $database->id,
-            'storage_id' => $storage->id,
-        ]);
-
-        $backupFile = app(RunBackup::class)->run($backup);
-
-        $this->post(route('backup-files.restore', [
-            'server' => $this->server,
-            'backup' => $backup,
-            'backupFile' => $backupFile,
-        ]), [
-            'database' => $database->id,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('backup_files', [
-            'id' => $backupFile->id,
-            'status' => BackupFileStatus::RESTORED,
-        ]);
-    }
-
-    #[DataProvider('data')]
-    public function test_database_backup_and_restore_are_streamed(string $db, string $version): void
-    {
-        Http::fake([
-            '*oauth2/token' => Http::response([
-                'access_token' => 'fresh-access',
-                'expires_in' => 14400,
-            ]),
-            '*' => Http::response([], 200),
-        ]);
-        SSH::fake();
-
-        $this->setupDatabase($db, $version);
-
-        $this->actingAs($this->user);
-
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $storage = StorageProvider::factory()->dropbox()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $backup = Backup::factory()->create([
-            'server_id' => $this->server->id,
-            'database_id' => $database->id,
-            'storage_id' => $storage->id,
-        ]);
-
-        $backupFile = app(RunBackup::class)->run($backup);
-
-        SSH::assertExecutedContains('| ');
-        SSH::assertExecutedContains('gzip');
-        SSH::assertNotExecutedContains('unzip');
-
-        $this->post(route('backup-files.restore', [
-            'server' => $this->server,
-            'backup' => $backup,
-            'backupFile' => $backupFile,
-        ]), [
-            'database' => $database->id,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        SSH::assertExecutedContains('gunzip -c');
-    }
-
-    public function test_database_backup_captures_compressed_size(): void
-    {
-        Http::fake();
-        SSH::fake('12345');
-
-        $this->setupDatabase('mysql', '8.4');
-
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $storage = StorageProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Local::id(),
-            'credentials' => ['path' => '/home/vito/backups'],
-        ]);
-
-        $backup = Backup::factory()->create([
-            'server_id' => $this->server->id,
-            'database_id' => $database->id,
-            'storage_id' => $storage->id,
-        ]);
-
-        $backupFile = app(RunBackup::class)->run($backup);
-
-        $this->assertDatabaseHas('backup_files', [
-            'id' => $backupFile->id,
-            'status' => BackupFileStatus::CREATED,
-            'size' => 12345,
-        ]);
-    }
-
-    public function test_database_backup_file_uses_sql_gz_extension(): void
-    {
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $storage = StorageProvider::factory()->dropbox()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $backup = Backup::factory()->create([
-            'type' => BackupType::DATABASE,
-            'server_id' => $this->server->id,
-            'database_id' => $database->id,
-            'storage_id' => $storage->id,
-        ]);
-
-        $file = BackupFile::factory()->create([
-            'backup_id' => $backup->id,
-            'name' => 'db-20260101000000',
-        ]);
-
-        $this->assertStringEndsWith('.sql.gz', $file->tempPath());
-        $this->assertStringEndsWith('.sql.gz', $file->path());
-    }
-
-    public function test_file_backup_file_uses_tar_gz_extension(): void
-    {
-        $this->assertStringEndsWith('.tar.gz', $this->backupFile->tempPath());
-    }
-
-    public function test_can_disable_backup(): void
-    {
-        $this->actingAs($this->user);
-
-        $backup = Backup::factory()->create([
-            'type' => BackupType::FILE,
-            'server_id' => $this->server->id,
-            'storage_id' => $this->storageProvider->id,
-            'path' => '/home/vito/x.com',
-            'status' => null,
-            'enabled' => true,
-        ]);
-
-        $this->post(route('backups.disable', ['server' => $this->server, 'backup' => $backup]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('backups', [
-            'id' => $backup->id,
-            'enabled' => false,
-            'status' => null,
-        ]);
-    }
-
-    public function test_can_enable_backup(): void
-    {
-        $this->actingAs($this->user);
-
-        $backup = Backup::factory()->create([
-            'type' => BackupType::FILE,
-            'server_id' => $this->server->id,
-            'storage_id' => $this->storageProvider->id,
-            'path' => '/home/vito/x.com',
-            'status' => null,
-            'enabled' => false,
-        ]);
-
-        $this->post(route('backups.enable', ['server' => $this->server, 'backup' => $backup]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('backups', [
-            'id' => $backup->id,
-            'enabled' => true,
-            'status' => null,
-        ]);
-    }
-
-    public function test_cannot_enable_a_backup_being_deleted(): void
-    {
-        $this->actingAs($this->user);
-
-        $backup = Backup::factory()->create([
-            'type' => BackupType::FILE,
-            'server_id' => $this->server->id,
-            'storage_id' => $this->storageProvider->id,
-            'path' => '/home/vito/x.com',
-            'status' => BackupStatus::DELETING,
-            'enabled' => false,
-        ]);
-
-        $this->post(route('backups.enable', ['server' => $this->server, 'backup' => $backup]))
-            ->assertSessionHasErrors('backup');
-
-        $this->assertDatabaseHas('backups', [
-            'id' => $backup->id,
-            'enabled' => false,
-            'status' => BackupStatus::DELETING->value,
-        ]);
-    }
-
-    public function test_delete_orphaned_backup_file_hard_deletes_without_dispatching_job(): void
-    {
-        Bus::fake();
-
-        $backup = Backup::factory()->create([
-            'type' => BackupType::DATABASE,
-            'server_id' => 999999,
-            'storage_id' => $this->storageProvider->id,
-            'status' => null,
-        ]);
-        $file = BackupFile::factory()->create([
-            'backup_id' => $backup->id,
-            'status' => BackupFileStatus::CREATED,
-        ]);
-
-        app(ManageBackupFile::class)->delete($file);
-
-        $this->assertDatabaseMissing('backup_files', ['id' => $file->id]);
-        Bus::assertNotDispatched(DeleteFileJob::class);
-    }
-
-    public function test_see_global_backups_list_scoped_to_current_project(): void
-    {
-        $this->actingAs($this->user);
-
-        $secondServer = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-        ]);
-        $secondBackup = Backup::factory()->create([
-            'type' => BackupType::FILE,
-            'server_id' => $secondServer->id,
-            'storage_id' => $this->storageProvider->id,
-            'path' => '/home/vito/y.com',
-            'status' => null,
-        ]);
-
-        $otherProject = Project::factory()->create();
-        $otherServer = Server::factory()->create([
-            'project_id' => $otherProject->id,
-            'user_id' => $this->user->id,
-        ]);
-        $otherBackup = Backup::factory()->create([
-            'type' => BackupType::FILE,
-            'server_id' => $otherServer->id,
-            'storage_id' => $this->storageProvider->id,
-            'path' => '/home/vito/z.com',
-            'status' => null,
-        ]);
-
-        $this->get(route('backups.all'))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('backups/index')
-                ->where('backups.data', function ($rows) use ($secondBackup, $otherBackup): bool {
-                    $ids = collect($rows)->pluck('id');
-
-                    return $ids->contains($this->backup->id)
-                        && $ids->contains($secondBackup->id)
-                        && ! $ids->contains($otherBackup->id);
-                })
-            );
-    }
-
-    public function test_per_server_backups_list_is_filtered_to_server(): void
-    {
-        $this->actingAs($this->user);
-
-        $secondServer = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-        ]);
-        $secondBackup = Backup::factory()->create([
-            'type' => BackupType::FILE,
-            'server_id' => $secondServer->id,
-            'storage_id' => $this->storageProvider->id,
-            'path' => '/home/vito/y.com',
-            'status' => null,
-        ]);
-
-        $this->get(route('backups', ['server' => $secondServer]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('backups/index')
-                ->where('backups.data', function ($rows) use ($secondBackup): bool {
-                    $ids = collect($rows)->pluck('id');
-
-                    return $ids->contains($secondBackup->id) && ! $ids->contains($this->backup->id);
-                })
-            );
-    }
-
-    public function test_backup_run_captures_database_engine_and_version(): void
-    {
-        Http::fake();
-        SSH::fake('8.0.36');
-
-        $this->setupDatabase('mysql', '8.4');
-
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $storage = StorageProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Local::id(),
-            'credentials' => ['path' => '/home/vito/backups'],
-        ]);
-
-        $backup = Backup::factory()->create([
-            'server_id' => $this->server->id,
-            'database_id' => $database->id,
-            'storage_id' => $storage->id,
-        ]);
-
-        $backupFile = app(RunBackup::class)->run($backup);
-
-        $this->assertDatabaseHas('backup_files', [
-            'id' => $backupFile->id,
-            'status' => BackupFileStatus::CREATED,
-            'database_engine' => 'mysql',
-            'database_version' => '8.0.36',
-        ]);
-    }
-
-    public function test_backup_run_succeeds_with_null_version_when_version_query_yields_nothing(): void
-    {
-        Http::fake();
-        SSH::fake();
-
-        $this->setupDatabase('mysql', '8.4');
-
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $storage = StorageProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Local::id(),
-            'credentials' => ['path' => '/home/vito/backups'],
-        ]);
-
-        $backup = Backup::factory()->create([
-            'server_id' => $this->server->id,
-            'database_id' => $database->id,
-            'storage_id' => $storage->id,
-        ]);
-
-        $backupFile = app(RunBackup::class)->run($backup);
-
-        $this->assertDatabaseHas('backup_files', [
-            'id' => $backupFile->id,
-            'status' => BackupFileStatus::CREATED,
-            'database_engine' => 'mysql',
-            'database_version' => null,
-        ]);
-    }
-
-    public function test_restore_to_database_on_same_server_without_metadata_is_allowed(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $backupFile = $this->databaseBackupFile();
-        $targetDatabase = Database::factory()->create(['server_id' => $this->server->id]);
-
-        $this->postRestore($backupFile, $targetDatabase)
-            ->assertSessionDoesntHaveErrors();
-
-        Bus::assertDispatched(RestoreDatabaseJob::class);
-    }
-
-    public function test_restore_to_compatible_server_is_allowed(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $backupFile = $this->databaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
-        $targetServer = $this->createTargetServer('mysql', '8.4');
-        $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
-
-        $this->postRestore($backupFile, $targetDatabase)
-            ->assertSessionDoesntHaveErrors();
-
-        Bus::assertDispatched(RestoreDatabaseJob::class);
-
-        $this->assertEquals(
-            "{$targetDatabase->name} ({$targetServer->name})",
-            $backupFile->refresh()->restored_to,
-        );
-    }
-
-    public function test_restore_to_server_with_lower_version_is_rejected(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $backupFile = $this->databaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
-        $targetServer = $this->createTargetServer('mysql', '5.7');
-        $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
-
-        $this->postRestore($backupFile, $targetDatabase)
-            ->assertSessionHasErrors('database');
-
-        Bus::assertNotDispatched(RestoreDatabaseJob::class);
-    }
-
-    public function test_restore_to_server_with_different_engine_is_rejected(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $backupFile = $this->databaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
-        $targetServer = $this->createTargetServer('mariadb', '11.4');
-        $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
-
-        $this->postRestore($backupFile, $targetDatabase)
-            ->assertSessionHasErrors('database');
-
-        Bus::assertNotDispatched(RestoreDatabaseJob::class);
-    }
-
-    public function test_restore_without_metadata_to_another_server_is_rejected(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $backupFile = $this->databaseBackupFile();
-        $targetServer = $this->createTargetServer('mysql', '8.4');
-        $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
-
-        $this->postRestore($backupFile, $targetDatabase)
-            ->assertSessionHasErrors('database');
-
-        Bus::assertNotDispatched(RestoreDatabaseJob::class);
-    }
-
-    public function test_restore_from_local_storage_to_another_server_is_rejected(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $localStorage = StorageProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Local::id(),
-            'credentials' => ['path' => '/home/vito/backups'],
-        ]);
-        $backupFile = $this->databaseBackupFile(
-            ['database_engine' => 'mysql', 'database_version' => '8.0.36'],
-            $localStorage,
-        );
-        $targetServer = $this->createTargetServer('mysql', '8.4');
-        $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
-
-        $this->postRestore($backupFile, $targetDatabase)
-            ->assertSessionHasErrors('database');
-
-        Bus::assertNotDispatched(RestoreDatabaseJob::class);
-    }
-
-    public function test_restore_to_database_in_another_project_is_rejected(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $backupFile = $this->databaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
-        $otherProject = Project::factory()->create();
-        $targetServer = $this->createTargetServer('mysql', '8.4', $otherProject->id);
-        $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
-
-        $this->postRestore($backupFile, $targetDatabase)
-            ->assertSessionHasErrors('database');
-
-        Bus::assertNotDispatched(RestoreDatabaseJob::class);
-    }
-
-    public function test_restore_to_not_ready_server_is_rejected(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $backupFile = $this->databaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
-        $targetServer = $this->createTargetServer('mysql', '8.4');
-        $targetServer->update(['status' => ServerStatus::INSTALLING]);
-        $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
-
-        $this->postRestore($backupFile, $targetDatabase)
-            ->assertSessionHasErrors('database');
-
-        Bus::assertNotDispatched(RestoreDatabaseJob::class);
-    }
-
-    public function test_restore_to_not_ready_database_is_rejected(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $backupFile = $this->databaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
-        $targetServer = $this->createTargetServer('mysql', '8.4');
-        $targetDatabase = Database::factory()->create([
-            'server_id' => $targetServer->id,
-            'status' => DatabaseStatus::DELETING,
-        ]);
-
-        $this->postRestore($backupFile, $targetDatabase)
-            ->assertSessionHasErrors('database');
-
-        Bus::assertNotDispatched(RestoreDatabaseJob::class);
-    }
-
-    public function test_restore_to_soft_deleted_database_is_rejected(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $backupFile = $this->databaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
-        $targetServer = $this->createTargetServer('mysql', '8.4');
-        $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
-        $targetDatabase->delete();
-
-        $this->postRestore($backupFile, $targetDatabase)
-            ->assertSessionHasErrors('database');
-
-        Bus::assertNotDispatched(RestoreDatabaseJob::class);
-    }
-
-    public function test_restore_is_rejected_when_target_version_cannot_be_determined(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $backupFile = $this->databaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
-        $targetServer = $this->createTargetServer('mysql', 'latest');
-        $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
-
-        $this->postRestore($backupFile, $targetDatabase)
-            ->assertSessionHasErrors('database');
-
-        Bus::assertNotDispatched(RestoreDatabaseJob::class);
-    }
-
-    public function test_restore_allows_less_precise_target_version(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $backupFile = $this->databaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.39']);
-        $targetServer = $this->createTargetServer('mysql', '8.0');
-        $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
-
-        $this->postRestore($backupFile, $targetDatabase)
-            ->assertSessionDoesntHaveErrors();
-
-        Bus::assertDispatched(RestoreDatabaseJob::class);
-    }
-
-    public function test_restore_with_foreign_backup_file_returns_404(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $backupFile = $this->databaseBackupFile();
-        $foreignFile = $this->databaseBackupFile();
-        $targetDatabase = Database::factory()->create(['server_id' => $this->server->id]);
-
-        $this->post(route('backup-files.restore', [
-            'server' => $this->server,
-            'backup' => $backupFile->backup,
-            'backupFile' => $foreignFile,
-        ]), [
-            'database' => $targetDatabase->id,
-        ])->assertNotFound();
-
-        Bus::assertNotDispatched(RestoreDatabaseJob::class);
-    }
-
-    public function test_delete_with_foreign_backup_file_returns_404(): void
-    {
-        $this->actingAs($this->user);
-
-        $backupFile = $this->databaseBackupFile();
-        $foreignFile = $this->databaseBackupFile();
-
-        $this->delete(route('backup-files.destroy', [
-            'server' => $this->server,
-            'backup' => $backupFile->backup,
-            'backupFile' => $foreignFile,
-        ]))->assertNotFound();
-
-        $this->assertDatabaseHas('backup_files', [
-            'id' => $foreignFile->id,
-            'status' => BackupFileStatus::CREATED,
-        ]);
-    }
-
-    public function test_restore_backup_on_another_server(): void
-    {
-        Http::fake([
-            '*oauth2/token' => Http::response([
-                'access_token' => 'fresh-access',
-                'expires_in' => 14400,
-            ]),
-            '*' => Http::response([], 200),
-        ]);
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $backupFile = $this->databaseBackupFile(['database_engine' => 'mysql', 'database_version' => '8.0.36']);
-        $targetServer = $this->createTargetServer('mysql', '8.4');
-        $targetDatabase = Database::factory()->create(['server_id' => $targetServer->id]);
-
-        $this->postRestore($backupFile, $targetDatabase)
-            ->assertSessionDoesntHaveErrors();
-
-        $backupFile->refresh();
-
-        $this->assertEquals(BackupFileStatus::RESTORED, $backupFile->status);
-        $this->assertEquals("{$targetDatabase->name} ({$targetServer->name})", $backupFile->restored_to);
-    }
-
-    public function test_temp_path_uses_target_server_ssh_user(): void
-    {
-        $targetServer = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'ssh_user' => 'other-user',
-        ]);
-
-        $this->assertStringStartsWith('/home/vito/', $this->backupFile->tempPath());
-        $this->assertStringStartsWith('/home/other-user/', $this->backupFile->tempPath($targetServer));
-    }
-
-    #[DataProvider('versionComparisons')]
-    public function test_version_gte(string $target, string $source, bool $expected): void
-    {
-        $this->assertSame($expected, BackupFile::versionGte($target, $source));
-    }
-
-    /**
-     * @return array<int, array<int, string|bool>>
-     */
-    public static function versionComparisons(): array
-    {
-        return [
-            ['8.4', '8.0.36', true],
-            ['8.0', '8.0.39', true],
-            ['16', '16.4', true],
-            ['15', '16.1', false],
-            ['5.7', '8.0.36', false],
-            ['10.11.6', '10.11.6', true],
-            ['11.4', '10.11.6', true],
-        ];
-    }
-
-    public function test_normalize_version(): void
-    {
-        $this->assertSame('8.0.42', BackupFile::normalizeVersion("8.0.42\n0.24.04"));
-        $this->assertSame('16', BackupFile::normalizeVersion('16'));
-        $this->assertSame('10.11.6', BackupFile::normalizeVersion('10.11.6-MariaDB'));
-        $this->assertNull(BackupFile::normalizeVersion('latest'));
-        $this->assertNull(BackupFile::normalizeVersion(''));
-        $this->assertNull(BackupFile::normalizeVersion(null));
-    }
-
-    /**
-     * @param  array<string, mixed>  $fileAttributes
-     */
-    private function databaseBackupFile(array $fileAttributes = [], ?StorageProvider $storage = null): BackupFile
-    {
-        $database = Database::factory()->create(['server_id' => $this->server->id]);
-        $backup = Backup::factory()->create([
-            'type' => BackupType::DATABASE,
-            'server_id' => $this->server->id,
-            'database_id' => $database->id,
-            'storage_id' => ($storage ?? StorageProvider::factory()->dropbox()->create(['user_id' => $this->user->id]))->id,
-            'status' => null,
-        ]);
-
-        return BackupFile::factory()->create([
-            'backup_id' => $backup->id,
-            'status' => BackupFileStatus::CREATED,
-            ...$fileAttributes,
-        ]);
-    }
-
-    private function createTargetServer(string $engine, string $version, ?int $projectId = null): Server
-    {
-        $server = Server::factory()->create([
-            'project_id' => $projectId ?? $this->server->project_id,
-            'user_id' => $this->user->id,
-        ]);
-        $server->services()->create([
-            'type' => 'database',
-            'name' => $engine,
-            'version' => $version,
-        ]);
-
-        return $server;
-    }
-
-    private function postRestore(BackupFile $backupFile, Database $targetDatabase): TestResponse
-    {
-        return $this->post(route('backup-files.restore', [
-            'server' => $backupFile->backup->server_id,
-            'backup' => $backupFile->backup_id,
-            'backupFile' => $backupFile,
-        ]), [
-            'database' => $targetDatabase->id,
-        ]);
-    }
-
-    private function setupDatabase(string $database, string $version): void
-    {
-        $this->server->services()->where('type', 'database')->delete();
-
-        $this->server->services()->create([
-            'type' => 'database',
-            'name' => $database,
-            'version' => $version,
-        ]);
-    }
-
-    /**
-     * @return array<int, array<int, string>>
-     */
-    public static function data(): array
-    {
-        return [
-            ['mysql', '8.4'],
-            ['mariadb', '10.11'],
-            ['postgresql', '16'],
-        ];
-    }
+    $database = Database::factory()->create(['server_id' => test()->server->id]);
+    $backup = Backup::factory()->create([
+        'type' => BackupType::DATABASE,
+        'server_id' => test()->server->id,
+        'database_id' => $database->id,
+        'storage_id' => ($storage ?? StorageProvider::factory()->dropbox()->create(['user_id' => test()->user->id]))->id,
+        'status' => null,
+    ]);
+
+    return BackupFile::factory()->create([
+        'backup_id' => $backup->id,
+        'status' => BackupFileStatus::CREATED,
+        ...$fileAttributes,
+    ]);
 }
+
+function vitoPestFeatureBackupTestCreateTargetServer(string $engine, string $version, ?int $projectId = null): Server
+{
+    $server = Server::factory()->create([
+        'project_id' => $projectId ?? test()->server->project_id,
+        'user_id' => test()->user->id,
+    ]);
+    $server->services()->create([
+        'type' => 'database',
+        'name' => $engine,
+        'version' => $version,
+    ]);
+
+    return $server;
+}
+
+function vitoPestFeatureBackupTestPostRestore(BackupFile $backupFile, Database $targetDatabase): TestResponse
+{
+    return test()->post(route('backup-files.restore', [
+        'server' => $backupFile->backup->server_id,
+        'backup' => $backupFile->backup_id,
+        'backupFile' => $backupFile,
+    ]), [
+        'database' => $targetDatabase->id,
+    ]);
+}
+
+function vitoPestFeatureBackupTestSetupDatabase(string $database, string $version): void
+{
+    test()->server->services()->where('type', 'database')->delete();
+
+    test()->server->services()->create([
+        'type' => 'database',
+        'name' => $database,
+        'version' => $version,
+    ]);
+}
+
+/**
+ * @return array<int, array<int, string>>
+ */
+dataset('data', function () {
+    return [
+        ['mysql', '8.4'],
+        ['mariadb', '10.11'],
+        ['postgresql', '16'],
+    ];
+});

--- a/tests/Feature/BackupTest.php
+++ b/tests/Feature/BackupTest.php
@@ -11,6 +11,7 @@ use App\Enums\ServerStatus;
 use App\Facades\SSH;
 use App\Jobs\Backup\DeleteFileJob;
 use App\Jobs\Backup\RestoreDatabaseJob;
+use App\Jobs\Backup\RestoreFileJob;
 use App\Models\Backup;
 use App\Models\BackupFile;
 use App\Models\Database;
@@ -28,7 +29,6 @@ use Inertia\Testing\AssertableInertia;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
-    // Additional setup for file restore tests
     $this->storageProvider = StorageProvider::factory()->create([
         'user_id' => $this->user->id,
     ]);
@@ -293,15 +293,10 @@ test('file restore dispatches job', function () {
         'permissions' => '755',
     ]);
 
-    // The job dispatch is tested by checking that the status is set correctly
-    // and the restored_to field is populated
-    $this->backupFile->refresh();
-    expect($this->backupFile->status)->toEqual(BackupFileStatus::RESTORING);
-    expect($this->backupFile->restored_to)->toEqual('/home/vito/restored-x.com');
+    Bus::assertDispatched(RestoreFileJob::class);
 });
 
 test('database restore validation requires database', function () {
-    // Create a database backup instead
     $databaseBackup = Backup::factory()->create([
         'type' => BackupType::DATABASE,
         'server_id' => $this->server->id,
@@ -321,7 +316,6 @@ test('database restore validation requires database', function () {
 });
 
 test('database restore validation database must exist', function () {
-    // Create a database backup instead
     $databaseBackup = Backup::factory()->create([
         'type' => BackupType::DATABASE,
         'server_id' => $this->server->id,
@@ -338,7 +332,7 @@ test('database restore validation database must exist', function () {
     $this->expectExceptionMessage('The selected database is invalid.');
 
     app(RestoreBackup::class)->restore($databaseBackupFile, [
-        'database' => 999, // Non-existent database
+        'database' => 999,
     ]);
 });
 

--- a/tests/Feature/CheckPendingDomainsCommandTest.php
+++ b/tests/Feature/CheckPendingDomainsCommandTest.php
@@ -1,78 +1,68 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\HostedDomainStatus;
 use App\Jobs\HostedDomain\CheckDomainJob;
 use App\Models\HostedDomain;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
-use Tests\TestCase;
 
-class CheckPendingDomainsCommandTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_dispatches_job_for_pending_domains(): void
-    {
-        Bus::fake();
+test('dispatches job for pending domains', function () {
+    Bus::fake();
 
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'pending.example.com',
-            'status' => HostedDomainStatus::PENDING,
-            'updated_at' => now()->subHours(1),
-        ]);
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'pending.example.com',
+        'status' => HostedDomainStatus::PENDING,
+        'updated_at' => now()->subHours(1),
+    ]);
 
-        $this->artisan('domains:check-pending')->assertSuccessful();
+    $this->artisan('domains:check-pending')->assertSuccessful();
 
-        Bus::assertDispatched(CheckDomainJob::class);
-    }
+    Bus::assertDispatched(CheckDomainJob::class);
+});
 
-    public function test_does_not_dispatch_for_active_domains(): void
-    {
-        Bus::fake();
+test('does not dispatch for active domains', function () {
+    Bus::fake();
 
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'active.example.com',
-            'status' => HostedDomainStatus::ACTIVE,
-            'updated_at' => now()->subHours(1),
-        ]);
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'active.example.com',
+        'status' => HostedDomainStatus::ACTIVE,
+        'updated_at' => now()->subHours(1),
+    ]);
 
-        $this->artisan('domains:check-pending')->assertSuccessful();
+    $this->artisan('domains:check-pending')->assertSuccessful();
 
-        Bus::assertNotDispatched(CheckDomainJob::class);
-    }
+    Bus::assertNotDispatched(CheckDomainJob::class);
+});
 
-    public function test_does_not_dispatch_for_old_pending_domains(): void
-    {
-        Bus::fake();
+test('does not dispatch for old pending domains', function () {
+    Bus::fake();
 
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'old-pending.example.com',
-            'status' => HostedDomainStatus::PENDING,
-            'updated_at' => now()->subHours(25),
-        ]);
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'old-pending.example.com',
+        'status' => HostedDomainStatus::PENDING,
+        'updated_at' => now()->subHours(25),
+    ]);
 
-        $this->artisan('domains:check-pending')->assertSuccessful();
+    $this->artisan('domains:check-pending')->assertSuccessful();
 
-        Bus::assertNotDispatched(CheckDomainJob::class);
-    }
+    Bus::assertNotDispatched(CheckDomainJob::class);
+});
 
-    public function test_dispatches_for_multiple_pending_domains(): void
-    {
-        Bus::fake();
+test('dispatches for multiple pending domains', function () {
+    Bus::fake();
 
-        HostedDomain::factory()->count(3)->create([
-            'site_id' => $this->site->id,
-            'status' => HostedDomainStatus::PENDING,
-            'updated_at' => now()->subHours(1),
-        ]);
+    HostedDomain::factory()->count(3)->create([
+        'site_id' => $this->site->id,
+        'status' => HostedDomainStatus::PENDING,
+        'updated_at' => now()->subHours(1),
+    ]);
 
-        $this->artisan('domains:check-pending')->assertSuccessful();
+    $this->artisan('domains:check-pending')->assertSuccessful();
 
-        Bus::assertDispatchedTimes(CheckDomainJob::class, 3);
-    }
-}
+    Bus::assertDispatchedTimes(CheckDomainJob::class, 3);
+});

--- a/tests/Feature/CheckServerUpdatesCommandTest.php
+++ b/tests/Feature/CheckServerUpdatesCommandTest.php
@@ -1,58 +1,49 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\ServerStatus;
 use App\Jobs\Server\CheckForUpdatesJob;
 use App\Models\Server;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
-use Tests\TestCase;
 
-class CheckServerUpdatesCommandTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_dispatches_job_for_ready_servers(): void
-    {
-        Bus::fake();
+test('dispatches job for ready servers', function () {
+    Bus::fake();
 
-        $this->artisan('servers:check-updates')->assertSuccessful();
+    $this->artisan('servers:check-updates')->assertSuccessful();
 
-        Bus::assertDispatched(CheckForUpdatesJob::class, function (CheckForUpdatesJob $job) {
-            return $job->queue === 'ssh';
-        });
-    }
+    Bus::assertDispatched(CheckForUpdatesJob::class, function (CheckForUpdatesJob $job) {
+        return $job->queue === 'ssh';
+    });
+});
 
-    public function test_does_not_dispatch_for_disconnected_servers(): void
-    {
-        Bus::fake();
+test('does not dispatch for disconnected servers', function () {
+    Bus::fake();
 
-        $this->server->update(['status' => ServerStatus::DISCONNECTED]);
+    $this->server->update(['status' => ServerStatus::DISCONNECTED]);
 
-        $this->artisan('servers:check-updates')->assertSuccessful();
+    $this->artisan('servers:check-updates')->assertSuccessful();
 
-        Bus::assertNotDispatched(CheckForUpdatesJob::class);
-    }
+    Bus::assertNotDispatched(CheckForUpdatesJob::class);
+});
 
-    public function test_dispatches_for_each_ready_server(): void
-    {
-        Bus::fake();
+test('dispatches for each ready server', function () {
+    Bus::fake();
 
-        Server::factory()->count(2)->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'status' => ServerStatus::READY,
-        ]);
+    Server::factory()->count(2)->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'status' => ServerStatus::READY,
+    ]);
 
-        Server::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'status' => ServerStatus::DISCONNECTED,
-        ]);
+    Server::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'status' => ServerStatus::DISCONNECTED,
+    ]);
 
-        $this->artisan('servers:check-updates')->assertSuccessful();
+    $this->artisan('servers:check-updates')->assertSuccessful();
 
-        Bus::assertDispatchedTimes(CheckForUpdatesJob::class, 3);
-    }
-}
+    Bus::assertDispatchedTimes(CheckForUpdatesJob::class, 3);
+});

--- a/tests/Feature/CheckSslExpiriesCommandTest.php
+++ b/tests/Feature/CheckSslExpiriesCommandTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\SSL\CertificateParser;
 use App\Enums\SslStatus;
 use App\Enums\SslType;
@@ -12,46 +10,43 @@ use App\Models\Ssl;
 use App\Notifications\SslCertificateExpiring;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
-use Tests\TestCase;
 
-class CheckSslExpiriesCommandTest extends TestCase
+uses(RefreshDatabase::class);
+
+function vitoPestFeatureCheckSslExpiriesCommandTestCreateSiteLeSsl(array $attributes = []): Ssl
 {
-    use RefreshDatabase;
+    return Ssl::factory()->create(array_merge([
+        'site_id' => test()->site->id,
+        'type' => SslType::LETSENCRYPT,
+        'status' => SslStatus::CREATED,
+        'certificate_path' => '/etc/letsencrypt/live/1/fullchain.pem',
+        'pk_path' => '/etc/letsencrypt/live/1/privkey.pem',
+        'expires_at' => now()->addDays(60),
+        'domains' => ['example.com'],
+    ], $attributes));
+}
 
-    private function createSiteLeSsl(array $attributes = []): Ssl
-    {
-        return Ssl::factory()->create(array_merge([
-            'site_id' => $this->site->id,
-            'type' => SslType::LETSENCRYPT,
-            'status' => SslStatus::CREATED,
-            'certificate_path' => '/etc/letsencrypt/live/1/fullchain.pem',
-            'pk_path' => '/etc/letsencrypt/live/1/privkey.pem',
-            'expires_at' => now()->addDays(60),
-            'domains' => ['example.com'],
-        ], $attributes));
-    }
+function vitoPestFeatureCheckSslExpiriesCommandTestGenerateTestCertificate(int $validDays = 90): string
+{
+    $key = openssl_pkey_new(['private_key_bits' => 2048]);
+    $csr = openssl_csr_new([
+        'CN' => 'example.com',
+    ], $key, ['config' => vitoPestFeatureCheckSslExpiriesCommandTestOpensslConfig()]);
 
-    private function generateTestCertificate(int $validDays = 90): string
-    {
-        $key = openssl_pkey_new(['private_key_bits' => 2048]);
-        $csr = openssl_csr_new([
-            'CN' => 'example.com',
-        ], $key, ['config' => $this->opensslConfig()]);
+    $cert = openssl_csr_sign($csr, null, $key, $validDays, [
+        'config' => vitoPestFeatureCheckSslExpiriesCommandTestOpensslConfig(),
+        'x509_extensions' => 'v3_req',
+    ]);
 
-        $cert = openssl_csr_sign($csr, null, $key, $validDays, [
-            'config' => $this->opensslConfig(),
-            'x509_extensions' => 'v3_req',
-        ]);
+    openssl_x509_export($cert, $certPem);
 
-        openssl_x509_export($cert, $certPem);
+    return $certPem;
+}
 
-        return $certPem;
-    }
-
-    private function opensslConfig(): string
-    {
-        $configPath = tempnam(sys_get_temp_dir(), 'openssl');
-        file_put_contents($configPath, <<<'INI'
+function vitoPestFeatureCheckSslExpiriesCommandTestOpensslConfig(): string
+{
+    $configPath = tempnam(sys_get_temp_dir(), 'openssl');
+    file_put_contents($configPath, <<<'INI'
 [req]
 distinguished_name = req_dn
 req_extensions = v3_req
@@ -63,201 +58,187 @@ CN = example.com
 subjectAltName = DNS:example.com,DNS:www.example.com
 INI);
 
-        return $configPath;
-    }
-
-    public function test_dispatches_job_for_site_level_le_ssl(): void
-    {
-        Bus::fake();
-
-        $this->createSiteLeSsl();
-
-        $this->artisan('ssl:check-expiry')->assertSuccessful();
-
-        Bus::assertDispatched(CheckSslExpiryJob::class);
-    }
-
-    public function test_does_not_dispatch_for_server_level_ssl(): void
-    {
-        Bus::fake();
-
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'type' => SslType::LETSENCRYPT,
-            'status' => SslStatus::CREATED,
-            'certificate_path' => '/etc/letsencrypt/live/1/fullchain.pem',
-            'expires_at' => now()->addDays(60),
-        ]);
-
-        $this->artisan('ssl:check-expiry')->assertSuccessful();
-
-        Bus::assertNotDispatched(CheckSslExpiryJob::class);
-    }
-
-    public function test_does_not_dispatch_for_custom_ssl(): void
-    {
-        Bus::fake();
-
-        $this->createSiteLeSsl(['type' => SslType::CUSTOM]);
-
-        $this->artisan('ssl:check-expiry')->assertSuccessful();
-
-        Bus::assertNotDispatched(CheckSslExpiryJob::class);
-    }
-
-    public function test_does_not_dispatch_for_failed_ssl(): void
-    {
-        Bus::fake();
-
-        $this->createSiteLeSsl(['status' => SslStatus::FAILED]);
-
-        $this->artisan('ssl:check-expiry')->assertSuccessful();
-
-        Bus::assertNotDispatched(CheckSslExpiryJob::class);
-    }
-
-    public function test_does_not_dispatch_for_ssl_without_certificate_path(): void
-    {
-        Bus::fake();
-
-        $this->createSiteLeSsl(['certificate_path' => null]);
-
-        $this->artisan('ssl:check-expiry')->assertSuccessful();
-
-        Bus::assertNotDispatched(CheckSslExpiryJob::class);
-    }
-
-    public function test_dispatches_one_job_per_server(): void
-    {
-        Bus::fake();
-
-        $this->createSiteLeSsl();
-        $this->createSiteLeSsl([
-            'certificate_path' => '/etc/letsencrypt/live/2/fullchain.pem',
-        ]);
-
-        $this->artisan('ssl:check-expiry')->assertSuccessful();
-
-        Bus::assertDispatchedTimes(CheckSslExpiryJob::class, 1);
-    }
-
-    public function test_job_updates_expires_at_when_cert_differs(): void
-    {
-        $certPem = $this->generateTestCertificate(90);
-        SSH::fake($certPem);
-
-        $ssl = $this->createSiteLeSsl([
-            'expires_at' => now()->addDays(10),
-        ]);
-
-        $oldExpiry = $ssl->expires_at->copy();
-
-        $job = new CheckSslExpiryJob($this->server);
-        $job->handle();
-
-        $ssl->refresh();
-        $this->assertFalse($ssl->expires_at->equalTo($oldExpiry));
-    }
-
-    public function test_job_does_not_update_when_cert_matches(): void
-    {
-        $certPem = $this->generateTestCertificate(60);
-        $parsed = CertificateParser::parse($certPem);
-
-        SSH::fake($certPem);
-
-        $ssl = $this->createSiteLeSsl([
-            'expires_at' => $parsed['expires_at'],
-            'domains' => $parsed['domains'],
-        ]);
-
-        $job = new CheckSslExpiryJob($this->server);
-        $job->handle();
-
-        $ssl->refresh();
-        $this->assertTrue($ssl->expires_at->equalTo($parsed['expires_at']));
-    }
-
-    public function test_job_skips_unreadable_cert_without_error(): void
-    {
-        SSH::fake('');
-
-        $ssl = $this->createSiteLeSsl([
-            'expires_at' => now()->addDays(10),
-        ]);
-
-        $originalExpiry = $ssl->expires_at->toDateTimeString();
-
-        $job = new CheckSslExpiryJob($this->server);
-        $job->handle();
-
-        $ssl->refresh();
-        $this->assertEquals($originalExpiry, $ssl->expires_at->toDateTimeString());
-    }
-
-    public function test_job_updates_domains_from_cert(): void
-    {
-        $certPem = $this->generateTestCertificate(90);
-        SSH::fake($certPem);
-
-        $ssl = $this->createSiteLeSsl([
-            'expires_at' => now()->addDays(10),
-            'domains' => ['old.example.com'],
-        ]);
-
-        $job = new CheckSslExpiryJob($this->server);
-        $job->handle();
-
-        $ssl->refresh();
-        $this->assertContains('example.com', $ssl->domains);
-    }
-
-    public function test_notifies_once_when_certificate_expiring_soon(): void
-    {
-        SSH::fake($this->generateTestCertificate(10));
-        Notifier::spy();
-
-        $ssl = $this->createSiteLeSsl();
-
-        $job = new CheckSslExpiryJob($this->server);
-        $job->handle();
-        $job->handle();
-
-        $ssl->refresh();
-        $this->assertNotNull($ssl->expiry_notified_at);
-        Notifier::shouldHaveReceived('send')->withArgs(
-            fn (object $notifiable, object $notification): bool => $notification instanceof SslCertificateExpiring
-        )->once();
-    }
-
-    public function test_does_not_notify_when_not_expiring_soon(): void
-    {
-        SSH::fake($this->generateTestCertificate(90));
-        Notifier::spy();
-
-        $ssl = $this->createSiteLeSsl();
-
-        (new CheckSslExpiryJob($this->server))->handle();
-
-        $ssl->refresh();
-        $this->assertNull($ssl->expiry_notified_at);
-        Notifier::shouldNotHaveReceived('send');
-    }
-
-    public function test_rearms_notification_after_renewal(): void
-    {
-        Notifier::spy();
-        $ssl = $this->createSiteLeSsl();
-
-        SSH::fake($this->generateTestCertificate(10));
-        (new CheckSslExpiryJob($this->server))->handle();
-        $ssl->refresh();
-        $this->assertNotNull($ssl->expiry_notified_at);
-
-        SSH::fake($this->generateTestCertificate(90));
-        (new CheckSslExpiryJob($this->server))->handle();
-        $ssl->refresh();
-        $this->assertNull($ssl->expiry_notified_at);
-    }
+    return $configPath;
 }
+
+test('dispatches job for site level le ssl', function () {
+    Bus::fake();
+
+    vitoPestFeatureCheckSslExpiriesCommandTestCreateSiteLeSsl();
+
+    $this->artisan('ssl:check-expiry')->assertSuccessful();
+
+    Bus::assertDispatched(CheckSslExpiryJob::class);
+});
+
+test('does not dispatch for server level ssl', function () {
+    Bus::fake();
+
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'type' => SslType::LETSENCRYPT,
+        'status' => SslStatus::CREATED,
+        'certificate_path' => '/etc/letsencrypt/live/1/fullchain.pem',
+        'expires_at' => now()->addDays(60),
+    ]);
+
+    $this->artisan('ssl:check-expiry')->assertSuccessful();
+
+    Bus::assertNotDispatched(CheckSslExpiryJob::class);
+});
+
+test('does not dispatch for custom ssl', function () {
+    Bus::fake();
+
+    vitoPestFeatureCheckSslExpiriesCommandTestCreateSiteLeSsl(['type' => SslType::CUSTOM]);
+
+    $this->artisan('ssl:check-expiry')->assertSuccessful();
+
+    Bus::assertNotDispatched(CheckSslExpiryJob::class);
+});
+
+test('does not dispatch for failed ssl', function () {
+    Bus::fake();
+
+    vitoPestFeatureCheckSslExpiriesCommandTestCreateSiteLeSsl(['status' => SslStatus::FAILED]);
+
+    $this->artisan('ssl:check-expiry')->assertSuccessful();
+
+    Bus::assertNotDispatched(CheckSslExpiryJob::class);
+});
+
+test('does not dispatch for ssl without certificate path', function () {
+    Bus::fake();
+
+    vitoPestFeatureCheckSslExpiriesCommandTestCreateSiteLeSsl(['certificate_path' => null]);
+
+    $this->artisan('ssl:check-expiry')->assertSuccessful();
+
+    Bus::assertNotDispatched(CheckSslExpiryJob::class);
+});
+
+test('dispatches one job per server', function () {
+    Bus::fake();
+
+    vitoPestFeatureCheckSslExpiriesCommandTestCreateSiteLeSsl();
+    vitoPestFeatureCheckSslExpiriesCommandTestCreateSiteLeSsl([
+        'certificate_path' => '/etc/letsencrypt/live/2/fullchain.pem',
+    ]);
+
+    $this->artisan('ssl:check-expiry')->assertSuccessful();
+
+    Bus::assertDispatchedTimes(CheckSslExpiryJob::class, 1);
+});
+
+test('job updates expires at when cert differs', function () {
+    $certPem = vitoPestFeatureCheckSslExpiriesCommandTestGenerateTestCertificate(90);
+    SSH::fake($certPem);
+
+    $ssl = vitoPestFeatureCheckSslExpiriesCommandTestCreateSiteLeSsl([
+        'expires_at' => now()->addDays(10),
+    ]);
+
+    $oldExpiry = $ssl->expires_at->copy();
+
+    $job = new CheckSslExpiryJob($this->server);
+    $job->handle();
+
+    $ssl->refresh();
+    expect($ssl->expires_at->equalTo($oldExpiry))->toBeFalse();
+});
+
+test('job does not update when cert matches', function () {
+    $certPem = vitoPestFeatureCheckSslExpiriesCommandTestGenerateTestCertificate(60);
+    $parsed = CertificateParser::parse($certPem);
+
+    SSH::fake($certPem);
+
+    $ssl = vitoPestFeatureCheckSslExpiriesCommandTestCreateSiteLeSsl([
+        'expires_at' => $parsed['expires_at'],
+        'domains' => $parsed['domains'],
+    ]);
+
+    $job = new CheckSslExpiryJob($this->server);
+    $job->handle();
+
+    $ssl->refresh();
+    expect($ssl->expires_at->equalTo($parsed['expires_at']))->toBeTrue();
+});
+
+test('job skips unreadable cert without error', function () {
+    SSH::fake('');
+
+    $ssl = vitoPestFeatureCheckSslExpiriesCommandTestCreateSiteLeSsl([
+        'expires_at' => now()->addDays(10),
+    ]);
+
+    $originalExpiry = $ssl->expires_at->toDateTimeString();
+
+    $job = new CheckSslExpiryJob($this->server);
+    $job->handle();
+
+    $ssl->refresh();
+    expect($ssl->expires_at->toDateTimeString())->toEqual($originalExpiry);
+});
+
+test('job updates domains from cert', function () {
+    $certPem = vitoPestFeatureCheckSslExpiriesCommandTestGenerateTestCertificate(90);
+    SSH::fake($certPem);
+
+    $ssl = vitoPestFeatureCheckSslExpiriesCommandTestCreateSiteLeSsl([
+        'expires_at' => now()->addDays(10),
+        'domains' => ['old.example.com'],
+    ]);
+
+    $job = new CheckSslExpiryJob($this->server);
+    $job->handle();
+
+    $ssl->refresh();
+    expect($ssl->domains)->toContain('example.com');
+});
+
+test('notifies once when certificate expiring soon', function () {
+    SSH::fake(vitoPestFeatureCheckSslExpiriesCommandTestGenerateTestCertificate(10));
+    Notifier::spy();
+
+    $ssl = vitoPestFeatureCheckSslExpiriesCommandTestCreateSiteLeSsl();
+
+    $job = new CheckSslExpiryJob($this->server);
+    $job->handle();
+    $job->handle();
+
+    $ssl->refresh();
+    expect($ssl->expiry_notified_at)->not->toBeNull();
+    Notifier::shouldHaveReceived('send')->withArgs(
+        fn (object $notifiable, object $notification): bool => $notification instanceof SslCertificateExpiring
+    )->once();
+});
+
+test('does not notify when not expiring soon', function () {
+    SSH::fake(vitoPestFeatureCheckSslExpiriesCommandTestGenerateTestCertificate(90));
+    Notifier::spy();
+
+    $ssl = vitoPestFeatureCheckSslExpiriesCommandTestCreateSiteLeSsl();
+
+    (new CheckSslExpiryJob($this->server))->handle();
+
+    $ssl->refresh();
+    expect($ssl->expiry_notified_at)->toBeNull();
+    Notifier::shouldNotHaveReceived('send');
+});
+
+test('rearms notification after renewal', function () {
+    Notifier::spy();
+    $ssl = vitoPestFeatureCheckSslExpiriesCommandTestCreateSiteLeSsl();
+
+    SSH::fake(vitoPestFeatureCheckSslExpiriesCommandTestGenerateTestCertificate(10));
+    (new CheckSslExpiryJob($this->server))->handle();
+    $ssl->refresh();
+    expect($ssl->expiry_notified_at)->not->toBeNull();
+
+    SSH::fake(vitoPestFeatureCheckSslExpiriesCommandTestGenerateTestCertificate(90));
+    (new CheckSslExpiryJob($this->server))->handle();
+    $ssl->refresh();
+    expect($ssl->expiry_notified_at)->toBeNull();
+});

--- a/tests/Feature/CommandsTest.php
+++ b/tests/Feature/CommandsTest.php
@@ -1,138 +1,126 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Facades\SSH;
 use App\Models\Command;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class CommandsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_see_commands(): void
-    {
-        $this->actingAs($this->user);
+test('see commands', function () {
+    $this->actingAs($this->user);
 
-        $this->get(route('commands', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('commands/index'));
-    }
+    $this->get(route('commands', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('commands/index'));
+});
 
-    public function test_create_command(): void
-    {
-        $this->actingAs($this->user);
+test('create command', function () {
+    $this->actingAs($this->user);
 
-        $this->post(route('commands.store', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'name' => 'Test Command',
-            'command' => 'echo "${MESSAGE}"',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('commands.store', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'name' => 'Test Command',
+        'command' => 'echo "${MESSAGE}"',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('commands', [
-            'site_id' => $this->site->id,
-            'name' => 'Test Command',
-            'command' => 'echo "${MESSAGE}"',
-        ]);
-    }
+    $this->assertDatabaseHas('commands', [
+        'site_id' => $this->site->id,
+        'name' => 'Test Command',
+        'command' => 'echo "${MESSAGE}"',
+    ]);
+});
 
-    public function test_edit_command(): void
-    {
-        $this->actingAs($this->user);
+test('edit command', function () {
+    $this->actingAs($this->user);
 
-        $command = $this->site->commands()->create([
-            'name' => 'Test Command',
-            'command' => 'echo "${MESSAGE}"',
-        ]);
+    $command = $this->site->commands()->create([
+        'name' => 'Test Command',
+        'command' => 'echo "${MESSAGE}"',
+    ]);
 
-        $this->put(route('commands.update', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'command' => $command,
-        ]), [
-            'name' => 'Updated Command',
-            'command' => 'ls -la',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->put(route('commands.update', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'command' => $command,
+    ]), [
+        'name' => 'Updated Command',
+        'command' => 'ls -la',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('commands', [
-            'id' => $command->id,
-            'site_id' => $this->site->id,
-            'name' => 'Updated Command',
-            'command' => 'ls -la',
-        ]);
-    }
+    $this->assertDatabaseHas('commands', [
+        'id' => $command->id,
+        'site_id' => $this->site->id,
+        'name' => 'Updated Command',
+        'command' => 'ls -la',
+    ]);
+});
 
-    public function test_delete_command(): void
-    {
-        $this->actingAs($this->user);
+test('delete command', function () {
+    $this->actingAs($this->user);
 
-        $command = $this->site->commands()->create([
-            'name' => 'Test Command',
-            'command' => 'echo "${MESSAGE}"',
-        ]);
+    $command = $this->site->commands()->create([
+        'name' => 'Test Command',
+        'command' => 'echo "${MESSAGE}"',
+    ]);
 
-        $this->delete(route('commands.destroy', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'command' => $command,
-        ]))
-            ->assertSessionDoesntHaveErrors();
+    $this->delete(route('commands.destroy', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'command' => $command,
+    ]))
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseMissing('commands', [
-            'id' => $command->id,
-        ]);
-    }
+    $this->assertDatabaseMissing('commands', [
+        'id' => $command->id,
+    ]);
+});
 
-    public function test_execute_command(): void
-    {
-        SSH::fake('echo "Hello, world!"');
+test('execute command', function () {
+    SSH::fake('echo "Hello, world!"');
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        /** @var Command $command */
-        $command = $this->site->commands()->create([
-            'name' => 'Test Command',
-            'command' => 'echo "${MESSAGE}"',
-        ]);
+    /** @var Command $command */
+    $command = $this->site->commands()->create([
+        'name' => 'Test Command',
+        'command' => 'echo "${MESSAGE}"',
+    ]);
 
-        $this->post(route('commands.execute', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'command' => $command,
-        ]), [
-            'MESSAGE' => 'Hello, world!',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('commands.execute', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'command' => $command,
+    ]), [
+        'MESSAGE' => 'Hello, world!',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('command_executions', [
-            'command_id' => $command->id,
-            'variables' => $this->castAsJson(['MESSAGE' => 'Hello, world!']),
-        ]);
-    }
+    $this->assertDatabaseHas('command_executions', [
+        'command_id' => $command->id,
+        'variables' => $this->castAsJson(['MESSAGE' => 'Hello, world!']),
+    ]);
+});
 
-    public function test_execute_command_validation_error(): void
-    {
-        $this->actingAs($this->user);
+test('execute command validation error', function () {
+    $this->actingAs($this->user);
 
-        $command = $this->site->commands()->create([
-            'name' => 'Test Command',
-            'command' => 'echo "${MESSAGE}"',
-        ]);
+    $command = $this->site->commands()->create([
+        'name' => 'Test Command',
+        'command' => 'echo "${MESSAGE}"',
+    ]);
 
-        $this->post(route('commands.execute', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'command' => $command,
-        ]))
-            ->assertSessionHasErrors();
-    }
-}
+    $this->post(route('commands.execute', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'command' => $command,
+    ]))
+        ->assertSessionHasErrors();
+});

--- a/tests/Feature/ConsoleTest.php
+++ b/tests/Feature/ConsoleTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\WebSockets\GenerateWebSocketToken;
 use App\Enums\UserRole;
 use App\Models\User;
@@ -10,303 +8,255 @@ use GuzzleHttp\Psr7\Request as PsrRequest;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use React\EventLoop\Loop;
-use Tests\TestCase;
-
-class ConsoleTest extends TestCase
-{
-    use RefreshDatabase;
-
-    public function test_see_console_page(): void
-    {
-        $this->withoutVite();
-        $this->actingAs($this->user);
-
-        $this->get(route('console', $this->server))
-            ->assertOk();
-    }
 
-    public function test_user_role_cannot_see_console(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::USER,
-        ]);
+uses(RefreshDatabase::class);
 
-        $this->actingAs($this->user);
-
-        $this->get(route('console', $this->server))
-            ->assertForbidden();
-    }
-
-    public function test_generate_token(): void
-    {
-        $this->actingAs($this->user);
-
-        $response = $this->post(route('console.token', $this->server), [
-            'user' => $this->server->getSshUser(),
-        ]);
-
-        $response->assertOk();
-        $response->assertJsonStructure(['token', 'url']);
-
-        $token = $response->json('token');
-        $this->assertNotEmpty($token);
-
-        // Verify token is stored in cache
-        $cached = Cache::get("terminal_token:{$token}");
-        $this->assertNotNull($cached);
-        $this->assertEquals($this->server->id, $cached['server_id']);
-        $this->assertEquals($this->user->id, $cached['user_id']);
-        $this->assertEquals($this->server->getSshUser(), $cached['ssh_user']);
-    }
-
-    public function test_generate_token_returns_websocket_url(): void
-    {
-        $this->actingAs($this->user);
-
-        $response = $this->post(route('console.token', $this->server), [
-            'user' => $this->server->getSshUser(),
-        ]);
-
-        $response->assertOk();
-
-        $url = $response->json('url');
-        $this->assertNotEmpty($url);
-        $this->assertStringContainsString('/ws/terminal', $url);
-    }
-
-    public function test_generate_token_with_root_user(): void
-    {
-        $this->actingAs($this->user);
-
-        $response = $this->post(route('console.token', $this->server), [
-            'user' => 'root',
-        ]);
-
-        $response->assertOk();
-
-        $token = $response->json('token');
-        $cached = Cache::get("terminal_token:{$token}");
-        $this->assertEquals('root', $cached['ssh_user']);
-    }
-
-    public function test_generate_token_validation_error(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->post(route('console.token', $this->server), [])
-            ->assertSessionHasErrors('user');
-
-        $this->post(route('console.token', $this->server), [
-            'user' => 'invalid-user',
-        ])->assertSessionHasErrors('user');
-    }
-
-    public function test_user_role_cannot_generate_token(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::USER,
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('console.token', $this->server), [
-            'user' => $this->server->getSshUser(),
-        ])->assertForbidden();
-    }
-
-    public function test_token_is_single_use(): void
-    {
-        $this->actingAs($this->user);
-
-        $response = $this->post(route('console.token', $this->server), [
-            'user' => $this->server->getSshUser(),
-        ]);
-
-        $token = $response->json('token');
-
-        // First validation should succeed
-        $action = new GenerateWebSocketToken;
-        $data = $action->validate('terminal_token', $token);
-        $this->assertNotNull($data);
-
-        // Second validation should fail (token consumed)
-        $data = $action->validate('terminal_token', $token);
-        $this->assertNull($data);
-    }
-
-    public function test_token_expires_after_ttl(): void
-    {
-        $action = new GenerateWebSocketToken;
-        $result = $action->generate('terminal_token', [
-            'server_id' => $this->server->id,
-            'user_id' => $this->user->id,
-            'ssh_user' => $this->server->getSshUser(),
-        ], 30);
-
-        // Token should exist
-        $this->assertNotNull($action->validate('terminal_token', $result['token']));
-
-        // Generate a new token and simulate expiry
-        $result = $action->generate('terminal_token', [
-            'server_id' => $this->server->id,
-            'user_id' => $this->user->id,
-            'ssh_user' => $this->server->getSshUser(),
-        ], 30);
-        Cache::forget("terminal_token:{$result['token']}");
-
-        $this->assertNull($action->validate('terminal_token', $result['token']));
-    }
-
-    public function test_terminal_handler_authenticate_with_valid_token(): void
-    {
-        $action = new GenerateWebSocketToken;
-        $result = $action->generate('terminal_token', [
-            'server_id' => $this->server->id,
-            'user_id' => $this->user->id,
-            'ssh_user' => $this->server->getSshUser(),
-        ], 30);
-
-        $handler = new TerminalHandler(Loop::get());
-
-        $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token'].'&cols=80&rows=24');
-
-        $error = $handler->authenticate($request);
-        $this->assertNull($error);
-    }
-
-    public function test_terminal_handler_authenticate_without_token(): void
-    {
-        $handler = new TerminalHandler(Loop::get());
-
-        $request = new PsrRequest('GET', '/ws/terminal');
-
-        $error = $handler->authenticate($request);
-        $this->assertEquals('Missing authentication token', $error);
-    }
-
-    public function test_terminal_handler_authenticate_with_invalid_token(): void
-    {
-        $handler = new TerminalHandler(Loop::get());
-
-        $request = new PsrRequest('GET', '/ws/terminal?token=invalid-token');
-
-        $error = $handler->authenticate($request);
-        $this->assertEquals('Invalid or expired token', $error);
-    }
-
-    public function test_terminal_handler_authenticate_with_expired_token(): void
-    {
-        $action = new GenerateWebSocketToken;
-        $result = $action->generate('terminal_token', [
-            'server_id' => $this->server->id,
-            'user_id' => $this->user->id,
-            'ssh_user' => $this->server->getSshUser(),
-        ], 30);
-
-        // Expire the token
-        Cache::forget("terminal_token:{$result['token']}");
-
-        $handler = new TerminalHandler(Loop::get());
-        $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token']);
-
-        $error = $handler->authenticate($request);
-        $this->assertEquals('Invalid or expired token', $error);
-    }
-
-    public function test_terminal_handler_authenticate_unauthorized_user(): void
-    {
-        // Change user role to USER (no write access)
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::USER,
-        ]);
-
-        $action = new GenerateWebSocketToken;
-        $result = $action->generate('terminal_token', [
-            'server_id' => $this->server->id,
-            'user_id' => $this->user->id,
-            'ssh_user' => $this->server->getSshUser(),
-        ], 30);
-
-        $handler = new TerminalHandler(Loop::get());
-        $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token']);
-
-        $error = $handler->authenticate($request);
-        $this->assertEquals('Unauthorized', $error);
-    }
-
-    public function test_terminal_handler_authenticate_deleted_server(): void
-    {
-        $action = new GenerateWebSocketToken;
-        $result = $action->generate('terminal_token', [
-            'server_id' => $this->server->id,
-            'user_id' => $this->user->id,
-            'ssh_user' => $this->server->getSshUser(),
-        ], 30);
-
-        // Delete the server after token generation
-        $this->server->forceDelete();
-
-        $handler = new TerminalHandler(Loop::get());
-        $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token']);
-
-        $error = $handler->authenticate($request);
-        $this->assertEquals('Server not found', $error);
-    }
-
-    public function test_terminal_handler_authenticate_deleted_user(): void
-    {
-        $action = new GenerateWebSocketToken;
-        $result = $action->generate('terminal_token', [
-            'server_id' => $this->server->id,
-            'user_id' => $this->user->id,
-            'ssh_user' => $this->server->getSshUser(),
-        ], 30);
-
-        // Delete the user after token generation
-        $this->user->forceDelete();
-
-        $handler = new TerminalHandler(Loop::get());
-        $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token']);
-
-        $error = $handler->authenticate($request);
-        $this->assertEquals('Server not found', $error);
-    }
-
-    public function test_terminal_handler_rate_limits_connections(): void
-    {
-        $handler = new TerminalHandler(Loop::get());
-        $action = new GenerateWebSocketToken;
-
-        // Authenticate MAX_CONNECTIONS_PER_USER (5) times
-        for ($i = 0; $i < 5; $i++) {
-            $result = $action->generate('terminal_token', [
-                'server_id' => $this->server->id,
-                'user_id' => $this->user->id,
-                'ssh_user' => $this->server->getSshUser(),
-            ], 30);
-            $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token'].'&cols=80&rows=24');
-            $error = $handler->authenticate($request);
-            $this->assertNull($error, "Connection $i should succeed");
-
-            // Simulate that the connection was opened by manually adding to connections via onOpen
-            // We need to call onOpen to track the connection, but it will try SSH which won't work.
-            // Instead, use reflection to add a fake connection entry
-            $reflection = new \ReflectionClass($handler);
-            $prop = $reflection->getProperty('connections');
-            $connections = $prop->getValue($handler);
-            $connections["fake-conn-$i"] = [
-                'connection' => null,
-                'session' => null,
-                'server_id' => $this->server->id,
-                'user_id' => $this->user->id,
-                'ssh_user' => $this->server->getSshUser(),
-                'initial_cols' => 80,
-                'initial_rows' => 24,
-            ];
-            $prop->setValue($handler, $connections);
-        }
-
-        // 6th connection should be rate limited
+test('see console page', function () {
+    $this->withoutVite();
+    $this->actingAs($this->user);
+
+    $this->get(route('console', $this->server))
+        ->assertOk();
+});
+
+test('user role cannot see console', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::USER,
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->get(route('console', $this->server))
+        ->assertForbidden();
+});
+
+test('generate token', function () {
+    $this->actingAs($this->user);
+
+    $response = $this->post(route('console.token', $this->server), [
+        'user' => $this->server->getSshUser(),
+    ]);
+
+    $response->assertOk();
+    $response->assertJsonStructure(['token', 'url']);
+
+    $token = $response->json('token');
+    expect($token)->not->toBeEmpty();
+
+    // Verify token is stored in cache
+    $cached = Cache::get("terminal_token:{$token}");
+    expect($cached)->not->toBeNull();
+    expect($cached['server_id'])->toEqual($this->server->id);
+    expect($cached['user_id'])->toEqual($this->user->id);
+    expect($cached['ssh_user'])->toEqual($this->server->getSshUser());
+});
+
+test('generate token returns websocket url', function () {
+    $this->actingAs($this->user);
+
+    $response = $this->post(route('console.token', $this->server), [
+        'user' => $this->server->getSshUser(),
+    ]);
+
+    $response->assertOk();
+
+    $url = $response->json('url');
+    expect($url)->not->toBeEmpty();
+    $this->assertStringContainsString('/ws/terminal', $url);
+});
+
+test('generate token with root user', function () {
+    $this->actingAs($this->user);
+
+    $response = $this->post(route('console.token', $this->server), [
+        'user' => 'root',
+    ]);
+
+    $response->assertOk();
+
+    $token = $response->json('token');
+    $cached = Cache::get("terminal_token:{$token}");
+    expect($cached['ssh_user'])->toEqual('root');
+});
+
+test('generate token validation error', function () {
+    $this->actingAs($this->user);
+
+    $this->post(route('console.token', $this->server), [])
+        ->assertSessionHasErrors('user');
+
+    $this->post(route('console.token', $this->server), [
+        'user' => 'invalid-user',
+    ])->assertSessionHasErrors('user');
+});
+
+test('user role cannot generate token', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::USER,
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('console.token', $this->server), [
+        'user' => $this->server->getSshUser(),
+    ])->assertForbidden();
+});
+
+test('token is single use', function () {
+    $this->actingAs($this->user);
+
+    $response = $this->post(route('console.token', $this->server), [
+        'user' => $this->server->getSshUser(),
+    ]);
+
+    $token = $response->json('token');
+
+    // First validation should succeed
+    $action = new GenerateWebSocketToken;
+    $data = $action->validate('terminal_token', $token);
+    expect($data)->not->toBeNull();
+
+    // Second validation should fail (token consumed)
+    $data = $action->validate('terminal_token', $token);
+    expect($data)->toBeNull();
+});
+
+test('token expires after ttl', function () {
+    $action = new GenerateWebSocketToken;
+    $result = $action->generate('terminal_token', [
+        'server_id' => $this->server->id,
+        'user_id' => $this->user->id,
+        'ssh_user' => $this->server->getSshUser(),
+    ], 30);
+
+    // Token should exist
+    expect($action->validate('terminal_token', $result['token']))->not->toBeNull();
+
+    // Generate a new token and simulate expiry
+    $result = $action->generate('terminal_token', [
+        'server_id' => $this->server->id,
+        'user_id' => $this->user->id,
+        'ssh_user' => $this->server->getSshUser(),
+    ], 30);
+    Cache::forget("terminal_token:{$result['token']}");
+
+    expect($action->validate('terminal_token', $result['token']))->toBeNull();
+});
+
+test('terminal handler authenticate with valid token', function () {
+    $action = new GenerateWebSocketToken;
+    $result = $action->generate('terminal_token', [
+        'server_id' => $this->server->id,
+        'user_id' => $this->user->id,
+        'ssh_user' => $this->server->getSshUser(),
+    ], 30);
+
+    $handler = new TerminalHandler(Loop::get());
+
+    $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token'].'&cols=80&rows=24');
+
+    $error = $handler->authenticate($request);
+    expect($error)->toBeNull();
+});
+
+test('terminal handler authenticate without token', function () {
+    $handler = new TerminalHandler(Loop::get());
+
+    $request = new PsrRequest('GET', '/ws/terminal');
+
+    $error = $handler->authenticate($request);
+    expect($error)->toEqual('Missing authentication token');
+});
+
+test('terminal handler authenticate with invalid token', function () {
+    $handler = new TerminalHandler(Loop::get());
+
+    $request = new PsrRequest('GET', '/ws/terminal?token=invalid-token');
+
+    $error = $handler->authenticate($request);
+    expect($error)->toEqual('Invalid or expired token');
+});
+
+test('terminal handler authenticate with expired token', function () {
+    $action = new GenerateWebSocketToken;
+    $result = $action->generate('terminal_token', [
+        'server_id' => $this->server->id,
+        'user_id' => $this->user->id,
+        'ssh_user' => $this->server->getSshUser(),
+    ], 30);
+
+    // Expire the token
+    Cache::forget("terminal_token:{$result['token']}");
+
+    $handler = new TerminalHandler(Loop::get());
+    $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token']);
+
+    $error = $handler->authenticate($request);
+    expect($error)->toEqual('Invalid or expired token');
+});
+
+test('terminal handler authenticate unauthorized user', function () {
+    // Change user role to USER (no write access)
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::USER,
+    ]);
+
+    $action = new GenerateWebSocketToken;
+    $result = $action->generate('terminal_token', [
+        'server_id' => $this->server->id,
+        'user_id' => $this->user->id,
+        'ssh_user' => $this->server->getSshUser(),
+    ], 30);
+
+    $handler = new TerminalHandler(Loop::get());
+    $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token']);
+
+    $error = $handler->authenticate($request);
+    expect($error)->toEqual('Unauthorized');
+});
+
+test('terminal handler authenticate deleted server', function () {
+    $action = new GenerateWebSocketToken;
+    $result = $action->generate('terminal_token', [
+        'server_id' => $this->server->id,
+        'user_id' => $this->user->id,
+        'ssh_user' => $this->server->getSshUser(),
+    ], 30);
+
+    // Delete the server after token generation
+    $this->server->forceDelete();
+
+    $handler = new TerminalHandler(Loop::get());
+    $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token']);
+
+    $error = $handler->authenticate($request);
+    expect($error)->toEqual('Server not found');
+});
+
+test('terminal handler authenticate deleted user', function () {
+    $action = new GenerateWebSocketToken;
+    $result = $action->generate('terminal_token', [
+        'server_id' => $this->server->id,
+        'user_id' => $this->user->id,
+        'ssh_user' => $this->server->getSshUser(),
+    ], 30);
+
+    // Delete the user after token generation
+    $this->user->forceDelete();
+
+    $handler = new TerminalHandler(Loop::get());
+    $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token']);
+
+    $error = $handler->authenticate($request);
+    expect($error)->toEqual('Server not found');
+});
+
+test('terminal handler rate limits connections', function () {
+    $handler = new TerminalHandler(Loop::get());
+    $action = new GenerateWebSocketToken;
+
+    // Authenticate MAX_CONNECTIONS_PER_USER (5) times
+    for ($i = 0; $i < 5; $i++) {
         $result = $action->generate('terminal_token', [
             'server_id' => $this->server->id,
             'user_id' => $this->user->id,
@@ -314,169 +264,187 @@ class ConsoleTest extends TestCase
         ], 30);
         $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token'].'&cols=80&rows=24');
         $error = $handler->authenticate($request);
-        $this->assertEquals('Too many connections', $error);
-    }
+        expect($error)->toBeNull("Connection $i should succeed");
 
-    public function test_terminal_handler_rate_limit_per_user(): void
-    {
-        $handler = new TerminalHandler(Loop::get());
-        $action = new GenerateWebSocketToken;
-
-        // Fill up connections for user 1
-        $reflection = new \ReflectionClass($handler);
+        // Simulate that the connection was opened by manually adding to connections via onOpen
+        // We need to call onOpen to track the connection, but it will try SSH which won't work.
+        // Instead, use reflection to add a fake connection entry
+        $reflection = new ReflectionClass($handler);
         $prop = $reflection->getProperty('connections');
-        $connections = [];
-        for ($i = 0; $i < 5; $i++) {
-            $connections["user1-conn-$i"] = [
-                'connection' => null,
-                'session' => null,
-                'server_id' => $this->server->id,
-                'user_id' => $this->user->id,
-                'ssh_user' => $this->server->getSshUser(),
-                'initial_cols' => 80,
-                'initial_rows' => 24,
-            ];
-        }
+        $connections = $prop->getValue($handler);
+        $connections["fake-conn-$i"] = [
+            'connection' => null,
+            'session' => null,
+            'server_id' => $this->server->id,
+            'user_id' => $this->user->id,
+            'ssh_user' => $this->server->getSshUser(),
+            'initial_cols' => 80,
+            'initial_rows' => 24,
+        ];
         $prop->setValue($handler, $connections);
+    }
 
-        // Another user should still be able to connect
-        $otherUser = User::factory()->create();
-        $this->server->project->users()->create([
-            'user_id' => $otherUser->id,
-            'role' => UserRole::ADMIN,
-        ]);
+    // 6th connection should be rate limited
+    $result = $action->generate('terminal_token', [
+        'server_id' => $this->server->id,
+        'user_id' => $this->user->id,
+        'ssh_user' => $this->server->getSshUser(),
+    ], 30);
+    $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token'].'&cols=80&rows=24');
+    $error = $handler->authenticate($request);
+    expect($error)->toEqual('Too many connections');
+});
 
-        $result = $action->generate('terminal_token', [
+test('terminal handler rate limit per user', function () {
+    $handler = new TerminalHandler(Loop::get());
+    $action = new GenerateWebSocketToken;
+
+    // Fill up connections for user 1
+    $reflection = new ReflectionClass($handler);
+    $prop = $reflection->getProperty('connections');
+    $connections = [];
+    for ($i = 0; $i < 5; $i++) {
+        $connections["user1-conn-$i"] = [
+            'connection' => null,
+            'session' => null,
             'server_id' => $this->server->id,
-            'user_id' => $otherUser->id,
+            'user_id' => $this->user->id,
             'ssh_user' => $this->server->getSshUser(),
-        ], 30);
-        $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token'].'&cols=80&rows=24');
-        $error = $handler->authenticate($request);
-        $this->assertNull($error);
+            'initial_cols' => 80,
+            'initial_rows' => 24,
+        ];
     }
+    $prop->setValue($handler, $connections);
 
-    public function test_terminal_handler_connection_count(): void
-    {
-        $handler = new TerminalHandler(Loop::get());
-        $this->assertEquals(0, $handler->getConnectionCount());
+    // Another user should still be able to connect
+    $otherUser = User::factory()->create();
+    $this->server->project->users()->create([
+        'user_id' => $otherUser->id,
+        'role' => UserRole::ADMIN,
+    ]);
 
-        // Add fake connections via reflection
-        $reflection = new \ReflectionClass($handler);
-        $prop = $reflection->getProperty('connections');
-        $prop->setValue($handler, [
-            'conn-1' => ['user_id' => 1],
-            'conn-2' => ['user_id' => 2],
-        ]);
+    $result = $action->generate('terminal_token', [
+        'server_id' => $this->server->id,
+        'user_id' => $otherUser->id,
+        'ssh_user' => $this->server->getSshUser(),
+    ], 30);
+    $request = new PsrRequest('GET', '/ws/terminal?token='.$result['token'].'&cols=80&rows=24');
+    $error = $handler->authenticate($request);
+    expect($error)->toBeNull();
+});
 
-        $this->assertEquals(2, $handler->getConnectionCount());
-    }
+test('terminal handler connection count', function () {
+    $handler = new TerminalHandler(Loop::get());
+    expect($handler->getConnectionCount())->toEqual(0);
 
-    public function test_terminal_handler_on_close_cleans_up(): void
-    {
-        $handler = new TerminalHandler(Loop::get());
+    // Add fake connections via reflection
+    $reflection = new ReflectionClass($handler);
+    $prop = $reflection->getProperty('connections');
+    $prop->setValue($handler, [
+        'conn-1' => ['user_id' => 1],
+        'conn-2' => ['user_id' => 2],
+    ]);
 
-        // Add a fake connection
-        $reflection = new \ReflectionClass($handler);
-        $prop = $reflection->getProperty('connections');
-        $prop->setValue($handler, [
-            'test-conn' => [
-                'connection' => null,
-                'session' => null,
-                'server_id' => $this->server->id,
-                'user_id' => $this->user->id,
-                'ssh_user' => $this->server->getSshUser(),
-                'initial_cols' => 80,
-                'initial_rows' => 24,
-            ],
-        ]);
+    expect($handler->getConnectionCount())->toEqual(2);
+});
 
-        $this->assertEquals(1, $handler->getConnectionCount());
+test('terminal handler on close cleans up', function () {
+    $handler = new TerminalHandler(Loop::get());
 
-        $handler->onClose('test-conn');
+    // Add a fake connection
+    $reflection = new ReflectionClass($handler);
+    $prop = $reflection->getProperty('connections');
+    $prop->setValue($handler, [
+        'test-conn' => [
+            'connection' => null,
+            'session' => null,
+            'server_id' => $this->server->id,
+            'user_id' => $this->user->id,
+            'ssh_user' => $this->server->getSshUser(),
+            'initial_cols' => 80,
+            'initial_rows' => 24,
+        ],
+    ]);
 
-        $this->assertEquals(0, $handler->getConnectionCount());
-    }
+    expect($handler->getConnectionCount())->toEqual(1);
 
-    public function test_terminal_handler_on_close_nonexistent_connection(): void
-    {
-        $handler = new TerminalHandler(Loop::get());
+    $handler->onClose('test-conn');
 
-        // Should not throw
-        $handler->onClose('nonexistent-conn');
+    expect($handler->getConnectionCount())->toEqual(0);
+});
 
-        $this->assertEquals(0, $handler->getConnectionCount());
-    }
+test('terminal handler on close nonexistent connection', function () {
+    $handler = new TerminalHandler(Loop::get());
 
-    public function test_terminal_handler_on_message_ignores_unknown_connection(): void
-    {
-        $handler = new TerminalHandler(Loop::get());
+    // Should not throw
+    $handler->onClose('nonexistent-conn');
 
-        // Should not throw
-        $handler->onMessage('nonexistent-conn', json_encode(['type' => 'input', 'data' => 'test']));
+    expect($handler->getConnectionCount())->toEqual(0);
+});
 
-        $this->assertEquals(0, $handler->getConnectionCount());
-    }
+test('terminal handler on message ignores unknown connection', function () {
+    $handler = new TerminalHandler(Loop::get());
 
-    public function test_terminal_handler_on_message_ignores_invalid_json(): void
-    {
-        $handler = new TerminalHandler(Loop::get());
+    // Should not throw
+    $handler->onMessage('nonexistent-conn', json_encode(['type' => 'input', 'data' => 'test']));
 
-        // Add a fake connection
-        $reflection = new \ReflectionClass($handler);
-        $prop = $reflection->getProperty('connections');
-        $prop->setValue($handler, [
-            'test-conn' => [
-                'connection' => null,
-                'session' => null,
-                'server_id' => $this->server->id,
-                'user_id' => $this->user->id,
-                'ssh_user' => $this->server->getSshUser(),
-                'initial_cols' => 80,
-                'initial_rows' => 24,
-            ],
-        ]);
+    expect($handler->getConnectionCount())->toEqual(0);
+});
 
-        // Should not throw on invalid JSON
-        $handler->onMessage('test-conn', 'not-json');
+test('terminal handler on message ignores invalid json', function () {
+    $handler = new TerminalHandler(Loop::get());
 
-        $this->assertEquals(1, $handler->getConnectionCount());
-    }
+    // Add a fake connection
+    $reflection = new ReflectionClass($handler);
+    $prop = $reflection->getProperty('connections');
+    $prop->setValue($handler, [
+        'test-conn' => [
+            'connection' => null,
+            'session' => null,
+            'server_id' => $this->server->id,
+            'user_id' => $this->user->id,
+            'ssh_user' => $this->server->getSshUser(),
+            'initial_cols' => 80,
+            'initial_rows' => 24,
+        ],
+    ]);
 
-    public function test_terminal_handler_on_message_ignores_missing_type(): void
-    {
-        $handler = new TerminalHandler(Loop::get());
+    // Should not throw on invalid JSON
+    $handler->onMessage('test-conn', 'not-json');
 
-        $reflection = new \ReflectionClass($handler);
-        $prop = $reflection->getProperty('connections');
-        $prop->setValue($handler, [
-            'test-conn' => [
-                'connection' => null,
-                'session' => null,
-                'server_id' => $this->server->id,
-                'user_id' => $this->user->id,
-                'ssh_user' => $this->server->getSshUser(),
-                'initial_cols' => 80,
-                'initial_rows' => 24,
-            ],
-        ]);
+    expect($handler->getConnectionCount())->toEqual(1);
+});
 
-        // Should not throw on message without type
-        $handler->onMessage('test-conn', json_encode(['data' => 'test']));
+test('terminal handler on message ignores missing type', function () {
+    $handler = new TerminalHandler(Loop::get());
 
-        $this->assertEquals(1, $handler->getConnectionCount());
-    }
+    $reflection = new ReflectionClass($handler);
+    $prop = $reflection->getProperty('connections');
+    $prop->setValue($handler, [
+        'test-conn' => [
+            'connection' => null,
+            'session' => null,
+            'server_id' => $this->server->id,
+            'user_id' => $this->user->id,
+            'ssh_user' => $this->server->getSshUser(),
+            'initial_cols' => 80,
+            'initial_rows' => 24,
+        ],
+    ]);
 
-    public function test_unauthenticated_user_cannot_access_console(): void
-    {
-        $this->get(route('console', $this->server))
-            ->assertRedirect();
-    }
+    // Should not throw on message without type
+    $handler->onMessage('test-conn', json_encode(['data' => 'test']));
 
-    public function test_unauthenticated_user_cannot_generate_token(): void
-    {
-        $this->post(route('console.token', $this->server), [
-            'user' => $this->server->getSshUser(),
-        ])->assertRedirect();
-    }
-}
+    expect($handler->getConnectionCount())->toEqual(1);
+});
+
+test('unauthenticated user cannot access console', function () {
+    $this->get(route('console', $this->server))
+        ->assertRedirect();
+});
+
+test('unauthenticated user cannot generate token', function () {
+    $this->post(route('console.token', $this->server), [
+        'user' => $this->server->getSshUser(),
+    ])->assertRedirect();
+});

--- a/tests/Feature/ConsoleTest.php
+++ b/tests/Feature/ConsoleTest.php
@@ -12,7 +12,6 @@ use React\EventLoop\Loop;
 uses(RefreshDatabase::class);
 
 test('see console page', function () {
-    $this->withoutVite();
     $this->actingAs($this->user);
 
     $this->get(route('console', $this->server))

--- a/tests/Feature/CronjobTest.php
+++ b/tests/Feature/CronjobTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\CronJob\SyncCronJobs;
 use App\Enums\CronjobStatus;
 use App\Facades\SSH;
@@ -10,435 +8,414 @@ use App\Models\Server;
 use App\Models\Site;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
-
-class CronjobTest extends TestCase
-{
-    use RefreshDatabase;
-
-    public function test_see_cronjobs_list(): void
-    {
-        $this->actingAs($this->user);
-
-        CronJob::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->get(route('cronjobs', $this->server))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('cronjobs/index'));
-    }
-
-    public function test_delete_cronjob(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'vito',
-        ]);
-
-        $this->delete(route('cronjobs.destroy', [
-            'server' => $this->server,
-            'cronJob' => $cronjob,
-        ]));
-
-        $this->assertDatabaseMissing('cron_jobs', [
-            'id' => $cronjob->id,
-        ]);
-
-        SSH::assertExecutedContains("echo '' | sudo -u vito crontab -");
-        SSH::assertExecutedContains('sudo -u vito crontab -l');
-    }
-
-    public function test_create_cronjob(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('cronjobs.store', ['server' => $this->server]), [
-            'command' => 'ls -la',
-            'user' => 'vito',
-            'frequency' => '* * * * *',
-            'name' => 'My Cronjob',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('cron_jobs', [
-            'server_id' => $this->server->id,
-            'command' => 'ls -la',
-            'user' => 'vito',
-            'frequency' => '* * * * *',
-            'status' => CronjobStatus::READY,
-            'name' => 'My Cronjob',
-        ]);
-
-        SSH::assertExecutedContains("echo '* * * * * bash -lc '\\''ls -la'\\''' | sudo -u vito crontab -");
-        SSH::assertExecutedContains('sudo -u vito crontab -l');
-    }
-
-    public function test_create_cronjob_for_isolated_user(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->site->user = 'example';
-        $this->site->save();
-
-        $this->post(route('cronjobs.store', ['server' => $this->server]), [
-            'command' => 'ls -la',
-            'user' => 'example',
-            'frequency' => '* * * * *',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('cron_jobs', [
-            'server_id' => $this->server->id,
-            'user' => 'example',
-        ]);
-
-        SSH::assertExecutedContains("echo '* * * * * bash -lc '\\''ls -la'\\''' | sudo -u example crontab -");
-        SSH::assertExecutedContains('sudo -u example crontab -l');
-    }
-
-    public function test_cannot_create_cronjob_for_non_existing_user(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->post(route('cronjobs.store', ['server' => $this->server]), [
-            'command' => 'ls -la',
-            'user' => 'example',
-            'frequency' => '* * * * *',
-        ])
-            ->assertSessionHasErrors();
-
-        $this->assertDatabaseMissing('cron_jobs', [
-            'server_id' => $this->server->id,
-            'user' => 'example',
-        ]);
-    }
-
-    public function test_cannot_create_cronjob_for_user_on_another_server(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        Site::factory()->create([
-            'server_id' => Server::factory()->create(['user_id' => 1])->id,
-            'user' => 'example',
-        ]);
-
-        $this->post(route('cronjobs.store', ['server' => $this->server]), [
-            'command' => 'ls -la',
-            'user' => 'example',
-            'frequency' => '* * * * *',
-        ])
-            ->assertSessionHasErrors();
-
-        $this->assertDatabaseMissing('cron_jobs', [
-            'user' => 'example',
-        ]);
-    }
-
-    public function test_create_custom_cronjob(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('cronjobs.store', ['server' => $this->server]), [
-            'command' => 'ls -la',
-            'user' => 'vito',
-            'frequency' => 'custom',
-            'custom' => '* * * 1 1',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('cron_jobs', [
-            'server_id' => $this->server->id,
-            'command' => 'ls -la',
-            'user' => 'vito',
-            'frequency' => '* * * 1 1',
-            'status' => CronjobStatus::READY,
-        ]);
-
-        SSH::assertExecutedContains("echo '* * * 1 1 bash -lc '\\''ls -la'\\''' | sudo -u vito crontab -");
-        SSH::assertExecutedContains('sudo -u vito crontab -l');
-    }
-
-    public function test_cronjob_is_wrapped_in_login_shell_and_survives_sync(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'vito',
-            'command' => "echo 'hi'",
-            'frequency' => '* * * * *',
-            'status' => CronjobStatus::READY,
-            'site_id' => null,
-        ]);
-
-        $crontab = CronJob::crontab($this->server, 'vito');
-        $this->assertSame("* * * * * bash -lc 'echo '\\''hi'\\'''", $crontab);
-        $this->assertSame("echo 'hi'", CronJob::unwrapCommand("bash -lc 'echo '\\''hi'\\'''"));
-
-        SSH::fake($crontab);
-        app(SyncCronJobs::class)->sync($this->server);
-
-        $cronjob->refresh();
-        $this->assertSame(CronjobStatus::READY, $cronjob->status);
-        $this->assertSame(1, CronJob::query()->where('user', 'vito')->where('command', "echo 'hi'")->count());
-    }
-
-    public function test_root_cronjob_is_not_wrapped(): void
-    {
-        $this->actingAs($this->user);
-
-        CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/backup.sh',
-            'frequency' => '0 2 * * *',
-            'status' => CronjobStatus::READY,
-            'site_id' => null,
-        ]);
-
-        $this->assertSame('0 2 * * * /usr/bin/backup.sh', CronJob::crontab($this->server, 'root'));
-    }
-
-    public function test_enable_cronjob(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'vito',
-            'command' => 'ls -la',
-            'frequency' => '* * * 1 1',
-            'status' => CronjobStatus::DISABLED,
-        ]);
-
-        $this->post(route('cronjobs.enable', [
-            'server' => $this->server,
-            'cronJob' => $cronjob,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $cronjob->refresh();
-
-        $this->assertEquals(CronjobStatus::READY, $cronjob->status);
-
-        SSH::assertExecutedContains("echo '* * * 1 1 bash -lc '\\''ls -la'\\''' | sudo -u vito crontab -");
-        SSH::assertExecutedContains('sudo -u vito crontab -l');
-    }
-
-    public function test_disable_cronjob(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'vito',
-            'command' => 'ls -la',
-            'frequency' => '* * * 1 1',
-            'status' => CronjobStatus::READY,
-        ]);
-
-        $this->post(route('cronjobs.disable', [
-            'server' => $this->server,
-            'cronJob' => $cronjob,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $cronjob->refresh();
-
-        $this->assertEquals(CronjobStatus::DISABLED, $cronjob->status);
-
-        SSH::assertExecutedContains("echo '' | sudo -u vito crontab -");
-        SSH::assertExecutedContains('sudo -u vito crontab -l');
-    }
-
-    public function test_create_cronjob_with_valid_site_id(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->post(route('cronjobs.store', ['server' => $this->server]), [
-            'command' => 'ls -la',
-            'user' => 'vito',
-            'frequency' => '* * * * *',
-            'site_id' => $site->id,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('cron_jobs', [
-            'server_id' => $this->server->id,
-            'site_id' => $site->id,
-            'command' => 'ls -la',
-            'user' => 'vito',
-            'frequency' => '* * * * *',
-            'status' => CronjobStatus::READY,
-        ]);
-    }
-
-    public function test_cannot_create_cronjob_with_invalid_site_id(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->post(route('cronjobs.store', ['server' => $this->server]), [
-            'command' => 'ls -la',
-            'user' => 'vito',
-            'frequency' => '* * * * *',
-            'site_id' => 99999, // Non-existent site ID
-        ])
-            ->assertSessionHasErrors(['site_id']);
-
-        $this->assertDatabaseMissing('cron_jobs', [
-            'server_id' => $this->server->id,
-            'site_id' => 99999,
-        ]);
-    }
-
-    public function test_cannot_create_cronjob_with_site_id_from_different_server(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        /** @var Server $otherServer */
-        $otherServer = Server::factory()->create(['user_id' => 1]);
-
-        /** @var Site $otherSite */
-        $otherSite = Site::factory()->create([
-            'server_id' => $otherServer->id,
-        ]);
-
-        $this->post(route('cronjobs.store', ['server' => $this->server]), [
-            'command' => 'ls -la',
-            'user' => 'vito',
-            'frequency' => '* * * * *',
-            'site_id' => $otherSite->id,
-        ])
-            ->assertSessionHasErrors(['site_id']);
-
-        $this->assertDatabaseMissing('cron_jobs', [
-            'server_id' => $this->server->id,
-            'site_id' => $otherSite->id,
-        ]);
-    }
-
-    public function test_edit_cronjob_with_valid_site_id(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->put(route('cronjobs.update', [
-            'server' => $this->server,
-            'cronJob' => $cronjob,
-        ]), [
-            'command' => 'updated command',
-            'user' => 'vito',
-            'frequency' => '* * * * *',
-            'site_id' => $site->id,
-            'name' => 'Updated Cronjob',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $cronjob->refresh();
-
-        $this->assertEquals($site->id, $cronjob->site_id);
-        $this->assertEquals('updated command', $cronjob->command);
-        $this->assertEquals('Updated Cronjob', $cronjob->name);
-    }
-
-    public function test_cannot_edit_cronjob_with_invalid_site_id(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->put(route('cronjobs.update', [
-            'server' => $this->server,
-            'cronJob' => $cronjob,
-        ]), [
-            'command' => 'updated command',
-            'user' => 'vito',
-            'frequency' => '* * * * *',
-            'site_id' => 99999, // Non-existent site ID
-        ])
-            ->assertSessionHasErrors(['site_id']);
-
-        $cronjob->refresh();
-
-        $this->assertNotEquals(99999, $cronjob->site_id);
-    }
-
-    public function test_cannot_edit_cronjob_with_site_id_from_different_server(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        /** @var Server $otherServer */
-        $otherServer = Server::factory()->create(['user_id' => 1]);
-
-        /** @var Site $otherSite */
-        $otherSite = Site::factory()->create([
-            'server_id' => $otherServer->id,
-        ]);
-
-        $this->put(route('cronjobs.update', [
-            'server' => $this->server,
-            'cronJob' => $cronjob,
-        ]), [
-            'command' => 'updated command',
-            'user' => 'vito',
-            'frequency' => '* * * * *',
-            'site_id' => $otherSite->id,
-        ])
-            ->assertSessionHasErrors(['site_id']);
-
-        $cronjob->refresh();
-
-        $this->assertNotEquals($otherSite->id, $cronjob->site_id);
-    }
-}
+
+uses(RefreshDatabase::class);
+
+test('see cronjobs list', function () {
+    $this->actingAs($this->user);
+
+    CronJob::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->get(route('cronjobs', $this->server))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('cronjobs/index'));
+});
+
+test('delete cronjob', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'vito',
+    ]);
+
+    $this->delete(route('cronjobs.destroy', [
+        'server' => $this->server,
+        'cronJob' => $cronjob,
+    ]));
+
+    $this->assertDatabaseMissing('cron_jobs', [
+        'id' => $cronjob->id,
+    ]);
+
+    SSH::assertExecutedContains("echo '' | sudo -u vito crontab -");
+    SSH::assertExecutedContains('sudo -u vito crontab -l');
+});
+
+test('create cronjob', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('cronjobs.store', ['server' => $this->server]), [
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+        'name' => 'My Cronjob',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('cron_jobs', [
+        'server_id' => $this->server->id,
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+        'status' => CronjobStatus::READY,
+        'name' => 'My Cronjob',
+    ]);
+
+    SSH::assertExecutedContains("echo '* * * * * bash -lc '\\''ls -la'\\''' | sudo -u vito crontab -");
+    SSH::assertExecutedContains('sudo -u vito crontab -l');
+});
+
+test('create cronjob for isolated user', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->site->user = 'example';
+    $this->site->save();
+
+    $this->post(route('cronjobs.store', ['server' => $this->server]), [
+        'command' => 'ls -la',
+        'user' => 'example',
+        'frequency' => '* * * * *',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('cron_jobs', [
+        'server_id' => $this->server->id,
+        'user' => 'example',
+    ]);
+
+    SSH::assertExecutedContains("echo '* * * * * bash -lc '\\''ls -la'\\''' | sudo -u example crontab -");
+    SSH::assertExecutedContains('sudo -u example crontab -l');
+});
+
+test('cannot create cronjob for non existing user', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->post(route('cronjobs.store', ['server' => $this->server]), [
+        'command' => 'ls -la',
+        'user' => 'example',
+        'frequency' => '* * * * *',
+    ])
+        ->assertSessionHasErrors();
+
+    $this->assertDatabaseMissing('cron_jobs', [
+        'server_id' => $this->server->id,
+        'user' => 'example',
+    ]);
+});
+
+test('cannot create cronjob for user on another server', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    Site::factory()->create([
+        'server_id' => Server::factory()->create(['user_id' => 1])->id,
+        'user' => 'example',
+    ]);
+
+    $this->post(route('cronjobs.store', ['server' => $this->server]), [
+        'command' => 'ls -la',
+        'user' => 'example',
+        'frequency' => '* * * * *',
+    ])
+        ->assertSessionHasErrors();
+
+    $this->assertDatabaseMissing('cron_jobs', [
+        'user' => 'example',
+    ]);
+});
+
+test('create custom cronjob', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('cronjobs.store', ['server' => $this->server]), [
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => 'custom',
+        'custom' => '* * * 1 1',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('cron_jobs', [
+        'server_id' => $this->server->id,
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => '* * * 1 1',
+        'status' => CronjobStatus::READY,
+    ]);
+
+    SSH::assertExecutedContains("echo '* * * 1 1 bash -lc '\\''ls -la'\\''' | sudo -u vito crontab -");
+    SSH::assertExecutedContains('sudo -u vito crontab -l');
+});
+
+test('cronjob is wrapped in login shell and survives sync', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'vito',
+        'command' => "echo 'hi'",
+        'frequency' => '* * * * *',
+        'status' => CronjobStatus::READY,
+        'site_id' => null,
+    ]);
+
+    $crontab = CronJob::crontab($this->server, 'vito');
+    expect($crontab)->toBe("* * * * * bash -lc 'echo '\\''hi'\\'''");
+    expect(CronJob::unwrapCommand("bash -lc 'echo '\\''hi'\\'''"))->toBe("echo 'hi'");
+
+    SSH::fake($crontab);
+    app(SyncCronJobs::class)->sync($this->server);
+
+    $cronjob->refresh();
+    expect($cronjob->status)->toBe(CronjobStatus::READY);
+    expect(CronJob::query()->where('user', 'vito')->where('command', "echo 'hi'")->count())->toBe(1);
+});
+
+test('root cronjob is not wrapped', function () {
+    $this->actingAs($this->user);
+
+    CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/backup.sh',
+        'frequency' => '0 2 * * *',
+        'status' => CronjobStatus::READY,
+        'site_id' => null,
+    ]);
+
+    expect(CronJob::crontab($this->server, 'root'))->toBe('0 2 * * * /usr/bin/backup.sh');
+});
+
+test('enable cronjob', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'vito',
+        'command' => 'ls -la',
+        'frequency' => '* * * 1 1',
+        'status' => CronjobStatus::DISABLED,
+    ]);
+
+    $this->post(route('cronjobs.enable', [
+        'server' => $this->server,
+        'cronJob' => $cronjob,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $cronjob->refresh();
+
+    expect($cronjob->status)->toEqual(CronjobStatus::READY);
+
+    SSH::assertExecutedContains("echo '* * * 1 1 bash -lc '\\''ls -la'\\''' | sudo -u vito crontab -");
+    SSH::assertExecutedContains('sudo -u vito crontab -l');
+});
+
+test('disable cronjob', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'vito',
+        'command' => 'ls -la',
+        'frequency' => '* * * 1 1',
+        'status' => CronjobStatus::READY,
+    ]);
+
+    $this->post(route('cronjobs.disable', [
+        'server' => $this->server,
+        'cronJob' => $cronjob,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $cronjob->refresh();
+
+    expect($cronjob->status)->toEqual(CronjobStatus::DISABLED);
+
+    SSH::assertExecutedContains("echo '' | sudo -u vito crontab -");
+    SSH::assertExecutedContains('sudo -u vito crontab -l');
+});
+
+test('create cronjob with valid site id', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->post(route('cronjobs.store', ['server' => $this->server]), [
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+        'site_id' => $site->id,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('cron_jobs', [
+        'server_id' => $this->server->id,
+        'site_id' => $site->id,
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+        'status' => CronjobStatus::READY,
+    ]);
+});
+
+test('cannot create cronjob with invalid site id', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->post(route('cronjobs.store', ['server' => $this->server]), [
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+        'site_id' => 99999, // Non-existent site ID
+    ])
+        ->assertSessionHasErrors(['site_id']);
+
+    $this->assertDatabaseMissing('cron_jobs', [
+        'server_id' => $this->server->id,
+        'site_id' => 99999,
+    ]);
+});
+
+test('cannot create cronjob with site id from different server', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    /** @var Server $otherServer */
+    $otherServer = Server::factory()->create(['user_id' => 1]);
+
+    /** @var Site $otherSite */
+    $otherSite = Site::factory()->create([
+        'server_id' => $otherServer->id,
+    ]);
+
+    $this->post(route('cronjobs.store', ['server' => $this->server]), [
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+        'site_id' => $otherSite->id,
+    ])
+        ->assertSessionHasErrors(['site_id']);
+
+    $this->assertDatabaseMissing('cron_jobs', [
+        'server_id' => $this->server->id,
+        'site_id' => $otherSite->id,
+    ]);
+});
+
+test('edit cronjob with valid site id', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->put(route('cronjobs.update', [
+        'server' => $this->server,
+        'cronJob' => $cronjob,
+    ]), [
+        'command' => 'updated command',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+        'site_id' => $site->id,
+        'name' => 'Updated Cronjob',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $cronjob->refresh();
+
+    expect($cronjob->site_id)->toEqual($site->id);
+    expect($cronjob->command)->toEqual('updated command');
+    expect($cronjob->name)->toEqual('Updated Cronjob');
+});
+
+test('cannot edit cronjob with invalid site id', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->put(route('cronjobs.update', [
+        'server' => $this->server,
+        'cronJob' => $cronjob,
+    ]), [
+        'command' => 'updated command',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+        'site_id' => 99999, // Non-existent site ID
+    ])
+        ->assertSessionHasErrors(['site_id']);
+
+    $cronjob->refresh();
+
+    $this->assertNotEquals(99999, $cronjob->site_id);
+});
+
+test('cannot edit cronjob with site id from different server', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    /** @var Server $otherServer */
+    $otherServer = Server::factory()->create(['user_id' => 1]);
+
+    /** @var Site $otherSite */
+    $otherSite = Site::factory()->create([
+        'server_id' => $otherServer->id,
+    ]);
+
+    $this->put(route('cronjobs.update', [
+        'server' => $this->server,
+        'cronJob' => $cronjob,
+    ]), [
+        'command' => 'updated command',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+        'site_id' => $otherSite->id,
+    ])
+        ->assertSessionHasErrors(['site_id']);
+
+    $cronjob->refresh();
+
+    $this->assertNotEquals($otherSite->id, $cronjob->site_id);
+});

--- a/tests/Feature/DNSProvidersTest.php
+++ b/tests/Feature/DNSProvidersTest.php
@@ -1,517 +1,487 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\DNSProvider;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
-use Tests\TestCase;
-
-class DNSProvidersTest extends TestCase
-{
-    use RefreshDatabase;
-
-    public function test_authenticated_user_can_view_dns_providers_index(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $response = $this->get(route('dns-providers'));
-
-        $response->assertSuccessful();
-        $response->assertInertia(fn ($page) => $page
-            ->component('dns-providers/index')
-            ->has('dnsProviders.data', 1)
-            ->where('dnsProviders.data.0.id', $dnsProvider->id)
-            ->where('dnsProviders.data.0.name', $dnsProvider->name)
-            ->where('dnsProviders.data.0.provider', $dnsProvider->provider)
-            ->where('dnsProviders.data.0.connected', $dnsProvider->connected)
-        );
-    }
-
-    public function test_authenticated_user_can_view_dns_providers_json(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $response = $this->get(route('dns-providers.json'));
-
-        $response->assertSuccessful();
-        $response->assertJsonFragment([
-            'id' => $dnsProvider->id,
-            'name' => $dnsProvider->name,
-            'provider' => $dnsProvider->provider,
-            'connected' => $dnsProvider->connected,
-            'project_id' => $dnsProvider->project_id,
-            'global' => is_null($dnsProvider->project_id),
-        ]);
-    }
-
-    public function test_authenticated_user_can_create_dns_provider(): void
-    {
-        $this->actingAs($this->user);
-
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'success' => true,
-                'result' => ['id' => 'test-user-id'],
-            ], 200),
-        ]);
-
-        $data = [
-            'name' => 'Test Cloudflare',
-            'provider' => 'cloudflare',
-            'token' => 'fake-token',
-        ];
-
-        $response = $this->post(route('dns-providers.store'), $data);
-
-        $response->assertRedirect();
-        $response->assertSessionHas('success', 'DNS provider created.');
-
-        $this->assertDatabaseHas('dns_providers', [
-            'user_id' => $this->user->id,
-            'name' => 'Test Cloudflare',
-            'provider' => 'cloudflare',
-            'project_id' => $this->user->current_project_id,
-            'connected' => true,
-        ]);
-    }
-
-    public function test_authenticated_user_can_create_global_dns_provider(): void
-    {
-        $this->actingAs($this->user);
-
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'success' => true,
-                'result' => ['id' => 'test-user-id'],
-            ], 200),
-        ]);
-
-        $data = [
-            'name' => 'Global Cloudflare',
-            'provider' => 'cloudflare',
-            'token' => 'fake-token',
-            'global' => true,
-        ];
-
-        $response = $this->post(route('dns-providers.store'), $data);
-
-        $response->assertRedirect();
-        $response->assertSessionHas('success', 'DNS provider created.');
 
-        $this->assertDatabaseHas('dns_providers', [
-            'user_id' => $this->user->id,
-            'name' => 'Global Cloudflare',
-            'provider' => 'cloudflare',
-            'project_id' => null,
-            'connected' => true,
-        ]);
-    }
+uses(RefreshDatabase::class);
+
+test('authenticated user can view dns providers index', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $response = $this->get(route('dns-providers'));
+
+    $response->assertSuccessful();
+    $response->assertInertia(fn ($page) => $page
+        ->component('dns-providers/index')
+        ->has('dnsProviders.data', 1)
+        ->where('dnsProviders.data.0.id', $dnsProvider->id)
+        ->where('dnsProviders.data.0.name', $dnsProvider->name)
+        ->where('dnsProviders.data.0.provider', $dnsProvider->provider)
+        ->where('dnsProviders.data.0.connected', $dnsProvider->connected)
+    );
+});
+
+test('authenticated user can view dns providers json', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $response = $this->get(route('dns-providers.json'));
+
+    $response->assertSuccessful();
+    $response->assertJsonFragment([
+        'id' => $dnsProvider->id,
+        'name' => $dnsProvider->name,
+        'provider' => $dnsProvider->provider,
+        'connected' => $dnsProvider->connected,
+        'project_id' => $dnsProvider->project_id,
+        'global' => is_null($dnsProvider->project_id),
+    ]);
+});
+
+test('authenticated user can create dns provider', function () {
+    $this->actingAs($this->user);
+
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'success' => true,
+            'result' => ['id' => 'test-user-id'],
+        ], 200),
+    ]);
+
+    $data = [
+        'name' => 'Test Cloudflare',
+        'provider' => 'cloudflare',
+        'token' => 'fake-token',
+    ];
+
+    $response = $this->post(route('dns-providers.store'), $data);
+
+    $response->assertRedirect();
+    $response->assertSessionHas('success', 'DNS provider created.');
+
+    $this->assertDatabaseHas('dns_providers', [
+        'user_id' => $this->user->id,
+        'name' => 'Test Cloudflare',
+        'provider' => 'cloudflare',
+        'project_id' => $this->user->current_project_id,
+        'connected' => true,
+    ]);
+});
+
+test('authenticated user can create global dns provider', function () {
+    $this->actingAs($this->user);
+
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'success' => true,
+            'result' => ['id' => 'test-user-id'],
+        ], 200),
+    ]);
+
+    $data = [
+        'name' => 'Global Cloudflare',
+        'provider' => 'cloudflare',
+        'token' => 'fake-token',
+        'global' => true,
+    ];
+
+    $response = $this->post(route('dns-providers.store'), $data);
+
+    $response->assertRedirect();
+    $response->assertSessionHas('success', 'DNS provider created.');
+
+    $this->assertDatabaseHas('dns_providers', [
+        'user_id' => $this->user->id,
+        'name' => 'Global Cloudflare',
+        'provider' => 'cloudflare',
+        'project_id' => null,
+        'connected' => true,
+    ]);
+});
 
-    public function test_dns_provider_creation_requires_name(): void
-    {
-        $this->actingAs($this->user);
+test('dns provider creation requires name', function () {
+    $this->actingAs($this->user);
 
-        $data = [
-            'provider' => 'cloudflare',
-            'token' => 'fake-token',
-        ];
-
-        $response = $this->post(route('dns-providers.store'), $data);
+    $data = [
+        'provider' => 'cloudflare',
+        'token' => 'fake-token',
+    ];
 
-        $response->assertSessionHasErrors(['name']);
-    }
+    $response = $this->post(route('dns-providers.store'), $data);
 
-    public function test_dns_provider_creation_requires_valid_provider(): void
-    {
-        $this->actingAs($this->user);
-
-        $data = [
-            'name' => 'Test Provider',
-            'provider' => 'invalid-provider',
-            'token' => 'fake-token',
-        ];
-
-        $response = $this->post(route('dns-providers.store'), $data);
-
-        $response->assertSessionHasErrors(['provider']);
-    }
-
-    public function test_dns_provider_creation_validates_credentials(): void
-    {
-        $this->actingAs($this->user);
-
-        $data = [
-            'name' => 'Test Cloudflare',
-            'provider' => 'cloudflare',
-            // Missing required 'token' field
-        ];
-
-        $response = $this->post(route('dns-providers.store'), $data);
-
-        $response->assertSessionHasErrors();
-    }
-
-    public function test_dns_provider_creation_fails_with_invalid_credentials(): void
-    {
-        $this->actingAs($this->user);
-
-        Http::fake([
-            '*' => Http::response([], 401),
-        ]);
-
-        $data = [
-            'name' => 'Test Cloudflare',
-            'provider' => 'cloudflare',
-            'token' => 'invalid-token',
-        ];
-
-        $response = $this->post(route('dns-providers.store'), $data);
-
-        $response->assertSessionHasErrors(['provider']);
-    }
-
-    public function test_authenticated_user_can_update_dns_provider(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $data = [
-            'name' => 'Updated Name',
-        ];
-
-        $response = $this->patch(route('dns-providers.update', $dnsProvider), $data);
-
-        $response->assertRedirect();
-        $response->assertSessionHas('success', 'DNS provider updated.');
-
-        $this->assertDatabaseHas('dns_providers', [
-            'id' => $dnsProvider->id,
-            'name' => 'Updated Name',
-            'connected' => true,
-        ]);
-    }
-
-    public function test_dns_provider_update_keeps_credentials_when_empty(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'credentials' => ['token' => 'original-token'],
-        ]);
-
-        $response = $this->patch(route('dns-providers.update', $dnsProvider), [
-            'name' => 'Updated Name',
-        ]);
-
-        $response->assertRedirect();
-
-        $dnsProvider->refresh();
-        $this->assertEquals('Updated Name', $dnsProvider->name);
-        $this->assertEquals(['token' => 'original-token'], $dnsProvider->credentials);
-    }
-
-    public function test_dns_provider_update_changes_credentials_when_provided(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'credentials' => ['token' => 'original-token'],
-        ]);
-
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'success' => true,
-                'result' => [],
-            ], 200),
-        ]);
-
-        $response = $this->patch(route('dns-providers.update', $dnsProvider), [
-            'name' => 'Updated Name',
-            'token' => 'new-token',
-        ]);
+    $response->assertSessionHasErrors(['name']);
+});
 
-        $response->assertRedirect();
-        $response->assertSessionHas('success', 'DNS provider updated.');
+test('dns provider creation requires valid provider', function () {
+    $this->actingAs($this->user);
 
-        $dnsProvider->refresh();
-        $this->assertEquals(['token' => 'new-token'], $dnsProvider->credentials);
-    }
+    $data = [
+        'name' => 'Test Provider',
+        'provider' => 'invalid-provider',
+        'token' => 'fake-token',
+    ];
 
-    public function test_dns_provider_update_rejects_invalid_credentials(): void
-    {
-        $this->actingAs($this->user);
+    $response = $this->post(route('dns-providers.store'), $data);
+
+    $response->assertSessionHasErrors(['provider']);
+});
 
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'credentials' => ['token' => 'original-token'],
-        ]);
+test('dns provider creation validates credentials', function () {
+    $this->actingAs($this->user);
 
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'success' => false,
-                'errors' => [['message' => 'Invalid token']],
-            ], 401),
-        ]);
+    $data = [
+        'name' => 'Test Cloudflare',
+        'provider' => 'cloudflare',
+        // Missing required 'token' field
+    ];
 
-        $response = $this->patch(route('dns-providers.update', $dnsProvider), [
-            'name' => 'Updated Name',
-            'token' => 'bad-token',
-        ]);
+    $response = $this->post(route('dns-providers.store'), $data);
 
-        $response->assertRedirect();
-        $response->assertSessionHasErrors('provider');
+    $response->assertSessionHasErrors();
+});
 
-        $dnsProvider->refresh();
-        $this->assertEquals(['token' => 'original-token'], $dnsProvider->credentials);
-    }
+test('dns provider creation fails with invalid credentials', function () {
+    $this->actingAs($this->user);
+
+    Http::fake([
+        '*' => Http::response([], 401),
+    ]);
+
+    $data = [
+        'name' => 'Test Cloudflare',
+        'provider' => 'cloudflare',
+        'token' => 'invalid-token',
+    ];
+
+    $response = $this->post(route('dns-providers.store'), $data);
+
+    $response->assertSessionHasErrors(['provider']);
+});
+
+test('authenticated user can update dns provider', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-    public function test_dns_provider_update_requires_name(): void
-    {
-        $this->actingAs($this->user);
+    $data = [
+        'name' => 'Updated Name',
+    ];
 
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $response = $this->patch(route('dns-providers.update', $dnsProvider), $data);
 
-        $data = [];
+    $response->assertRedirect();
+    $response->assertSessionHas('success', 'DNS provider updated.');
 
-        $response = $this->patch(route('dns-providers.update', $dnsProvider), $data);
+    $this->assertDatabaseHas('dns_providers', [
+        'id' => $dnsProvider->id,
+        'name' => 'Updated Name',
+        'connected' => true,
+    ]);
+});
 
-        $response->assertSessionHasErrors(['name']);
-    }
+test('dns provider update keeps credentials when empty', function () {
+    $this->actingAs($this->user);
 
-    public function test_authenticated_user_can_delete_dns_provider(): void
-    {
-        $this->actingAs($this->user);
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'credentials' => ['token' => 'original-token'],
+    ]);
 
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $response = $this->patch(route('dns-providers.update', $dnsProvider), [
+        'name' => 'Updated Name',
+    ]);
 
-        $response = $this->delete(route('dns-providers.destroy', $dnsProvider));
+    $response->assertRedirect();
 
-        $response->assertRedirect(route('dns-providers'));
-        $response->assertSessionHas('success', 'DNS provider deleted.');
+    $dnsProvider->refresh();
+    expect($dnsProvider->name)->toEqual('Updated Name');
+    expect($dnsProvider->credentials)->toEqual(['token' => 'original-token']);
+});
 
-        $this->assertDatabaseMissing('dns_providers', [
-            'id' => $dnsProvider->id,
-        ]);
-    }
+test('dns provider update changes credentials when provided', function () {
+    $this->actingAs($this->user);
 
-    public function test_guest_cannot_access_dns_providers(): void
-    {
-        $response = $this->get(route('dns-providers'));
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'credentials' => ['token' => 'original-token'],
+    ]);
 
-        $response->assertRedirect();
-    }
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'success' => true,
+            'result' => [],
+        ], 200),
+    ]);
 
-    public function test_guest_cannot_create_dns_provider(): void
-    {
-        $data = [
-            'name' => 'Test Provider',
-            'provider' => 'cloudflare',
-            'token' => 'fake-token',
-        ];
+    $response = $this->patch(route('dns-providers.update', $dnsProvider), [
+        'name' => 'Updated Name',
+        'token' => 'new-token',
+    ]);
 
-        $response = $this->post(route('dns-providers.store'), $data);
+    $response->assertRedirect();
+    $response->assertSessionHas('success', 'DNS provider updated.');
 
-        $response->assertRedirect();
-    }
+    $dnsProvider->refresh();
+    expect($dnsProvider->credentials)->toEqual(['token' => 'new-token']);
+});
 
-    public function test_guest_cannot_update_dns_provider(): void
-    {
-        $dnsProvider = DNSProvider::factory()->create();
+test('dns provider update rejects invalid credentials', function () {
+    $this->actingAs($this->user);
 
-        $data = [
-            'name' => 'Updated Name',
-        ];
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'credentials' => ['token' => 'original-token'],
+    ]);
 
-        $response = $this->patch(route('dns-providers.update', $dnsProvider), $data);
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'success' => false,
+            'errors' => [['message' => 'Invalid token']],
+        ], 401),
+    ]);
 
-        $response->assertRedirect();
-    }
-
-    public function test_guest_cannot_delete_dns_provider(): void
-    {
-        $dnsProvider = DNSProvider::factory()->create();
-
-        $response = $this->delete(route('dns-providers.destroy', $dnsProvider));
-
-        $response->assertRedirect();
-    }
-
-    public function test_user_cannot_view_other_users_dns_providers(): void
-    {
-        $this->actingAs($this->user);
-
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-
-        DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherUser->current_project_id,
-        ]);
-
-        $response = $this->get(route('dns-providers'));
-
-        $response->assertSuccessful();
-        $response->assertInertia(fn ($page) => $page
-            ->component('dns-providers/index')
-            ->has('dnsProviders.data', 0)
-        );
-    }
-
-    public function test_user_cannot_update_other_users_dns_provider(): void
-    {
-        $this->actingAs($this->user);
-
-        $otherUser = User::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
-
-        $data = [
-            'name' => 'Hacked Name',
-        ];
-
-        $response = $this->patch(route('dns-providers.update', $otherDnsProvider), $data);
-
-        $response->assertForbidden();
-    }
-
-    public function test_user_cannot_delete_other_users_dns_provider(): void
-    {
-        $this->actingAs($this->user);
-
-        $otherUser = User::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
-
-        $response = $this->delete(route('dns-providers.destroy', $otherDnsProvider));
-
-        $response->assertForbidden();
-    }
-
-    public function test_user_can_only_see_own_dns_providers_in_json(): void
-    {
-        $this->actingAs($this->user);
-
-        $ownDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherUser->current_project_id,
-        ]);
-
-        $response = $this->get(route('dns-providers.json'));
-
-        $response->assertSuccessful();
-        $response->assertJsonFragment([
-            'id' => $ownDnsProvider->id,
-        ]);
-        $response->assertJsonMissing([
-            'id' => $otherDnsProvider->id,
-        ]);
-    }
-
-    public function test_dns_providers_are_filtered_by_project(): void
-    {
-        $this->actingAs($this->user);
-
-        // Create DNS provider for current project
-        $projectDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        // Create global DNS provider (no project)
-        $globalDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => null,
-        ]);
-
-        // Create DNS provider for different project
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-        $otherProjectDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherUser->current_project_id,
-        ]);
-
-        $response = $this->get(route('dns-providers.json'));
-
-        $response->assertSuccessful();
-        $response->assertJsonFragment([
-            'id' => $projectDnsProvider->id,
-        ]);
-        $response->assertJsonFragment([
-            'id' => $globalDnsProvider->id,
-        ]);
-        $response->assertJsonMissing([
-            'id' => $otherProjectDnsProvider->id,
-        ]);
-    }
-
-    public function test_dns_provider_creation_ignores_user_id_manipulation(): void
-    {
-        $this->actingAs($this->user);
-
-        $otherUser = User::factory()->create();
-
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'success' => true,
-                'result' => ['id' => 'test-user-id'],
-            ], 200),
-        ]);
-
-        $data = [
-            'name' => 'Test Provider',
-            'provider' => 'cloudflare',
-            'token' => 'fake-token',
-            'user_id' => $otherUser->id, // Attempt to set different user
-        ];
-
-        $response = $this->post(route('dns-providers.store'), $data);
-
-        $response->assertRedirect();
-        $response->assertSessionHas('success', 'DNS provider created.');
-
-        $this->assertDatabaseHas('dns_providers', [
-            'user_id' => $this->user->id, // Should be set to authenticated user
-            'name' => 'Test Provider',
-        ]);
-
-        $this->assertDatabaseMissing('dns_providers', [
-            'user_id' => $otherUser->id,
-        ]);
-    }
-}
+    $response = $this->patch(route('dns-providers.update', $dnsProvider), [
+        'name' => 'Updated Name',
+        'token' => 'bad-token',
+    ]);
+
+    $response->assertRedirect();
+    $response->assertSessionHasErrors('provider');
+
+    $dnsProvider->refresh();
+    expect($dnsProvider->credentials)->toEqual(['token' => 'original-token']);
+});
+
+test('dns provider update requires name', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $data = [];
+
+    $response = $this->patch(route('dns-providers.update', $dnsProvider), $data);
+
+    $response->assertSessionHasErrors(['name']);
+});
+
+test('authenticated user can delete dns provider', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $response = $this->delete(route('dns-providers.destroy', $dnsProvider));
+
+    $response->assertRedirect(route('dns-providers'));
+    $response->assertSessionHas('success', 'DNS provider deleted.');
+
+    $this->assertDatabaseMissing('dns_providers', [
+        'id' => $dnsProvider->id,
+    ]);
+});
+
+test('guest cannot access dns providers', function () {
+    $response = $this->get(route('dns-providers'));
+
+    $response->assertRedirect();
+});
+
+test('guest cannot create dns provider', function () {
+    $data = [
+        'name' => 'Test Provider',
+        'provider' => 'cloudflare',
+        'token' => 'fake-token',
+    ];
+
+    $response = $this->post(route('dns-providers.store'), $data);
+
+    $response->assertRedirect();
+});
+
+test('guest cannot update dns provider', function () {
+    $dnsProvider = DNSProvider::factory()->create();
+
+    $data = [
+        'name' => 'Updated Name',
+    ];
+
+    $response = $this->patch(route('dns-providers.update', $dnsProvider), $data);
+
+    $response->assertRedirect();
+});
+
+test('guest cannot delete dns provider', function () {
+    $dnsProvider = DNSProvider::factory()->create();
+
+    $response = $this->delete(route('dns-providers.destroy', $dnsProvider));
+
+    $response->assertRedirect();
+});
+
+test('user cannot view other users dns providers', function () {
+    $this->actingAs($this->user);
+
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+
+    DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherUser->current_project_id,
+    ]);
+
+    $response = $this->get(route('dns-providers'));
+
+    $response->assertSuccessful();
+    $response->assertInertia(fn ($page) => $page
+        ->component('dns-providers/index')
+        ->has('dnsProviders.data', 0)
+    );
+});
+
+test('user cannot update other users dns provider', function () {
+    $this->actingAs($this->user);
+
+    $otherUser = User::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    $data = [
+        'name' => 'Hacked Name',
+    ];
+
+    $response = $this->patch(route('dns-providers.update', $otherDnsProvider), $data);
+
+    $response->assertForbidden();
+});
+
+test('user cannot delete other users dns provider', function () {
+    $this->actingAs($this->user);
+
+    $otherUser = User::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    $response = $this->delete(route('dns-providers.destroy', $otherDnsProvider));
+
+    $response->assertForbidden();
+});
+
+test('user can only see own dns providers in json', function () {
+    $this->actingAs($this->user);
+
+    $ownDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherUser->current_project_id,
+    ]);
+
+    $response = $this->get(route('dns-providers.json'));
+
+    $response->assertSuccessful();
+    $response->assertJsonFragment([
+        'id' => $ownDnsProvider->id,
+    ]);
+    $response->assertJsonMissing([
+        'id' => $otherDnsProvider->id,
+    ]);
+});
+
+test('dns providers are filtered by project', function () {
+    $this->actingAs($this->user);
+
+    // Create DNS provider for current project
+    $projectDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    // Create global DNS provider (no project)
+    $globalDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => null,
+    ]);
+
+    // Create DNS provider for different project
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+    $otherProjectDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherUser->current_project_id,
+    ]);
+
+    $response = $this->get(route('dns-providers.json'));
+
+    $response->assertSuccessful();
+    $response->assertJsonFragment([
+        'id' => $projectDnsProvider->id,
+    ]);
+    $response->assertJsonFragment([
+        'id' => $globalDnsProvider->id,
+    ]);
+    $response->assertJsonMissing([
+        'id' => $otherProjectDnsProvider->id,
+    ]);
+});
+
+test('dns provider creation ignores user id manipulation', function () {
+    $this->actingAs($this->user);
+
+    $otherUser = User::factory()->create();
+
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'success' => true,
+            'result' => ['id' => 'test-user-id'],
+        ], 200),
+    ]);
+
+    $data = [
+        'name' => 'Test Provider',
+        'provider' => 'cloudflare',
+        'token' => 'fake-token',
+        'user_id' => $otherUser->id, // Attempt to set different user
+    ];
+
+    $response = $this->post(route('dns-providers.store'), $data);
+
+    $response->assertRedirect();
+    $response->assertSessionHas('success', 'DNS provider created.');
+
+    $this->assertDatabaseHas('dns_providers', [
+        'user_id' => $this->user->id, // Should be set to authenticated user
+        'name' => 'Test Provider',
+    ]);
+
+    $this->assertDatabaseMissing('dns_providers', [
+        'user_id' => $otherUser->id,
+    ]);
+});

--- a/tests/Feature/DatabaseTest.php
+++ b/tests/Feature/DatabaseTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\DatabaseStatus;
 use App\Enums\DatabaseUserStatus;
 use App\Enums\ServiceStatus;
@@ -12,233 +10,219 @@ use App\Services\Database\Mysql;
 use App\Services\Database\Postgresql;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class DatabaseTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_database(): void
-    {
-        $this->actingAs($this->user);
+test('create database', function () {
+    $this->actingAs($this->user);
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->post(route('databases.store', $this->server), [
-            'name' => 'database',
-            'charset' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
-        ])->assertSessionDoesntHaveErrors();
+    $this->post(route('databases.store', $this->server), [
+        'name' => 'database',
+        'charset' => 'utf8mb4',
+        'collation' => 'utf8mb4_unicode_ci',
+    ])->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('databases', [
-            'name' => 'database',
-            'status' => DatabaseStatus::READY,
-        ]);
-    }
+    $this->assertDatabaseHas('databases', [
+        'name' => 'database',
+        'status' => DatabaseStatus::READY,
+    ]);
+});
 
-    public function test_create_database_with_user(): void
-    {
-        $this->actingAs($this->user);
+test('create database with user', function () {
+    $this->actingAs($this->user);
 
-        SSH::fake();
+    SSH::fake();
 
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'user',
-            'databases' => [],
-            'status' => DatabaseUserStatus::READY,
-        ]);
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'user',
+        'databases' => [],
+        'status' => DatabaseUserStatus::READY,
+    ]);
 
-        $this->post(route('databases.store', $this->server), [
-            'name' => 'database',
-            'charset' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
-            'user' => true,
-            'existing_user_id' => $databaseUser->id,
-        ])->assertSessionDoesntHaveErrors();
+    $this->post(route('databases.store', $this->server), [
+        'name' => 'database',
+        'charset' => 'utf8mb4',
+        'collation' => 'utf8mb4_unicode_ci',
+        'user' => true,
+        'existing_user_id' => $databaseUser->id,
+    ])->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('databases', [
-            'name' => 'database',
-            'status' => DatabaseStatus::READY,
-        ]);
+    $this->assertDatabaseHas('databases', [
+        'name' => 'database',
+        'status' => DatabaseStatus::READY,
+    ]);
 
-        $databaseUser->refresh();
-        $this->assertContains('database', $databaseUser->databases);
-    }
+    $databaseUser->refresh();
+    expect($databaseUser->databases)->toContain('database');
+});
 
-    public function test_create_database_with_existing_user(): void
-    {
-        $this->actingAs($this->user);
+test('create database with existing user', function () {
+    $this->actingAs($this->user);
 
-        SSH::fake();
+    SSH::fake();
 
-        Database::factory()->create([
-            'server_id' => $this->server,
-            'name' => 'existing_db',
-            'status' => DatabaseStatus::READY,
-        ]);
+    Database::factory()->create([
+        'server_id' => $this->server,
+        'name' => 'existing_db',
+        'status' => DatabaseStatus::READY,
+    ]);
 
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'existing_user',
-            'databases' => ['existing_db'],
-            'status' => DatabaseUserStatus::READY,
-        ]);
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'existing_user',
+        'databases' => ['existing_db'],
+        'status' => DatabaseUserStatus::READY,
+    ]);
 
-        $this->post(route('databases.store', $this->server), [
-            'name' => 'new_database',
-            'charset' => 'utf8mb3',
-            'collation' => 'utf8mb3_general_ci',
-            'user' => true,
-            'existing_user_id' => $databaseUser->id,
-        ])->assertSessionDoesntHaveErrors();
+    $this->post(route('databases.store', $this->server), [
+        'name' => 'new_database',
+        'charset' => 'utf8mb3',
+        'collation' => 'utf8mb3_general_ci',
+        'user' => true,
+        'existing_user_id' => $databaseUser->id,
+    ])->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('databases', [
-            'name' => 'new_database',
-            'status' => DatabaseStatus::READY,
-        ]);
+    $this->assertDatabaseHas('databases', [
+        'name' => 'new_database',
+        'status' => DatabaseStatus::READY,
+    ]);
 
-        $databaseUser->refresh();
-        $this->assertContains('existing_db', $databaseUser->databases);
-        $this->assertContains('new_database', $databaseUser->databases);
-    }
+    $databaseUser->refresh();
+    expect($databaseUser->databases)->toContain('existing_db');
+    expect($databaseUser->databases)->toContain('new_database');
+});
 
-    public function test_see_databases_list(): void
-    {
-        $this->actingAs($this->user);
+test('see databases list', function () {
+    $this->actingAs($this->user);
 
-        Database::factory()->create([
-            'server_id' => $this->server,
-        ]);
+    Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
 
-        $this->get(route('databases', $this->server))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('databases/index'));
-    }
+    $this->get(route('databases', $this->server))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('databases/index'));
+});
 
-    public function test_delete_database(): void
-    {
-        $this->actingAs($this->user);
+test('delete database', function () {
+    $this->actingAs($this->user);
 
-        SSH::fake();
+    SSH::fake();
 
-        /** @var Database $database */
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
-        ]);
+    /** @var Database $database */
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
 
-        $this->delete(route('databases.destroy', [
-            'server' => $this->server,
-            'database' => $database,
-        ]))->assertSessionDoesntHaveErrors();
+    $this->delete(route('databases.destroy', [
+        'server' => $this->server,
+        'database' => $database,
+    ]))->assertSessionDoesntHaveErrors();
 
-        $this->assertSoftDeleted('databases', [
-            'id' => $database->id,
-        ]);
-    }
+    $this->assertSoftDeleted('databases', [
+        'id' => $database->id,
+    ]);
+});
 
-    public function test_sync_databases(): void
-    {
-        $this->actingAs($this->user);
+test('sync databases', function () {
+    $this->actingAs($this->user);
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->patch(route('databases.sync', $this->server))
-            ->assertSessionDoesntHaveErrors();
-    }
+    $this->patch(route('databases.sync', $this->server))
+        ->assertSessionDoesntHaveErrors();
+});
 
-    public function test_create_postgresql_database_with_icu_collation(): void
-    {
-        $this->actingAs($this->user);
+test('create postgresql database with icu collation', function () {
+    $this->actingAs($this->user);
 
-        $this->usePostgresql();
+    vitoPestFeatureDatabaseTestUsePostgresql();
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->post(route('databases.store', $this->server), [
-            'name' => 'pg_database',
-            'charset' => 'UTF8',
-            'collation' => 'en-US-x-icu',
-        ])->assertSessionDoesntHaveErrors();
+    $this->post(route('databases.store', $this->server), [
+        'name' => 'pg_database',
+        'charset' => 'UTF8',
+        'collation' => 'en-US-x-icu',
+    ])->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('databases', [
-            'name' => 'pg_database',
-            'collation' => 'en-US-x-icu',
-            'status' => DatabaseStatus::READY,
-        ]);
-    }
+    $this->assertDatabaseHas('databases', [
+        'name' => 'pg_database',
+        'collation' => 'en-US-x-icu',
+        'status' => DatabaseStatus::READY,
+    ]);
+});
 
-    public function test_create_database_rejects_malicious_collation(): void
-    {
-        $this->actingAs($this->user);
+test('create database rejects malicious collation', function () {
+    $this->actingAs($this->user);
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->post(route('databases.store', $this->server), [
-            'name' => 'database',
-            'charset' => 'utf8mb4',
-            'collation' => "x'; DROP DATABASE postgres; --",
-        ])->assertSessionHasErrors('collation');
+    $this->post(route('databases.store', $this->server), [
+        'name' => 'database',
+        'charset' => 'utf8mb4',
+        'collation' => "x'; DROP DATABASE postgres; --",
+    ])->assertSessionHasErrors('collation');
 
-        $this->assertDatabaseMissing('databases', [
-            'name' => 'database',
-        ]);
-    }
+    $this->assertDatabaseMissing('databases', [
+        'name' => 'database',
+    ]);
+});
 
-    public function test_postgresql_create_script_applies_collation_locale(): void
-    {
-        $rendered = view('ssh.services.database.postgresql.create', [
-            'name' => 'pg_database',
-            'charset' => 'UTF8',
-            'collation' => 'en-US-x-icu',
-        ])->render();
+test('postgresql create script applies collation locale', function () {
+    $rendered = view('ssh.services.database.postgresql.create', [
+        'name' => 'pg_database',
+        'charset' => 'UTF8',
+        'collation' => 'en-US-x-icu',
+    ])->render();
 
-        $this->assertStringContainsString('CREATE DATABASE', $rendered);
-        $this->assertStringContainsString('LOCALE_PROVIDER', $rendered);
-        $this->assertStringContainsString('\gexec', $rendered);
-        $this->assertStringContainsString('en-US-x-icu', $rendered);
-    }
+    $this->assertStringContainsString('CREATE DATABASE', $rendered);
+    $this->assertStringContainsString('LOCALE_PROVIDER', $rendered);
+    $this->assertStringContainsString('\gexec', $rendered);
+    $this->assertStringContainsString('en-US-x-icu', $rendered);
+});
 
-    public function test_sync_postgresql_preserves_icu_collation(): void
-    {
-        $this->actingAs($this->user);
+test('sync postgresql preserves icu collation', function () {
+    $this->actingAs($this->user);
 
-        $this->usePostgresql();
+    vitoPestFeatureDatabaseTestUsePostgresql();
 
-        Database::factory()->create([
-            'server_id' => $this->server,
-            'name' => 'pg_database',
-            'charset' => 'UTF8',
-            'collation' => 'af-NA-x-icu',
-            'status' => DatabaseStatus::READY,
-        ]);
+    Database::factory()->create([
+        'server_id' => $this->server,
+        'name' => 'pg_database',
+        'charset' => 'UTF8',
+        'collation' => 'af-NA-x-icu',
+        'status' => DatabaseStatus::READY,
+    ]);
 
-        SSH::fake(<<<'EOD'
+    SSH::fake(<<<'EOD'
          database_name | charset | collation
         ---------------+---------+-------------
          pg_database   | UTF8    | af-NA-x-icu
         (1 row)
         EOD);
 
-        $this->patch(route('databases.sync', $this->server))
-            ->assertSessionDoesntHaveErrors();
+    $this->patch(route('databases.sync', $this->server))
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('databases', [
-            'server_id' => $this->server->id,
-            'name' => 'pg_database',
-            'collation' => 'af-NA-x-icu',
-        ]);
-    }
+    $this->assertDatabaseHas('databases', [
+        'server_id' => $this->server->id,
+        'name' => 'pg_database',
+        'collation' => 'af-NA-x-icu',
+    ]);
+});
 
-    private function usePostgresql(): void
-    {
-        $this->server->services()->where('type', Mysql::type())->delete();
-        $this->server->services()->create([
-            'type' => Postgresql::type(),
-            'name' => Postgresql::id(),
-            'version' => '15',
-            'status' => ServiceStatus::READY,
-        ]);
-        $this->server->refresh();
-    }
+function vitoPestFeatureDatabaseTestUsePostgresql(): void
+{
+    test()->server->services()->where('type', Mysql::type())->delete();
+    test()->server->services()->create([
+        'type' => Postgresql::type(),
+        'name' => Postgresql::id(),
+        'version' => '15',
+        'status' => ServiceStatus::READY,
+    ]);
+    test()->server->refresh();
 }

--- a/tests/Feature/DatabaseUserTest.php
+++ b/tests/Feature/DatabaseUserTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\DatabaseUserPermission;
 use App\Enums\DatabaseUserStatus;
 use App\Enums\ServiceStatus;
@@ -12,794 +10,742 @@ use App\Services\Database\Mysql;
 use App\Services\Database\Postgresql;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class DatabaseUserTest extends TestCase
+uses(RefreshDatabase::class);
+
+test('create database user', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $this->post(route('database-users.store', [
+        'server' => $this->server,
+    ]), [
+        'username' => 'user',
+        'password' => 'password',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('database_users', [
+        'username' => 'user',
+        'status' => DatabaseUserStatus::READY,
+    ]);
+});
+
+test('create database user with remote', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $this->post(route('database-users.store', [
+        'server' => $this->server,
+    ]), [
+        'username' => 'user',
+        'password' => 'password',
+        'remote' => true,
+        'host' => '%',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('database_users', [
+        'username' => 'user',
+        'host' => '%',
+        'status' => DatabaseUserStatus::READY,
+    ]);
+});
+
+test('see database users list', function () {
+    $this->actingAs($this->user);
+
+    DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $this->get(route('database-users', $this->server))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('database-users/index'));
+});
+
+test('delete database user', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $this->delete(route('database-users.destroy', [
+        'server' => $this->server,
+        'databaseUser' => $databaseUser,
+    ]))->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseMissing('database_users', [
+        'id' => $databaseUser->id,
+    ]);
+});
+
+test('unlink database', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $this->put(route('database-users.link', [
+        'server' => $this->server,
+        'databaseUser' => $databaseUser,
+    ]), [
+        'databases' => [],
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('database_users', [
+        'username' => $databaseUser->username,
+        'databases' => $this->castAsJson([]),
+    ]);
+});
+
+test('update database user password', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'password' => 'old_password',
+    ]);
+
+    $this->put(route('database-users.update', [
+        'server' => $this->server,
+        'databaseUser' => $databaseUser,
+    ]), [
+        'password' => 'new_password',
+        'permission' => $databaseUser->permission->value,
+    ])->assertSessionDoesntHaveErrors();
+
+    $databaseUser->refresh();
+
+    expect($databaseUser->password)->toEqual('new_password');
+});
+
+test('update database user host', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'host' => 'localhost',
+    ]);
+
+    $this->put(route('database-users.update', [
+        'server' => $this->server,
+        'databaseUser' => $databaseUser,
+    ]), [
+        'remote' => true,
+        'host' => '%',
+        'permission' => $databaseUser->permission->value,
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('database_users', [
+        'id' => $databaseUser->id,
+        'host' => '%',
+    ]);
+});
+
+test('update database user password and host', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'password' => 'old_password',
+        'host' => 'localhost',
+    ]);
+
+    $this->put(route('database-users.update', [
+        'server' => $this->server,
+        'databaseUser' => $databaseUser,
+    ]), [
+        'password' => 'new_password',
+        'remote' => true,
+        'host' => '192.168.1.1',
+        'permission' => $databaseUser->permission->value,
+    ])->assertSessionDoesntHaveErrors();
+
+    $databaseUser->refresh();
+
+    expect($databaseUser->password)->toEqual('new_password');
+    expect($databaseUser->host)->toEqual('192.168.1.1');
+});
+
+test('create database user with admin permission', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $this->post(route('database-users.store', [
+        'server' => $this->server,
+    ]), [
+        'username' => 'user',
+        'password' => 'password',
+        'permission' => 'admin',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('database_users', [
+        'username' => 'user',
+        'permission' => 'admin',
+        'status' => DatabaseUserStatus::READY,
+    ]);
+});
+
+test('create database user with write permission', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $this->post(route('database-users.store', [
+        'server' => $this->server,
+    ]), [
+        'username' => 'user',
+        'password' => 'password',
+        'permission' => 'write',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('database_users', [
+        'username' => 'user',
+        'permission' => 'write',
+        'status' => DatabaseUserStatus::READY,
+    ]);
+});
+
+test('create database user with read permission', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $this->post(route('database-users.store', [
+        'server' => $this->server,
+    ]), [
+        'username' => 'user',
+        'password' => 'password',
+        'permission' => 'read',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('database_users', [
+        'username' => 'user',
+        'permission' => 'read',
+        'status' => DatabaseUserStatus::READY,
+    ]);
+});
+
+test('update database user permission', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+        'name' => 'test_db',
+    ]);
+
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'permission' => 'admin',
+        'databases' => ['test_db'],
+    ]);
+
+    $this->put(route('database-users.update', [
+        'server' => $this->server,
+        'databaseUser' => $databaseUser,
+    ]), [
+        'permission' => 'read',
+    ])->assertSessionDoesntHaveErrors();
+
+    $databaseUser->refresh();
+
+    expect($databaseUser->permission)->toEqual(DatabaseUserPermission::READ);
+});
+
+test('sync database users creates rows per host for mysql', function () {
+    $this->actingAs($this->user);
+
+    $mysqlFakeOutput = implode("\n", [
+        "User\tHost\tPrivileges",
+        "app\tlocalhost\tappdb",
+        "app\t127.0.0.1\tappdb,devdb",
+    ]);
+
+    SSH::fake($mysqlFakeOutput);
+
+    $this->patch(route('database-users.sync', ['server' => $this->server]))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('database_users', [
+        'server_id' => $this->server->id,
+        'username' => 'app',
+        'host' => 'localhost',
+        'databases' => $this->castAsJson(['appdb']),
+    ]);
+
+    $this->assertDatabaseHas('database_users', [
+        'server_id' => $this->server->id,
+        'username' => 'app',
+        'host' => '127.0.0.1',
+        'databases' => $this->castAsJson(['appdb', 'devdb']),
+    ]);
+
+    expect(DatabaseUser::where('server_id', $this->server->id)->where('username', 'app')->count())->toBe(2);
+});
+
+test('sync database users is idempotent for mysql multi host', function () {
+    $this->actingAs($this->user);
+
+    $mysqlFakeOutput = implode("\n", [
+        "User\tHost\tPrivileges",
+        "app\tlocalhost\tappdb",
+        "app\t127.0.0.1\tappdb,devdb",
+    ]);
+
+    SSH::fake($mysqlFakeOutput);
+
+    $this->patch(route('database-users.sync', ['server' => $this->server]));
+    $this->patch(route('database-users.sync', ['server' => $this->server]));
+
+    expect(DatabaseUser::where('server_id', $this->server->id)->where('username', 'app')->count())->toBe(2);
+});
+
+test('sync database users does not duplicate postgresql rows', function () {
+    $this->actingAs($this->user);
+
+    $this->server->services()->where('type', Mysql::type())->delete();
+    $this->server->services()->create([
+        'type' => Postgresql::type(),
+        'name' => Postgresql::id(),
+        'version' => '15',
+        'status' => ServiceStatus::READY,
+    ]);
+    $this->server->refresh();
+
+    DatabaseUser::factory()->create([
+        'server_id' => $this->server->id,
+        'username' => 'appuser',
+        'host' => 'localhost',
+        'databases' => [],
+    ]);
+
+    $pgFakeOutput = implode("\n", [
+        ' username | host | databases',
+        '----------+------+-----------',
+        ' appuser  |      | appdb',
+        '(1 row)',
+    ]);
+
+    SSH::fake($pgFakeOutput);
+
+    $this->patch(route('database-users.sync', ['server' => $this->server]));
+    $this->patch(route('database-users.sync', ['server' => $this->server]));
+
+    expect(DatabaseUser::where('server_id', $this->server->id)->where('username', 'appuser')->count())->toBe(1);
+
+    $this->assertDatabaseHas('database_users', [
+        'server_id' => $this->server->id,
+        'username' => 'appuser',
+        'host' => 'localhost',
+        'databases' => $this->castAsJson(['appdb']),
+    ]);
+});
+
+test('create database user same username different host succeeds', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'app',
+        'host' => 'localhost',
+    ]);
+
+    $this->post(route('database-users.store', ['server' => $this->server]), [
+        'username' => 'app',
+        'password' => 'password',
+        'remote' => true,
+        'host' => '10.0.0.1',
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('database_users', [
+        'server_id' => $this->server->id,
+        'username' => 'app',
+        'host' => '10.0.0.1',
+    ]);
+
+    expect(DatabaseUser::where('server_id', $this->server->id)->where('username', 'app')->count())->toBe(2);
+});
+
+test('create database user duplicate username and host fails', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'app',
+        'host' => '%',
+    ]);
+
+    $this->post(route('database-users.store', ['server' => $this->server]), [
+        'username' => 'app',
+        'password' => 'password',
+        'remote' => true,
+        'host' => '%',
+    ])->assertSessionHasErrors('username');
+
+    expect(DatabaseUser::where('server_id', $this->server->id)->where('username', 'app')->count())->toBe(1);
+});
+
+test('create database user duplicate username fails for postgresql', function () {
+    $this->actingAs($this->user);
+
+    vitoPestFeatureDatabaseUserTestUsePostgresql();
+
+    SSH::fake();
+
+    DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'appuser',
+        'host' => 'localhost',
+    ]);
+
+    $this->post(route('database-users.store', ['server' => $this->server]), [
+        'username' => 'appuser',
+        'password' => 'password',
+    ])->assertSessionHasErrors('username');
+
+    expect(DatabaseUser::where('server_id', $this->server->id)->where('username', 'appuser')->count())->toBe(1);
+});
+
+test('update database user host collision fails', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'app',
+        'host' => '10.0.0.1',
+    ]);
+
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'app',
+        'host' => 'localhost',
+    ]);
+
+    $this->put(route('database-users.update', [
+        'server' => $this->server,
+        'databaseUser' => $databaseUser,
+    ]), [
+        'remote' => true,
+        'host' => '10.0.0.1',
+        'permission' => $databaseUser->permission->value,
+    ])->assertSessionHasErrors('host');
+
+    $this->assertDatabaseHas('database_users', [
+        'id' => $databaseUser->id,
+        'host' => 'localhost',
+    ]);
+});
+
+test('create database user rejects malicious host', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $this->post(route('database-users.store', ['server' => $this->server]), [
+        'username' => 'user',
+        'password' => 'password',
+        'remote' => true,
+        'host' => '$(touch /tmp/pwn)',
+    ])->assertSessionHasErrors('host');
+
+    $this->assertDatabaseMissing('database_users', [
+        'username' => 'user',
+    ]);
+});
+
+test('create database user with empty host defaults to localhost', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $this->post(route('database-users.store', ['server' => $this->server]), [
+        'username' => 'user',
+        'password' => 'password',
+        'remote' => false,
+        'host' => '',
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('database_users', [
+        'username' => 'user',
+        'host' => 'localhost',
+    ]);
+});
+
+test('update synced postgresql user with empty host succeeds', function () {
+    $this->actingAs($this->user);
+
+    vitoPestFeatureDatabaseUserTestUsePostgresql();
+
+    SSH::fake();
+
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'appuser',
+        'host' => '',
+        'permission' => 'admin',
+    ]);
+
+    $this->put(route('database-users.update', [
+        'server' => $this->server,
+        'databaseUser' => $databaseUser,
+    ]), [
+        'remote' => true,
+        'host' => '',
+        'permission' => 'read',
+    ])->assertSessionDoesntHaveErrors();
+
+    $databaseUser->refresh();
+
+    expect($databaseUser->permission)->toEqual(DatabaseUserPermission::READ);
+    expect($databaseUser->host)->toBe('');
+});
+
+test('database users index shows host column for mysql', function () {
+    $this->actingAs($this->user);
+
+    $this->get(route('database-users', $this->server))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('database-users/index')
+            ->where('databaseUsers.columns', fn ($columns) => collect($columns)->contains(
+                fn ($column) => ($column['name'] ?? null) === 'host' && empty($column['hidden'])
+            ))
+        );
+});
+
+test('database users index hides host column for postgresql', function () {
+    $this->actingAs($this->user);
+
+    vitoPestFeatureDatabaseUserTestUsePostgresql();
+
+    $this->get(route('database-users', $this->server))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('database-users/index')
+            ->where('databaseUsers.columns', fn ($columns) => collect($columns)->doesntContain(
+                fn ($column) => ($column['name'] ?? null) === 'host' && empty($column['hidden'])
+            ))
+        );
+});
+
+test('postgresql multiple admins get cross default privileges', function () {
+    $this->actingAs($this->user);
+
+    vitoPestFeatureDatabaseUserTestUsePostgresql();
+
+    SSH::fake();
+
+    Database::factory()->create(['server_id' => $this->server, 'name' => 'app']);
+
+    $adminA = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'admin_a',
+        'permission' => 'admin',
+        'host' => '',
+    ]);
+    $this->put(route('database-users.link', [
+        'server' => $this->server,
+        'databaseUser' => $adminA,
+    ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
+
+    $adminB = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'admin_b',
+        'permission' => 'admin',
+        'host' => '',
+    ]);
+    $this->put(route('database-users.link', [
+        'server' => $this->server,
+        'databaseUser' => $adminB,
+    ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
+
+    SSH::assertExecutedContains('ALTER DEFAULT PRIVILEGES FOR ROLE \"admin_a\" IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO \"admin_b\"');
+    SSH::assertExecutedContains('ALTER DEFAULT PRIVILEGES FOR ROLE \"admin_b\" IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO \"admin_a\"');
+});
+
+test('postgresql write user is a creator with write default privileges', function () {
+    $this->actingAs($this->user);
+
+    vitoPestFeatureDatabaseUserTestUsePostgresql();
+
+    SSH::fake();
+
+    Database::factory()->create(['server_id' => $this->server, 'name' => 'app']);
+
+    $admin = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'admin_a',
+        'permission' => 'admin',
+        'host' => '',
+    ]);
+    $this->put(route('database-users.link', [
+        'server' => $this->server,
+        'databaseUser' => $admin,
+    ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
+
+    $writer = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'writer',
+        'permission' => 'write',
+        'host' => '',
+    ]);
+    $this->put(route('database-users.link', [
+        'server' => $this->server,
+        'databaseUser' => $writer,
+    ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
+
+    SSH::assertExecutedContains('ALTER DEFAULT PRIVILEGES FOR ROLE \"admin_a\" IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES, TRIGGER ON TABLES TO \"writer\"');
+    SSH::assertExecutedContains('ALTER DEFAULT PRIVILEGES FOR ROLE \"writer\" IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO \"admin_a\"');
+});
+
+test('postgresql read user is not a creator but is granted', function () {
+    $this->actingAs($this->user);
+
+    vitoPestFeatureDatabaseUserTestUsePostgresql();
+
+    SSH::fake();
+
+    Database::factory()->create(['server_id' => $this->server, 'name' => 'app']);
+
+    $admin = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'admin_a',
+        'permission' => 'admin',
+        'host' => '',
+    ]);
+    $this->put(route('database-users.link', [
+        'server' => $this->server,
+        'databaseUser' => $admin,
+    ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
+
+    $reader = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'reader',
+        'permission' => 'read',
+        'host' => '',
+    ]);
+    $this->put(route('database-users.link', [
+        'server' => $this->server,
+        'databaseUser' => $reader,
+    ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
+
+    SSH::assertExecutedContains('ALTER DEFAULT PRIVILEGES FOR ROLE \"admin_a\" IN SCHEMA public GRANT SELECT ON TABLES TO \"reader\"');
+    SSH::assertNotExecutedContains('FOR ROLE \"reader\" IN SCHEMA public GRANT');
+});
+
+test('postgresql v15 user gets schema create', function () {
+    $this->actingAs($this->user);
+
+    vitoPestFeatureDatabaseUserTestUsePostgresql();
+
+    SSH::fake();
+
+    Database::factory()->create(['server_id' => $this->server, 'name' => 'app']);
+
+    $admin = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'admin_a',
+        'permission' => 'admin',
+        'host' => '',
+    ]);
+    $this->put(route('database-users.link', [
+        'server' => $this->server,
+        'databaseUser' => $admin,
+    ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
+
+    SSH::assertExecutedContains('GRANT USAGE, CREATE ON SCHEMA public TO \"admin_a\"');
+});
+
+test('postgresql deleting user revokes its default privileges before drop', function () {
+    $this->actingAs($this->user);
+
+    vitoPestFeatureDatabaseUserTestUsePostgresql();
+
+    SSH::fake();
+
+    Database::factory()->create(['server_id' => $this->server, 'name' => 'app']);
+
+    $adminA = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'admin_a',
+        'permission' => 'admin',
+        'host' => '',
+        'databases' => ['app'],
+    ]);
+    $adminB = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'admin_b',
+        'permission' => 'admin',
+        'host' => '',
+        'databases' => ['app'],
+    ]);
+
+    $this->delete(route('database-users.destroy', [
+        'server' => $this->server,
+        'databaseUser' => $adminB,
+    ]))->assertSessionDoesntHaveErrors();
+
+    SSH::assertExecutedContains('ALTER DEFAULT PRIVILEGES FOR ROLE \"admin_b\" IN SCHEMA public REVOKE ALL ON TABLES FROM \"admin_b\"');
+    SSH::assertExecutedContains('ALTER DEFAULT PRIVILEGES FOR ROLE \"admin_a\" IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO \"admin_a\"');
+    $this->assertDatabaseMissing('database_users', ['id' => $adminB->id]);
+});
+
+test('mysql link does not run privilege reconcile', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    Database::factory()->create(['server_id' => $this->server, 'name' => 'app']);
+
+    $databaseUser = DatabaseUser::factory()->create([
+        'server_id' => $this->server,
+        'username' => 'app',
+        'host' => 'localhost',
+    ]);
+
+    $this->put(route('database-users.link', [
+        'server' => $this->server,
+        'databaseUser' => $databaseUser,
+    ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
+
+    SSH::assertNotExecutedContains('ALTER DEFAULT PRIVILEGES');
+});
+
+function vitoPestFeatureDatabaseUserTestUsePostgresql(): void
 {
-    use RefreshDatabase;
-
-    public function test_create_database_user(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $this->post(route('database-users.store', [
-            'server' => $this->server,
-        ]), [
-            'username' => 'user',
-            'password' => 'password',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('database_users', [
-            'username' => 'user',
-            'status' => DatabaseUserStatus::READY,
-        ]);
-    }
-
-    public function test_create_database_user_with_remote(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $this->post(route('database-users.store', [
-            'server' => $this->server,
-        ]), [
-            'username' => 'user',
-            'password' => 'password',
-            'remote' => true,
-            'host' => '%',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('database_users', [
-            'username' => 'user',
-            'host' => '%',
-            'status' => DatabaseUserStatus::READY,
-        ]);
-    }
-
-    public function test_see_database_users_list(): void
-    {
-        $this->actingAs($this->user);
-
-        DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $this->get(route('database-users', $this->server))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('database-users/index'));
-    }
-
-    public function test_delete_database_user(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $this->delete(route('database-users.destroy', [
-            'server' => $this->server,
-            'databaseUser' => $databaseUser,
-        ]))->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('database_users', [
-            'id' => $databaseUser->id,
-        ]);
-    }
-
-    public function test_unlink_database(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-        ]);
-
-        $this->put(route('database-users.link', [
-            'server' => $this->server,
-            'databaseUser' => $databaseUser,
-        ]), [
-            'databases' => [],
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('database_users', [
-            'username' => $databaseUser->username,
-            'databases' => $this->castAsJson([]),
-        ]);
-    }
-
-    public function test_update_database_user_password(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'password' => 'old_password',
-        ]);
-
-        $this->put(route('database-users.update', [
-            'server' => $this->server,
-            'databaseUser' => $databaseUser,
-        ]), [
-            'password' => 'new_password',
-            'permission' => $databaseUser->permission->value,
-        ])->assertSessionDoesntHaveErrors();
-
-        $databaseUser->refresh();
-
-        $this->assertEquals('new_password', $databaseUser->password);
-    }
-
-    public function test_update_database_user_host(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'host' => 'localhost',
-        ]);
-
-        $this->put(route('database-users.update', [
-            'server' => $this->server,
-            'databaseUser' => $databaseUser,
-        ]), [
-            'remote' => true,
-            'host' => '%',
-            'permission' => $databaseUser->permission->value,
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('database_users', [
-            'id' => $databaseUser->id,
-            'host' => '%',
-        ]);
-    }
-
-    public function test_update_database_user_password_and_host(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'password' => 'old_password',
-            'host' => 'localhost',
-        ]);
-
-        $this->put(route('database-users.update', [
-            'server' => $this->server,
-            'databaseUser' => $databaseUser,
-        ]), [
-            'password' => 'new_password',
-            'remote' => true,
-            'host' => '192.168.1.1',
-            'permission' => $databaseUser->permission->value,
-        ])->assertSessionDoesntHaveErrors();
-
-        $databaseUser->refresh();
-
-        $this->assertEquals('new_password', $databaseUser->password);
-        $this->assertEquals('192.168.1.1', $databaseUser->host);
-    }
-
-    public function test_create_database_user_with_admin_permission(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $this->post(route('database-users.store', [
-            'server' => $this->server,
-        ]), [
-            'username' => 'user',
-            'password' => 'password',
-            'permission' => 'admin',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('database_users', [
-            'username' => 'user',
-            'permission' => 'admin',
-            'status' => DatabaseUserStatus::READY,
-        ]);
-    }
-
-    public function test_create_database_user_with_write_permission(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $this->post(route('database-users.store', [
-            'server' => $this->server,
-        ]), [
-            'username' => 'user',
-            'password' => 'password',
-            'permission' => 'write',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('database_users', [
-            'username' => 'user',
-            'permission' => 'write',
-            'status' => DatabaseUserStatus::READY,
-        ]);
-    }
-
-    public function test_create_database_user_with_read_permission(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $this->post(route('database-users.store', [
-            'server' => $this->server,
-        ]), [
-            'username' => 'user',
-            'password' => 'password',
-            'permission' => 'read',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('database_users', [
-            'username' => 'user',
-            'permission' => 'read',
-            'status' => DatabaseUserStatus::READY,
-        ]);
-    }
-
-    public function test_update_database_user_permission(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
-            'name' => 'test_db',
-        ]);
-
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'permission' => 'admin',
-            'databases' => ['test_db'],
-        ]);
-
-        $this->put(route('database-users.update', [
-            'server' => $this->server,
-            'databaseUser' => $databaseUser,
-        ]), [
-            'permission' => 'read',
-        ])->assertSessionDoesntHaveErrors();
-
-        $databaseUser->refresh();
-
-        $this->assertEquals(DatabaseUserPermission::READ, $databaseUser->permission);
-    }
-
-    public function test_sync_database_users_creates_rows_per_host_for_mysql(): void
-    {
-        $this->actingAs($this->user);
-
-        $mysqlFakeOutput = implode("\n", [
-            "User\tHost\tPrivileges",
-            "app\tlocalhost\tappdb",
-            "app\t127.0.0.1\tappdb,devdb",
-        ]);
-
-        SSH::fake($mysqlFakeOutput);
-
-        $this->patch(route('database-users.sync', ['server' => $this->server]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('database_users', [
-            'server_id' => $this->server->id,
-            'username' => 'app',
-            'host' => 'localhost',
-            'databases' => $this->castAsJson(['appdb']),
-        ]);
-
-        $this->assertDatabaseHas('database_users', [
-            'server_id' => $this->server->id,
-            'username' => 'app',
-            'host' => '127.0.0.1',
-            'databases' => $this->castAsJson(['appdb', 'devdb']),
-        ]);
-
-        $this->assertSame(
-            2,
-            DatabaseUser::where('server_id', $this->server->id)->where('username', 'app')->count(),
-        );
-    }
-
-    public function test_sync_database_users_is_idempotent_for_mysql_multi_host(): void
-    {
-        $this->actingAs($this->user);
-
-        $mysqlFakeOutput = implode("\n", [
-            "User\tHost\tPrivileges",
-            "app\tlocalhost\tappdb",
-            "app\t127.0.0.1\tappdb,devdb",
-        ]);
-
-        SSH::fake($mysqlFakeOutput);
-
-        $this->patch(route('database-users.sync', ['server' => $this->server]));
-        $this->patch(route('database-users.sync', ['server' => $this->server]));
-
-        $this->assertSame(
-            2,
-            DatabaseUser::where('server_id', $this->server->id)->where('username', 'app')->count(),
-        );
-    }
-
-    public function test_sync_database_users_does_not_duplicate_postgresql_rows(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->server->services()->where('type', Mysql::type())->delete();
-        $this->server->services()->create([
-            'type' => Postgresql::type(),
-            'name' => Postgresql::id(),
-            'version' => '15',
-            'status' => ServiceStatus::READY,
-        ]);
-        $this->server->refresh();
-
-        DatabaseUser::factory()->create([
-            'server_id' => $this->server->id,
-            'username' => 'appuser',
-            'host' => 'localhost',
-            'databases' => [],
-        ]);
-
-        $pgFakeOutput = implode("\n", [
-            ' username | host | databases',
-            '----------+------+-----------',
-            ' appuser  |      | appdb',
-            '(1 row)',
-        ]);
-
-        SSH::fake($pgFakeOutput);
-
-        $this->patch(route('database-users.sync', ['server' => $this->server]));
-        $this->patch(route('database-users.sync', ['server' => $this->server]));
-
-        $this->assertSame(
-            1,
-            DatabaseUser::where('server_id', $this->server->id)->where('username', 'appuser')->count(),
-        );
-
-        $this->assertDatabaseHas('database_users', [
-            'server_id' => $this->server->id,
-            'username' => 'appuser',
-            'host' => 'localhost',
-            'databases' => $this->castAsJson(['appdb']),
-        ]);
-    }
-
-    public function test_create_database_user_same_username_different_host_succeeds(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'app',
-            'host' => 'localhost',
-        ]);
-
-        $this->post(route('database-users.store', ['server' => $this->server]), [
-            'username' => 'app',
-            'password' => 'password',
-            'remote' => true,
-            'host' => '10.0.0.1',
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('database_users', [
-            'server_id' => $this->server->id,
-            'username' => 'app',
-            'host' => '10.0.0.1',
-        ]);
-
-        $this->assertSame(
-            2,
-            DatabaseUser::where('server_id', $this->server->id)->where('username', 'app')->count(),
-        );
-    }
-
-    public function test_create_database_user_duplicate_username_and_host_fails(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'app',
-            'host' => '%',
-        ]);
-
-        $this->post(route('database-users.store', ['server' => $this->server]), [
-            'username' => 'app',
-            'password' => 'password',
-            'remote' => true,
-            'host' => '%',
-        ])->assertSessionHasErrors('username');
-
-        $this->assertSame(
-            1,
-            DatabaseUser::where('server_id', $this->server->id)->where('username', 'app')->count(),
-        );
-    }
-
-    public function test_create_database_user_duplicate_username_fails_for_postgresql(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->usePostgresql();
-
-        SSH::fake();
-
-        DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'appuser',
-            'host' => 'localhost',
-        ]);
-
-        $this->post(route('database-users.store', ['server' => $this->server]), [
-            'username' => 'appuser',
-            'password' => 'password',
-        ])->assertSessionHasErrors('username');
-
-        $this->assertSame(
-            1,
-            DatabaseUser::where('server_id', $this->server->id)->where('username', 'appuser')->count(),
-        );
-    }
-
-    public function test_update_database_user_host_collision_fails(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'app',
-            'host' => '10.0.0.1',
-        ]);
-
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'app',
-            'host' => 'localhost',
-        ]);
-
-        $this->put(route('database-users.update', [
-            'server' => $this->server,
-            'databaseUser' => $databaseUser,
-        ]), [
-            'remote' => true,
-            'host' => '10.0.0.1',
-            'permission' => $databaseUser->permission->value,
-        ])->assertSessionHasErrors('host');
-
-        $this->assertDatabaseHas('database_users', [
-            'id' => $databaseUser->id,
-            'host' => 'localhost',
-        ]);
-    }
-
-    public function test_create_database_user_rejects_malicious_host(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $this->post(route('database-users.store', ['server' => $this->server]), [
-            'username' => 'user',
-            'password' => 'password',
-            'remote' => true,
-            'host' => '$(touch /tmp/pwn)',
-        ])->assertSessionHasErrors('host');
-
-        $this->assertDatabaseMissing('database_users', [
-            'username' => 'user',
-        ]);
-    }
-
-    public function test_create_database_user_with_empty_host_defaults_to_localhost(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $this->post(route('database-users.store', ['server' => $this->server]), [
-            'username' => 'user',
-            'password' => 'password',
-            'remote' => false,
-            'host' => '',
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('database_users', [
-            'username' => 'user',
-            'host' => 'localhost',
-        ]);
-    }
-
-    public function test_update_synced_postgresql_user_with_empty_host_succeeds(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->usePostgresql();
-
-        SSH::fake();
-
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'appuser',
-            'host' => '',
-            'permission' => 'admin',
-        ]);
-
-        $this->put(route('database-users.update', [
-            'server' => $this->server,
-            'databaseUser' => $databaseUser,
-        ]), [
-            'remote' => true,
-            'host' => '',
-            'permission' => 'read',
-        ])->assertSessionDoesntHaveErrors();
-
-        $databaseUser->refresh();
-
-        $this->assertEquals(DatabaseUserPermission::READ, $databaseUser->permission);
-        $this->assertSame('', $databaseUser->host);
-    }
-
-    public function test_database_users_index_shows_host_column_for_mysql(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->get(route('database-users', $this->server))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('database-users/index')
-                ->where('databaseUsers.columns', fn ($columns) => collect($columns)->contains(
-                    fn ($column) => ($column['name'] ?? null) === 'host' && empty($column['hidden'])
-                ))
-            );
-    }
-
-    public function test_database_users_index_hides_host_column_for_postgresql(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->usePostgresql();
-
-        $this->get(route('database-users', $this->server))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('database-users/index')
-                ->where('databaseUsers.columns', fn ($columns) => collect($columns)->doesntContain(
-                    fn ($column) => ($column['name'] ?? null) === 'host' && empty($column['hidden'])
-                ))
-            );
-    }
-
-    public function test_postgresql_multiple_admins_get_cross_default_privileges(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->usePostgresql();
-
-        SSH::fake();
-
-        Database::factory()->create(['server_id' => $this->server, 'name' => 'app']);
-
-        $adminA = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'admin_a',
-            'permission' => 'admin',
-            'host' => '',
-        ]);
-        $this->put(route('database-users.link', [
-            'server' => $this->server,
-            'databaseUser' => $adminA,
-        ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
-
-        $adminB = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'admin_b',
-            'permission' => 'admin',
-            'host' => '',
-        ]);
-        $this->put(route('database-users.link', [
-            'server' => $this->server,
-            'databaseUser' => $adminB,
-        ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
-
-        SSH::assertExecutedContains('ALTER DEFAULT PRIVILEGES FOR ROLE \"admin_a\" IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO \"admin_b\"');
-        SSH::assertExecutedContains('ALTER DEFAULT PRIVILEGES FOR ROLE \"admin_b\" IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO \"admin_a\"');
-    }
-
-    public function test_postgresql_write_user_is_a_creator_with_write_default_privileges(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->usePostgresql();
-
-        SSH::fake();
-
-        Database::factory()->create(['server_id' => $this->server, 'name' => 'app']);
-
-        $admin = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'admin_a',
-            'permission' => 'admin',
-            'host' => '',
-        ]);
-        $this->put(route('database-users.link', [
-            'server' => $this->server,
-            'databaseUser' => $admin,
-        ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
-
-        $writer = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'writer',
-            'permission' => 'write',
-            'host' => '',
-        ]);
-        $this->put(route('database-users.link', [
-            'server' => $this->server,
-            'databaseUser' => $writer,
-        ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
-
-        SSH::assertExecutedContains('ALTER DEFAULT PRIVILEGES FOR ROLE \"admin_a\" IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES, TRIGGER ON TABLES TO \"writer\"');
-        SSH::assertExecutedContains('ALTER DEFAULT PRIVILEGES FOR ROLE \"writer\" IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO \"admin_a\"');
-    }
-
-    public function test_postgresql_read_user_is_not_a_creator_but_is_granted(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->usePostgresql();
-
-        SSH::fake();
-
-        Database::factory()->create(['server_id' => $this->server, 'name' => 'app']);
-
-        $admin = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'admin_a',
-            'permission' => 'admin',
-            'host' => '',
-        ]);
-        $this->put(route('database-users.link', [
-            'server' => $this->server,
-            'databaseUser' => $admin,
-        ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
-
-        $reader = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'reader',
-            'permission' => 'read',
-            'host' => '',
-        ]);
-        $this->put(route('database-users.link', [
-            'server' => $this->server,
-            'databaseUser' => $reader,
-        ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
-
-        SSH::assertExecutedContains('ALTER DEFAULT PRIVILEGES FOR ROLE \"admin_a\" IN SCHEMA public GRANT SELECT ON TABLES TO \"reader\"');
-        SSH::assertNotExecutedContains('FOR ROLE \"reader\" IN SCHEMA public GRANT');
-    }
-
-    public function test_postgresql_v15_user_gets_schema_create(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->usePostgresql();
-
-        SSH::fake();
-
-        Database::factory()->create(['server_id' => $this->server, 'name' => 'app']);
-
-        $admin = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'admin_a',
-            'permission' => 'admin',
-            'host' => '',
-        ]);
-        $this->put(route('database-users.link', [
-            'server' => $this->server,
-            'databaseUser' => $admin,
-        ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
-
-        SSH::assertExecutedContains('GRANT USAGE, CREATE ON SCHEMA public TO \"admin_a\"');
-    }
-
-    public function test_postgresql_deleting_user_revokes_its_default_privileges_before_drop(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->usePostgresql();
-
-        SSH::fake();
-
-        Database::factory()->create(['server_id' => $this->server, 'name' => 'app']);
-
-        $adminA = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'admin_a',
-            'permission' => 'admin',
-            'host' => '',
-            'databases' => ['app'],
-        ]);
-        $adminB = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'admin_b',
-            'permission' => 'admin',
-            'host' => '',
-            'databases' => ['app'],
-        ]);
-
-        $this->delete(route('database-users.destroy', [
-            'server' => $this->server,
-            'databaseUser' => $adminB,
-        ]))->assertSessionDoesntHaveErrors();
-
-        SSH::assertExecutedContains('ALTER DEFAULT PRIVILEGES FOR ROLE \"admin_b\" IN SCHEMA public REVOKE ALL ON TABLES FROM \"admin_b\"');
-        SSH::assertExecutedContains('ALTER DEFAULT PRIVILEGES FOR ROLE \"admin_a\" IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO \"admin_a\"');
-        $this->assertDatabaseMissing('database_users', ['id' => $adminB->id]);
-    }
-
-    public function test_mysql_link_does_not_run_privilege_reconcile(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        Database::factory()->create(['server_id' => $this->server, 'name' => 'app']);
-
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server,
-            'username' => 'app',
-            'host' => 'localhost',
-        ]);
-
-        $this->put(route('database-users.link', [
-            'server' => $this->server,
-            'databaseUser' => $databaseUser,
-        ]), ['databases' => ['app']])->assertSessionDoesntHaveErrors();
-
-        SSH::assertNotExecutedContains('ALTER DEFAULT PRIVILEGES');
-    }
-
-    private function usePostgresql(): void
-    {
-        $this->server->services()->where('type', Mysql::type())->delete();
-        $this->server->services()->create([
-            'type' => Postgresql::type(),
-            'name' => Postgresql::id(),
-            'version' => '15',
-            'status' => ServiceStatus::READY,
-        ]);
-        $this->server->refresh();
-    }
+    test()->server->services()->where('type', Mysql::type())->delete();
+    test()->server->services()->create([
+        'type' => Postgresql::type(),
+        'name' => Postgresql::id(),
+        'version' => '15',
+        'status' => ServiceStatus::READY,
+    ]);
+    test()->server->refresh();
 }

--- a/tests/Feature/DomainsTest.php
+++ b/tests/Feature/DomainsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\DNSProvider;
 use App\Models\DNSRecord;
 use App\Models\Domain;
@@ -10,256 +8,1100 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
-use Tests\TestCase;
 
-class DomainsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    protected User $otherUser;
+beforeEach(function () {
+    // Create a user for testing
+    $this->user = User::factory()->create();
+    $this->user->ensureHasDefaultProject();
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+    // Create a second user for authorization tests
+    $this->otherUser = User::factory()->create();
+    $this->otherUser->ensureHasDefaultProject();
+});
 
-        // Create a user for testing
-        $this->user = User::factory()->create();
-        $this->user->ensureHasDefaultProject();
+test('authenticated user can view domains index', function () {
+    $this->actingAs($this->user);
 
-        // Create a second user for authorization tests
-        $this->otherUser = User::factory()->create();
-        $this->otherUser->ensureHasDefaultProject();
-    }
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-    public function test_authenticated_user_can_view_domains_index(): void
-    {
-        $this->actingAs($this->user);
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    $response = $this->get('/domains');
 
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('domains/index')
+            ->has('domains.data', 1)
+            ->has('dnsProviders', 1)
+            ->where('domains.data.0.id', $domain->id)
+            ->where('dnsProviders.0.id', $dnsProvider->id)
+        );
+});
 
-        $response = $this->get('/domains');
+test('unauthenticated user cannot view domains index', function () {
+    $response = $this->get('/domains');
 
-        $response->assertOk()
-            ->assertInertia(fn ($page) => $page
-                ->component('domains/index')
-                ->has('domains.data', 1)
-                ->has('dnsProviders', 1)
-                ->where('domains.data.0.id', $domain->id)
-                ->where('dnsProviders.0.id', $dnsProvider->id)
-            );
-    }
+    $response->assertRedirect();
+});
 
-    public function test_unauthenticated_user_cannot_view_domains_index(): void
-    {
-        $response = $this->get('/domains');
+test('user can see all domains in their current project', function () {
+    $this->actingAs($this->user);
 
-        $response->assertRedirect();
-    }
+    // Create a DNS provider for the current user's project
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-    public function test_user_can_see_all_domains_in_their_current_project(): void
-    {
-        $this->actingAs($this->user);
+    // Create a domain for the current user in their project
+    $userDomain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        // Create a DNS provider for the current user's project
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    // Create a domain for another user in the same project
+    $otherUserDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        // Create a domain for the current user in their project
-        $userDomain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    // Create a domain for the other user in a different project
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+    Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
 
-        // Create a domain for another user in the same project
-        $otherUserDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    $response = $this->get('/domains');
 
-        // Create a domain for the other user in a different project
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-        Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('domains/index')
+            ->has('domains.data', 2)
+            ->where('domains.data.0.id', $userDomain->id)
+            ->where('domains.data.1.id', $otherUserDomain->id)
+        );
+});
 
-        $response = $this->get('/domains');
+test('user can access domains created by other users in same project', function () {
+    $this->actingAs($this->user);
 
-        $response->assertOk()
-            ->assertInertia(fn ($page) => $page
-                ->component('domains/index')
-                ->has('domains.data', 2)
-                ->where('domains.data.0.id', $userDomain->id)
-                ->where('domains.data.1.id', $otherUserDomain->id)
-            );
-    }
+    // Create a DNS provider for the current user's project
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-    public function test_user_can_access_domains_created_by_other_users_in_same_project(): void
-    {
-        $this->actingAs($this->user);
+    // Create a domain for another user in the same project
+    $otherUserDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        // Create a DNS provider for the current user's project
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    // User should be able to view the domain created by another user in the same project
+    $response = $this->get("/domains/{$otherUserDomain->id}");
 
-        // Create a domain for another user in the same project
-        $otherUserDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('domains/show')
+            ->where('domain.id', $otherUserDomain->id)
+        );
+});
 
-        // User should be able to view the domain created by another user in the same project
-        $response = $this->get("/domains/{$otherUserDomain->id}");
+test('authenticated user can get domains json', function () {
+    $this->actingAs($this->user);
 
-        $response->assertOk()
-            ->assertInertia(fn ($page) => $page
-                ->component('domains/show')
-                ->where('domain.id', $otherUserDomain->id)
-            );
-    }
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-    public function test_authenticated_user_can_get_domains_json(): void
-    {
-        $this->actingAs($this->user);
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    $response = $this->get('/domains/json');
 
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $response = $this->get('/domains/json');
-
-        $response->assertOk()
-            ->assertJsonStructure([
-                '*' => [
+    $response->assertOk()
+        ->assertJsonStructure([
+            '*' => [
+                'id',
+                'domain',
+                'dns_provider_id',
+                'metadata',
+                'dns_provider' => [
                     'id',
-                    'domain',
-                    'dns_provider_id',
-                    'metadata',
-                    'dns_provider' => [
-                        'id',
-                        'name',
-                        'provider',
-                        'connected',
-                        'project_id',
-                        'global',
-                    ],
-                    'created_at',
-                    'updated_at',
+                    'name',
+                    'provider',
+                    'connected',
+                    'project_id',
+                    'global',
                 ],
-            ])
-            ->assertJsonFragment([
-                'id' => $domain->id,
-                'domain' => $domain->domain,
-            ]);
-    }
-
-    public function test_unauthenticated_user_cannot_get_domains_json(): void
-    {
-        $response = $this->get('/domains/json');
-
-        $response->assertRedirect();
-    }
-
-    public function test_authenticated_user_can_view_domain_show(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
+                'created_at',
+                'updated_at',
+            ],
+        ])
+        ->assertJsonFragment([
+            'id' => $domain->id,
+            'domain' => $domain->domain,
         ]);
+});
 
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+test('unauthenticated user cannot get domains json', function () {
+    $response = $this->get('/domains/json');
 
-        $record = DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
+    $response->assertRedirect();
+});
+
+test('authenticated user can view domain show', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $record = DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+    ]);
+
+    $response = $this->get("/domains/{$domain->id}");
+
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('domains/show')
+            ->has('domain')
+            ->has('records', 1)
+            ->where('domain.id', $domain->id)
+            ->where('records.0.id', $record->id)
+        );
+});
+
+test('user cannot view domains from other projects', function () {
+    $this->actingAs($this->user);
+
+    // Create a different project for the other user
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $response = $this->get("/domains/{$otherDomain->id}");
+
+    $response->assertForbidden();
+});
+
+test('authenticated user can create domain', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    // Mock the DNS provider API calls (getDomain + getRecords)
+    Http::fake([
+        'api.cloudflare.com/client/v4/zones/test-domain-id/dns_records*' => Http::response([
+            'result' => [],
+            'success' => true,
+        ], 200),
+        'api.cloudflare.com/*' => Http::response([
+            'result' => [
+                'id' => 'test-domain-id',
+                'name' => 'example.com',
+                'status' => 'active',
+                'created_on' => '2023-01-01T00:00:00Z',
+                'modified_on' => '2023-01-01T00:00:00Z',
+            ],
+            'success' => true,
+        ], 200),
+    ]);
+
+    $domainData = [
+        'dns_provider_id' => $dnsProvider->id,
+        'provider_domain_id' => 'test-domain-id',
+    ];
+
+    $response = $this->post('/domains', $domainData);
+
+    $response->assertRedirect()
+        ->assertSessionHas('success', 'Domain added.');
+
+    $this->assertDatabaseHas('domains', [
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'provider_domain_id' => 'test-domain-id',
+    ]);
+});
+
+test('user cannot create domain with dns provider from other project', function () {
+    $this->actingAs($this->user);
+
+    // Create a different project for the other user
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $domainData = [
+        'dns_provider_id' => $otherDnsProvider->id,
+        'provider_domain_id' => 'test-domain-id',
+    ];
+
+    $response = $this->post('/domains', $domainData);
+
+    $response->assertForbidden();
+});
+
+test('authenticated user can delete domain', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $response = $this->delete("/domains/{$domain->id}");
+
+    $response->assertRedirectToRoute('domains')
+        ->assertSessionHas('success', 'Domain removed.');
+
+    $this->assertDatabaseMissing('domains', ['id' => $domain->id]);
+});
+
+test('user cannot delete domains from other projects', function () {
+    $this->actingAs($this->user);
+
+    // Create a different project for the other user
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $response = $this->delete("/domains/{$otherDomain->id}");
+
+    $response->assertForbidden();
+
+    $this->assertDatabaseHas('domains', ['id' => $otherDomain->id]);
+});
+
+test('authenticated user can get available domains from dns provider', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $response = $this->get("/domains/{$dnsProvider->id}/available");
+
+    $response->assertOk();
+});
+
+test('user cannot get available domains from dns provider in other project', function () {
+    $this->actingAs($this->user);
+
+    // Create a different project for the other user
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $response = $this->get("/domains/{$otherDnsProvider->id}/available");
+
+    $response->assertForbidden();
+});
+
+test('authenticated user can view dns records index', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $record = DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+    ]);
+
+    $response = $this->get("/domains/{$domain->id}/records");
+
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->has('domain')
+            ->has('records', 1)
+            ->where('domain.id', $domain->id)
+            ->where('records.0.id', $record->id)
+        );
+});
+
+test('user cannot view dns records for domains from other projects', function () {
+    $this->actingAs($this->user);
+
+    // Create a different project for the other user
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $response = $this->get("/domains/{$otherDomain->id}/records");
+
+    $response->assertForbidden();
+});
+
+test('authenticated user can get dns records json', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $record1 = DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+    ]);
+
+    $record2 = DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'CNAME',
+        'name' => 'mail',
+        'content' => 'example.com',
+    ]);
+
+    $response = $this->get("/domains/{$domain->id}/records/json");
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            '*' => [
+                'id',
+                'type',
+                'name',
+                'formatted_name',
+                'content',
+                'ttl',
+                'proxied',
+                'domain_id',
+                'created_at',
+                'updated_at',
+            ],
+        ])
+        ->assertJsonFragment([
+            'id' => $record1->id,
             'type' => 'A',
             'name' => 'www',
-            'content' => '192.168.1.1',
+        ])
+        ->assertJsonFragment([
+            'id' => $record2->id,
+            'type' => 'CNAME',
+            'name' => 'mail',
         ]);
+});
 
-        $response = $this->get("/domains/{$domain->id}");
+test('user cannot get dns records json for domains from other projects', function () {
+    $this->actingAs($this->user);
 
-        $response->assertOk()
-            ->assertInertia(fn ($page) => $page
-                ->component('domains/show')
-                ->has('domain')
-                ->has('records', 1)
-                ->where('domain.id', $domain->id)
-                ->where('records.0.id', $record->id)
-            );
-    }
+    // Create a different project for the other user
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
 
-    public function test_user_cannot_view_domains_from_other_projects(): void
-    {
-        $this->actingAs($this->user);
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
 
-        // Create a different project for the other user
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
+    $response = $this->get("/domains/{$otherDomain->id}/records/json");
 
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
+    $response->assertForbidden();
+});
 
-        $response = $this->get("/domains/{$otherDomain->id}");
+test('authenticated user can create dns record', function () {
+    $this->actingAs($this->user);
 
-        $response->assertForbidden();
-    }
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-    public function test_authenticated_user_can_create_domain(): void
-    {
-        $this->actingAs($this->user);
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+        'provider_domain_id' => 'test-domain-id',
+    ]);
 
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    // Mock the DNS provider API call
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'result' => [
+                'id' => 'test-record-id',
+                'type' => 'A',
+                'name' => 'www',
+                'content' => '192.168.1.1',
+                'ttl' => 300,
+                'proxied' => false,
+            ],
+            'success' => true,
+        ], 200),
+    ]);
 
-        // Mock the DNS provider API calls (getDomain + getRecords)
-        Http::fake([
-            'api.cloudflare.com/client/v4/zones/test-domain-id/dns_records*' => Http::response([
-                'result' => [],
-                'success' => true,
-            ], 200),
-            'api.cloudflare.com/*' => Http::response([
+    $recordData = [
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+        'ttl' => 300,
+        'proxied' => false,
+    ];
+
+    $response = $this->post("/domains/{$domain->id}/records", $recordData);
+
+    $response->assertRedirect()
+        ->assertSessionHas('success', 'DNS record created.');
+
+    $this->assertDatabaseHas('dns_records', [
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+    ]);
+});
+
+test('user cannot create dns record for domains from other projects', function () {
+    $this->actingAs($this->user);
+
+    // Create a different project for the other user
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $recordData = [
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+    ];
+
+    $response = $this->post("/domains/{$otherDomain->id}/records", $recordData);
+
+    $response->assertForbidden();
+});
+
+test('authenticated user can update dns record', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+        'provider_domain_id' => 'test-domain-id',
+    ]);
+
+    $record = DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+        'provider_record_id' => 'test-record-id',
+    ]);
+
+    // Mock the DNS provider API call
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'result' => [
+                'id' => 'test-record-id',
+                'type' => 'A',
+                'name' => 'www',
+                'content' => '192.168.1.2',
+                'ttl' => 600,
+                'proxied' => false,
+            ],
+            'success' => true,
+        ], 200),
+    ]);
+
+    $updateData = [
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.2',
+        'ttl' => 600,
+    ];
+
+    $response = $this->patch("/domains/{$domain->id}/records/{$record->id}", $updateData);
+
+    $response->assertRedirect()
+        ->assertSessionHas('success', 'DNS record updated.');
+
+    $this->assertDatabaseHas('dns_records', [
+        'id' => $record->id,
+        'content' => '192.168.1.2',
+        'ttl' => 600,
+    ]);
+});
+
+test('user cannot update dns record from domains in other projects', function () {
+    $this->actingAs($this->user);
+
+    // Create a different project for the other user
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $otherRecord = DNSRecord::factory()->create([
+        'domain_id' => $otherDomain->id,
+    ]);
+
+    $updateData = ['content' => '192.168.1.2'];
+
+    $response = $this->patch("/domains/{$otherDomain->id}/records/{$otherRecord->id}", $updateData);
+
+    $response->assertForbidden();
+});
+
+test('user cannot update dns record that does not belong to domain', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $record = DNSRecord::factory()->create([
+        'domain_id' => $otherDomain->id,
+    ]);
+
+    $updateData = ['content' => '192.168.1.2'];
+
+    $response = $this->patch("/domains/{$domain->id}/records/{$record->id}", $updateData);
+
+    $response->assertNotFound();
+});
+
+test('authenticated user can delete dns record', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $record = DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+    ]);
+
+    $response = $this->delete("/domains/{$domain->id}/records/{$record->id}");
+
+    $response->assertRedirect()
+        ->assertSessionHas('success', 'DNS record deleted.');
+
+    $this->assertDatabaseMissing('dns_records', ['id' => $record->id]);
+});
+
+test('user cannot delete dns record from domains in other projects', function () {
+    $this->actingAs($this->user);
+
+    // Create a different project for the other user
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $otherRecord = DNSRecord::factory()->create([
+        'domain_id' => $otherDomain->id,
+    ]);
+
+    $response = $this->delete("/domains/{$otherDomain->id}/records/{$otherRecord->id}");
+
+    $response->assertForbidden();
+
+    $this->assertDatabaseHas('dns_records', ['id' => $otherRecord->id]);
+});
+
+test('user cannot delete dns record that does not belong to domain', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $record = DNSRecord::factory()->create([
+        'domain_id' => $otherDomain->id,
+    ]);
+
+    $response = $this->delete("/domains/{$domain->id}/records/{$record->id}");
+
+    $response->assertNotFound();
+
+    $this->assertDatabaseHas('dns_records', ['id' => $record->id]);
+});
+
+test('domain not found returns 404', function () {
+    $this->actingAs($this->user);
+
+    $response = $this->get('/domains/999999');
+
+    $response->assertNotFound();
+});
+
+test('dns record show route does not exist', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    // There's no GET route for individual DNS records in the regular controller
+    $response = $this->get("/domains/{$domain->id}/records/999999");
+
+    $response->assertStatus(405);
+    // Method not allowed
+});
+
+test('dns provider not found returns 404', function () {
+    $this->actingAs($this->user);
+
+    $response = $this->get('/domains/999999/available');
+
+    $response->assertNotFound();
+});
+
+test('dns records are ordered by type and name', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    // Create records in random order
+    DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'CNAME',
+        'name' => 'zebra',
+    ]);
+
+    DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'alpha',
+    ]);
+
+    DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'beta',
+    ]);
+
+    DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'CNAME',
+        'name' => 'alpha',
+    ]);
+
+    $response = $this->get("/domains/{$domain->id}/records/json");
+
+    $response->assertOk();
+
+    $records = $response->json();
+    expect($records)->toHaveCount(4);
+
+    // Should be ordered by type first (A before CNAME), then by name
+    expect($records[0]['type'])->toEqual('A');
+    expect($records[0]['name'])->toEqual('alpha');
+    expect($records[1]['type'])->toEqual('A');
+    expect($records[1]['name'])->toEqual('beta');
+    expect($records[2]['type'])->toEqual('CNAME');
+    expect($records[2]['name'])->toEqual('alpha');
+    expect($records[3]['type'])->toEqual('CNAME');
+    expect($records[3]['name'])->toEqual('zebra');
+});
+
+test('user cannot access domains from other projects', function () {
+    $this->actingAs($this->user);
+
+    // Create a second project for a different user (not the current user)
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+    $otherProject = $otherUser->currentProject;
+
+    // Create DNS provider for the other project
+    $otherProjectDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    // Create domain in the other project
+    $otherProjectDomain = Domain::factory()->create([
+        'user_id' => $otherUser->id,
+        'dns_provider_id' => $otherProjectDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    // Create domain in current project (before switching)
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $currentProjectDomain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    // Should only see domains from current project
+    $response = $this->get('/domains');
+
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('domains/index')
+            ->has('domains.data', 1) // Only domains from current project
+            ->where('domains.data.0.id', $currentProjectDomain->id)
+        );
+
+    // Should not be able to access domain from other project
+    $response = $this->get("/domains/{$otherProjectDomain->id}");
+
+    $response->assertForbidden();
+});
+
+test('user cannot create domain in other project', function () {
+    $this->actingAs($this->user);
+
+    // Create a second project for a different user
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+    $otherProject = $otherUser->currentProject;
+
+    // Create DNS provider for the other project
+    $otherProjectDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    // Try to create domain with DNS provider from other project
+    $domainData = [
+        'dns_provider_id' => $otherProjectDnsProvider->id,
+        'provider_domain_id' => 'test-domain-id',
+    ];
+
+    $response = $this->post('/domains', $domainData);
+
+    $response->assertForbidden();
+});
+
+test('user cannot delete domain from other project', function () {
+    $this->actingAs($this->user);
+
+    // Create a second project for a different user
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+    $otherProject = $otherUser->currentProject;
+
+    // Create DNS provider for the other project
+    $otherProjectDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    // Create domain in the other project
+    $otherProjectDomain = Domain::factory()->create([
+        'user_id' => $otherUser->id,
+        'dns_provider_id' => $otherProjectDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    // Try to delete domain from other project
+    $response = $this->delete("/domains/{$otherProjectDomain->id}");
+
+    $response->assertForbidden();
+
+    $this->assertDatabaseHas('domains', ['id' => $otherProjectDomain->id]);
+});
+
+test('authenticated user can sync dns records', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+        'provider_domain_id' => 'test-domain-id',
+    ]);
+
+    // Create an existing record that will be replaced
+    DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'old',
+        'content' => '192.168.1.1',
+    ]);
+
+    // Mock the DNS provider API call to return records
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response([
+            'result' => [
+                [
+                    'id' => 'record-1',
+                    'type' => 'A',
+                    'name' => 'www',
+                    'content' => '192.168.1.1',
+                    'ttl' => 300,
+                    'proxied' => false,
+                    'created_on' => '2023-01-01T00:00:00Z',
+                    'modified_on' => '2023-01-01T00:00:00Z',
+                ],
+                [
+                    'id' => 'record-2',
+                    'type' => 'CNAME',
+                    'name' => 'mail',
+                    'content' => 'example.com',
+                    'ttl' => 600,
+                    'proxied' => false,
+                    'created_on' => '2023-01-01T00:00:00Z',
+                    'modified_on' => '2023-01-01T00:00:00Z',
+                ],
+            ],
+            'success' => true,
+        ], 200),
+    ]);
+
+    $response = $this->post("/domains/{$domain->id}/records/sync");
+
+    $response->assertRedirect()
+        ->assertSessionHas('success', 'DNS records synced successfully.');
+
+    // Check that old record was deleted and new records were created
+    $this->assertDatabaseMissing('dns_records', [
+        'domain_id' => $domain->id,
+        'name' => 'old',
+    ]);
+
+    $this->assertDatabaseHas('dns_records', [
+        'domain_id' => $domain->id,
+        'provider_record_id' => 'record-1',
+        'type' => 'A',
+        'name' => 'www',
+        'content' => '192.168.1.1',
+    ]);
+
+    $this->assertDatabaseHas('dns_records', [
+        'domain_id' => $domain->id,
+        'provider_record_id' => 'record-2',
+        'type' => 'CNAME',
+        'name' => 'mail',
+        'content' => 'example.com',
+    ]);
+});
+
+test('sync dns records returns error when provider fails', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $domain = Domain::factory()->create([
+        'user_id' => $this->user->id,
+        'dns_provider_id' => $dnsProvider->id,
+        'project_id' => $this->user->current_project_id,
+        'provider_domain_id' => 'test-domain-id',
+    ]);
+
+    $existingRecord = DNSRecord::factory()->create([
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'name' => 'existing',
+        'content' => '192.168.1.1',
+    ]);
+
+    // Mock the DNS provider API call to throw an exception
+    Http::fake(function () {
+        throw new RuntimeException('Domain is not opted in to API access.');
+    });
+
+    $response = $this->post("/domains/{$domain->id}/records/sync");
+
+    $response->assertRedirect()
+        ->assertSessionHas('error');
+
+    // Existing record should remain intact after a failed sync
+    $this->assertDatabaseHas('dns_records', [
+        'id' => $existingRecord->id,
+        'domain_id' => $domain->id,
+        'name' => 'existing',
+    ]);
+});
+
+test('add domain fails when record sync fails', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $callCount = 0;
+
+    // First call (getDomain) succeeds, subsequent calls throw
+    Http::fake(function () use (&$callCount) {
+        $callCount++;
+        if ($callCount === 1) {
+            return Http::response([
                 'result' => [
                     'id' => 'test-domain-id',
                     'name' => 'example.com',
@@ -268,1033 +1110,141 @@ class DomainsTest extends TestCase
                     'modified_on' => '2023-01-01T00:00:00Z',
                 ],
                 'success' => true,
-            ], 200),
-        ]);
+            ], 200);
+        }
 
-        $domainData = [
-            'dns_provider_id' => $dnsProvider->id,
-            'provider_domain_id' => 'test-domain-id',
-        ];
+        throw new RuntimeException('Domain is not opted in to API access.');
+    });
 
-        $response = $this->post('/domains', $domainData);
-
-        $response->assertRedirect()
-            ->assertSessionHas('success', 'Domain added.');
-
-        $this->assertDatabaseHas('domains', [
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'provider_domain_id' => 'test-domain-id',
-        ]);
-    }
+    $domainData = [
+        'dns_provider_id' => $dnsProvider->id,
+        'provider_domain_id' => 'test-domain-id',
+    ];
 
-    public function test_user_cannot_create_domain_with_dns_provider_from_other_project(): void
-    {
-        $this->actingAs($this->user);
+    $response = $this->post('/domains', $domainData);
 
-        // Create a different project for the other user
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $domainData = [
-            'dns_provider_id' => $otherDnsProvider->id,
-            'provider_domain_id' => 'test-domain-id',
-        ];
-
-        $response = $this->post('/domains', $domainData);
-
-        $response->assertForbidden();
-    }
-
-    public function test_authenticated_user_can_delete_domain(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $response = $this->delete("/domains/{$domain->id}");
-
-        $response->assertRedirectToRoute('domains')
-            ->assertSessionHas('success', 'Domain removed.');
-
-        $this->assertDatabaseMissing('domains', ['id' => $domain->id]);
-    }
-
-    public function test_user_cannot_delete_domains_from_other_projects(): void
-    {
-        $this->actingAs($this->user);
-
-        // Create a different project for the other user
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $response = $this->delete("/domains/{$otherDomain->id}");
-
-        $response->assertForbidden();
-
-        $this->assertDatabaseHas('domains', ['id' => $otherDomain->id]);
-    }
-
-    public function test_authenticated_user_can_get_available_domains_from_dns_provider(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $response = $this->get("/domains/{$dnsProvider->id}/available");
-
-        $response->assertOk();
-    }
-
-    public function test_user_cannot_get_available_domains_from_dns_provider_in_other_project(): void
-    {
-        $this->actingAs($this->user);
-
-        // Create a different project for the other user
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $response = $this->get("/domains/{$otherDnsProvider->id}/available");
-
-        $response->assertForbidden();
-    }
-
-    public function test_authenticated_user_can_view_dns_records_index(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $record = DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.1',
-        ]);
-
-        $response = $this->get("/domains/{$domain->id}/records");
-
-        $response->assertOk()
-            ->assertInertia(fn ($page) => $page
-                ->has('domain')
-                ->has('records', 1)
-                ->where('domain.id', $domain->id)
-                ->where('records.0.id', $record->id)
-            );
-    }
-
-    public function test_user_cannot_view_dns_records_for_domains_from_other_projects(): void
-    {
-        $this->actingAs($this->user);
-
-        // Create a different project for the other user
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $response = $this->get("/domains/{$otherDomain->id}/records");
-
-        $response->assertForbidden();
-    }
-
-    public function test_authenticated_user_can_get_dns_records_json(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $record1 = DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.1',
-        ]);
-
-        $record2 = DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'CNAME',
-            'name' => 'mail',
-            'content' => 'example.com',
-        ]);
-
-        $response = $this->get("/domains/{$domain->id}/records/json");
-
-        $response->assertOk()
-            ->assertJsonStructure([
-                '*' => [
-                    'id',
-                    'type',
-                    'name',
-                    'formatted_name',
-                    'content',
-                    'ttl',
-                    'proxied',
-                    'domain_id',
-                    'created_at',
-                    'updated_at',
-                ],
-            ])
-            ->assertJsonFragment([
-                'id' => $record1->id,
-                'type' => 'A',
-                'name' => 'www',
-            ])
-            ->assertJsonFragment([
-                'id' => $record2->id,
-                'type' => 'CNAME',
-                'name' => 'mail',
-            ]);
-    }
-
-    public function test_user_cannot_get_dns_records_json_for_domains_from_other_projects(): void
-    {
-        $this->actingAs($this->user);
-
-        // Create a different project for the other user
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $response = $this->get("/domains/{$otherDomain->id}/records/json");
-
-        $response->assertForbidden();
-    }
-
-    public function test_authenticated_user_can_create_dns_record(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-            'provider_domain_id' => 'test-domain-id',
-        ]);
-
-        // Mock the DNS provider API call
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'result' => [
-                    'id' => 'test-record-id',
-                    'type' => 'A',
-                    'name' => 'www',
-                    'content' => '192.168.1.1',
-                    'ttl' => 300,
-                    'proxied' => false,
-                ],
-                'success' => true,
-            ], 200),
-        ]);
-
-        $recordData = [
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.1',
-            'ttl' => 300,
-            'proxied' => false,
-        ];
-
-        $response = $this->post("/domains/{$domain->id}/records", $recordData);
-
-        $response->assertRedirect()
-            ->assertSessionHas('success', 'DNS record created.');
-
-        $this->assertDatabaseHas('dns_records', [
-            'domain_id' => $domain->id,
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.1',
-        ]);
-    }
-
-    public function test_user_cannot_create_dns_record_for_domains_from_other_projects(): void
-    {
-        $this->actingAs($this->user);
-
-        // Create a different project for the other user
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $recordData = [
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.1',
-        ];
-
-        $response = $this->post("/domains/{$otherDomain->id}/records", $recordData);
-
-        $response->assertForbidden();
-    }
-
-    public function test_authenticated_user_can_update_dns_record(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-            'provider_domain_id' => 'test-domain-id',
-        ]);
-
-        $record = DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.1',
-            'provider_record_id' => 'test-record-id',
-        ]);
-
-        // Mock the DNS provider API call
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'result' => [
-                    'id' => 'test-record-id',
-                    'type' => 'A',
-                    'name' => 'www',
-                    'content' => '192.168.1.2',
-                    'ttl' => 600,
-                    'proxied' => false,
-                ],
-                'success' => true,
-            ], 200),
-        ]);
-
-        $updateData = [
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.2',
-            'ttl' => 600,
-        ];
-
-        $response = $this->patch("/domains/{$domain->id}/records/{$record->id}", $updateData);
-
-        $response->assertRedirect()
-            ->assertSessionHas('success', 'DNS record updated.');
-
-        $this->assertDatabaseHas('dns_records', [
-            'id' => $record->id,
-            'content' => '192.168.1.2',
-            'ttl' => 600,
-        ]);
-    }
-
-    public function test_user_cannot_update_dns_record_from_domains_in_other_projects(): void
-    {
-        $this->actingAs($this->user);
-
-        // Create a different project for the other user
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $otherRecord = DNSRecord::factory()->create([
-            'domain_id' => $otherDomain->id,
-        ]);
-
-        $updateData = ['content' => '192.168.1.2'];
-
-        $response = $this->patch("/domains/{$otherDomain->id}/records/{$otherRecord->id}", $updateData);
-
-        $response->assertForbidden();
-    }
-
-    public function test_user_cannot_update_dns_record_that_does_not_belong_to_domain(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $record = DNSRecord::factory()->create([
-            'domain_id' => $otherDomain->id,
-        ]);
-
-        $updateData = ['content' => '192.168.1.2'];
-
-        $response = $this->patch("/domains/{$domain->id}/records/{$record->id}", $updateData);
-
-        $response->assertNotFound();
-    }
-
-    public function test_authenticated_user_can_delete_dns_record(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $record = DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-        ]);
-
-        $response = $this->delete("/domains/{$domain->id}/records/{$record->id}");
-
-        $response->assertRedirect()
-            ->assertSessionHas('success', 'DNS record deleted.');
-
-        $this->assertDatabaseMissing('dns_records', ['id' => $record->id]);
-    }
-
-    public function test_user_cannot_delete_dns_record_from_domains_in_other_projects(): void
-    {
-        $this->actingAs($this->user);
-
-        // Create a different project for the other user
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $otherRecord = DNSRecord::factory()->create([
-            'domain_id' => $otherDomain->id,
-        ]);
-
-        $response = $this->delete("/domains/{$otherDomain->id}/records/{$otherRecord->id}");
-
-        $response->assertForbidden();
-
-        $this->assertDatabaseHas('dns_records', ['id' => $otherRecord->id]);
-    }
-
-    public function test_user_cannot_delete_dns_record_that_does_not_belong_to_domain(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $record = DNSRecord::factory()->create([
-            'domain_id' => $otherDomain->id,
-        ]);
-
-        $response = $this->delete("/domains/{$domain->id}/records/{$record->id}");
-
-        $response->assertNotFound();
-
-        $this->assertDatabaseHas('dns_records', ['id' => $record->id]);
-    }
-
-    public function test_domain_not_found_returns_404(): void
-    {
-        $this->actingAs($this->user);
-
-        $response = $this->get('/domains/999999');
-
-        $response->assertNotFound();
-    }
-
-    public function test_dns_record_show_route_does_not_exist(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        // There's no GET route for individual DNS records in the regular controller
-        $response = $this->get("/domains/{$domain->id}/records/999999");
-
-        $response->assertStatus(405); // Method not allowed
-    }
-
-    public function test_dns_provider_not_found_returns_404(): void
-    {
-        $this->actingAs($this->user);
-
-        $response = $this->get('/domains/999999/available');
-
-        $response->assertNotFound();
-    }
-
-    public function test_dns_records_are_ordered_by_type_and_name(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        // Create records in random order
-        DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'CNAME',
-            'name' => 'zebra',
-        ]);
-
-        DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'A',
-            'name' => 'alpha',
-        ]);
-
-        DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'A',
-            'name' => 'beta',
-        ]);
-
-        DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'CNAME',
-            'name' => 'alpha',
-        ]);
-
-        $response = $this->get("/domains/{$domain->id}/records/json");
-
-        $response->assertOk();
-
-        $records = $response->json();
-        $this->assertCount(4, $records);
-
-        // Should be ordered by type first (A before CNAME), then by name
-        $this->assertEquals('A', $records[0]['type']);
-        $this->assertEquals('alpha', $records[0]['name']);
-        $this->assertEquals('A', $records[1]['type']);
-        $this->assertEquals('beta', $records[1]['name']);
-        $this->assertEquals('CNAME', $records[2]['type']);
-        $this->assertEquals('alpha', $records[2]['name']);
-        $this->assertEquals('CNAME', $records[3]['type']);
-        $this->assertEquals('zebra', $records[3]['name']);
-    }
-
-    public function test_user_cannot_access_domains_from_other_projects(): void
-    {
-        $this->actingAs($this->user);
-
-        // Create a second project for a different user (not the current user)
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-        $otherProject = $otherUser->currentProject;
-
-        // Create DNS provider for the other project
-        $otherProjectDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        // Create domain in the other project
-        $otherProjectDomain = Domain::factory()->create([
-            'user_id' => $otherUser->id,
-            'dns_provider_id' => $otherProjectDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        // Create domain in current project (before switching)
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $currentProjectDomain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        // Should only see domains from current project
-        $response = $this->get('/domains');
-
-        $response->assertOk()
-            ->assertInertia(fn ($page) => $page
-                ->component('domains/index')
-                ->has('domains.data', 1) // Only domains from current project
-                ->where('domains.data.0.id', $currentProjectDomain->id)
-            );
-
-        // Should not be able to access domain from other project
-        $response = $this->get("/domains/{$otherProjectDomain->id}");
-
-        $response->assertForbidden();
-    }
-
-    public function test_user_cannot_create_domain_in_other_project(): void
-    {
-        $this->actingAs($this->user);
-
-        // Create a second project for a different user
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-        $otherProject = $otherUser->currentProject;
-
-        // Create DNS provider for the other project
-        $otherProjectDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        // Try to create domain with DNS provider from other project
-        $domainData = [
-            'dns_provider_id' => $otherProjectDnsProvider->id,
-            'provider_domain_id' => 'test-domain-id',
-        ];
-
-        $response = $this->post('/domains', $domainData);
-
-        $response->assertForbidden();
-    }
-
-    public function test_user_cannot_delete_domain_from_other_project(): void
-    {
-        $this->actingAs($this->user);
-
-        // Create a second project for a different user
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-        $otherProject = $otherUser->currentProject;
-
-        // Create DNS provider for the other project
-        $otherProjectDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        // Create domain in the other project
-        $otherProjectDomain = Domain::factory()->create([
-            'user_id' => $otherUser->id,
-            'dns_provider_id' => $otherProjectDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        // Try to delete domain from other project
-        $response = $this->delete("/domains/{$otherProjectDomain->id}");
-
-        $response->assertForbidden();
-
-        $this->assertDatabaseHas('domains', ['id' => $otherProjectDomain->id]);
-    }
-
-    public function test_authenticated_user_can_sync_dns_records(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-            'provider_domain_id' => 'test-domain-id',
-        ]);
-
-        // Create an existing record that will be replaced
-        DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'A',
-            'name' => 'old',
-            'content' => '192.168.1.1',
-        ]);
-
-        // Mock the DNS provider API call to return records
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response([
-                'result' => [
-                    [
-                        'id' => 'record-1',
-                        'type' => 'A',
-                        'name' => 'www',
-                        'content' => '192.168.1.1',
-                        'ttl' => 300,
-                        'proxied' => false,
-                        'created_on' => '2023-01-01T00:00:00Z',
-                        'modified_on' => '2023-01-01T00:00:00Z',
-                    ],
-                    [
-                        'id' => 'record-2',
-                        'type' => 'CNAME',
-                        'name' => 'mail',
-                        'content' => 'example.com',
-                        'ttl' => 600,
-                        'proxied' => false,
-                        'created_on' => '2023-01-01T00:00:00Z',
-                        'modified_on' => '2023-01-01T00:00:00Z',
-                    ],
-                ],
-                'success' => true,
-            ], 200),
-        ]);
-
-        $response = $this->post("/domains/{$domain->id}/records/sync");
-
-        $response->assertRedirect()
-            ->assertSessionHas('success', 'DNS records synced successfully.');
-
-        // Check that old record was deleted and new records were created
-        $this->assertDatabaseMissing('dns_records', [
-            'domain_id' => $domain->id,
-            'name' => 'old',
-        ]);
-
-        $this->assertDatabaseHas('dns_records', [
-            'domain_id' => $domain->id,
-            'provider_record_id' => 'record-1',
-            'type' => 'A',
-            'name' => 'www',
-            'content' => '192.168.1.1',
-        ]);
-
-        $this->assertDatabaseHas('dns_records', [
-            'domain_id' => $domain->id,
-            'provider_record_id' => 'record-2',
-            'type' => 'CNAME',
-            'name' => 'mail',
-            'content' => 'example.com',
-        ]);
-    }
-
-    public function test_sync_dns_records_returns_error_when_provider_fails(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $domain = Domain::factory()->create([
-            'user_id' => $this->user->id,
-            'dns_provider_id' => $dnsProvider->id,
-            'project_id' => $this->user->current_project_id,
-            'provider_domain_id' => 'test-domain-id',
-        ]);
-
-        $existingRecord = DNSRecord::factory()->create([
-            'domain_id' => $domain->id,
-            'type' => 'A',
-            'name' => 'existing',
-            'content' => '192.168.1.1',
-        ]);
-
-        // Mock the DNS provider API call to throw an exception
-        Http::fake(function () {
-            throw new \RuntimeException('Domain is not opted in to API access.');
-        });
-
-        $response = $this->post("/domains/{$domain->id}/records/sync");
-
-        $response->assertRedirect()
-            ->assertSessionHas('error');
-
-        // Existing record should remain intact after a failed sync
-        $this->assertDatabaseHas('dns_records', [
-            'id' => $existingRecord->id,
-            'domain_id' => $domain->id,
-            'name' => 'existing',
-        ]);
-    }
-
-    public function test_add_domain_fails_when_record_sync_fails(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $callCount = 0;
-
-        // First call (getDomain) succeeds, subsequent calls throw
-        Http::fake(function () use (&$callCount) {
-            $callCount++;
-            if ($callCount === 1) {
-                return Http::response([
-                    'result' => [
-                        'id' => 'test-domain-id',
-                        'name' => 'example.com',
-                        'status' => 'active',
-                        'created_on' => '2023-01-01T00:00:00Z',
-                        'modified_on' => '2023-01-01T00:00:00Z',
-                    ],
-                    'success' => true,
-                ], 200);
-            }
-
-            throw new \RuntimeException('Domain is not opted in to API access.');
-        });
-
-        $domainData = [
-            'dns_provider_id' => $dnsProvider->id,
-            'provider_domain_id' => 'test-domain-id',
-        ];
-
-        $response = $this->post('/domains', $domainData);
-
-        $response->assertRedirect()
-            ->assertSessionHasErrors('domain');
-
-        // Domain should not have been persisted due to transaction rollback
-        $this->assertDatabaseMissing('domains', [
-            'provider_domain_id' => 'test-domain-id',
-        ]);
-    }
-
-    public function test_user_cannot_sync_dns_records_for_domains_from_other_projects(): void
-    {
-        $this->actingAs($this->user);
-
-        // Create a different project for the other user
-        $otherProject = Project::factory()->create();
-        $otherDnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $otherDomain = Domain::factory()->create([
-            'user_id' => $this->otherUser->id,
-            'dns_provider_id' => $otherDnsProvider->id,
-            'project_id' => $otherProject->id,
-        ]);
-
-        $response = $this->post("/domains/{$otherDomain->id}/records/sync");
-
-        $response->assertForbidden();
-    }
-
-    public function test_available_domains_returns_cached_value_when_cache_exists(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $cachedDomains = [
-            ['id' => 'cached-zone-1', 'name' => 'cached.com', 'status' => 'active'],
-        ];
-
-        Cache::put("dns_provider_{$dnsProvider->id}_domains", $cachedDomains, 3600);
-
-        // Should NOT make an API call — Http::fake with no matching routes would throw if called
-        Http::fake([]);
-
-        $response = $this->get("/domains/{$dnsProvider->id}/available");
-
-        $response->assertOk();
-        $this->assertEquals($cachedDomains, $response->json());
-    }
-
-    public function test_refresh_domains_skips_cache_and_fetches_from_provider(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $staleDomains = [
-            ['id' => 'stale-zone-1', 'name' => 'stale.com', 'status' => 'active'],
-        ];
-
-        Cache::put("dns_provider_{$dnsProvider->id}_domains", $staleDomains, 3600);
-
-        $freshDomains = [
-            ['id' => 'zone-1', 'name' => 'fresh.com', 'status' => 'active', 'created_on' => '2023-01-01', 'modified_on' => '2023-01-02'],
-            ['id' => 'zone-2', 'name' => 'new.com', 'status' => 'active', 'created_on' => '2023-01-03', 'modified_on' => '2023-01-04'],
-        ];
-
-        Http::fake([
-            'api.cloudflare.com/client/v4/zones*' => Http::response([
-                'success' => true,
-                'result' => $freshDomains,
-            ], 200),
-        ]);
-
-        $response = $this->get("/domains/{$dnsProvider->id}/refresh");
-
-        $response->assertOk();
-
-        $data = $response->json();
-        $this->assertCount(2, $data);
-        $this->assertEquals('fresh.com', $data[0]['name']);
-        $this->assertEquals('new.com', $data[1]['name']);
-
-        // Cache should now be updated with fresh data
-        $cached = Cache::get("dns_provider_{$dnsProvider->id}_domains");
-        $this->assertCount(2, $cached);
-        $this->assertEquals('fresh.com', $cached[0]['name']);
-    }
-
-    public function test_refresh_domains_updates_cache_for_subsequent_available_calls(): void
-    {
-        $this->actingAs($this->user);
-
-        $dnsProvider = DNSProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $freshDomains = [
-            ['id' => 'zone-1', 'name' => 'example.com', 'status' => 'active', 'created_on' => '2023-01-01', 'modified_on' => '2023-01-02'],
-        ];
-
-        Http::fake([
-            'api.cloudflare.com/client/v4/zones*' => Http::response([
-                'success' => true,
-                'result' => $freshDomains,
-            ], 200),
-        ]);
-
-        // First call: refresh to populate cache
-        $this->get("/domains/{$dnsProvider->id}/refresh")->assertOk();
-
-        // Second call: available should use cache (no API call needed)
-        Http::fake([]);
-
-        $response = $this->get("/domains/{$dnsProvider->id}/available");
-
-        $response->assertOk();
-        $this->assertCount(1, $response->json());
-        $this->assertEquals('example.com', $response->json()[0]['name']);
-    }
-}
+    $response->assertRedirect()
+        ->assertSessionHasErrors('domain');
+
+    // Domain should not have been persisted due to transaction rollback
+    $this->assertDatabaseMissing('domains', [
+        'provider_domain_id' => 'test-domain-id',
+    ]);
+});
+
+test('user cannot sync dns records for domains from other projects', function () {
+    $this->actingAs($this->user);
+
+    // Create a different project for the other user
+    $otherProject = Project::factory()->create();
+    $otherDnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $otherDomain = Domain::factory()->create([
+        'user_id' => $this->otherUser->id,
+        'dns_provider_id' => $otherDnsProvider->id,
+        'project_id' => $otherProject->id,
+    ]);
+
+    $response = $this->post("/domains/{$otherDomain->id}/records/sync");
+
+    $response->assertForbidden();
+});
+
+test('available domains returns cached value when cache exists', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $cachedDomains = [
+        ['id' => 'cached-zone-1', 'name' => 'cached.com', 'status' => 'active'],
+    ];
+
+    Cache::put("dns_provider_{$dnsProvider->id}_domains", $cachedDomains, 3600);
+
+    // Should NOT make an API call — Http::fake with no matching routes would throw if called
+    Http::fake([]);
+
+    $response = $this->get("/domains/{$dnsProvider->id}/available");
+
+    $response->assertOk();
+    expect($response->json())->toEqual($cachedDomains);
+});
+
+test('refresh domains skips cache and fetches from provider', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $staleDomains = [
+        ['id' => 'stale-zone-1', 'name' => 'stale.com', 'status' => 'active'],
+    ];
+
+    Cache::put("dns_provider_{$dnsProvider->id}_domains", $staleDomains, 3600);
+
+    $freshDomains = [
+        ['id' => 'zone-1', 'name' => 'fresh.com', 'status' => 'active', 'created_on' => '2023-01-01', 'modified_on' => '2023-01-02'],
+        ['id' => 'zone-2', 'name' => 'new.com', 'status' => 'active', 'created_on' => '2023-01-03', 'modified_on' => '2023-01-04'],
+    ];
+
+    Http::fake([
+        'api.cloudflare.com/client/v4/zones*' => Http::response([
+            'success' => true,
+            'result' => $freshDomains,
+        ], 200),
+    ]);
+
+    $response = $this->get("/domains/{$dnsProvider->id}/refresh");
+
+    $response->assertOk();
+
+    $data = $response->json();
+    expect($data)->toHaveCount(2);
+    expect($data[0]['name'])->toEqual('fresh.com');
+    expect($data[1]['name'])->toEqual('new.com');
+
+    // Cache should now be updated with fresh data
+    $cached = Cache::get("dns_provider_{$dnsProvider->id}_domains");
+    expect($cached)->toHaveCount(2);
+    expect($cached[0]['name'])->toEqual('fresh.com');
+});
+
+test('refresh domains updates cache for subsequent available calls', function () {
+    $this->actingAs($this->user);
+
+    $dnsProvider = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $freshDomains = [
+        ['id' => 'zone-1', 'name' => 'example.com', 'status' => 'active', 'created_on' => '2023-01-01', 'modified_on' => '2023-01-02'],
+    ];
+
+    Http::fake([
+        'api.cloudflare.com/client/v4/zones*' => Http::response([
+            'success' => true,
+            'result' => $freshDomains,
+        ], 200),
+    ]);
+
+    // First call: refresh to populate cache
+    $this->get("/domains/{$dnsProvider->id}/refresh")->assertOk();
+
+    // Second call: available should use cache (no API call needed)
+    Http::fake([]);
+
+    $response = $this->get("/domains/{$dnsProvider->id}/available");
+
+    $response->assertOk();
+    expect($response->json())->toHaveCount(1);
+    expect($response->json()[0]['name'])->toEqual('example.com');
+});

--- a/tests/Feature/EventsHandlerTest.php
+++ b/tests/Feature/EventsHandlerTest.php
@@ -1,177 +1,163 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\WebSockets\GenerateWebSocketToken;
 use App\WebSocket\EventsHandler;
 use App\WebSocket\WebSocketConnection;
 use GuzzleHttp\Psr7\Request as PsrRequest;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class EventsHandlerTest extends TestCase
+uses(RefreshDatabase::class);
+
+function vitoPestFeatureEventsHandlerTestCreateHandler(): EventsHandler
 {
-    use RefreshDatabase;
-
-    private function createHandler(): EventsHandler
-    {
-        return new EventsHandler;
-    }
-
-    private function generateEventsToken(array $data): string
-    {
-        $result = (new GenerateWebSocketToken)->generate('events_token', $data);
-
-        return $result['token'];
-    }
-
-    public function test_authenticate_with_valid_token(): void
-    {
-        $token = $this->generateEventsToken([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $handler = $this->createHandler();
-        $request = new PsrRequest('GET', '/ws/events?token='.$token);
-
-        $this->assertNull($handler->authenticate($request));
-    }
-
-    public function test_authenticate_rejects_missing_and_invalid_tokens(): void
-    {
-        $handler = $this->createHandler();
-
-        $this->assertEquals('Missing authentication token', $handler->authenticate(new PsrRequest('GET', '/ws/events')));
-        $this->assertEquals('Invalid or expired token', $handler->authenticate(new PsrRequest('GET', '/ws/events?token=bad')));
-    }
-
-    public function test_authenticate_rate_limits_connections_per_user(): void
-    {
-        $handler = $this->createHandler();
-
-        $reflection = new \ReflectionClass($handler);
-        $prop = $reflection->getProperty('connections');
-        $connections = [];
-        for ($i = 0; $i < 10; $i++) {
-            $connections["fake-conn-$i"] = [
-                'connection' => null,
-                'user_id' => $this->user->id,
-                'project_id' => $this->user->current_project_id,
-            ];
-        }
-        $prop->setValue($handler, $connections);
-
-        $token = $this->generateEventsToken([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $this->assertEquals('Too many connections', $handler->authenticate(new PsrRequest('GET', '/ws/events?token='.$token)));
-    }
-
-    public function test_subscribe_rate_limit_reached(): void
-    {
-        $handler = $this->createHandler();
-        $reflection = new \ReflectionClass($handler);
-
-        $prop = $reflection->getProperty('userSubscribeTimestamps');
-        $now = microtime(true);
-        $timestamps = [];
-        for ($i = 0; $i < 20; $i++) {
-            $timestamps[] = $now - $i;
-        }
-        $prop->setValue($handler, [$this->user->id => $timestamps]);
-
-        $method = $reflection->getMethod('isSubscribeRateLimited');
-        $this->assertTrue($method->invoke($handler, $this->user->id));
-    }
-
-    public function test_subscribe_rate_limit_window_expiry(): void
-    {
-        $handler = $this->createHandler();
-        $reflection = new \ReflectionClass($handler);
-
-        $prop = $reflection->getProperty('userSubscribeTimestamps');
-        $timestamps = [];
-        for ($i = 0; $i < 20; $i++) {
-            $timestamps[] = microtime(true) - 61;
-        }
-        $prop->setValue($handler, [$this->user->id => $timestamps]);
-
-        $method = $reflection->getMethod('isSubscribeRateLimited');
-        $this->assertFalse($method->invoke($handler, $this->user->id));
-    }
-
-    public function test_subscribe_rate_limit_is_per_user(): void
-    {
-        $handler = $this->createHandler();
-        $reflection = new \ReflectionClass($handler);
-
-        $prop = $reflection->getProperty('userSubscribeTimestamps');
-        $now = microtime(true);
-        $timestamps = [];
-        for ($i = 0; $i < 20; $i++) {
-            $timestamps[] = $now - $i;
-        }
-        $prop->setValue($handler, [$this->user->id => $timestamps]);
-
-        $method = $reflection->getMethod('isSubscribeRateLimited');
-        $this->assertTrue($method->invoke($handler, $this->user->id));
-        $this->assertFalse($method->invoke($handler, 99999));
-    }
-
-    public function test_on_close_cleans_up_connection_subscription_and_timestamps(): void
-    {
-        $handler = $this->createHandler();
-        $reflection = new \ReflectionClass($handler);
-
-        $connProp = $reflection->getProperty('connections');
-        $subProp = $reflection->getProperty('projectSubscriptions');
-        $tsProp = $reflection->getProperty('userSubscribeTimestamps');
-
-        $projectId = $this->user->current_project_id;
-        $connProp->setValue($handler, [
-            'test-conn' => [
-                'connection' => null,
-                'user_id' => $this->user->id,
-                'project_id' => $projectId,
-            ],
-        ]);
-        $subProp->setValue($handler, [$projectId => ['test-conn' => true]]);
-        $tsProp->setValue($handler, [$this->user->id => [microtime(true)]]);
-
-        $handler->onClose('test-conn');
-
-        $this->assertEquals(0, $handler->getConnectionCount());
-        $this->assertEmpty($subProp->getValue($handler));
-        $this->assertArrayNotHasKey($this->user->id, $tsProp->getValue($handler));
-    }
-
-    public function test_broadcast_to_project(): void
-    {
-        $handler = $this->createHandler();
-        $reflection = new \ReflectionClass($handler);
-
-        $connProp = $reflection->getProperty('connections');
-        $subProp = $reflection->getProperty('projectSubscriptions');
-
-        $mockConnection = $this->createMock(WebSocketConnection::class);
-        $mockConnection->expects($this->once())->method('send');
-
-        $mockOtherConnection = $this->createMock(WebSocketConnection::class);
-        $mockOtherConnection->expects($this->never())->method('send');
-
-        $projectId = $this->user->current_project_id;
-        $connProp->setValue($handler, [
-            'conn-1' => ['connection' => $mockConnection, 'user_id' => $this->user->id, 'project_id' => $projectId],
-            'conn-2' => ['connection' => $mockOtherConnection, 'user_id' => $this->user->id, 'project_id' => 99999],
-        ]);
-        $subProp->setValue($handler, [
-            $projectId => ['conn-1' => true],
-            99999 => ['conn-2' => true],
-        ]);
-
-        $handler->broadcastToProject($projectId, ['type' => 'test', 'project_id' => $projectId]);
-    }
+    return new EventsHandler;
 }
+
+function vitoPestFeatureEventsHandlerTestGenerateEventsToken(array $data): string
+{
+    $result = (new GenerateWebSocketToken)->generate('events_token', $data);
+
+    return $result['token'];
+}
+
+test('authenticate with valid token', function () {
+    $token = vitoPestFeatureEventsHandlerTestGenerateEventsToken([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $handler = vitoPestFeatureEventsHandlerTestCreateHandler();
+    $request = new PsrRequest('GET', '/ws/events?token='.$token);
+
+    expect($handler->authenticate($request))->toBeNull();
+});
+
+test('authenticate rejects missing and invalid tokens', function () {
+    $handler = vitoPestFeatureEventsHandlerTestCreateHandler();
+
+    expect($handler->authenticate(new PsrRequest('GET', '/ws/events')))->toEqual('Missing authentication token');
+    expect($handler->authenticate(new PsrRequest('GET', '/ws/events?token=bad')))->toEqual('Invalid or expired token');
+});
+
+test('authenticate rate limits connections per user', function () {
+    $handler = vitoPestFeatureEventsHandlerTestCreateHandler();
+
+    $reflection = new ReflectionClass($handler);
+    $prop = $reflection->getProperty('connections');
+    $connections = [];
+    for ($i = 0; $i < 10; $i++) {
+        $connections["fake-conn-$i"] = [
+            'connection' => null,
+            'user_id' => $this->user->id,
+            'project_id' => $this->user->current_project_id,
+        ];
+    }
+    $prop->setValue($handler, $connections);
+
+    $token = vitoPestFeatureEventsHandlerTestGenerateEventsToken([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    expect($handler->authenticate(new PsrRequest('GET', '/ws/events?token='.$token)))->toEqual('Too many connections');
+});
+
+test('subscribe rate limit reached', function () {
+    $handler = vitoPestFeatureEventsHandlerTestCreateHandler();
+    $reflection = new ReflectionClass($handler);
+
+    $prop = $reflection->getProperty('userSubscribeTimestamps');
+    $now = microtime(true);
+    $timestamps = [];
+    for ($i = 0; $i < 20; $i++) {
+        $timestamps[] = $now - $i;
+    }
+    $prop->setValue($handler, [$this->user->id => $timestamps]);
+
+    $method = $reflection->getMethod('isSubscribeRateLimited');
+    expect($method->invoke($handler, $this->user->id))->toBeTrue();
+});
+
+test('subscribe rate limit window expiry', function () {
+    $handler = vitoPestFeatureEventsHandlerTestCreateHandler();
+    $reflection = new ReflectionClass($handler);
+
+    $prop = $reflection->getProperty('userSubscribeTimestamps');
+    $timestamps = [];
+    for ($i = 0; $i < 20; $i++) {
+        $timestamps[] = microtime(true) - 61;
+    }
+    $prop->setValue($handler, [$this->user->id => $timestamps]);
+
+    $method = $reflection->getMethod('isSubscribeRateLimited');
+    expect($method->invoke($handler, $this->user->id))->toBeFalse();
+});
+
+test('subscribe rate limit is per user', function () {
+    $handler = vitoPestFeatureEventsHandlerTestCreateHandler();
+    $reflection = new ReflectionClass($handler);
+
+    $prop = $reflection->getProperty('userSubscribeTimestamps');
+    $now = microtime(true);
+    $timestamps = [];
+    for ($i = 0; $i < 20; $i++) {
+        $timestamps[] = $now - $i;
+    }
+    $prop->setValue($handler, [$this->user->id => $timestamps]);
+
+    $method = $reflection->getMethod('isSubscribeRateLimited');
+    expect($method->invoke($handler, $this->user->id))->toBeTrue();
+    expect($method->invoke($handler, 99999))->toBeFalse();
+});
+
+test('on close cleans up connection subscription and timestamps', function () {
+    $handler = vitoPestFeatureEventsHandlerTestCreateHandler();
+    $reflection = new ReflectionClass($handler);
+
+    $connProp = $reflection->getProperty('connections');
+    $subProp = $reflection->getProperty('projectSubscriptions');
+    $tsProp = $reflection->getProperty('userSubscribeTimestamps');
+
+    $projectId = $this->user->current_project_id;
+    $connProp->setValue($handler, [
+        'test-conn' => [
+            'connection' => null,
+            'user_id' => $this->user->id,
+            'project_id' => $projectId,
+        ],
+    ]);
+    $subProp->setValue($handler, [$projectId => ['test-conn' => true]]);
+    $tsProp->setValue($handler, [$this->user->id => [microtime(true)]]);
+
+    $handler->onClose('test-conn');
+
+    expect($handler->getConnectionCount())->toEqual(0);
+    expect($subProp->getValue($handler))->toBeEmpty();
+    $this->assertArrayNotHasKey($this->user->id, $tsProp->getValue($handler));
+});
+
+test('broadcast to project', function () {
+    $handler = vitoPestFeatureEventsHandlerTestCreateHandler();
+    $reflection = new ReflectionClass($handler);
+
+    $connProp = $reflection->getProperty('connections');
+    $subProp = $reflection->getProperty('projectSubscriptions');
+
+    $mockConnection = $this->createMock(WebSocketConnection::class);
+    $mockConnection->expects($this->once())->method('send');
+
+    $mockOtherConnection = $this->createMock(WebSocketConnection::class);
+    $mockOtherConnection->expects($this->never())->method('send');
+
+    $projectId = $this->user->current_project_id;
+    $connProp->setValue($handler, [
+        'conn-1' => ['connection' => $mockConnection, 'user_id' => $this->user->id, 'project_id' => $projectId],
+        'conn-2' => ['connection' => $mockOtherConnection, 'user_id' => $this->user->id, 'project_id' => 99999],
+    ]);
+    $subProp->setValue($handler, [
+        $projectId => ['conn-1' => true],
+        99999 => ['conn-2' => true],
+    ]);
+
+    $handler->broadcastToProject($projectId, ['type' => 'test', 'project_id' => $projectId]);
+});

--- a/tests/Feature/FirewallTest.php
+++ b/tests/Feature/FirewallTest.php
@@ -1,179 +1,163 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\FirewallRuleStatus;
 use App\Facades\SSH;
 use App\Models\FirewallRule;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class FirewallTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_firewall_rule(): void
-    {
-        SSH::fake();
+test('create firewall rule', function () {
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->post(route('firewall.store', ['server' => $this->server]), [
-            'name' => 'Test',
+    $this->post(route('firewall.store', ['server' => $this->server]), [
+        'name' => 'Test',
+        'type' => 'allow',
+        'protocol' => 'tcp',
+        'port' => '1234',
+        'source' => '0.0.0.0',
+        'mask' => '1',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('firewall_rules', [
+        'port' => '1234',
+        'status' => FirewallRuleStatus::READY,
+    ]);
+});
+
+test('see firewall rules', function () {
+    $this->actingAs($this->user);
+
+    FirewallRule::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->get(route('firewall', $this->server))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('firewall/index'));
+});
+
+test('create firewall rule with port range', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('firewall.store', ['server' => $this->server]), [
+        'name' => 'Range',
+        'type' => 'allow',
+        'protocol' => 'tcp',
+        'port' => '3000:3010',
+        'source' => null,
+        'mask' => null,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('firewall_rules', [
+        'port' => '3000:3010',
+        'status' => FirewallRuleStatus::READY,
+    ]);
+
+    SSH::assertExecutedContains('port 3000:3010');
+});
+
+test('port validation accepts max span', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('firewall.store', ['server' => $this->server]), [
+        'name' => 'MaxSpan',
+        'type' => 'allow',
+        'protocol' => 'tcp',
+        'port' => '1:65535',
+        'source' => null,
+        'mask' => null,
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('firewall_rules', [
+        'port' => '1:65535',
+    ]);
+});
+
+test('port validation rejects invalid input', function (string $port) {
+    $this->actingAs($this->user);
+
+    $this->from(route('firewall', $this->server))
+        ->post(route('firewall.store', ['server' => $this->server]), [
+            'name' => 'Invalid',
             'type' => 'allow',
             'protocol' => 'tcp',
-            'port' => '1234',
-            'source' => '0.0.0.0',
-            'mask' => '1',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('firewall_rules', [
-            'port' => '1234',
-            'status' => FirewallRuleStatus::READY,
-        ]);
-    }
-
-    public function test_see_firewall_rules(): void
-    {
-        $this->actingAs($this->user);
-
-        FirewallRule::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->get(route('firewall', $this->server))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('firewall/index'));
-    }
-
-    public function test_create_firewall_rule_with_port_range(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('firewall.store', ['server' => $this->server]), [
-            'name' => 'Range',
-            'type' => 'allow',
-            'protocol' => 'tcp',
-            'port' => '3000:3010',
+            'port' => $port,
             'source' => null,
             'mask' => null,
         ])
-            ->assertSessionDoesntHaveErrors();
+        ->assertSessionHasErrors(['port']);
+})->with('invalidPortProvider');
 
-        $this->assertDatabaseHas('firewall_rules', [
-            'port' => '3000:3010',
-            'status' => FirewallRuleStatus::READY,
-        ]);
+/**
+ * @return array<string, array<int, string>>
+ */
+dataset('invalidPortProvider', function () {
+    return [
+        'zero' => ['0'],
+        'above max' => ['65536'],
+        'both above max' => ['100000:200000'],
+        'reversed range' => ['5000:4000'],
+        'equal range' => ['3000:3000'],
+        'non-numeric' => ['abc'],
+        'trailing colon' => ['3000:'],
+        'leading zero' => ['01234'],
+        'empty' => [''],
+    ];
+});
 
-        SSH::assertExecutedContains('port 3000:3010');
-    }
+test('existing single port rule can be edited', function () {
+    SSH::fake();
 
-    public function test_port_validation_accepts_max_span(): void
-    {
-        SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $rule = FirewallRule::factory()->create([
+        'server_id' => $this->server->id,
+        'port' => '22',
+    ]);
 
-        $this->post(route('firewall.store', ['server' => $this->server]), [
-            'name' => 'MaxSpan',
-            'type' => 'allow',
-            'protocol' => 'tcp',
-            'port' => '1:65535',
-            'source' => null,
-            'mask' => null,
-        ])->assertSessionDoesntHaveErrors();
+    $this->put(route('firewall.update', [
+        'server' => $this->server,
+        'firewallRule' => $rule,
+    ]), [
+        'name' => 'SSH',
+        'type' => 'allow',
+        'protocol' => 'tcp',
+        'port' => '2222',
+        'source' => null,
+        'mask' => null,
+    ])->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('firewall_rules', [
-            'port' => '1:65535',
-        ]);
-    }
+    $this->assertDatabaseHas('firewall_rules', [
+        'id' => $rule->id,
+        'port' => '2222',
+    ]);
+});
 
-    #[DataProvider('invalidPortProvider')]
-    public function test_port_validation_rejects_invalid_input(string $port): void
-    {
-        $this->actingAs($this->user);
+test('delete firewall rule', function () {
+    SSH::fake();
 
-        $this->from(route('firewall', $this->server))
-            ->post(route('firewall.store', ['server' => $this->server]), [
-                'name' => 'Invalid',
-                'type' => 'allow',
-                'protocol' => 'tcp',
-                'port' => $port,
-                'source' => null,
-                'mask' => null,
-            ])
-            ->assertSessionHasErrors(['port']);
-    }
+    $this->actingAs($this->user);
 
-    /**
-     * @return array<string, array<int, string>>
-     */
-    public static function invalidPortProvider(): array
-    {
-        return [
-            'zero' => ['0'],
-            'above max' => ['65536'],
-            'both above max' => ['100000:200000'],
-            'reversed range' => ['5000:4000'],
-            'equal range' => ['3000:3000'],
-            'non-numeric' => ['abc'],
-            'trailing colon' => ['3000:'],
-            'leading zero' => ['01234'],
-            'empty' => [''],
-        ];
-    }
+    $rule = FirewallRule::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-    public function test_existing_single_port_rule_can_be_edited(): void
-    {
-        SSH::fake();
+    $this->delete(route('firewall.destroy', [
+        'server' => $this->server,
+        'firewallRule' => $rule,
+    ]))->assertSessionDoesntHaveErrors();
 
-        $this->actingAs($this->user);
-
-        $rule = FirewallRule::factory()->create([
-            'server_id' => $this->server->id,
-            'port' => '22',
-        ]);
-
-        $this->put(route('firewall.update', [
-            'server' => $this->server,
-            'firewallRule' => $rule,
-        ]), [
-            'name' => 'SSH',
-            'type' => 'allow',
-            'protocol' => 'tcp',
-            'port' => '2222',
-            'source' => null,
-            'mask' => null,
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('firewall_rules', [
-            'id' => $rule->id,
-            'port' => '2222',
-        ]);
-    }
-
-    public function test_delete_firewall_rule(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $rule = FirewallRule::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->delete(route('firewall.destroy', [
-            'server' => $this->server,
-            'firewallRule' => $rule,
-        ]))->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('firewall_rules', [
-            'id' => $rule->id,
-        ]);
-    }
-}
+    $this->assertDatabaseMissing('firewall_rules', [
+        'id' => $rule->id,
+    ]);
+});

--- a/tests/Feature/GithubAppTest.php
+++ b/tests/Feature/GithubAppTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Facades\SSH;
 use App\Models\GitHook;
 use App\Models\GithubApp;
@@ -12,581 +10,543 @@ use App\SourceControlProviders\GithubApp as GithubAppProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
-use Tests\TestCase;
 
-class GithubAppTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    protected User $admin;
+beforeEach(function () {
+    $this->admin = User::factory()->create(['is_admin' => true]);
+    $this->admin->ensureHasDefaultProject();
+});
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+test('non admin cannot access settings page', function () {
+    $nonAdmin = User::factory()->create(['is_admin' => false]);
+    $nonAdmin->ensureHasDefaultProject();
 
-        $this->admin = User::factory()->create(['is_admin' => true]);
-        $this->admin->ensureHasDefaultProject();
-    }
+    $this->actingAs($nonAdmin)
+        ->get(route('github-app'))
+        ->assertNotFound();
+});
 
-    public function test_non_admin_cannot_access_settings_page(): void
-    {
-        $nonAdmin = User::factory()->create(['is_admin' => false]);
-        $nonAdmin->ensureHasDefaultProject();
+test('admin can view settings page when no app', function () {
+    $this->actingAs($this->admin)
+        ->get(route('github-app'))
+        ->assertOk();
+});
 
-        $this->actingAs($nonAdmin)
-            ->get(route('github-app'))
-            ->assertNotFound();
-    }
+test('admin can view settings page when app exists', function () {
+    GithubApp::factory()->create();
 
-    public function test_admin_can_view_settings_page_when_no_app(): void
-    {
-        $this->actingAs($this->admin)
-            ->get(route('github-app'))
-            ->assertOk();
-    }
+    $this->actingAs($this->admin)
+        ->get(route('github-app'))
+        ->assertOk();
+});
 
-    public function test_admin_can_view_settings_page_when_app_exists(): void
-    {
-        GithubApp::factory()->create();
+test('manifest callback creates app', function () {
+    Http::fake([
+        'api.github.com/app-manifests/test-code/conversions' => Http::response([
+            'id' => 12345,
+            'slug' => 'vito-test',
+            'name' => 'Vito Test',
+            'client_id' => 'Iv1.abc',
+            'client_secret' => 'secret',
+            'webhook_secret' => 'whsecret',
+            'pem' => vitoPestFeatureGithubAppTestGeneratePrivateKey(),
+            'html_url' => 'https://github.com/apps/vito-test',
+        ], 201),
+    ]);
 
-        $this->actingAs($this->admin)
-            ->get(route('github-app'))
-            ->assertOk();
-    }
+    $this->actingAs($this->admin)
+        ->get(route('github-app.manifest-callback', ['code' => 'test-code']))
+        ->assertRedirect(route('github-app'));
 
-    public function test_manifest_callback_creates_app(): void
-    {
-        Http::fake([
-            'api.github.com/app-manifests/test-code/conversions' => Http::response([
-                'id' => 12345,
-                'slug' => 'vito-test',
-                'name' => 'Vito Test',
-                'client_id' => 'Iv1.abc',
-                'client_secret' => 'secret',
-                'webhook_secret' => 'whsecret',
-                'pem' => $this->generatePrivateKey(),
-                'html_url' => 'https://github.com/apps/vito-test',
-            ], 201),
-        ]);
+    $this->assertDatabaseHas('github_app', [
+        'app_id' => 12345,
+        'app_slug' => 'vito-test',
+    ]);
 
-        $this->actingAs($this->admin)
-            ->get(route('github-app.manifest-callback', ['code' => 'test-code']))
-            ->assertRedirect(route('github-app'));
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.github.com/app-manifests/test-code/conversions'
+            && $request->body() === '';
+    });
+});
 
-        $this->assertDatabaseHas('github_app', [
-            'app_id' => 12345,
-            'app_slug' => 'vito-test',
-        ]);
+test('manifest callback rejects missing code', function () {
+    $this->actingAs($this->admin)
+        ->get(route('github-app.manifest-callback'))
+        ->assertRedirect(route('github-app'));
 
-        Http::assertSent(function ($request) {
-            return $request->url() === 'https://api.github.com/app-manifests/test-code/conversions'
-                && $request->body() === '';
-        });
-    }
+    $this->assertDatabaseMissing('github_app', ['app_slug' => 'vito-test']);
+});
 
-    public function test_manifest_callback_rejects_missing_code(): void
-    {
-        $this->actingAs($this->admin)
-            ->get(route('github-app.manifest-callback'))
-            ->assertRedirect(route('github-app'));
+test('manual creation persists app', function () {
+    $pem = vitoPestFeatureGithubAppTestGeneratePrivateKey();
 
-        $this->assertDatabaseMissing('github_app', ['app_slug' => 'vito-test']);
-    }
-
-    public function test_manual_creation_persists_app(): void
-    {
-        $pem = $this->generatePrivateKey();
-
-        $this->actingAs($this->admin)
-            ->post(route('github-app.manual'), [
-                'app_id' => 5555,
-                'name' => 'Manual Vito',
-                'client_id' => 'Iv1.manualclient',
-                'client_secret' => 'manualsecret',
-                'webhook_secret' => 'manualwhsecret',
-                'private_key' => $pem,
-                'html_url' => 'https://github.com/apps/manual-vito',
-            ])
-            ->assertRedirect(route('github-app'));
-
-        $this->assertDatabaseHas('github_app', [
+    $this->actingAs($this->admin)
+        ->post(route('github-app.manual'), [
             'app_id' => 5555,
-            'app_slug' => 'manual-vito',
-        ]);
-    }
+            'name' => 'Manual Vito',
+            'client_id' => 'Iv1.manualclient',
+            'client_secret' => 'manualsecret',
+            'webhook_secret' => 'manualwhsecret',
+            'private_key' => $pem,
+            'html_url' => 'https://github.com/apps/manual-vito',
+        ])
+        ->assertRedirect(route('github-app'));
 
-    public function test_manual_creation_rejects_invalid_html_url(): void
-    {
-        $pem = $this->generatePrivateKey();
+    $this->assertDatabaseHas('github_app', [
+        'app_id' => 5555,
+        'app_slug' => 'manual-vito',
+    ]);
+});
 
-        $this->actingAs($this->admin)
-            ->post(route('github-app.manual'), [
-                'app_id' => 5555,
-                'client_id' => 'x',
-                'client_secret' => 'x',
-                'webhook_secret' => 'x',
-                'private_key' => $pem,
-                'html_url' => 'https://example.com/not-an-app-url',
-            ])
-            ->assertSessionHasErrors('html_url');
-    }
+test('manual creation rejects invalid html url', function () {
+    $pem = vitoPestFeatureGithubAppTestGeneratePrivateKey();
 
-    public function test_manual_creation_rejects_bad_private_key(): void
-    {
-        $this->actingAs($this->admin)
-            ->post(route('github-app.manual'), [
-                'app_id' => 5555,
-                'client_id' => 'x',
-                'client_secret' => 'x',
-                'webhook_secret' => 'x',
-                'private_key' => 'not-a-key',
-                'html_url' => 'https://github.com/apps/manual-vito',
-            ])
-            ->assertSessionHasErrors('private_key');
-    }
+    $this->actingAs($this->admin)
+        ->post(route('github-app.manual'), [
+            'app_id' => 5555,
+            'client_id' => 'x',
+            'client_secret' => 'x',
+            'webhook_secret' => 'x',
+            'private_key' => $pem,
+            'html_url' => 'https://example.com/not-an-app-url',
+        ])
+        ->assertSessionHasErrors('html_url');
+});
 
-    public function test_install_callback_creates_source_control(): void
-    {
-        $app = GithubApp::factory()->create();
+test('manual creation rejects bad private key', function () {
+    $this->actingAs($this->admin)
+        ->post(route('github-app.manual'), [
+            'app_id' => 5555,
+            'client_id' => 'x',
+            'client_secret' => 'x',
+            'webhook_secret' => 'x',
+            'private_key' => 'not-a-key',
+            'html_url' => 'https://github.com/apps/manual-vito',
+        ])
+        ->assertSessionHasErrors('private_key');
+});
 
-        Http::fake([
-            'api.github.com/app/installations/999' => Http::response([
-                'id' => 999,
-                'html_url' => 'https://github.com/organizations/acme/settings/installations/999',
-                'account' => [
-                    'id' => 555,
-                    'login' => 'acme',
-                    'type' => 'Organization',
-                ],
-            ], 200),
-        ]);
+test('install callback creates source control', function () {
+    $app = GithubApp::factory()->create();
 
-        $this->actingAs($this->admin)
-            ->get(route('github-app.install-callback', ['installation_id' => 999]))
-            ->assertRedirect(route('source-controls'));
-
-        $this->assertDatabaseHas('source_controls', [
-            'provider' => SourceControl::PROVIDER_GITHUB_APP,
-            'external_identifier' => '999',
-            'profile' => 'acme',
-        ]);
-
-        unset($app);
-    }
-
-    public function test_install_callback_restores_soft_deleted_installation(): void
-    {
-        GithubApp::factory()->create();
-
-        $existing = SourceControl::factory()->githubApp()->create([
-            'external_identifier' => '777',
-            'user_id' => $this->admin->id,
-        ]);
-        $existing->delete();
-        $this->assertSoftDeleted($existing);
-
-        Http::fake([
-            'api.github.com/app/installations/777' => Http::response([
-                'id' => 777,
-                'html_url' => 'https://github.com/organizations/acme/settings/installations/777',
-                'account' => ['id' => 1, 'login' => 'acme', 'type' => 'Organization'],
-            ], 200),
-        ]);
-
-        $this->actingAs($this->admin)
-            ->get(route('github-app.install-callback', ['installation_id' => 777]))
-            ->assertRedirect(route('source-controls'));
-
-        $existing->refresh();
-        $this->assertNull($existing->deleted_at);
-    }
-
-    public function test_sync_removes_missing_installations_and_imports_new(): void
-    {
-        GithubApp::factory()->create();
-
-        $kept = SourceControl::factory()->githubApp()->create([
-            'external_identifier' => '111',
-            'user_id' => $this->admin->id,
-        ]);
-        $stale = SourceControl::factory()->githubApp()->create([
-            'external_identifier' => '222',
-            'user_id' => $this->admin->id,
-        ]);
-
-        Http::fake([
-            'api.github.com/app/installations*' => Http::response([
-                [
-                    'id' => 111,
-                    'html_url' => 'https://github.com/x',
-                    'account' => ['id' => 11, 'login' => 'kept-org', 'type' => 'Organization'],
-                ],
-                [
-                    'id' => 333,
-                    'html_url' => 'https://github.com/y',
-                    'account' => ['id' => 33, 'login' => 'new-org', 'type' => 'Organization'],
-                ],
-            ], 200),
-        ]);
-
-        $this->actingAs($this->admin)
-            ->post(route('github-app.sync'))
-            ->assertRedirect(route('github-app'));
-
-        $this->assertNotSoftDeleted($kept);
-        $this->assertSoftDeleted($stale);
-        $this->assertDatabaseHas('source_controls', [
-            'provider' => SourceControl::PROVIDER_GITHUB_APP,
-            'external_identifier' => '333',
-            'profile' => 'new-org',
-        ]);
-    }
-
-    public function test_cannot_manually_create_source_control_with_github_app_provider(): void
-    {
-        $this->actingAs($this->user)
-            ->from(route('source-controls'))
-            ->post(route('source-controls.store'), [
-                'name' => 'fake',
-                'provider' => SourceControl::PROVIDER_GITHUB_APP,
-            ])
-            ->assertSessionHasErrors('provider');
-    }
-
-    public function test_cannot_delete_github_app_source_control(): void
-    {
-        GithubApp::factory()->create();
-        $sc = SourceControl::factory()->githubApp()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->actingAs($this->user)
-            ->delete(route('source-controls.destroy', $sc->id))
-            ->assertForbidden();
-
-        $this->assertDatabaseHas('source_controls', ['id' => $sc->id, 'deleted_at' => null]);
-    }
-
-    public function test_cannot_rename_github_app_source_control(): void
-    {
-        GithubApp::factory()->create();
-        $sc = SourceControl::factory()->githubApp()->create([
-            'user_id' => $this->user->id,
-            'profile' => 'acme',
-        ]);
-
-        $this->actingAs($this->user)
-            ->patch(route('source-controls.update', $sc->id), [
-                'name' => 'changed',
-                'global' => true,
-            ])
-            ->assertRedirect();
-
-        $sc->refresh();
-        $this->assertSame('acme', $sc->profile);
-        $this->assertNull($sc->project_id);
-    }
-
-    public function test_can_create_site_with_github_app_source_control(): void
-    {
-        SSH::fake();
-        GithubApp::factory()->create();
-        $sc = SourceControl::factory()->githubApp()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        Http::fake([
-            'api.github.com/repos/test/test' => Http::response(['full_name' => 'test/test'], 200),
-            'api.github.com/repos/test/test/commits/main' => Http::response([], 200),
-            'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'ghs_TESTTOKEN'], 201),
-        ]);
-
-        $this->actingAs($this->user)
-            ->post(route('sites.store', ['server' => $this->server]), [
-                'type' => Laravel::id(),
-                'domain' => 'example.com',
-                'php_version' => '8.2',
-                'web_directory' => 'public',
-                'repository' => 'test/test',
-                'branch' => 'main',
-                'composer' => true,
-                'user' => 'example',
-                'source_control' => $sc->id,
-            ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('sites', [
-            'domain' => 'example.com',
-            'source_control_id' => $sc->id,
-        ]);
-
-        Http::assertNotSent(fn ($request) => str_contains($request->url(), '/keys'));
-    }
-
-    public function test_can_update_site_to_use_github_app_source_control(): void
-    {
-        SSH::fake();
-        GithubApp::factory()->create();
-        $sc = SourceControl::factory()->githubApp()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        Http::fake([
-            'api.github.com/repos/*' => Http::response(['full_name' => 'test/test'], 200),
-            'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'ghs_TESTTOKEN'], 201),
-        ]);
-
-        $this->actingAs($this->user)
-            ->patch(route('site-settings.update-source-control', ['server' => $this->server, 'site' => $this->site]), [
-                'source_control' => $sc->id,
-            ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('sites', [
-            'id' => $this->site->id,
-            'source_control_id' => $sc->id,
-        ]);
-    }
-
-    public function test_cannot_remove_github_app_when_trashed_source_control_still_has_sites(): void
-    {
-        GithubApp::factory()->create();
-
-        $sc = SourceControl::factory()->githubApp()->create([
-            'user_id' => $this->admin->id,
-            'external_identifier' => '999',
-        ]);
-        $this->site->update(['source_control_id' => $sc->id]);
-        $sc->delete();
-
-        $this->actingAs($this->admin)
-            ->from(route('github-app'))
-            ->delete(route('github-app.destroy'))
-            ->assertSessionHasErrors('github_app');
-
-        $this->assertDatabaseCount('github_app', 1);
-        $this->assertDatabaseHas('source_controls', ['id' => $sc->id]);
-    }
-
-    public function test_remove_github_app_force_deletes_trashed_source_controls(): void
-    {
-        GithubApp::factory()->create();
-
-        $sc = SourceControl::factory()->githubApp()->create([
-            'user_id' => $this->admin->id,
-            'external_identifier' => '888',
-        ]);
-        $sc->delete();
-
-        $this->actingAs($this->admin)
-            ->delete(route('github-app.destroy'))
-            ->assertRedirect(route('github-app'));
-
-        $this->assertDatabaseMissing('source_controls', ['id' => $sc->id]);
-        $this->assertDatabaseCount('github_app', 0);
-    }
-
-    public function test_webhook_rejects_bad_signature(): void
-    {
-        GithubApp::factory()->create();
-
-        $this->postJson('/api/webhooks/github-app', ['action' => 'deleted'])
-            ->assertStatus(401);
-    }
-
-    public function test_webhook_handles_installation_deleted(): void
-    {
-        $app = GithubApp::factory()->create();
-        $sc = SourceControl::factory()->githubApp()->create([
-            'external_identifier' => '444',
-            'user_id' => $this->admin->id,
-        ]);
-
-        $payload = json_encode([
-            'action' => 'deleted',
-            'installation' => ['id' => 444],
-        ]);
-
-        $sig = 'sha256='.hash_hmac('sha256', $payload, $app->webhook_secret);
-
-        $this->call('POST', '/api/webhooks/github-app', [], [], [], [
-            'CONTENT_TYPE' => 'application/json',
-            'HTTP_X_HUB_SIGNATURE_256' => $sig,
-            'HTTP_X_GITHUB_EVENT' => 'installation',
-        ], $payload)->assertOk();
-
-        $this->assertSoftDeleted($sc);
-    }
-
-    public function test_webhook_handles_installation_created(): void
-    {
-        $app = GithubApp::factory()->create();
-
-        $payload = json_encode([
-            'action' => 'created',
-            'installation' => [
-                'id' => 888,
-                'html_url' => 'https://github.com/x',
-                'account' => ['id' => 1, 'login' => 'new-acme', 'type' => 'Organization'],
+    Http::fake([
+        'api.github.com/app/installations/999' => Http::response([
+            'id' => 999,
+            'html_url' => 'https://github.com/organizations/acme/settings/installations/999',
+            'account' => [
+                'id' => 555,
+                'login' => 'acme',
+                'type' => 'Organization',
             ],
-        ]);
+        ], 200),
+    ]);
 
-        $sig = 'sha256='.hash_hmac('sha256', $payload, $app->webhook_secret);
+    $this->actingAs($this->admin)
+        ->get(route('github-app.install-callback', ['installation_id' => 999]))
+        ->assertRedirect(route('source-controls'));
 
-        $this->call('POST', '/api/webhooks/github-app', [], [], [], [
-            'CONTENT_TYPE' => 'application/json',
-            'HTTP_X_HUB_SIGNATURE_256' => $sig,
-            'HTTP_X_GITHUB_EVENT' => 'installation',
-        ], $payload)->assertOk();
+    $this->assertDatabaseHas('source_controls', [
+        'provider' => SourceControl::PROVIDER_GITHUB_APP,
+        'external_identifier' => '999',
+        'profile' => 'acme',
+    ]);
 
-        $this->assertDatabaseHas('source_controls', [
-            'provider' => SourceControl::PROVIDER_GITHUB_APP,
-            'external_identifier' => '888',
-            'profile' => 'new-acme',
-        ]);
-    }
+    unset($app);
+});
 
-    public function test_provider_implements_deployment_surface(): void
-    {
-        $sc = SourceControl::factory()->githubApp()->create([
-            'user_id' => $this->admin->id,
-        ]);
-        $provider = new GithubAppProvider($sc);
+test('install callback restores soft deleted installation', function () {
+    GithubApp::factory()->create();
 
-        $this->assertSame(
-            'https://github.com/owner/repo.git',
-            $provider->fullRepoUrl('owner/repo', 'irrelevant-key')
-        );
+    $existing = SourceControl::factory()->githubApp()->create([
+        'external_identifier' => '777',
+        'user_id' => $this->admin->id,
+    ]);
+    $existing->delete();
+    $this->assertSoftDeleted($existing);
 
-        $this->assertSame('', $provider->deployKey('t', 'owner/repo', 'public-key'));
-        $provider->deleteDeployKey('deploy-key-id', 'owner/repo');
+    Http::fake([
+        'api.github.com/app/installations/777' => Http::response([
+            'id' => 777,
+            'html_url' => 'https://github.com/organizations/acme/settings/installations/777',
+            'account' => ['id' => 1, 'login' => 'acme', 'type' => 'Organization'],
+        ], 200),
+    ]);
 
-        $hookResult = $provider->deployHook('owner/repo', ['push'], 'secret');
-        $this->assertSame('app-installation', $hookResult['hook_id']);
-        $this->assertSame('github-app-installation', $hookResult['hook_response']['source']);
+    $this->actingAs($this->admin)
+        ->get(route('github-app.install-callback', ['installation_id' => 777]))
+        ->assertRedirect(route('source-controls'));
 
-        $provider->destroyHook('owner/repo', 'app-installation');
-    }
+    $existing->refresh();
+    expect($existing->deleted_at)->toBeNull();
+});
 
-    public function test_environment_variables_include_git_http_token_for_github_app_sites(): void
-    {
-        GithubApp::factory()->create();
-        $sc = SourceControl::factory()->githubApp()->create([
-            'user_id' => $this->user->id,
-            'external_identifier' => '12345',
-        ]);
-        $this->site->update(['source_control_id' => $sc->id]);
-        $this->site->refresh();
+test('sync removes missing installations and imports new', function () {
+    GithubApp::factory()->create();
 
-        Cache::put('github_app_token_12345', 'ghs_CACHEDTOKEN', 60);
+    $kept = SourceControl::factory()->githubApp()->create([
+        'external_identifier' => '111',
+        'user_id' => $this->admin->id,
+    ]);
+    $stale = SourceControl::factory()->githubApp()->create([
+        'external_identifier' => '222',
+        'user_id' => $this->admin->id,
+    ]);
 
-        $vars = $this->site->environmentVariables();
-
-        $this->assertArrayHasKey('GIT_HTTP_TOKEN', $vars);
-        $this->assertSame('ghs_CACHEDTOKEN', $vars['GIT_HTTP_TOKEN']);
-    }
-
-    public function test_environment_variables_omit_git_http_token_for_non_github_app_sites(): void
-    {
-        $vars = $this->site->environmentVariables();
-
-        $this->assertArrayNotHasKey('GIT_HTTP_TOKEN', $vars);
-    }
-
-    public function test_webhook_handles_push_event_triggers_deploy(): void
-    {
-        SSH::fake();
-        $app = GithubApp::factory()->create();
-        $sc = SourceControl::factory()->githubApp()->create([
-            'user_id' => $this->user->id,
-            'external_identifier' => '555',
-        ]);
-        $this->site->update([
-            'source_control_id' => $sc->id,
-            'repository' => 'acme/widgets',
-            'branch' => 'main',
-        ]);
-        $this->site->deploymentScript->update(['content' => 'echo deploying']);
-        GitHook::factory()->create([
-            'site_id' => $this->site->id,
-            'source_control_id' => $sc->id,
-            'events' => ['push'],
-            'actions' => ['deploy'],
-            'hook_id' => 'app-installation',
-        ]);
-
-        Http::fake([
-            'api.github.com/repos/acme/widgets' => Http::response(['full_name' => 'acme/widgets'], 200),
-            'api.github.com/repos/acme/widgets/commits/main' => Http::response([
-                'sha' => 'abc123',
-                'commit' => ['committer' => ['name' => 'a', 'email' => 'a@b'], 'message' => 'm'],
+    Http::fake([
+        'api.github.com/app/installations*' => Http::response([
+            [
+                'id' => 111,
                 'html_url' => 'https://github.com/x',
-            ], 200),
-            'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'ghs_TESTTOKEN'], 201),
-        ]);
+                'account' => ['id' => 11, 'login' => 'kept-org', 'type' => 'Organization'],
+            ],
+            [
+                'id' => 333,
+                'html_url' => 'https://github.com/y',
+                'account' => ['id' => 33, 'login' => 'new-org', 'type' => 'Organization'],
+            ],
+        ], 200),
+    ]);
 
-        $payload = json_encode([
-            'ref' => 'refs/heads/main',
-            'installation' => ['id' => 555],
-            'repository' => ['full_name' => 'acme/widgets'],
-        ]);
-        $sig = 'sha256='.hash_hmac('sha256', $payload, $app->webhook_secret);
+    $this->actingAs($this->admin)
+        ->post(route('github-app.sync'))
+        ->assertRedirect(route('github-app'));
 
-        $this->call('POST', '/api/webhooks/github-app', [], [], [], [
-            'CONTENT_TYPE' => 'application/json',
-            'HTTP_X_HUB_SIGNATURE_256' => $sig,
-            'HTTP_X_GITHUB_EVENT' => 'push',
-        ], $payload)->assertOk();
+    $this->assertNotSoftDeleted($kept);
+    $this->assertSoftDeleted($stale);
+    $this->assertDatabaseHas('source_controls', [
+        'provider' => SourceControl::PROVIDER_GITHUB_APP,
+        'external_identifier' => '333',
+        'profile' => 'new-org',
+    ]);
+});
 
-        $this->assertDatabaseHas('deployments', [
-            'site_id' => $this->site->id,
-            'commit_id' => 'abc123',
-        ]);
-    }
+test('cannot manually create source control with github app provider', function () {
+    $this->actingAs($this->user)
+        ->from(route('source-controls'))
+        ->post(route('source-controls.store'), [
+            'name' => 'fake',
+            'provider' => SourceControl::PROVIDER_GITHUB_APP,
+        ])
+        ->assertSessionHasErrors('provider');
+});
 
-    public function test_webhook_push_event_for_unmatched_branch_does_not_deploy(): void
-    {
-        $app = GithubApp::factory()->create();
-        $sc = SourceControl::factory()->githubApp()->create([
-            'user_id' => $this->user->id,
-            'external_identifier' => '666',
-        ]);
-        $this->site->update([
-            'source_control_id' => $sc->id,
-            'repository' => 'acme/widgets',
+test('cannot delete github app source control', function () {
+    GithubApp::factory()->create();
+    $sc = SourceControl::factory()->githubApp()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->actingAs($this->user)
+        ->delete(route('source-controls.destroy', $sc->id))
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('source_controls', ['id' => $sc->id, 'deleted_at' => null]);
+});
+
+test('cannot rename github app source control', function () {
+    GithubApp::factory()->create();
+    $sc = SourceControl::factory()->githubApp()->create([
+        'user_id' => $this->user->id,
+        'profile' => 'acme',
+    ]);
+
+    $this->actingAs($this->user)
+        ->patch(route('source-controls.update', $sc->id), [
+            'name' => 'changed',
+            'global' => true,
+        ])
+        ->assertRedirect();
+
+    $sc->refresh();
+    expect($sc->profile)->toBe('acme');
+    expect($sc->project_id)->toBeNull();
+});
+
+test('can create site with github app source control', function () {
+    SSH::fake();
+    GithubApp::factory()->create();
+    $sc = SourceControl::factory()->githubApp()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/test/test' => Http::response(['full_name' => 'test/test'], 200),
+        'api.github.com/repos/test/test/commits/main' => Http::response([], 200),
+        'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'ghs_TESTTOKEN'], 201),
+    ]);
+
+    $this->actingAs($this->user)
+        ->post(route('sites.store', ['server' => $this->server]), [
+            'type' => Laravel::id(),
+            'domain' => 'example.com',
+            'php_version' => '8.2',
+            'web_directory' => 'public',
+            'repository' => 'test/test',
             'branch' => 'main',
-        ]);
-        GitHook::factory()->create([
-            'site_id' => $this->site->id,
-            'source_control_id' => $sc->id,
-            'events' => ['push'],
-            'actions' => ['deploy'],
-        ]);
+            'composer' => true,
+            'user' => 'example',
+            'source_control' => $sc->id,
+        ])
+        ->assertSessionDoesntHaveErrors();
 
-        $payload = json_encode([
-            'ref' => 'refs/heads/develop',
-            'installation' => ['id' => 666],
-            'repository' => ['full_name' => 'acme/widgets'],
-        ]);
-        $sig = 'sha256='.hash_hmac('sha256', $payload, $app->webhook_secret);
+    $this->assertDatabaseHas('sites', [
+        'domain' => 'example.com',
+        'source_control_id' => $sc->id,
+    ]);
 
-        $this->call('POST', '/api/webhooks/github-app', [], [], [], [
-            'CONTENT_TYPE' => 'application/json',
-            'HTTP_X_HUB_SIGNATURE_256' => $sig,
-            'HTTP_X_GITHUB_EVENT' => 'push',
-        ], $payload)->assertOk();
+    Http::assertNotSent(fn ($request) => str_contains($request->url(), '/keys'));
+});
 
-        $this->assertDatabaseMissing('deployments', [
-            'site_id' => $this->site->id,
-        ]);
-    }
+test('can update site to use github app source control', function () {
+    SSH::fake();
+    GithubApp::factory()->create();
+    $sc = SourceControl::factory()->githubApp()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-    private function generatePrivateKey(): string
-    {
-        $res = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
-        $pem = '';
-        openssl_pkey_export($res, $pem);
+    Http::fake([
+        'api.github.com/repos/*' => Http::response(['full_name' => 'test/test'], 200),
+        'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'ghs_TESTTOKEN'], 201),
+    ]);
 
-        return $pem;
-    }
+    $this->actingAs($this->user)
+        ->patch(route('site-settings.update-source-control', ['server' => $this->server, 'site' => $this->site]), [
+            'source_control' => $sc->id,
+        ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('sites', [
+        'id' => $this->site->id,
+        'source_control_id' => $sc->id,
+    ]);
+});
+
+test('cannot remove github app when trashed source control still has sites', function () {
+    GithubApp::factory()->create();
+
+    $sc = SourceControl::factory()->githubApp()->create([
+        'user_id' => $this->admin->id,
+        'external_identifier' => '999',
+    ]);
+    $this->site->update(['source_control_id' => $sc->id]);
+    $sc->delete();
+
+    $this->actingAs($this->admin)
+        ->from(route('github-app'))
+        ->delete(route('github-app.destroy'))
+        ->assertSessionHasErrors('github_app');
+
+    $this->assertDatabaseCount('github_app', 1);
+    $this->assertDatabaseHas('source_controls', ['id' => $sc->id]);
+});
+
+test('remove github app force deletes trashed source controls', function () {
+    GithubApp::factory()->create();
+
+    $sc = SourceControl::factory()->githubApp()->create([
+        'user_id' => $this->admin->id,
+        'external_identifier' => '888',
+    ]);
+    $sc->delete();
+
+    $this->actingAs($this->admin)
+        ->delete(route('github-app.destroy'))
+        ->assertRedirect(route('github-app'));
+
+    $this->assertDatabaseMissing('source_controls', ['id' => $sc->id]);
+    $this->assertDatabaseCount('github_app', 0);
+});
+
+test('webhook rejects bad signature', function () {
+    GithubApp::factory()->create();
+
+    $this->postJson('/api/webhooks/github-app', ['action' => 'deleted'])
+        ->assertStatus(401);
+});
+
+test('webhook handles installation deleted', function () {
+    $app = GithubApp::factory()->create();
+    $sc = SourceControl::factory()->githubApp()->create([
+        'external_identifier' => '444',
+        'user_id' => $this->admin->id,
+    ]);
+
+    $payload = json_encode([
+        'action' => 'deleted',
+        'installation' => ['id' => 444],
+    ]);
+
+    $sig = 'sha256='.hash_hmac('sha256', $payload, $app->webhook_secret);
+
+    $this->call('POST', '/api/webhooks/github-app', [], [], [], [
+        'CONTENT_TYPE' => 'application/json',
+        'HTTP_X_HUB_SIGNATURE_256' => $sig,
+        'HTTP_X_GITHUB_EVENT' => 'installation',
+    ], $payload)->assertOk();
+
+    $this->assertSoftDeleted($sc);
+});
+
+test('webhook handles installation created', function () {
+    $app = GithubApp::factory()->create();
+
+    $payload = json_encode([
+        'action' => 'created',
+        'installation' => [
+            'id' => 888,
+            'html_url' => 'https://github.com/x',
+            'account' => ['id' => 1, 'login' => 'new-acme', 'type' => 'Organization'],
+        ],
+    ]);
+
+    $sig = 'sha256='.hash_hmac('sha256', $payload, $app->webhook_secret);
+
+    $this->call('POST', '/api/webhooks/github-app', [], [], [], [
+        'CONTENT_TYPE' => 'application/json',
+        'HTTP_X_HUB_SIGNATURE_256' => $sig,
+        'HTTP_X_GITHUB_EVENT' => 'installation',
+    ], $payload)->assertOk();
+
+    $this->assertDatabaseHas('source_controls', [
+        'provider' => SourceControl::PROVIDER_GITHUB_APP,
+        'external_identifier' => '888',
+        'profile' => 'new-acme',
+    ]);
+});
+
+test('provider implements deployment surface', function () {
+    $sc = SourceControl::factory()->githubApp()->create([
+        'user_id' => $this->admin->id,
+    ]);
+    $provider = new GithubAppProvider($sc);
+
+    expect($provider->fullRepoUrl('owner/repo', 'irrelevant-key'))->toBe('https://github.com/owner/repo.git');
+
+    expect($provider->deployKey('t', 'owner/repo', 'public-key'))->toBe('');
+    $provider->deleteDeployKey('deploy-key-id', 'owner/repo');
+
+    $hookResult = $provider->deployHook('owner/repo', ['push'], 'secret');
+    expect($hookResult['hook_id'])->toBe('app-installation');
+    expect($hookResult['hook_response']['source'])->toBe('github-app-installation');
+
+    $provider->destroyHook('owner/repo', 'app-installation');
+});
+
+test('environment variables include git http token for github app sites', function () {
+    GithubApp::factory()->create();
+    $sc = SourceControl::factory()->githubApp()->create([
+        'user_id' => $this->user->id,
+        'external_identifier' => '12345',
+    ]);
+    $this->site->update(['source_control_id' => $sc->id]);
+    $this->site->refresh();
+
+    Cache::put('github_app_token_12345', 'ghs_CACHEDTOKEN', 60);
+
+    $vars = $this->site->environmentVariables();
+
+    expect($vars)->toHaveKey('GIT_HTTP_TOKEN');
+    expect($vars['GIT_HTTP_TOKEN'])->toBe('ghs_CACHEDTOKEN');
+});
+
+test('environment variables omit git http token for non github app sites', function () {
+    $vars = $this->site->environmentVariables();
+
+    $this->assertArrayNotHasKey('GIT_HTTP_TOKEN', $vars);
+});
+
+test('webhook handles push event triggers deploy', function () {
+    SSH::fake();
+    $app = GithubApp::factory()->create();
+    $sc = SourceControl::factory()->githubApp()->create([
+        'user_id' => $this->user->id,
+        'external_identifier' => '555',
+    ]);
+    $this->site->update([
+        'source_control_id' => $sc->id,
+        'repository' => 'acme/widgets',
+        'branch' => 'main',
+    ]);
+    $this->site->deploymentScript->update(['content' => 'echo deploying']);
+    GitHook::factory()->create([
+        'site_id' => $this->site->id,
+        'source_control_id' => $sc->id,
+        'events' => ['push'],
+        'actions' => ['deploy'],
+        'hook_id' => 'app-installation',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/acme/widgets' => Http::response(['full_name' => 'acme/widgets'], 200),
+        'api.github.com/repos/acme/widgets/commits/main' => Http::response([
+            'sha' => 'abc123',
+            'commit' => ['committer' => ['name' => 'a', 'email' => 'a@b'], 'message' => 'm'],
+            'html_url' => 'https://github.com/x',
+        ], 200),
+        'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'ghs_TESTTOKEN'], 201),
+    ]);
+
+    $payload = json_encode([
+        'ref' => 'refs/heads/main',
+        'installation' => ['id' => 555],
+        'repository' => ['full_name' => 'acme/widgets'],
+    ]);
+    $sig = 'sha256='.hash_hmac('sha256', $payload, $app->webhook_secret);
+
+    $this->call('POST', '/api/webhooks/github-app', [], [], [], [
+        'CONTENT_TYPE' => 'application/json',
+        'HTTP_X_HUB_SIGNATURE_256' => $sig,
+        'HTTP_X_GITHUB_EVENT' => 'push',
+    ], $payload)->assertOk();
+
+    $this->assertDatabaseHas('deployments', [
+        'site_id' => $this->site->id,
+        'commit_id' => 'abc123',
+    ]);
+});
+
+test('webhook push event for unmatched branch does not deploy', function () {
+    $app = GithubApp::factory()->create();
+    $sc = SourceControl::factory()->githubApp()->create([
+        'user_id' => $this->user->id,
+        'external_identifier' => '666',
+    ]);
+    $this->site->update([
+        'source_control_id' => $sc->id,
+        'repository' => 'acme/widgets',
+        'branch' => 'main',
+    ]);
+    GitHook::factory()->create([
+        'site_id' => $this->site->id,
+        'source_control_id' => $sc->id,
+        'events' => ['push'],
+        'actions' => ['deploy'],
+    ]);
+
+    $payload = json_encode([
+        'ref' => 'refs/heads/develop',
+        'installation' => ['id' => 666],
+        'repository' => ['full_name' => 'acme/widgets'],
+    ]);
+    $sig = 'sha256='.hash_hmac('sha256', $payload, $app->webhook_secret);
+
+    $this->call('POST', '/api/webhooks/github-app', [], [], [], [
+        'CONTENT_TYPE' => 'application/json',
+        'HTTP_X_HUB_SIGNATURE_256' => $sig,
+        'HTTP_X_GITHUB_EVENT' => 'push',
+    ], $payload)->assertOk();
+
+    $this->assertDatabaseMissing('deployments', [
+        'site_id' => $this->site->id,
+    ]);
+});
+
+function vitoPestFeatureGithubAppTestGeneratePrivateKey(): string
+{
+    $res = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+    $pem = '';
+    openssl_pkey_export($res, $pem);
+
+    return $pem;
 }

--- a/tests/Feature/HostedDomainsTest.php
+++ b/tests/Feature/HostedDomainsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\HostedDomainStatus;
 use App\Enums\HostedDomainType;
 use App\Enums\SslMethod;
@@ -15,631 +13,602 @@ use App\Models\Ssl;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
-
-class HostedDomainsTest extends TestCase
-{
-    use RefreshDatabase;
-
-    public function test_see_hosted_domains_list(): void
-    {
-        $this->actingAs($this->user);
-
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'alias.example.com',
-        ]);
-
-        $this->get(route('hosted-domains', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-        ]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('hosted-domains/index')
-                ->has('hostedDomains.data', 1)
-            );
-    }
-
-    public function test_create_alias_domain(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('hosted-domains.store', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-        ]), [
-            'domain' => 'alias.example.com',
-            'type' => HostedDomainType::ALIAS->value,
-            'ssl_method' => SslMethod::NONE->value,
-        ])
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('hosted_domains', [
-            'site_id' => $this->site->id,
-            'domain' => 'alias.example.com',
-            'type' => HostedDomainType::ALIAS->value,
-            'ssl_method' => SslMethod::NONE->value,
-        ]);
-    }
-
-    public function test_create_redirect_domain(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('hosted-domains.store', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-        ]), [
-            'domain' => 'redirect.example.com',
-            'type' => HostedDomainType::REDIRECT->value,
-            'ssl_method' => SslMethod::NONE->value,
-        ])
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('hosted_domains', [
-            'site_id' => $this->site->id,
-            'domain' => 'redirect.example.com',
-            'type' => HostedDomainType::REDIRECT->value,
-        ]);
-    }
-
-    public function test_create_domain_validation_requires_fields(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->post(route('hosted-domains.store', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-        ]), [])
-            ->assertSessionHasErrors(['domain', 'type', 'ssl_method']);
-    }
-
-    public function test_create_domain_validation_invalid_domain_format(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->post(route('hosted-domains.store', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-        ]), [
-            'domain' => 'not a domain',
-            'type' => HostedDomainType::ALIAS->value,
-            'ssl_method' => SslMethod::NONE->value,
-        ])
-            ->assertSessionHasErrors('domain');
-    }
-
-    public function test_create_domain_rejects_primary_type(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->post(route('hosted-domains.store', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-        ]), [
-            'domain' => 'primary.example.com',
-            'type' => HostedDomainType::PRIMARY->value,
-            'ssl_method' => SslMethod::NONE->value,
-        ])
-            ->assertSessionHasErrors('type');
-    }
-
-    public function test_create_domain_rejects_duplicate_on_same_server(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'duplicate.example.com',
-        ]);
-
-        $this->post(route('hosted-domains.store', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-        ]), [
-            'domain' => 'duplicate.example.com',
-            'type' => HostedDomainType::ALIAS->value,
-            'ssl_method' => SslMethod::NONE->value,
-        ])
-            ->assertSessionHasErrors('domain');
-    }
-
-    public function test_create_domain_with_custom_ssl(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $ssl = Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'status' => SslStatus::CREATED,
-            'domains' => ['*.example.com'],
-        ]);
-
-        $this->post(route('hosted-domains.store', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-        ]), [
-            'domain' => 'app.example.com',
-            'type' => HostedDomainType::ALIAS->value,
-            'ssl_method' => SslMethod::CUSTOM->value,
-            'ssl_id' => $ssl->id,
-        ])
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('hosted_domains', [
-            'site_id' => $this->site->id,
-            'domain' => 'app.example.com',
-            'ssl_method' => SslMethod::CUSTOM->value,
-            'ssl_id' => $ssl->id,
-        ]);
-    }
-
-    public function test_create_domain_custom_ssl_requires_ssl_id(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->post(route('hosted-domains.store', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-        ]), [
-            'domain' => 'app.example.com',
-            'type' => HostedDomainType::ALIAS->value,
-            'ssl_method' => SslMethod::CUSTOM->value,
-        ])
-            ->assertSessionHasErrors('ssl_id');
-    }
-
-    public function test_update_domain(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $domain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'old.example.com',
-            'type' => HostedDomainType::ALIAS,
-            'status' => HostedDomainStatus::ACTIVE,
-            'ssl_method' => SslMethod::NONE,
-        ]);
-
-        $this->put(route('hosted-domains.update', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'hostedDomain' => $domain->id,
-        ]), [
-            'domain' => 'new.example.com',
-            'type' => HostedDomainType::ALIAS->value,
-            'ssl_method' => SslMethod::NONE->value,
-        ])
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('hosted_domains', [
-            'id' => $domain->id,
-            'domain' => 'new.example.com',
-        ]);
-    }
-
-    public function test_cannot_update_primary_domain_name(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $domain = HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'primary.example.com',
-            'status' => HostedDomainStatus::ACTIVE,
-            'ssl_method' => SslMethod::NONE,
-        ]);
-
-        $this->put(route('hosted-domains.update', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'hostedDomain' => $domain->id,
-        ]), [
-            'domain' => 'changed.example.com',
-            'type' => HostedDomainType::ALIAS->value,
-            'ssl_method' => SslMethod::NONE->value,
-        ])
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('hosted_domains', [
-            'id' => $domain->id,
-            'domain' => 'primary.example.com',
-        ]);
-    }
-
-    public function test_cannot_update_processing_domain(): void
-    {
-        $this->actingAs($this->user);
-
-        $domain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'processing.example.com',
-            'status' => HostedDomainStatus::CREATING,
-            'ssl_method' => SslMethod::NONE,
-        ]);
-
-        $this->put(route('hosted-domains.update', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'hostedDomain' => $domain->id,
-        ]), [
-            'domain' => 'new.example.com',
-            'type' => HostedDomainType::ALIAS->value,
-            'ssl_method' => SslMethod::NONE->value,
-        ])
-            ->assertSessionHasErrors('domain');
-    }
-
-    public function test_delete_domain(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $domain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'delete-me.example.com',
-            'status' => HostedDomainStatus::ACTIVE,
-        ]);
-
-        $this->delete(route('hosted-domains.destroy', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'hostedDomain' => $domain->id,
-        ]))
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('hosted_domains', ['id' => $domain->id]);
-    }
-
-    public function test_cannot_delete_primary_domain(): void
-    {
-        $this->actingAs($this->user);
-
-        $domain = HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'primary.example.com',
-            'status' => HostedDomainStatus::ACTIVE,
-        ]);
-
-        $this->delete(route('hosted-domains.destroy', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'hostedDomain' => $domain->id,
-        ]))
-            ->assertSessionHasErrors('domain');
-
-        $this->assertDatabaseHas('hosted_domains', ['id' => $domain->id]);
-    }
-
-    public function test_cannot_delete_processing_domain(): void
-    {
-        $this->actingAs($this->user);
-
-        $domain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'processing.example.com',
-            'status' => HostedDomainStatus::CREATING,
-        ]);
-
-        $this->delete(route('hosted-domains.destroy', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'hostedDomain' => $domain->id,
-        ]))
-            ->assertSessionHasErrors('domain');
-
-        $this->assertDatabaseHas('hosted_domains', ['id' => $domain->id]);
-    }
-
-    public function test_force_activate_domain(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $domain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'pending.example.com',
-            'status' => HostedDomainStatus::PENDING,
-            'ssl_method' => SslMethod::NONE,
-        ]);
-
-        $this->post(route('hosted-domains.force-activate', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'hostedDomain' => $domain->id,
-        ]))
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('hosted_domains', [
-            'id' => $domain->id,
-            'status' => HostedDomainStatus::ACTIVE,
-        ]);
-    }
-
-    public function test_deactivate_domain(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $domain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'active.example.com',
-            'status' => HostedDomainStatus::ACTIVE,
-        ]);
-
-        $this->post(route('hosted-domains.deactivate', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'hostedDomain' => $domain->id,
-        ]))
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('hosted_domains', [
-            'id' => $domain->id,
-            'status' => HostedDomainStatus::INACTIVE,
-        ]);
-    }
-
-    public function test_cannot_deactivate_primary_domain(): void
-    {
-        $this->actingAs($this->user);
-
-        $domain = HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'primary.example.com',
-            'status' => HostedDomainStatus::ACTIVE,
-        ]);
-
-        $this->post(route('hosted-domains.deactivate', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'hostedDomain' => $domain->id,
-        ]))
-            ->assertSessionHasErrors('domain');
-    }
-
-    public function test_reactivate_inactive_domain(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $domain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'inactive.example.com',
-            'status' => HostedDomainStatus::INACTIVE,
-        ]);
-
-        $this->post(route('hosted-domains.reactivate', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'hostedDomain' => $domain->id,
-        ]))
-            ->assertRedirect();
-
-        $this->assertDatabaseHas('hosted_domains', [
-            'id' => $domain->id,
-            'status' => HostedDomainStatus::UPDATING,
-        ]);
-
-        Bus::assertDispatched(CheckDomainJob::class);
-    }
-
-    public function test_cannot_reactivate_active_domain(): void
-    {
-        $this->actingAs($this->user);
-
-        $domain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'active.example.com',
-            'status' => HostedDomainStatus::ACTIVE,
-        ]);
-
-        $this->post(route('hosted-domains.reactivate', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'hostedDomain' => $domain->id,
-        ]))
-            ->assertSessionHasErrors('domain');
-    }
-
-    public function test_check_dns(): void
-    {
-        Bus::fake();
-
-        $this->actingAs($this->user);
-
-        $domain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'check.example.com',
-            'status' => HostedDomainStatus::ACTIVE,
-        ]);
-
-        $this->post(route('hosted-domains.check-dns', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'hostedDomain' => $domain->id,
-        ]))
-            ->assertRedirect();
-
-        $this->assertDatabaseHas('hosted_domains', [
-            'id' => $domain->id,
-            'status' => HostedDomainStatus::UPDATING,
-        ]);
-
-        Bus::assertDispatched(CheckDomainJob::class);
-    }
-
-    public function test_matching_ssls_returns_matches(): void
-    {
-        $this->actingAs($this->user);
-
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'status' => SslStatus::CREATED,
-            'domains' => ['*.example.com'],
-        ]);
-
-        $this->getJson(route('hosted-domains.matching-ssls', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'domain' => 'sub.example.com',
-        ]))
-            ->assertSuccessful()
-            ->assertJsonCount(1, 'certificates');
-    }
-
-    public function test_matching_ssls_returns_empty_for_invalid_domain(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->getJson(route('hosted-domains.matching-ssls', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'domain' => 'not valid',
-        ]))
-            ->assertSuccessful()
-            ->assertJsonCount(0, 'certificates');
-    }
-
-    public function test_check_expiry_refreshes_date_without_notifying(): void
-    {
-        SSH::fake($this->generateTestCertificate(90));
-        Notifier::spy();
-
-        $this->actingAs($this->user);
-
-        $ssl = Ssl::factory()->create([
-            'site_id' => $this->site->id,
-            'type' => SslType::LETSENCRYPT,
-            'status' => SslStatus::CREATED,
-            'certificate_path' => '/etc/letsencrypt/live/1/fullchain.pem',
-            'expires_at' => now()->addDays(5),
-            'domains' => ['old.example.com'],
-        ]);
-
-        $hostedDomain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'ssl_id' => $ssl->id,
-        ]);
-
-        $this->post(route('hosted-domains.check-expiry', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'hostedDomain' => $hostedDomain->id,
-        ]))
-            ->assertRedirect()
-            ->assertSessionHas('success');
 
+uses(RefreshDatabase::class);
+
+test('see hosted domains list', function () {
+    $this->actingAs($this->user);
+
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'alias.example.com',
+    ]);
+
+    $this->get(route('hosted-domains', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+    ]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('hosted-domains/index')
+            ->has('hostedDomains.data', 1)
+        );
+});
+
+test('create alias domain', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('hosted-domains.store', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+    ]), [
+        'domain' => 'alias.example.com',
+        'type' => HostedDomainType::ALIAS->value,
+        'ssl_method' => SslMethod::NONE->value,
+    ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('hosted_domains', [
+        'site_id' => $this->site->id,
+        'domain' => 'alias.example.com',
+        'type' => HostedDomainType::ALIAS->value,
+        'ssl_method' => SslMethod::NONE->value,
+    ]);
+});
+
+test('create redirect domain', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('hosted-domains.store', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+    ]), [
+        'domain' => 'redirect.example.com',
+        'type' => HostedDomainType::REDIRECT->value,
+        'ssl_method' => SslMethod::NONE->value,
+    ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('hosted_domains', [
+        'site_id' => $this->site->id,
+        'domain' => 'redirect.example.com',
+        'type' => HostedDomainType::REDIRECT->value,
+    ]);
+});
+
+test('create domain validation requires fields', function () {
+    $this->actingAs($this->user);
+
+    $this->post(route('hosted-domains.store', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+    ]), [])
+        ->assertSessionHasErrors(['domain', 'type', 'ssl_method']);
+});
+
+test('create domain validation invalid domain format', function () {
+    $this->actingAs($this->user);
+
+    $this->post(route('hosted-domains.store', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+    ]), [
+        'domain' => 'not a domain',
+        'type' => HostedDomainType::ALIAS->value,
+        'ssl_method' => SslMethod::NONE->value,
+    ])
+        ->assertSessionHasErrors('domain');
+});
+
+test('create domain rejects primary type', function () {
+    $this->actingAs($this->user);
+
+    $this->post(route('hosted-domains.store', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+    ]), [
+        'domain' => 'primary.example.com',
+        'type' => HostedDomainType::PRIMARY->value,
+        'ssl_method' => SslMethod::NONE->value,
+    ])
+        ->assertSessionHasErrors('type');
+});
+
+test('create domain rejects duplicate on same server', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'duplicate.example.com',
+    ]);
+
+    $this->post(route('hosted-domains.store', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+    ]), [
+        'domain' => 'duplicate.example.com',
+        'type' => HostedDomainType::ALIAS->value,
+        'ssl_method' => SslMethod::NONE->value,
+    ])
+        ->assertSessionHasErrors('domain');
+});
+
+test('create domain with custom ssl', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $ssl = Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'status' => SslStatus::CREATED,
+        'domains' => ['*.example.com'],
+    ]);
+
+    $this->post(route('hosted-domains.store', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+    ]), [
+        'domain' => 'app.example.com',
+        'type' => HostedDomainType::ALIAS->value,
+        'ssl_method' => SslMethod::CUSTOM->value,
+        'ssl_id' => $ssl->id,
+    ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('hosted_domains', [
+        'site_id' => $this->site->id,
+        'domain' => 'app.example.com',
+        'ssl_method' => SslMethod::CUSTOM->value,
+        'ssl_id' => $ssl->id,
+    ]);
+});
+
+test('create domain custom ssl requires ssl id', function () {
+    $this->actingAs($this->user);
+
+    $this->post(route('hosted-domains.store', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+    ]), [
+        'domain' => 'app.example.com',
+        'type' => HostedDomainType::ALIAS->value,
+        'ssl_method' => SslMethod::CUSTOM->value,
+    ])
+        ->assertSessionHasErrors('ssl_id');
+});
+
+test('update domain', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $domain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'old.example.com',
+        'type' => HostedDomainType::ALIAS,
+        'status' => HostedDomainStatus::ACTIVE,
+        'ssl_method' => SslMethod::NONE,
+    ]);
+
+    $this->put(route('hosted-domains.update', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'hostedDomain' => $domain->id,
+    ]), [
+        'domain' => 'new.example.com',
+        'type' => HostedDomainType::ALIAS->value,
+        'ssl_method' => SslMethod::NONE->value,
+    ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('hosted_domains', [
+        'id' => $domain->id,
+        'domain' => 'new.example.com',
+    ]);
+});
+
+test('cannot update primary domain name', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $domain = HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'primary.example.com',
+        'status' => HostedDomainStatus::ACTIVE,
+        'ssl_method' => SslMethod::NONE,
+    ]);
+
+    $this->put(route('hosted-domains.update', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'hostedDomain' => $domain->id,
+    ]), [
+        'domain' => 'changed.example.com',
+        'type' => HostedDomainType::ALIAS->value,
+        'ssl_method' => SslMethod::NONE->value,
+    ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('hosted_domains', [
+        'id' => $domain->id,
+        'domain' => 'primary.example.com',
+    ]);
+});
+
+test('cannot update processing domain', function () {
+    $this->actingAs($this->user);
+
+    $domain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'processing.example.com',
+        'status' => HostedDomainStatus::CREATING,
+        'ssl_method' => SslMethod::NONE,
+    ]);
+
+    $this->put(route('hosted-domains.update', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'hostedDomain' => $domain->id,
+    ]), [
+        'domain' => 'new.example.com',
+        'type' => HostedDomainType::ALIAS->value,
+        'ssl_method' => SslMethod::NONE->value,
+    ])
+        ->assertSessionHasErrors('domain');
+});
+
+test('delete domain', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $domain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'delete-me.example.com',
+        'status' => HostedDomainStatus::ACTIVE,
+    ]);
+
+    $this->delete(route('hosted-domains.destroy', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'hostedDomain' => $domain->id,
+    ]))
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseMissing('hosted_domains', ['id' => $domain->id]);
+});
+
+test('cannot delete primary domain', function () {
+    $this->actingAs($this->user);
+
+    $domain = HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'primary.example.com',
+        'status' => HostedDomainStatus::ACTIVE,
+    ]);
+
+    $this->delete(route('hosted-domains.destroy', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'hostedDomain' => $domain->id,
+    ]))
+        ->assertSessionHasErrors('domain');
+
+    $this->assertDatabaseHas('hosted_domains', ['id' => $domain->id]);
+});
+
+test('cannot delete processing domain', function () {
+    $this->actingAs($this->user);
+
+    $domain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'processing.example.com',
+        'status' => HostedDomainStatus::CREATING,
+    ]);
+
+    $this->delete(route('hosted-domains.destroy', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'hostedDomain' => $domain->id,
+    ]))
+        ->assertSessionHasErrors('domain');
+
+    $this->assertDatabaseHas('hosted_domains', ['id' => $domain->id]);
+});
+
+test('force activate domain', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $domain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'pending.example.com',
+        'status' => HostedDomainStatus::PENDING,
+        'ssl_method' => SslMethod::NONE,
+    ]);
+
+    $this->post(route('hosted-domains.force-activate', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'hostedDomain' => $domain->id,
+    ]))
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('hosted_domains', [
+        'id' => $domain->id,
+        'status' => HostedDomainStatus::ACTIVE,
+    ]);
+});
+
+test('deactivate domain', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $domain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'active.example.com',
+        'status' => HostedDomainStatus::ACTIVE,
+    ]);
+
+    $this->post(route('hosted-domains.deactivate', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'hostedDomain' => $domain->id,
+    ]))
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('hosted_domains', [
+        'id' => $domain->id,
+        'status' => HostedDomainStatus::INACTIVE,
+    ]);
+});
+
+test('cannot deactivate primary domain', function () {
+    $this->actingAs($this->user);
+
+    $domain = HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'primary.example.com',
+        'status' => HostedDomainStatus::ACTIVE,
+    ]);
+
+    $this->post(route('hosted-domains.deactivate', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'hostedDomain' => $domain->id,
+    ]))
+        ->assertSessionHasErrors('domain');
+});
+
+test('reactivate inactive domain', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $domain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'inactive.example.com',
+        'status' => HostedDomainStatus::INACTIVE,
+    ]);
+
+    $this->post(route('hosted-domains.reactivate', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'hostedDomain' => $domain->id,
+    ]))
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('hosted_domains', [
+        'id' => $domain->id,
+        'status' => HostedDomainStatus::UPDATING,
+    ]);
+
+    Bus::assertDispatched(CheckDomainJob::class);
+});
+
+test('cannot reactivate active domain', function () {
+    $this->actingAs($this->user);
+
+    $domain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'active.example.com',
+        'status' => HostedDomainStatus::ACTIVE,
+    ]);
+
+    $this->post(route('hosted-domains.reactivate', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'hostedDomain' => $domain->id,
+    ]))
+        ->assertSessionHasErrors('domain');
+});
+
+test('check dns', function () {
+    Bus::fake();
+
+    $this->actingAs($this->user);
+
+    $domain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'check.example.com',
+        'status' => HostedDomainStatus::ACTIVE,
+    ]);
+
+    $this->post(route('hosted-domains.check-dns', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'hostedDomain' => $domain->id,
+    ]))
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('hosted_domains', [
+        'id' => $domain->id,
+        'status' => HostedDomainStatus::UPDATING,
+    ]);
+
+    Bus::assertDispatched(CheckDomainJob::class);
+});
+
+test('matching ssls returns matches', function () {
+    $this->actingAs($this->user);
+
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'status' => SslStatus::CREATED,
+        'domains' => ['*.example.com'],
+    ]);
+
+    $this->getJson(route('hosted-domains.matching-ssls', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'domain' => 'sub.example.com',
+    ]))
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'certificates');
+});
+
+test('matching ssls returns empty for invalid domain', function () {
+    $this->actingAs($this->user);
+
+    $this->getJson(route('hosted-domains.matching-ssls', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'domain' => 'not valid',
+    ]))
+        ->assertSuccessful()
+        ->assertJsonCount(0, 'certificates');
+});
+
+test('check expiry refreshes date without notifying', function () {
+    SSH::fake(vitoPestFeatureHostedDomainsTestGenerateTestCertificate(90));
+    Notifier::spy();
+
+    $this->actingAs($this->user);
+
+    $ssl = Ssl::factory()->create([
+        'site_id' => $this->site->id,
+        'type' => SslType::LETSENCRYPT,
+        'status' => SslStatus::CREATED,
+        'certificate_path' => '/etc/letsencrypt/live/1/fullchain.pem',
+        'expires_at' => now()->addDays(5),
+        'domains' => ['old.example.com'],
+    ]);
+
+    $hostedDomain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'ssl_id' => $ssl->id,
+    ]);
+
+    $this->post(route('hosted-domains.check-expiry', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'hostedDomain' => $hostedDomain->id,
+    ]))
+        ->assertRedirect()
+        ->assertSessionHas('success');
+
+    $ssl->refresh();
+    expect($ssl->expires_at->isAfter(now()->addDays(80)))->toBeTrue();
+    expect($ssl->domains)->toEqualCanonicalizing(['example.com', 'www.example.com']);
+    expect($ssl->domains)->not->toContain('old.example.com');
+    Notifier::shouldNotHaveReceived('send');
+});
+
+test('check expiry errors when domain has no ssl', function () {
+    $this->actingAs($this->user);
+
+    $hostedDomain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'ssl_id' => null,
+    ]);
+
+    $this->post(route('hosted-domains.check-expiry', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+        'hostedDomain' => $hostedDomain->id,
+    ]))
+        ->assertRedirect()
+        ->assertSessionHas('error');
+});
+
+test('check expiry all refreshes every site certificate', function () {
+    SSH::fake(vitoPestFeatureHostedDomainsTestGenerateTestCertificate(90));
+    Notifier::spy();
+
+    $this->actingAs($this->user);
+
+    $sslOne = Ssl::factory()->create([
+        'site_id' => $this->site->id,
+        'type' => SslType::LETSENCRYPT,
+        'status' => SslStatus::CREATED,
+        'certificate_path' => '/etc/letsencrypt/live/1/fullchain.pem',
+        'expires_at' => now()->addDays(5),
+        'domains' => ['old.example.com'],
+    ]);
+
+    $sslTwo = Ssl::factory()->create([
+        'site_id' => $this->site->id,
+        'type' => SslType::LETSENCRYPT,
+        'status' => SslStatus::CREATED,
+        'certificate_path' => '/etc/letsencrypt/live/2/fullchain.pem',
+        'expires_at' => now()->addDays(5),
+        'domains' => ['old.example.com'],
+    ]);
+
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'ssl_id' => $sslOne->id,
+    ]);
+
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'ssl_id' => $sslTwo->id,
+    ]);
+
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'ssl_id' => $sslOne->id,
+    ]);
+
+    $this->post(route('hosted-domains.check-expiry-all', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+    ]))
+        ->assertRedirect()
+        ->assertSessionHas('success');
+
+    foreach ([$sslOne, $sslTwo] as $ssl) {
         $ssl->refresh();
-        $this->assertTrue($ssl->expires_at->isAfter(now()->addDays(80)));
-        $this->assertEqualsCanonicalizing(['example.com', 'www.example.com'], $ssl->domains);
-        $this->assertNotContains('old.example.com', $ssl->domains);
-        Notifier::shouldNotHaveReceived('send');
+        expect($ssl->expires_at->isAfter(now()->addDays(80)))->toBeTrue();
+        expect($ssl->domains)->not->toContain('old.example.com');
     }
 
-    public function test_check_expiry_errors_when_domain_has_no_ssl(): void
-    {
-        $this->actingAs($this->user);
+    Notifier::shouldNotHaveReceived('send');
+});
 
-        $hostedDomain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'ssl_id' => null,
-        ]);
-
-        $this->post(route('hosted-domains.check-expiry', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-            'hostedDomain' => $hostedDomain->id,
-        ]))
-            ->assertRedirect()
-            ->assertSessionHas('error');
-    }
-
-    public function test_check_expiry_all_refreshes_every_site_certificate(): void
-    {
-        SSH::fake($this->generateTestCertificate(90));
-        Notifier::spy();
-
-        $this->actingAs($this->user);
-
-        $sslOne = Ssl::factory()->create([
-            'site_id' => $this->site->id,
-            'type' => SslType::LETSENCRYPT,
-            'status' => SslStatus::CREATED,
-            'certificate_path' => '/etc/letsencrypt/live/1/fullchain.pem',
-            'expires_at' => now()->addDays(5),
-            'domains' => ['old.example.com'],
-        ]);
-
-        $sslTwo = Ssl::factory()->create([
-            'site_id' => $this->site->id,
-            'type' => SslType::LETSENCRYPT,
-            'status' => SslStatus::CREATED,
-            'certificate_path' => '/etc/letsencrypt/live/2/fullchain.pem',
-            'expires_at' => now()->addDays(5),
-            'domains' => ['old.example.com'],
-        ]);
-
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'ssl_id' => $sslOne->id,
-        ]);
-
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'ssl_id' => $sslTwo->id,
-        ]);
-
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'ssl_id' => $sslOne->id,
-        ]);
-
-        $this->post(route('hosted-domains.check-expiry-all', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-        ]))
-            ->assertRedirect()
-            ->assertSessionHas('success');
-
-        foreach ([$sslOne, $sslTwo] as $ssl) {
-            $ssl->refresh();
-            $this->assertTrue($ssl->expires_at->isAfter(now()->addDays(80)));
-            $this->assertNotContains('old.example.com', $ssl->domains);
-        }
-
-        Notifier::shouldNotHaveReceived('send');
-    }
-
-    private function generateTestCertificate(int $validDays = 90): string
-    {
-        $config = tempnam(sys_get_temp_dir(), 'openssl');
-        file_put_contents($config, <<<'INI'
+function vitoPestFeatureHostedDomainsTestGenerateTestCertificate(int $validDays = 90): string
+{
+    $config = tempnam(sys_get_temp_dir(), 'openssl');
+    file_put_contents($config, <<<'INI'
 [req]
 distinguished_name = req_dn
 req_extensions = v3_req
@@ -651,15 +620,14 @@ CN = example.com
 subjectAltName = DNS:example.com,DNS:www.example.com
 INI);
 
-        $key = openssl_pkey_new(['private_key_bits' => 2048, 'config' => $config]);
-        $csr = openssl_csr_new(['CN' => 'example.com'], $key, ['config' => $config]);
-        $cert = openssl_csr_sign($csr, null, $key, $validDays, [
-            'config' => $config,
-            'x509_extensions' => 'v3_req',
-        ]);
+    $key = openssl_pkey_new(['private_key_bits' => 2048, 'config' => $config]);
+    $csr = openssl_csr_new(['CN' => 'example.com'], $key, ['config' => $config]);
+    $cert = openssl_csr_sign($csr, null, $key, $validDays, [
+        'config' => $config,
+        'x509_extensions' => 'v3_req',
+    ]);
 
-        openssl_x509_export($cert, $certPem);
+    openssl_x509_export($cert, $certPem);
 
-        return $certPem;
-    }
+    return $certPem;
 }

--- a/tests/Feature/IsolatedUserMigrationTest.php
+++ b/tests/Feature/IsolatedUserMigrationTest.php
@@ -1,125 +1,118 @@
 <?php
 
-namespace Tests\Feature;
-
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Tests\TestCase;
 
-class IsolatedUserMigrationTest extends TestCase
+uses(RefreshDatabase::class);
+
+test('backfill creates iusers for isolated sites only', function () {
+    vitoPestFeatureIsolatedUserMigrationTestTeardownIsolatedUserSchema();
+
+    $serverA = vitoPestFeatureIsolatedUserMigrationTestInsertServer('vito');
+    $serverB = vitoPestFeatureIsolatedUserMigrationTestInsertServer('deploy');
+    $serverC = vitoPestFeatureIsolatedUserMigrationTestInsertServer('');
+
+    // Server A — vito default
+    vitoPestFeatureIsolatedUserMigrationTestInsertSite($serverA, null, 'a-null.test');
+    $vitoOnA = vitoPestFeatureIsolatedUserMigrationTestInsertSite($serverA, 'vito', 'vito-on-a.test');
+    $alpha1 = vitoPestFeatureIsolatedUserMigrationTestInsertSite($serverA, 'alpha', 'alpha-1.test');
+    $alpha2 = vitoPestFeatureIsolatedUserMigrationTestInsertSite($serverA, 'alpha', 'alpha-2.test');
+
+    // Server B — ssh_user 'deploy'; sites with user='vito' are treated as isolated.
+    vitoPestFeatureIsolatedUserMigrationTestInsertSite($serverB, 'deploy', 'b-deploy.test');
+    $vitoOnB = vitoPestFeatureIsolatedUserMigrationTestInsertSite($serverB, 'vito', 'vito-on-b.test');
+
+    // Server C — empty ssh_user; falls back to config('core.ssh_user')='vito'.
+    $vitoOnC = vitoPestFeatureIsolatedUserMigrationTestInsertSite($serverC, 'vito', 'vito-on-c.test');
+    $betaOnC = vitoPestFeatureIsolatedUserMigrationTestInsertSite($serverC, 'beta', 'beta-1.test');
+
+    vitoPestFeatureIsolatedUserMigrationTestRunIsolatedUserMigration();
+
+    $iuserByKey = DB::table('isolated_users')->get()->keyBy(fn ($u) => $u->server_id.':'.$u->username);
+
+    expect($iuserByKey)->toHaveCount(3, 'expected exactly alpha@A, vito@B, beta@C');
+    expect($iuserByKey->has($serverA.':alpha'))->toBeTrue();
+    expect($iuserByKey->has($serverB.':vito'))->toBeTrue();
+    expect($iuserByKey->has($serverC.':beta'))->toBeTrue();
+
+    // No iuser for the null-user, vito-on-A or vito-on-C rows.
+    expect($iuserByKey->has($serverA.':vito'))->toBeFalse();
+    expect($iuserByKey->has($serverC.':vito'))->toBeFalse();
+    expect(DB::table('sites')->where('id', $vitoOnA)->value('isolated_user_id'))->toBeNull();
+    expect(DB::table('sites')->where('id', $vitoOnC)->value('isolated_user_id'))->toBeNull();
+
+    // FK assignment
+    expect(DB::table('sites')->where('id', $alpha1)->value('isolated_user_id'))->toBe($iuserByKey[$serverA.':alpha']->id);
+    expect(DB::table('sites')->where('id', $alpha2)->value('isolated_user_id'))->toBe($iuserByKey[$serverA.':alpha']->id);
+    expect(DB::table('sites')->where('id', $vitoOnB)->value('isolated_user_id'))->toBe($iuserByKey[$serverB.':vito']->id);
+    expect(DB::table('sites')->where('id', $betaOnC)->value('isolated_user_id'))->toBe($iuserByKey[$serverC.':beta']->id);
+
+    // ssh_key + installed_tooling left NULL for backfilled rows.
+    expect($iuserByKey[$serverA.':alpha']->ssh_key)->toBeNull();
+    expect($iuserByKey[$serverA.':alpha']->installed_tooling)->toBeNull();
+});
+
+function vitoPestFeatureIsolatedUserMigrationTestTeardownIsolatedUserSchema(): void
 {
-    use RefreshDatabase;
-
-    public function test_backfill_creates_iusers_for_isolated_sites_only(): void
-    {
-        $this->teardownIsolatedUserSchema();
-
-        $serverA = $this->insertServer('vito');
-        $serverB = $this->insertServer('deploy');
-        $serverC = $this->insertServer('');
-
-        // Server A — vito default
-        $this->insertSite($serverA, null, 'a-null.test');
-        $vitoOnA = $this->insertSite($serverA, 'vito', 'vito-on-a.test');
-        $alpha1 = $this->insertSite($serverA, 'alpha', 'alpha-1.test');
-        $alpha2 = $this->insertSite($serverA, 'alpha', 'alpha-2.test');
-
-        // Server B — ssh_user 'deploy'; sites with user='vito' are treated as isolated.
-        $this->insertSite($serverB, 'deploy', 'b-deploy.test');
-        $vitoOnB = $this->insertSite($serverB, 'vito', 'vito-on-b.test');
-
-        // Server C — empty ssh_user; falls back to config('core.ssh_user')='vito'.
-        $vitoOnC = $this->insertSite($serverC, 'vito', 'vito-on-c.test');
-        $betaOnC = $this->insertSite($serverC, 'beta', 'beta-1.test');
-
-        $this->runIsolatedUserMigration();
-
-        $iuserByKey = DB::table('isolated_users')->get()->keyBy(fn ($u) => $u->server_id.':'.$u->username);
-
-        $this->assertCount(3, $iuserByKey, 'expected exactly alpha@A, vito@B, beta@C');
-        $this->assertTrue($iuserByKey->has($serverA.':alpha'));
-        $this->assertTrue($iuserByKey->has($serverB.':vito'));
-        $this->assertTrue($iuserByKey->has($serverC.':beta'));
-
-        // No iuser for the null-user, vito-on-A or vito-on-C rows.
-        $this->assertFalse($iuserByKey->has($serverA.':vito'));
-        $this->assertFalse($iuserByKey->has($serverC.':vito'));
-        $this->assertNull(DB::table('sites')->where('id', $vitoOnA)->value('isolated_user_id'));
-        $this->assertNull(DB::table('sites')->where('id', $vitoOnC)->value('isolated_user_id'));
-
-        // FK assignment
-        $this->assertSame($iuserByKey[$serverA.':alpha']->id, DB::table('sites')->where('id', $alpha1)->value('isolated_user_id'));
-        $this->assertSame($iuserByKey[$serverA.':alpha']->id, DB::table('sites')->where('id', $alpha2)->value('isolated_user_id'));
-        $this->assertSame($iuserByKey[$serverB.':vito']->id, DB::table('sites')->where('id', $vitoOnB)->value('isolated_user_id'));
-        $this->assertSame($iuserByKey[$serverC.':beta']->id, DB::table('sites')->where('id', $betaOnC)->value('isolated_user_id'));
-
-        // ssh_key + installed_tooling left NULL for backfilled rows.
-        $this->assertNull($iuserByKey[$serverA.':alpha']->ssh_key);
-        $this->assertNull($iuserByKey[$serverA.':alpha']->installed_tooling);
+    if (Schema::hasColumn('sites', 'isolated_user_id')) {
+        Schema::table('sites', function ($t): void {
+            $t->dropForeign(['isolated_user_id']);
+            $t->dropIndex(['isolated_user_id']);
+            $t->dropColumn('isolated_user_id');
+        });
     }
+    Schema::dropIfExists('isolated_users');
+}
 
-    private function teardownIsolatedUserSchema(): void
-    {
-        if (Schema::hasColumn('sites', 'isolated_user_id')) {
-            Schema::table('sites', function ($t): void {
-                $t->dropForeign(['isolated_user_id']);
-                $t->dropIndex(['isolated_user_id']);
-                $t->dropColumn('isolated_user_id');
-            });
-        }
-        Schema::dropIfExists('isolated_users');
-    }
+function vitoPestFeatureIsolatedUserMigrationTestRunIsolatedUserMigration(): void
+{
+    $path = base_path('database/migrations/2026_05_24_100123_create_isolated_users_table.php');
+    $migration = require $path;
+    $migration->up();
+}
 
-    private function runIsolatedUserMigration(): void
-    {
-        $path = base_path('database/migrations/2026_05_24_100123_create_isolated_users_table.php');
-        $migration = require $path;
-        $migration->up();
-    }
+function vitoPestFeatureIsolatedUserMigrationTestInsertServer(string $sshUser): int
+{
+    static $i = 0;
+    $i++;
 
-    private function insertServer(string $sshUser): int
-    {
-        static $i = 0;
-        $i++;
+    return DB::table('servers')->insertGetId([
+        'project_id' => test()->server->project_id,
+        'user_id' => test()->user->id,
+        'name' => 'srv-'.$i,
+        'ssh_user' => $sshUser,
+        'ip' => '127.0.0.'.$i,
+        'port' => 22,
+        'os' => 'ubuntu_22',
+        'provider' => 'custom',
+        'provider_data' => '{}',
+        'authentication' => 'X',
+        'public_key' => 'pk',
+        'status' => 'ready',
+        'updates' => 0,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
 
-        return DB::table('servers')->insertGetId([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'name' => 'srv-'.$i,
-            'ssh_user' => $sshUser,
-            'ip' => '127.0.0.'.$i,
-            'port' => 22,
-            'os' => 'ubuntu_22',
-            'provider' => 'custom',
-            'provider_data' => '{}',
-            'authentication' => 'X',
-            'public_key' => 'pk',
-            'status' => 'ready',
-            'updates' => 0,
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
-    }
-
-    private function insertSite(int $serverId, ?string $user, string $domain): int
-    {
-        return DB::table('sites')->insertGetId([
-            'server_id' => $serverId,
-            'type' => 'php',
-            'type_data' => json_encode([]),
-            'domain' => $domain,
-            'web_directory' => '',
-            'path' => '/home/'.($user ?? 'x').'/'.$domain,
-            'php_version' => '8.2',
-            'status' => 'ready',
-            'progress' => 100,
-            'user' => $user,
-            'force_ssl' => false,
-            'ssl_enabled' => false,
-            'vhost_generation_enabled' => true,
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
-    }
+function vitoPestFeatureIsolatedUserMigrationTestInsertSite(int $serverId, ?string $user, string $domain): int
+{
+    return DB::table('sites')->insertGetId([
+        'server_id' => $serverId,
+        'type' => 'php',
+        'type_data' => json_encode([]),
+        'domain' => $domain,
+        'web_directory' => '',
+        'path' => '/home/'.($user ?? 'x').'/'.$domain,
+        'php_version' => '8.2',
+        'status' => 'ready',
+        'progress' => 100,
+        'user' => $user,
+        'force_ssl' => false,
+        'ssl_enabled' => false,
+        'vhost_generation_enabled' => true,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
 }

--- a/tests/Feature/Jobs/BackupJobsTest.php
+++ b/tests/Feature/Jobs/BackupJobsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Jobs;
-
 use App\Enums\BackupFileStatus;
 use App\Enums\BackupType;
 use App\Facades\SSH;
@@ -17,203 +15,181 @@ use App\Models\StorageProvider;
 use App\Notifications\RestoreFailed;
 use App\StorageProviders\Dropbox;
 use App\StorageProviders\S3;
-use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
-use Tests\TestCase;
 
-class BackupJobsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    protected StorageProvider $storageProvider;
+beforeEach(function () {
+    $this->storageProvider = StorageProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Dropbox::id(),
+    ]);
 
-    protected Backup $backup;
+    $this->backup = Backup::factory()->create([
+        'type' => BackupType::DATABASE,
+        'server_id' => $this->server->id,
+        'storage_id' => $this->storageProvider->id,
+        'database_id' => Database::factory()->create(['server_id' => $this->server->id])->id,
+        'status' => null,
+    ]);
 
-    protected BackupFile $backupFile;
+    $this->backupFile = BackupFile::factory()->create([
+        'backup_id' => $this->backup->id,
+        'status' => BackupFileStatus::CREATING,
+    ]);
+});
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+test('run job failed sets file to failed and logs', function () {
+    SSH::fake();
 
-        $this->storageProvider = StorageProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Dropbox::id(),
-        ]);
+    $job = new RunJob($this->backupFile, $this->backup);
+    $job->failed(new Exception('Backup failed'));
 
-        $this->backup = Backup::factory()->create([
-            'type' => BackupType::DATABASE,
-            'server_id' => $this->server->id,
-            'storage_id' => $this->storageProvider->id,
-            'database_id' => Database::factory()->create(['server_id' => $this->server->id])->id,
-            'status' => null,
-        ]);
+    $this->backup->refresh();
+    $this->backupFile->refresh();
 
-        $this->backupFile = BackupFile::factory()->create([
-            'backup_id' => $this->backup->id,
-            'status' => BackupFileStatus::CREATING,
-        ]);
-    }
+    expect($this->backup->status)->toBeNull();
+    expect($this->backupFile->status)->toEqual(BackupFileStatus::FAILED);
+    expect($this->backupFile->message)->toBe('Backup failed');
 
-    public function test_run_job_failed_sets_file_to_failed_and_logs(): void
-    {
-        SSH::fake();
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'run-backup-failed',
+    ]);
+});
 
-        $job = new RunJob($this->backupFile, $this->backup);
-        $job->failed(new Exception('Backup failed'));
+test('restore database job failed sends notification', function () {
+    SSH::fake();
+    Notification::fake();
 
-        $this->backup->refresh();
-        $this->backupFile->refresh();
+    $database = Database::factory()->create(['server_id' => $this->server->id]);
+    $this->backupFile->update(['status' => BackupFileStatus::RESTORING]);
 
-        $this->assertNull($this->backup->status);
-        $this->assertEquals(BackupFileStatus::FAILED, $this->backupFile->status);
-        $this->assertSame('Backup failed', $this->backupFile->message);
+    $job = new RestoreDatabaseJob($this->backupFile, $database);
+    $job->failed(new Exception('Restore failed'));
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'run-backup-failed',
-        ]);
-    }
+    Notification::assertSentTo($this->notificationChannel, RestoreFailed::class);
+});
 
-    public function test_restore_database_job_failed_sends_notification(): void
-    {
-        SSH::fake();
-        Notification::fake();
+test('delete file keeps row when remote delete fails', function () {
+    SSH::fake();
 
-        $database = Database::factory()->create(['server_id' => $this->server->id]);
-        $this->backupFile->update(['status' => BackupFileStatus::RESTORING]);
+    $storage = StorageProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => S3::id(),
+        'credentials' => [
+            'key' => 'k',
+            'secret' => 's',
+            'region' => 'us-east-1',
+            'bucket' => 'b',
+            'path' => 'backups',
+        ],
+    ]);
 
-        $job = new RestoreDatabaseJob($this->backupFile, $database);
-        $job->failed(new Exception('Restore failed'));
+    $backup = Backup::factory()->create([
+        'type' => BackupType::DATABASE,
+        'server_id' => $this->server->id,
+        'storage_id' => $storage->id,
+        'database_id' => Database::factory()->create(['server_id' => $this->server->id])->id,
+    ]);
 
-        Notification::assertSentTo($this->notificationChannel, RestoreFailed::class);
-    }
+    $file = BackupFile::factory()->create([
+        'backup_id' => $backup->id,
+        'status' => BackupFileStatus::DELETING,
+    ]);
 
-    public function test_delete_file_keeps_row_when_remote_delete_fails(): void
-    {
-        SSH::fake();
+    $file->deleteFile();
 
-        $storage = StorageProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => S3::id(),
-            'credentials' => [
-                'key' => 'k',
-                'secret' => 's',
-                'region' => 'us-east-1',
-                'bucket' => 'b',
-                'path' => 'backups',
-            ],
-        ]);
+    $this->assertDatabaseHas('backup_files', [
+        'id' => $file->id,
+        'status' => BackupFileStatus::DELETE_FAILED->value,
+    ]);
+});
 
-        $backup = Backup::factory()->create([
-            'type' => BackupType::DATABASE,
-            'server_id' => $this->server->id,
-            'storage_id' => $storage->id,
-            'database_id' => Database::factory()->create(['server_id' => $this->server->id])->id,
-        ]);
+test('reconcile marks stuck creating files as failed', function () {
+    Notification::fake();
 
-        $file = BackupFile::factory()->create([
-            'backup_id' => $backup->id,
-            'status' => BackupFileStatus::DELETING,
-        ]);
+    $this->backupFile->update(['status' => BackupFileStatus::CREATING]);
+    BackupFile::query()
+        ->whereKey($this->backupFile->id)
+        ->update(['updated_at' => now()->subSeconds(2 * (int) config('core.backup_run_timeout') + 60)]);
 
-        $file->deleteFile();
+    $this->artisan('backups:reconcile')->assertSuccessful();
 
-        $this->assertDatabaseHas('backup_files', [
-            'id' => $file->id,
-            'status' => BackupFileStatus::DELETE_FAILED->value,
-        ]);
-    }
+    $this->assertDatabaseHas('backup_files', [
+        'id' => $this->backupFile->id,
+        'status' => BackupFileStatus::FAILED->value,
+    ]);
+});
 
-    public function test_reconcile_marks_stuck_creating_files_as_failed(): void
-    {
-        Notification::fake();
+test('restore database job failed sets restore failed and logs', function () {
+    SSH::fake();
 
-        $this->backupFile->update(['status' => BackupFileStatus::CREATING]);
-        BackupFile::query()
-            ->whereKey($this->backupFile->id)
-            ->update(['updated_at' => now()->subSeconds(2 * (int) config('core.backup_run_timeout') + 60)]);
+    $database = Database::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        $this->artisan('backups:reconcile')->assertSuccessful();
+    $this->backupFile->update(['status' => BackupFileStatus::RESTORING]);
 
-        $this->assertDatabaseHas('backup_files', [
-            'id' => $this->backupFile->id,
-            'status' => BackupFileStatus::FAILED->value,
-        ]);
-    }
+    $job = new RestoreDatabaseJob($this->backupFile, $database);
+    $job->failed(new Exception('Restore failed'));
 
-    public function test_restore_database_job_failed_sets_restore_failed_and_logs(): void
-    {
-        SSH::fake();
+    $this->backupFile->refresh();
 
-        $database = Database::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+    expect($this->backupFile->status)->toEqual(BackupFileStatus::RESTORE_FAILED);
 
-        $this->backupFile->update(['status' => BackupFileStatus::RESTORING]);
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'restore-database-failed',
+    ]);
+});
 
-        $job = new RestoreDatabaseJob($this->backupFile, $database);
-        $job->failed(new Exception('Restore failed'));
+test('restore file job failed sets restore failed and logs', function () {
+    SSH::fake();
 
-        $this->backupFile->refresh();
+    $fileBackup = Backup::factory()->create([
+        'type' => BackupType::FILE,
+        'server_id' => $this->server->id,
+        'storage_id' => $this->storageProvider->id,
+        'path' => '/home/vito/app',
+        'status' => null,
+    ]);
 
-        $this->assertEquals(BackupFileStatus::RESTORE_FAILED, $this->backupFile->status);
+    $file = BackupFile::factory()->create([
+        'backup_id' => $fileBackup->id,
+        'status' => BackupFileStatus::RESTORING,
+    ]);
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'restore-database-failed',
-        ]);
-    }
+    $job = new RestoreFileJob($file, '/home/vito/restored', 'vito:vito', '755');
+    $job->failed(new Exception('Restore failed'));
 
-    public function test_restore_file_job_failed_sets_restore_failed_and_logs(): void
-    {
-        SSH::fake();
+    $file->refresh();
 
-        $fileBackup = Backup::factory()->create([
-            'type' => BackupType::FILE,
-            'server_id' => $this->server->id,
-            'storage_id' => $this->storageProvider->id,
-            'path' => '/home/vito/app',
-            'status' => null,
-        ]);
+    expect($file->status)->toEqual(BackupFileStatus::RESTORE_FAILED);
 
-        $file = BackupFile::factory()->create([
-            'backup_id' => $fileBackup->id,
-            'status' => BackupFileStatus::RESTORING,
-        ]);
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'restore-file-failed',
+    ]);
+});
 
-        $job = new RestoreFileJob($file, '/home/vito/restored', 'vito:vito', '755');
-        $job->failed(new Exception('Restore failed'));
+test('delete job failed logs', function () {
+    $job = new DeleteJob($this->backup);
+    $job->failed(new Exception('Delete failed'));
 
-        $file->refresh();
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'delete-backup-failed',
+    ]);
+});
 
-        $this->assertEquals(BackupFileStatus::RESTORE_FAILED, $file->status);
+test('delete file job failed logs', function () {
+    $job = new DeleteFileJob($this->backupFile);
+    $job->failed(new Exception('Delete file failed'));
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'restore-file-failed',
-        ]);
-    }
-
-    public function test_delete_job_failed_logs(): void
-    {
-        $job = new DeleteJob($this->backup);
-        $job->failed(new Exception('Delete failed'));
-
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'delete-backup-failed',
-        ]);
-    }
-
-    public function test_delete_file_job_failed_logs(): void
-    {
-        $job = new DeleteFileJob($this->backupFile);
-        $job->failed(new Exception('Delete file failed'));
-
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'delete-backup-file-failed',
-        ]);
-    }
-}
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'delete-backup-file-failed',
+    ]);
+});

--- a/tests/Feature/Jobs/FirewallApplyRulesJobTest.php
+++ b/tests/Feature/Jobs/FirewallApplyRulesJobTest.php
@@ -1,49 +1,41 @@
 <?php
 
-namespace Tests\Feature\Jobs;
-
 use App\Enums\FirewallRuleStatus;
 use App\Jobs\FirewallRule\ApplyRulesJob;
 use App\Models\FirewallRule;
-use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class FirewallApplyRulesJobTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_apply_rules_job_failed_sets_non_ready_rules_to_failed_and_logs(): void
-    {
-        $creatingRule = FirewallRule::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => FirewallRuleStatus::CREATING,
-        ]);
+test('apply rules job failed sets non ready rules to failed and logs', function () {
+    $creatingRule = FirewallRule::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => FirewallRuleStatus::CREATING,
+    ]);
 
-        $readyRule = FirewallRule::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => FirewallRuleStatus::READY,
-        ]);
+    $readyRule = FirewallRule::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => FirewallRuleStatus::READY,
+    ]);
 
-        $deletingRule = FirewallRule::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => FirewallRuleStatus::DELETING,
-        ]);
+    $deletingRule = FirewallRule::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => FirewallRuleStatus::DELETING,
+    ]);
 
-        $job = new ApplyRulesJob($creatingRule);
-        $job->failed(new Exception('Firewall error'));
+    $job = new ApplyRulesJob($creatingRule);
+    $job->failed(new Exception('Firewall error'));
 
-        $creatingRule->refresh();
-        $readyRule->refresh();
-        $deletingRule->refresh();
+    $creatingRule->refresh();
+    $readyRule->refresh();
+    $deletingRule->refresh();
 
-        $this->assertEquals(FirewallRuleStatus::FAILED, $creatingRule->status);
-        $this->assertEquals(FirewallRuleStatus::READY, $readyRule->status);
-        $this->assertEquals(FirewallRuleStatus::FAILED, $deletingRule->status);
+    expect($creatingRule->status)->toEqual(FirewallRuleStatus::FAILED);
+    expect($readyRule->status)->toEqual(FirewallRuleStatus::READY);
+    expect($deletingRule->status)->toEqual(FirewallRuleStatus::FAILED);
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'apply-firewall-rules-failed',
-        ]);
-    }
-}
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'apply-firewall-rules-failed',
+    ]);
+});

--- a/tests/Feature/Jobs/ScriptExecuteJobTest.php
+++ b/tests/Feature/Jobs/ScriptExecuteJobTest.php
@@ -1,47 +1,39 @@
 <?php
 
-namespace Tests\Feature\Jobs;
-
 use App\Enums\ScriptExecutionStatus;
 use App\Jobs\Script\ExecuteJob;
 use App\Models\Script;
 use App\Models\ScriptExecution;
 use App\Models\ServerLog;
-use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class ScriptExecuteJobTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_execute_job_failed_sets_status_to_failed_and_logs(): void
-    {
-        /** @var Script $script */
-        $script = Script::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+test('execute job failed sets status to failed and logs', function () {
+    /** @var Script $script */
+    $script = Script::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-        /** @var ScriptExecution $execution */
-        $execution = ScriptExecution::factory()->create([
-            'script_id' => $script->id,
-            'server_id' => $this->server->id,
-            'status' => ScriptExecutionStatus::EXECUTING,
-        ]);
+    /** @var ScriptExecution $execution */
+    $execution = ScriptExecution::factory()->create([
+        'script_id' => $script->id,
+        'server_id' => $this->server->id,
+        'status' => ScriptExecutionStatus::EXECUTING,
+    ]);
 
-        $log = ServerLog::newLog($this->server, 'execute-script');
-        $log->save();
+    $log = ServerLog::newLog($this->server, 'execute-script');
+    $log->save();
 
-        $job = new ExecuteJob($execution, $log);
-        $job->failed(new Exception('Script execution timed out'));
+    $job = new ExecuteJob($execution, $log);
+    $job->failed(new Exception('Script execution timed out'));
 
-        $execution->refresh();
+    $execution->refresh();
 
-        $this->assertEquals(ScriptExecutionStatus::FAILED, $execution->status);
+    expect($execution->status)->toEqual(ScriptExecutionStatus::FAILED);
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'execute-script-failed',
-        ]);
-    }
-}
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'execute-script-failed',
+    ]);
+});

--- a/tests/Feature/Jobs/ServerInstallJobTest.php
+++ b/tests/Feature/Jobs/ServerInstallJobTest.php
@@ -1,34 +1,26 @@
 <?php
 
-namespace Tests\Feature\Jobs;
-
 use App\Enums\ServerStatus;
 use App\Jobs\Server\InstallJob;
-use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
-use Tests\TestCase;
 
-class ServerInstallJobTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_install_job_failed_sets_status_to_installation_failed_and_logs(): void
-    {
-        Notification::fake();
+test('install job failed sets status to installation failed and logs', function () {
+    Notification::fake();
 
-        $this->server->update(['status' => ServerStatus::INSTALLING]);
+    $this->server->update(['status' => ServerStatus::INSTALLING]);
 
-        $job = new InstallJob($this->server);
-        $job->failed(new Exception('Installation failed'));
+    $job = new InstallJob($this->server);
+    $job->failed(new Exception('Installation failed'));
 
-        $this->server->refresh();
+    $this->server->refresh();
 
-        $this->assertEquals(ServerStatus::INSTALLATION_FAILED, $this->server->status);
+    expect($this->server->status)->toEqual(ServerStatus::INSTALLATION_FAILED);
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'server-installation-failed',
-        ]);
-    }
-}
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'server-installation-failed',
+    ]);
+});

--- a/tests/Feature/Jobs/ServiceManageJobTest.php
+++ b/tests/Feature/Jobs/ServiceManageJobTest.php
@@ -1,111 +1,98 @@
 <?php
 
-namespace Tests\Feature\Jobs;
-
 use App\Enums\ServiceStatus;
 use App\Facades\SSH;
 use App\Jobs\Service\ManageJob;
-use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class ServiceManageJobTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_manage_job_handle_sets_ready_on_active_response(): void
-    {
-        SSH::fake('Active: active');
+test('manage job handle sets ready on active response', function () {
+    SSH::fake('Active: active');
 
-        $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
-        $service->status = ServiceStatus::RESTARTING;
-        $service->save();
+    $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
+    $service->status = ServiceStatus::RESTARTING;
+    $service->save();
 
-        $job = new ManageJob($service, 'restart', ServiceStatus::READY);
-        $job->handle();
+    $job = new ManageJob($service, 'restart', ServiceStatus::READY);
+    $job->handle();
 
-        $service->refresh();
+    $service->refresh();
 
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-    }
+    expect($service->status)->toEqual(ServiceStatus::READY);
+});
 
-    public function test_manage_job_handle_sets_failed_on_inactive_response(): void
-    {
-        SSH::fake('Active: inactive');
+test('manage job handle sets failed on inactive response', function () {
+    SSH::fake('Active: inactive');
 
-        $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
-        $service->status = ServiceStatus::RESTARTING;
-        $service->save();
+    $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
+    $service->status = ServiceStatus::RESTARTING;
+    $service->save();
 
-        $job = new ManageJob($service, 'restart', ServiceStatus::READY);
-        $job->handle();
+    $job = new ManageJob($service, 'restart', ServiceStatus::READY);
+    $job->handle();
 
-        $service->refresh();
+    $service->refresh();
 
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-    }
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+});
 
-    public function test_manage_job_stop_expects_inactive_state(): void
-    {
-        SSH::fake('Active: inactive');
+test('manage job stop expects inactive state', function () {
+    SSH::fake('Active: inactive');
 
-        $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
-        $service->status = ServiceStatus::STOPPING;
-        $service->save();
+    $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
+    $service->status = ServiceStatus::STOPPING;
+    $service->save();
 
-        $job = new ManageJob($service, 'stop', ServiceStatus::STOPPED);
-        $job->handle();
+    $job = new ManageJob($service, 'stop', ServiceStatus::STOPPED);
+    $job->handle();
 
-        $service->refresh();
+    $service->refresh();
 
-        $this->assertEquals(ServiceStatus::STOPPED, $service->status);
-    }
+    expect($service->status)->toEqual(ServiceStatus::STOPPED);
+});
 
-    public function test_manage_job_disable_expects_inactive_state(): void
-    {
-        SSH::fake('Active: inactive');
+test('manage job disable expects inactive state', function () {
+    SSH::fake('Active: inactive');
 
-        $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
-        $service->status = ServiceStatus::DISABLING;
-        $service->save();
+    $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
+    $service->status = ServiceStatus::DISABLING;
+    $service->save();
 
-        $job = new ManageJob($service, 'disable', ServiceStatus::DISABLED);
-        $job->handle();
+    $job = new ManageJob($service, 'disable', ServiceStatus::DISABLED);
+    $job->handle();
 
-        $service->refresh();
+    $service->refresh();
 
-        $this->assertEquals(ServiceStatus::DISABLED, $service->status);
-    }
+    expect($service->status)->toEqual(ServiceStatus::DISABLED);
+});
 
-    public function test_manage_job_failed_sets_status_to_failed_and_logs(): void
-    {
-        $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
-        $service->status = ServiceStatus::RESTARTING;
-        $service->save();
+test('manage job failed sets status to failed and logs', function () {
+    $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
+    $service->status = ServiceStatus::RESTARTING;
+    $service->save();
 
-        $job = new ManageJob($service, 'restart', ServiceStatus::READY);
-        $job->failed(new Exception('SSH connection failed'));
+    $job = new ManageJob($service, 'restart', ServiceStatus::READY);
+    $job->failed(new Exception('SSH connection failed'));
 
-        $service->refresh();
+    $service->refresh();
 
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'restart-service-failed',
-        ]);
-    }
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'restart-service-failed',
+    ]);
+});
 
-    public function test_manage_job_stop_failed_logs_correct_type(): void
-    {
-        $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
+test('manage job stop failed logs correct type', function () {
+    $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
 
-        $job = new ManageJob($service, 'stop', ServiceStatus::STOPPED);
-        $job->failed(new Exception('SSH connection failed'));
+    $job = new ManageJob($service, 'stop', ServiceStatus::STOPPED);
+    $job->failed(new Exception('SSH connection failed'));
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'stop-service-failed',
-        ]);
-    }
-}
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'stop-service-failed',
+    ]);
+});

--- a/tests/Feature/Jobs/SiteExecuteCommandJobTest.php
+++ b/tests/Feature/Jobs/SiteExecuteCommandJobTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Jobs;
-
 use App\Enums\CommandExecutionStatus;
 use App\Facades\SSH;
 use App\Jobs\Site\ExecuteCommandJob;
@@ -10,83 +8,76 @@ use App\Models\CommandExecution;
 use App\Models\ServerLog;
 use App\Models\Site;
 use App\SiteTypes\Laravel;
-use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class SiteExecuteCommandJobTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_execute_command_job_runs_with_installed_tooling_on_path(): void
-    {
-        SSH::fake();
+test('execute command job runs with installed tooling on path', function () {
+    SSH::fake();
 
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'isolated-cmd',
-            'path' => '/home/isolated-cmd/site.test',
-            'type' => Laravel::id(),
-            'type_data' => [],
-        ]);
-        $site->isolatedUser->setToolingVersion('node', '22');
-        $site->refresh();
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'isolated-cmd',
+        'path' => '/home/isolated-cmd/site.test',
+        'type' => Laravel::id(),
+        'type_data' => [],
+    ]);
+    $site->isolatedUser->setToolingVersion('node', '22');
+    $site->refresh();
 
-        /** @var Command $command */
-        $command = Command::factory()->create([
-            'site_id' => $site->id,
-            'command' => 'npm -v',
-        ]);
+    /** @var Command $command */
+    $command = Command::factory()->create([
+        'site_id' => $site->id,
+        'command' => 'npm -v',
+    ]);
 
-        /** @var CommandExecution $execution */
-        $execution = CommandExecution::factory()->create([
-            'command_id' => $command->id,
-            'server_id' => $this->server->id,
-            'user_id' => $this->user->id,
-            'status' => CommandExecutionStatus::EXECUTING,
-            'variables' => [],
-        ]);
+    /** @var CommandExecution $execution */
+    $execution = CommandExecution::factory()->create([
+        'command_id' => $command->id,
+        'server_id' => $this->server->id,
+        'user_id' => $this->user->id,
+        'status' => CommandExecutionStatus::EXECUTING,
+        'variables' => [],
+    ]);
 
-        $log = ServerLog::newLog($this->server, 'execute-command');
-        $log->save();
+    $log = ServerLog::newLog($this->server, 'execute-command');
+    $log->save();
 
-        (new ExecuteCommandJob($execution, $command, $log))->handle();
+    (new ExecuteCommandJob($execution, $command, $log))->handle();
 
-        SSH::assertExecutedContains('/home/isolated-cmd/.local/share/mise/shims');
+    SSH::assertExecutedContains('/home/isolated-cmd/.local/share/mise/shims');
 
-        $execution->refresh();
-        $this->assertEquals(CommandExecutionStatus::COMPLETED, $execution->status);
-    }
+    $execution->refresh();
+    expect($execution->status)->toEqual(CommandExecutionStatus::COMPLETED);
+});
 
-    public function test_execute_command_job_failed_sets_status_to_failed_and_logs(): void
-    {
-        /** @var Command $command */
-        $command = Command::factory()->create([
-            'site_id' => $this->site->id,
-        ]);
+test('execute command job failed sets status to failed and logs', function () {
+    /** @var Command $command */
+    $command = Command::factory()->create([
+        'site_id' => $this->site->id,
+    ]);
 
-        /** @var CommandExecution $execution */
-        $execution = CommandExecution::factory()->create([
-            'command_id' => $command->id,
-            'server_id' => $this->server->id,
-            'user_id' => $this->user->id,
-            'status' => CommandExecutionStatus::EXECUTING,
-        ]);
+    /** @var CommandExecution $execution */
+    $execution = CommandExecution::factory()->create([
+        'command_id' => $command->id,
+        'server_id' => $this->server->id,
+        'user_id' => $this->user->id,
+        'status' => CommandExecutionStatus::EXECUTING,
+    ]);
 
-        $log = ServerLog::newLog($this->server, 'execute-command');
-        $log->save();
+    $log = ServerLog::newLog($this->server, 'execute-command');
+    $log->save();
 
-        $job = new ExecuteCommandJob($execution, $command, $log);
-        $job->failed(new Exception('Command execution timed out'));
+    $job = new ExecuteCommandJob($execution, $command, $log);
+    $job->failed(new Exception('Command execution timed out'));
 
-        $execution->refresh();
+    $execution->refresh();
 
-        $this->assertEquals(CommandExecutionStatus::FAILED, $execution->status);
+    expect($execution->status)->toEqual(CommandExecutionStatus::FAILED);
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'execute-command-failed',
-        ]);
-    }
-}
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'execute-command-failed',
+    ]);
+});

--- a/tests/Feature/Jobs/WorkerJobsTest.php
+++ b/tests/Feature/Jobs/WorkerJobsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Jobs;
-
 use App\Enums\WorkerStatus;
 use App\Exceptions\SSHCommandError;
 use App\Exceptions\SSHConnectionError;
@@ -12,171 +10,158 @@ use App\Jobs\Worker\EditJob;
 use App\Jobs\Worker\ManageJob;
 use App\Models\ServerLog;
 use App\Models\Worker;
-use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
-use Tests\TestCase;
 
-class WorkerJobsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_job_failed_keeps_worker_failed_and_logs(): void
-    {
-        SSH::fake();
+test('create job failed keeps worker failed and logs', function () {
+    SSH::fake();
 
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::CREATING,
-        ]);
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::CREATING,
+    ]);
 
-        $job = new CreateJob($worker);
-        $job->failed(new Exception('SSH connection failed'));
+    $job = new CreateJob($worker);
+    $job->failed(new Exception('SSH connection failed'));
 
-        $worker->refresh();
+    $worker->refresh();
 
-        $this->assertSame(WorkerStatus::FAILED, $worker->status);
+    expect($worker->status)->toBe(WorkerStatus::FAILED);
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'create-worker-failed',
-        ]);
-    }
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'create-worker-failed',
+    ]);
+});
 
-    public function test_manage_job_failed_stores_supervisor_error_from_log(): void
-    {
-        Storage::fake(config('core.logs_disk'));
+test('manage job failed stores supervisor error from log', function () {
+    Storage::fake(config('core.logs_disk'));
 
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::STARTING,
-        ]);
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::STARTING,
+    ]);
 
-        $log = ServerLog::log($this->server, 'start-worker', "+ supervisorctl start 10:*\n10:10_00: ERROR (no such file)\n");
+    $log = ServerLog::log($this->server, 'start-worker', "+ supervisorctl start 10:*\n10:10_00: ERROR (no such file)\n");
 
-        $job = new ManageJob($worker, 'start', WorkerStatus::RUNNING);
-        $job->failed(new SSHCommandError(message: 'SSH command failed with an error', log: $log));
+    $job = new ManageJob($worker, 'start', WorkerStatus::RUNNING);
+    $job->failed(new SSHCommandError(message: 'SSH command failed with an error', log: $log));
 
-        $worker->refresh();
+    $worker->refresh();
 
-        $this->assertSame(WorkerStatus::FAILED, $worker->status);
-        $this->assertSame('10:10_00: ERROR (no such file)', $worker->error);
-    }
+    expect($worker->status)->toBe(WorkerStatus::FAILED);
+    expect($worker->error)->toBe('10:10_00: ERROR (no such file)');
+});
 
-    public function test_manage_job_failed_falls_back_to_message_when_log_has_no_error_lines(): void
-    {
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::STARTING,
-        ]);
+test('manage job failed falls back to message when log has no error lines', function () {
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::STARTING,
+    ]);
 
-        $job = new ManageJob($worker, 'start', WorkerStatus::RUNNING);
-        $job->failed(new SSHConnectionError('Connection failed'));
+    $job = new ManageJob($worker, 'start', WorkerStatus::RUNNING);
+    $job->failed(new SSHConnectionError('Connection failed'));
 
-        $worker->refresh();
+    $worker->refresh();
 
-        $this->assertSame(WorkerStatus::FAILED, $worker->status);
-        $this->assertSame('Connection failed', $worker->error);
-    }
+    expect($worker->status)->toBe(WorkerStatus::FAILED);
+    expect($worker->error)->toBe('Connection failed');
+});
 
-    public function test_worker_resource_exposes_error(): void
-    {
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => WorkerStatus::FAILED,
-            'error' => '10:10_00: ERROR (no such file)',
-        ]);
+test('worker resource exposes error', function () {
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => WorkerStatus::FAILED,
+        'error' => '10:10_00: ERROR (no such file)',
+    ]);
 
-        $resource = (new WorkerResource($worker))->toArray(new Request);
+    $resource = (new WorkerResource($worker))->toArray(new Request);
 
-        $this->assertSame('10:10_00: ERROR (no such file)', $resource['error']);
-    }
+    expect($resource['error'])->toBe('10:10_00: ERROR (no such file)');
+});
 
-    public function test_edit_job_failed_sets_status_to_failed_and_logs(): void
-    {
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
+test('edit job failed sets status to failed and logs', function () {
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
 
-        $job = new EditJob($worker);
-        $job->failed(new Exception('SSH connection failed'));
+    $job = new EditJob($worker);
+    $job->failed(new Exception('SSH connection failed'));
 
-        $worker->refresh();
+    $worker->refresh();
 
-        $this->assertSame(WorkerStatus::FAILED, $worker->status);
+    expect($worker->status)->toBe(WorkerStatus::FAILED);
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'edit-worker-failed',
-        ]);
-    }
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'edit-worker-failed',
+    ]);
+});
 
-    public function test_manage_job_start_failed_sets_status_to_failed_and_logs(): void
-    {
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::STARTING,
-        ]);
+test('manage job start failed sets status to failed and logs', function () {
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::STARTING,
+    ]);
 
-        $job = new ManageJob($worker, 'start', WorkerStatus::RUNNING);
-        $job->failed(new Exception('Process manager error'));
+    $job = new ManageJob($worker, 'start', WorkerStatus::RUNNING);
+    $job->failed(new Exception('Process manager error'));
 
-        $worker->refresh();
+    $worker->refresh();
 
-        $this->assertSame(WorkerStatus::FAILED, $worker->status);
+    expect($worker->status)->toBe(WorkerStatus::FAILED);
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'start-worker-failed',
-        ]);
-    }
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'start-worker-failed',
+    ]);
+});
 
-    public function test_manage_job_stop_failed_sets_status_to_failed_and_logs(): void
-    {
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::STOPPING,
-        ]);
+test('manage job stop failed sets status to failed and logs', function () {
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::STOPPING,
+    ]);
 
-        $job = new ManageJob($worker, 'stop', WorkerStatus::STOPPED);
-        $job->failed(new Exception('Process manager error'));
+    $job = new ManageJob($worker, 'stop', WorkerStatus::STOPPED);
+    $job->failed(new Exception('Process manager error'));
 
-        $worker->refresh();
+    $worker->refresh();
 
-        $this->assertSame(WorkerStatus::FAILED, $worker->status);
+    expect($worker->status)->toBe(WorkerStatus::FAILED);
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'stop-worker-failed',
-        ]);
-    }
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'stop-worker-failed',
+    ]);
+});
 
-    public function test_manage_job_restart_failed_sets_status_to_failed_and_logs(): void
-    {
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RESTARTING,
-        ]);
+test('manage job restart failed sets status to failed and logs', function () {
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RESTARTING,
+    ]);
 
-        $job = new ManageJob($worker, 'restart', WorkerStatus::RUNNING);
-        $job->failed(new Exception('Process manager error'));
+    $job = new ManageJob($worker, 'restart', WorkerStatus::RUNNING);
+    $job->failed(new Exception('Process manager error'));
 
-        $worker->refresh();
+    $worker->refresh();
 
-        $this->assertSame(WorkerStatus::FAILED, $worker->status);
+    expect($worker->status)->toBe(WorkerStatus::FAILED);
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'restart-worker-failed',
-        ]);
-    }
-}
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'restart-worker-failed',
+    ]);
+});

--- a/tests/Feature/Jobs/WorkflowRunJobTest.php
+++ b/tests/Feature/Jobs/WorkflowRunJobTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Jobs;
-
 use App\DTOs\WorkflowActionDTO;
 use App\Enums\WorkflowRunStatus;
 use App\Facades\SSH;
@@ -9,136 +7,128 @@ use App\Jobs\Workflow\RunJob;
 use App\Models\Workflow;
 use App\Models\WorkflowRun;
 use App\WorkflowActions\General\RunCommand;
-use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
-use Tests\TestCase;
 
-class WorkflowRunJobTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_run_job_failed_sets_status_to_failed_and_logs(): void
-    {
-        Log::spy();
+test('run job failed sets status to failed and logs', function () {
+    Log::spy();
 
-        /** @var Workflow $workflow */
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    /** @var Workflow $workflow */
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        /** @var WorkflowRun $run */
-        $run = WorkflowRun::factory()->create([
-            'workflow_id' => $workflow->id,
-            'user_id' => $this->user->id,
-            'status' => WorkflowRunStatus::RUNNING,
-        ]);
+    /** @var WorkflowRun $run */
+    $run = WorkflowRun::factory()->create([
+        'workflow_id' => $workflow->id,
+        'user_id' => $this->user->id,
+        'status' => WorkflowRunStatus::RUNNING,
+    ]);
 
-        $executionTree = new WorkflowActionDTO(
-            label: 'Test Action',
-            handler: 'App\\WorkflowActions\\SomeAction',
-            outputs: [],
-            inputs: [],
-            id: 'node-1',
-        );
+    $executionTree = new WorkflowActionDTO(
+        label: 'Test Action',
+        handler: 'App\\WorkflowActions\\SomeAction',
+        outputs: [],
+        inputs: [],
+        id: 'node-1',
+    );
 
-        $job = new RunJob($run, $this->user, $workflow, $executionTree, ['inputs' => []]);
-        $job->failed(new Exception('Workflow execution failed'));
+    $job = new RunJob($run, $this->user, $workflow, $executionTree, ['inputs' => []]);
+    $job->failed(new Exception('Workflow execution failed'));
 
-        $run->refresh();
+    $run->refresh();
 
-        $this->assertEquals(WorkflowRunStatus::FAILED, $run->status);
+    expect($run->status)->toEqual(WorkflowRunStatus::FAILED);
 
-        Log::shouldHaveReceived('error')
-            ->withArgs(function (string $message, array $context) {
-                return $message === 'run-workflow-failed'
-                    && $context['error'] === 'Workflow execution failed';
-            })
-            ->once();
-    }
+    Log::shouldHaveReceived('error')
+        ->withArgs(function (string $message, array $context) {
+            return $message === 'run-workflow-failed'
+                && $context['error'] === 'Workflow execution failed';
+        })
+        ->once();
+});
 
-    public function test_verbose_run_logs_command_output(): void
-    {
-        Storage::fake('server-logs');
-        SSH::fake('command-output-line');
+test('verbose run logs command output', function () {
+    Storage::fake('server-logs');
+    SSH::fake('command-output-line');
 
-        /** @var Workflow $workflow */
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    /** @var Workflow $workflow */
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        /** @var WorkflowRun $run */
-        $run = WorkflowRun::factory()->create([
-            'workflow_id' => $workflow->id,
-            'user_id' => $this->user->id,
-            'status' => WorkflowRunStatus::RUNNING,
-            'verbose' => true,
-            'log_disk' => 'server-logs',
-            'log_path' => 'workflow_run_test.log',
-        ]);
+    /** @var WorkflowRun $run */
+    $run = WorkflowRun::factory()->create([
+        'workflow_id' => $workflow->id,
+        'user_id' => $this->user->id,
+        'status' => WorkflowRunStatus::RUNNING,
+        'verbose' => true,
+        'log_disk' => 'server-logs',
+        'log_path' => 'workflow_run_test.log',
+    ]);
 
-        $executionTree = new WorkflowActionDTO(
-            label: 'Run Command',
-            handler: RunCommand::class,
-            outputs: [],
-            inputs: [
-                'server_id' => $this->server->id,
-                'command' => 'echo hello',
-                'user' => null,
-            ],
-            id: 'node-1',
-        );
+    $executionTree = new WorkflowActionDTO(
+        label: 'Run Command',
+        handler: RunCommand::class,
+        outputs: [],
+        inputs: [
+            'server_id' => $this->server->id,
+            'command' => 'echo hello',
+            'user' => null,
+        ],
+        id: 'node-1',
+    );
 
-        $job = new RunJob($run, $this->user, $workflow, $executionTree, ['inputs' => []]);
-        $job->handle();
+    $job = new RunJob($run, $this->user, $workflow, $executionTree, ['inputs' => []]);
+    $job->handle();
 
-        $run->refresh();
+    $run->refresh();
 
-        $this->assertEquals(WorkflowRunStatus::COMPLETED, $run->status);
-        $this->assertStringContainsString('command-output-line', $run->getLogContent());
-    }
+    expect($run->status)->toEqual(WorkflowRunStatus::COMPLETED);
+    $this->assertStringContainsString('command-output-line', $run->getLogContent());
+});
 
-    public function test_verbose_log_does_not_leak_after_run(): void
-    {
-        Storage::fake('server-logs');
-        SSH::fake('command-output-line');
+test('verbose log does not leak after run', function () {
+    Storage::fake('server-logs');
+    SSH::fake('command-output-line');
 
-        /** @var Workflow $workflow */
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    /** @var Workflow $workflow */
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        /** @var WorkflowRun $run */
-        $run = WorkflowRun::factory()->create([
-            'workflow_id' => $workflow->id,
-            'user_id' => $this->user->id,
-            'status' => WorkflowRunStatus::RUNNING,
-            'verbose' => true,
-            'log_disk' => 'server-logs',
-            'log_path' => 'workflow_run_test.log',
-        ]);
+    /** @var WorkflowRun $run */
+    $run = WorkflowRun::factory()->create([
+        'workflow_id' => $workflow->id,
+        'user_id' => $this->user->id,
+        'status' => WorkflowRunStatus::RUNNING,
+        'verbose' => true,
+        'log_disk' => 'server-logs',
+        'log_path' => 'workflow_run_test.log',
+    ]);
 
-        $executionTree = new WorkflowActionDTO(
-            label: 'Run Command',
-            handler: RunCommand::class,
-            outputs: [],
-            inputs: [
-                'server_id' => $this->server->id,
-                'command' => 'echo hello',
-                'user' => null,
-            ],
-            id: 'node-1',
-        );
+    $executionTree = new WorkflowActionDTO(
+        label: 'Run Command',
+        handler: RunCommand::class,
+        outputs: [],
+        inputs: [
+            'server_id' => $this->server->id,
+            'command' => 'echo hello',
+            'user' => null,
+        ],
+        id: 'node-1',
+    );
 
-        $job = new RunJob($run, $this->user, $workflow, $executionTree, ['inputs' => []]);
-        $job->handle();
+    $job = new RunJob($run, $this->user, $workflow, $executionTree, ['inputs' => []]);
+    $job->handle();
 
-        $this->server->ssh()->exec('echo after-run');
+    $this->server->ssh()->exec('echo after-run');
 
-        $this->assertStringNotContainsString('after-run', $run->refresh()->getLogContent());
-    }
-}
+    $this->assertStringNotContainsString('after-run', $run->refresh()->getLogContent());
+});

--- a/tests/Feature/LoadBalancerTest.php
+++ b/tests/Feature/LoadBalancerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\Site\UpdateLoadBalancer;
 use App\Enums\LoadBalancerMethod;
 use App\Facades\SSH;
@@ -9,187 +7,177 @@ use App\Models\Project;
 use App\Models\Server;
 use App\Models\Site;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 use Tests\Traits\PrepareLoadBalancer;
 
-class LoadBalancerTest extends TestCase
-{
-    use PrepareLoadBalancer;
-    use RefreshDatabase;
+uses(PrepareLoadBalancer::class);
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+uses(RefreshDatabase::class);
 
-        $this->prepare();
-    }
+beforeEach(function () {
+    $this->prepare();
+});
 
-    public function test_update_load_balancer_servers(): void
-    {
-        SSH::fake();
+test('update load balancer servers', function () {
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $servers = Server::query()->where('id', '!=', $this->server->id)->get();
-        $this->assertEquals(2, $servers->count());
+    $servers = Server::query()->where('id', '!=', $this->server->id)->get();
+    expect($servers->count())->toEqual(2);
 
-        $this->post(route('application.update-load-balancer', [
-            'server' => $this->server->id,
-            'site' => $this->site->id,
-        ]), [
-            'method' => LoadBalancerMethod::ROUND_ROBIN->value,
-            'servers' => [
-                [
-                    'ip' => $servers[0]->local_ip,
-                    'port' => 80,
-                    'weight' => 1,
-                    'backup' => false,
-                ],
-                [
-                    'ip' => $servers[1]->local_ip,
-                    'port' => 80,
-                    'weight' => 1,
-                    'backup' => false,
-                ],
+    $this->post(route('application.update-load-balancer', [
+        'server' => $this->server->id,
+        'site' => $this->site->id,
+    ]), [
+        'method' => LoadBalancerMethod::ROUND_ROBIN->value,
+        'servers' => [
+            [
+                'ip' => $servers[0]->local_ip,
+                'port' => 80,
+                'weight' => 1,
+                'backup' => false,
             ],
-        ])
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('load_balancer_servers', [
-            'load_balancer_id' => $this->site->id,
-            'ip' => $servers[0]->local_ip,
-            'port' => 80,
-            'weight' => 1,
-            'backup' => false,
-        ]);
-        $this->assertDatabaseHas('load_balancer_servers', [
-            'load_balancer_id' => $this->site->id,
-            'ip' => $servers[1]->local_ip,
-            'port' => 80,
-            'weight' => 1,
-            'backup' => false,
-        ]);
-    }
-
-    public function test_updates_load_balancer_method_in_type_data(): void
-    {
-        $project = Project::factory()->create();
-        $server = Server::factory()->create(['project_id' => $project->id]);
-        $site = Site::factory()->create([
-            'server_id' => $server->id,
-            'type' => 'load-balancer',
-            'type_data' => ['method' => LoadBalancerMethod::ROUND_ROBIN->value],
-        ]);
-
-        $input = [
-            'method' => LoadBalancerMethod::LEAST_CONNECTIONS->value,
-            'servers' => [
-                [
-                    'ip' => $server->local_ip,
-                    'port' => 80,
-                    'weight' => 1,
-                    'backup' => false,
-                ],
+            [
+                'ip' => $servers[1]->local_ip,
+                'port' => 80,
+                'weight' => 1,
+                'backup' => false,
             ],
-        ];
+        ],
+    ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
 
-        /** @var Site $site */
-        $site = \Mockery::mock($site)->makePartial();
-        $site->shouldReceive('webserver->updateVHost')->andReturn();
+    $this->assertDatabaseHas('load_balancer_servers', [
+        'load_balancer_id' => $this->site->id,
+        'ip' => $servers[0]->local_ip,
+        'port' => 80,
+        'weight' => 1,
+        'backup' => false,
+    ]);
+    $this->assertDatabaseHas('load_balancer_servers', [
+        'load_balancer_id' => $this->site->id,
+        'ip' => $servers[1]->local_ip,
+        'port' => 80,
+        'weight' => 1,
+        'backup' => false,
+    ]);
+});
 
-        app(UpdateLoadBalancer::class)->update($site, $input);
+test('updates load balancer method in type data', function () {
+    $project = Project::factory()->create();
+    $server = Server::factory()->create(['project_id' => $project->id]);
+    $site = Site::factory()->create([
+        'server_id' => $server->id,
+        'type' => 'load-balancer',
+        'type_data' => ['method' => LoadBalancerMethod::ROUND_ROBIN->value],
+    ]);
 
-        $site->refresh();
-        $this->assertEquals(LoadBalancerMethod::LEAST_CONNECTIONS->value, $site->type_data['method']);
-    }
-
-    public function test_creates_load_balancer_servers(): void
-    {
-        $project = Project::factory()->create();
-        $server = Server::factory()->create(['project_id' => $project->id]);
-        $site = Site::factory()->create([
-            'server_id' => $server->id,
-            'type' => 'load-balancer',
-            'type_data' => ['method' => LoadBalancerMethod::ROUND_ROBIN->value],
-        ]);
-
-        $input = [
-            'method' => LoadBalancerMethod::ROUND_ROBIN->value,
-            'servers' => [
-                [
-                    'ip' => $server->local_ip,
-                    'port' => 80,
-                    'weight' => 1,
-                    'backup' => false,
-                ],
-                [
-                    'ip' => $server->local_ip,
-                    'port' => 8080,
-                    'weight' => 2,
-                    'backup' => true,
-                ],
+    $input = [
+        'method' => LoadBalancerMethod::LEAST_CONNECTIONS->value,
+        'servers' => [
+            [
+                'ip' => $server->local_ip,
+                'port' => 80,
+                'weight' => 1,
+                'backup' => false,
             ],
-        ];
+        ],
+    ];
 
-        /** @var Site $site */
-        $site = \Mockery::mock($site)->makePartial();
-        $site->shouldReceive('webserver->updateVHost')->andReturn();
+    /** @var Site $site */
+    $site = Mockery::mock($site)->makePartial();
+    $site->shouldReceive('webserver->updateVHost')->andReturn();
 
-        app(UpdateLoadBalancer::class)->update($site, $input);
+    app(UpdateLoadBalancer::class)->update($site, $input);
 
-        $this->assertCount(2, $site->loadBalancerServers);
+    $site->refresh();
+    expect($site->type_data['method'])->toEqual(LoadBalancerMethod::LEAST_CONNECTIONS->value);
+});
 
-        $firstServer = $site->loadBalancerServers->first();
-        $this->assertEquals($server->local_ip, $firstServer->ip);
-        $this->assertEquals(80, $firstServer->port);
-        $this->assertEquals(1, $firstServer->weight);
-        $this->assertFalse($firstServer->backup);
+test('creates load balancer servers', function () {
+    $project = Project::factory()->create();
+    $server = Server::factory()->create(['project_id' => $project->id]);
+    $site = Site::factory()->create([
+        'server_id' => $server->id,
+        'type' => 'load-balancer',
+        'type_data' => ['method' => LoadBalancerMethod::ROUND_ROBIN->value],
+    ]);
 
-        $secondServer = $site->loadBalancerServers->last();
-        $this->assertEquals($server->local_ip, $secondServer->ip);
-        $this->assertEquals(8080, $secondServer->port);
-        $this->assertEquals(2, $secondServer->weight);
-        $this->assertTrue($secondServer->backup);
-    }
-
-    public function test_deletes_existing_load_balancer_servers_before_creating_new_ones(): void
-    {
-        $project = Project::factory()->create();
-        $server = Server::factory()->create(['project_id' => $project->id]);
-        $site = Site::factory()->create([
-            'server_id' => $server->id,
-            'type' => 'load-balancer',
-            'type_data' => ['method' => LoadBalancerMethod::ROUND_ROBIN->value],
-        ]);
-
-        // Create existing load balancer servers
-        $site->loadBalancerServers()->create([
-            'ip' => '192.168.1.1',
-            'port' => 80,
-            'weight' => 1,
-            'backup' => false,
-        ]);
-
-        $input = [
-            'method' => LoadBalancerMethod::ROUND_ROBIN->value,
-            'servers' => [
-                [
-                    'ip' => $server->local_ip,
-                    'port' => 80,
-                    'weight' => 1,
-                    'backup' => false,
-                ],
+    $input = [
+        'method' => LoadBalancerMethod::ROUND_ROBIN->value,
+        'servers' => [
+            [
+                'ip' => $server->local_ip,
+                'port' => 80,
+                'weight' => 1,
+                'backup' => false,
             ],
-        ];
+            [
+                'ip' => $server->local_ip,
+                'port' => 8080,
+                'weight' => 2,
+                'backup' => true,
+            ],
+        ],
+    ];
 
-        /** @var Site $site */
-        $site = \Mockery::mock($site)->makePartial();
-        $site->shouldReceive('webserver->updateVHost')->andReturn();
+    /** @var Site $site */
+    $site = Mockery::mock($site)->makePartial();
+    $site->shouldReceive('webserver->updateVHost')->andReturn();
 
-        app(UpdateLoadBalancer::class)->update($site, $input);
+    app(UpdateLoadBalancer::class)->update($site, $input);
 
-        $this->assertCount(1, $site->loadBalancerServers);
-        $this->assertEquals($server->local_ip, $site->loadBalancerServers->first()->ip);
-    }
-}
+    expect($site->loadBalancerServers)->toHaveCount(2);
+
+    $firstServer = $site->loadBalancerServers->first();
+    expect($firstServer->ip)->toEqual($server->local_ip);
+    expect($firstServer->port)->toEqual(80);
+    expect($firstServer->weight)->toEqual(1);
+    expect($firstServer->backup)->toBeFalse();
+
+    $secondServer = $site->loadBalancerServers->last();
+    expect($secondServer->ip)->toEqual($server->local_ip);
+    expect($secondServer->port)->toEqual(8080);
+    expect($secondServer->weight)->toEqual(2);
+    expect($secondServer->backup)->toBeTrue();
+});
+
+test('deletes existing load balancer servers before creating new ones', function () {
+    $project = Project::factory()->create();
+    $server = Server::factory()->create(['project_id' => $project->id]);
+    $site = Site::factory()->create([
+        'server_id' => $server->id,
+        'type' => 'load-balancer',
+        'type_data' => ['method' => LoadBalancerMethod::ROUND_ROBIN->value],
+    ]);
+
+    // Create existing load balancer servers
+    $site->loadBalancerServers()->create([
+        'ip' => '192.168.1.1',
+        'port' => 80,
+        'weight' => 1,
+        'backup' => false,
+    ]);
+
+    $input = [
+        'method' => LoadBalancerMethod::ROUND_ROBIN->value,
+        'servers' => [
+            [
+                'ip' => $server->local_ip,
+                'port' => 80,
+                'weight' => 1,
+                'backup' => false,
+            ],
+        ],
+    ];
+
+    /** @var Site $site */
+    $site = Mockery::mock($site)->makePartial();
+    $site->shouldReceive('webserver->updateVHost')->andReturn();
+
+    app(UpdateLoadBalancer::class)->update($site, $input);
+
+    expect($site->loadBalancerServers)->toHaveCount(1);
+    expect($site->loadBalancerServers->first()->ip)->toEqual($server->local_ip);
+});

--- a/tests/Feature/LogsTest.php
+++ b/tests/Feature/LogsTest.php
@@ -1,95 +1,84 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Facades\SSH;
 use App\Models\ServerLog;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class LogsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_see_logs(): void
-    {
-        $this->actingAs($this->user);
+test('see logs', function () {
+    $this->actingAs($this->user);
 
-        ServerLog::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+    ServerLog::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        $this->get(route('logs', $this->server))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('server-logs/index'));
-    }
+    $this->get(route('logs', $this->server))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('server-logs/index'));
+});
 
-    public function test_see_logs_remote(): void
-    {
-        $this->actingAs($this->user);
+test('see logs remote', function () {
+    $this->actingAs($this->user);
 
-        ServerLog::factory()->create([
-            'server_id' => $this->server->id,
-            'is_remote' => true,
-            'type' => 'remote',
-            'name' => 'see-remote-log',
-        ]);
+    ServerLog::factory()->create([
+        'server_id' => $this->server->id,
+        'is_remote' => true,
+        'type' => 'remote',
+        'name' => 'see-remote-log',
+    ]);
 
-        $this->get(route('logs.remote', $this->server))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('server-logs/index'));
-    }
+    $this->get(route('logs.remote', $this->server))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('server-logs/index'));
+});
 
-    public function test_create_remote_log(): void
-    {
-        $this->actingAs($this->user);
+test('create remote log', function () {
+    $this->actingAs($this->user);
 
-        $this->post(route('logs.store', $this->server), [
-            'path' => 'test-path',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('logs.store', $this->server), [
+        'path' => 'test-path',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('server_logs', [
-            'is_remote' => true,
-            'name' => 'test-path',
-        ]);
-    }
+    $this->assertDatabaseHas('server_logs', [
+        'is_remote' => true,
+        'name' => 'test-path',
+    ]);
+});
 
-    public function test_clear_remote_log(): void
-    {
-        $this->actingAs($this->user);
+test('clear remote log', function () {
+    $this->actingAs($this->user);
 
-        $log = ServerLog::factory()->create([
-            'server_id' => $this->server->id,
-            'is_remote' => true,
-            'type' => 'remote',
-            'name' => 'test-remote-log',
-        ]);
+    $log = ServerLog::factory()->create([
+        'server_id' => $this->server->id,
+        'is_remote' => true,
+        'type' => 'remote',
+        'name' => 'test-remote-log',
+    ]);
 
-        // Mock the SSH connection to avoid actual SSH calls
-        SSH::fake();
+    // Mock the SSH connection to avoid actual SSH calls
+    SSH::fake();
 
-        $this->post(route('logs.clear', [$this->server, 'log' => $log->id]))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Log cleared successfully');
-    }
+    $this->post(route('logs.clear', [$this->server, 'log' => $log->id]))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Log cleared successfully');
+});
 
-    public function test_unauthorized_user_cannot_clear_log(): void
-    {
-        /** @var User $unauthorizedUser */
-        $unauthorizedUser = User::factory()->create();
-        $this->actingAs($unauthorizedUser);
+test('unauthorized user cannot clear log', function () {
+    /** @var User $unauthorizedUser */
+    $unauthorizedUser = User::factory()->create();
+    $this->actingAs($unauthorizedUser);
 
-        $log = ServerLog::factory()->create([
-            'server_id' => $this->server->id,
-            'is_remote' => true,
-            'type' => 'remote',
-            'name' => 'test-remote-log',
-        ]);
+    $log = ServerLog::factory()->create([
+        'server_id' => $this->server->id,
+        'is_remote' => true,
+        'type' => 'remote',
+        'name' => 'test-remote-log',
+    ]);
 
-        $this->post(route('logs.clear', [$this->server, 'log' => $log->id]))
-            ->assertForbidden();
-    }
-}
+    $this->post(route('logs.clear', [$this->server, 'log' => $log->id]))
+        ->assertForbidden();
+});

--- a/tests/Feature/MetricsTest.php
+++ b/tests/Feature/MetricsTest.php
@@ -1,140 +1,129 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\ServiceStatus;
 use App\Models\Metric;
 use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class MetricsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_visit_metrics(): void
-    {
-        $this->actingAs($this->user);
+test('visit metrics', function () {
+    $this->actingAs($this->user);
 
-        Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'vito-agent',
-            'type' => 'monitoring',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
+    Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'vito-agent',
+        'type' => 'monitoring',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
 
-        $this->get(route('monitoring', $this->server))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('monitoring/index'));
-    }
+    $this->get(route('monitoring', $this->server))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('monitoring/index'));
+});
 
-    public function test_update_data_retention(): void
-    {
-        $this->actingAs($this->user);
+test('update data retention', function () {
+    $this->actingAs($this->user);
 
-        Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'vito-agent',
-            'type' => 'monitoring',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
+    Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'vito-agent',
+        'type' => 'monitoring',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
 
-        $this->patch(route('monitoring.update', $this->server), [
-            'data_retention' => 365,
+    $this->patch(route('monitoring.update', $this->server), [
+        'data_retention' => 365,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('services', [
+        'server_id' => $this->server->id,
+        'type' => 'monitoring',
+        'type_data->data_retention' => 365,
+    ]);
+});
+
+test('monitoring json returns current and history', function () {
+    $this->actingAs($this->user);
+
+    Metric::factory()->create([
+        'server_id' => $this->server->id,
+        'cpu_cores' => 4,
+        'cpu_physical_cores' => 2,
+        'cpu_usage_percent' => 12.34,
+        'memory_total' => 2000,
+        'memory_used' => 1010,
+        'memory_free' => 990,
+        'swap_used_percent' => 0,
+        'disk_total' => 1000,
+        'disk_used' => 250,
+        'disk_free' => 750,
+        'uptime_seconds' => 3600,
+        'reboot_required' => false,
+    ]);
+
+    $response = $this->getJson(route('monitoring.json', ['server' => $this->server, 'period' => '10m']));
+
+    $response->assertSuccessful()
+        ->assertJsonStructure([
+            'current' => [
+                'date',
+                'cpu_cores',
+                'cpu_physical_cores',
+                'cpu_usage_percent',
+                'memory_used_percent',
+                'swap_used_percent',
+                'disk_used_percent',
+                'uptime_seconds',
+                'reboot_required',
+            ],
+            'history' => [],
         ])
-            ->assertSessionDoesntHaveErrors();
+        ->assertJsonPath('current.cpu_cores', 4)
+        ->assertJsonPath('current.cpu_usage_percent', 12.34)
+        ->assertJsonPath('current.disk_used_percent', 25)
+        ->assertJsonPath('current.memory_used_percent', 50.5)
+        ->assertJsonPath('current.uptime_seconds', 3600);
 
-        $this->assertDatabaseHas('services', [
-            'server_id' => $this->server->id,
-            'type' => 'monitoring',
-            'type_data->data_retention' => 365,
-        ]);
+    $history = $response->json('history');
+    expect($history)->toBeArray();
+    expect($history)->not->toBeEmpty();
+    foreach (['cpu_cores', 'cpu_physical_cores', 'uptime_seconds', 'reboot_required', 'date_interval'] as $excluded) {
+        $this->assertArrayNotHasKey($excluded, $history[0]);
     }
+    expect($history[0])->toHaveKey('load');
+    expect($history[0])->toHaveKey('cpu_usage_percent');
+    expect($history[0])->toHaveKey('disk_used_percent');
+    expect($history[0]['disk_used_percent'])->toEqual(25.0);
+    expect($history[0])->toHaveKey('memory_used_percent');
+    expect($history[0]['memory_used_percent'])->toEqual(50.5);
 
-    public function test_monitoring_json_returns_current_and_history(): void
-    {
-        $this->actingAs($this->user);
-
-        Metric::factory()->create([
-            'server_id' => $this->server->id,
-            'cpu_cores' => 4,
-            'cpu_physical_cores' => 2,
-            'cpu_usage_percent' => 12.34,
-            'memory_total' => 2000,
-            'memory_used' => 1010,
-            'memory_free' => 990,
-            'swap_used_percent' => 0,
-            'disk_total' => 1000,
-            'disk_used' => 250,
-            'disk_free' => 750,
-            'uptime_seconds' => 3600,
-            'reboot_required' => false,
-        ]);
-
-        $response = $this->getJson(route('monitoring.json', ['server' => $this->server, 'period' => '10m']));
-
-        $response->assertSuccessful()
-            ->assertJsonStructure([
-                'current' => [
-                    'date',
-                    'cpu_cores',
-                    'cpu_physical_cores',
-                    'cpu_usage_percent',
-                    'memory_used_percent',
-                    'swap_used_percent',
-                    'disk_used_percent',
-                    'uptime_seconds',
-                    'reboot_required',
-                ],
-                'history' => [],
-            ])
-            ->assertJsonPath('current.cpu_cores', 4)
-            ->assertJsonPath('current.cpu_usage_percent', 12.34)
-            ->assertJsonPath('current.disk_used_percent', 25)
-            ->assertJsonPath('current.memory_used_percent', 50.5)
-            ->assertJsonPath('current.uptime_seconds', 3600);
-
-        $history = $response->json('history');
-        $this->assertIsArray($history);
-        $this->assertNotEmpty($history);
-        foreach (['cpu_cores', 'cpu_physical_cores', 'uptime_seconds', 'reboot_required', 'date_interval'] as $excluded) {
-            $this->assertArrayNotHasKey($excluded, $history[0]);
-        }
-        $this->assertArrayHasKey('load', $history[0]);
-        $this->assertArrayHasKey('cpu_usage_percent', $history[0]);
-        $this->assertArrayHasKey('disk_used_percent', $history[0]);
-        $this->assertEquals(25.0, $history[0]['disk_used_percent']);
-        $this->assertArrayHasKey('memory_used_percent', $history[0]);
-        $this->assertEquals(50.5, $history[0]['memory_used_percent']);
-
-        foreach (['load', 'memory_total', 'cpu_usage_percent', 'disk_used_percent'] as $key) {
-            if ($history[0][$key] !== null) {
-                $this->assertIsNumeric($history[0][$key], "history.0.{$key} should be numeric (not a string)");
-                $this->assertIsNotString($history[0][$key], "history.0.{$key} must not be serialised as a JSON string");
-            }
+    foreach (['load', 'memory_total', 'cpu_usage_percent', 'disk_used_percent'] as $key) {
+        if ($history[0][$key] !== null) {
+            expect($history[0][$key])->toBeNumeric("history.0.{$key} should be numeric (not a string)");
+            $this->assertIsNotString($history[0][$key], "history.0.{$key} must not be serialised as a JSON string");
         }
     }
+});
 
-    public function test_monitoring_json_returns_null_current_when_no_metrics(): void
-    {
-        $this->actingAs($this->user);
+test('monitoring json returns null current when no metrics', function () {
+    $this->actingAs($this->user);
 
-        $this->getJson(route('monitoring.json', ['server' => $this->server, 'period' => '10m']))
-            ->assertSuccessful()
-            ->assertJsonPath('current', null)
-            ->assertJsonPath('history', []);
-    }
+    $this->getJson(route('monitoring.json', ['server' => $this->server, 'period' => '10m']))
+        ->assertSuccessful()
+        ->assertJsonPath('current', null)
+        ->assertJsonPath('history', []);
+});
 
-    public function test_monitoring_json_defaults_period_when_missing(): void
-    {
-        $this->actingAs($this->user);
+test('monitoring json defaults period when missing', function () {
+    $this->actingAs($this->user);
 
-        $this->getJson(route('monitoring.json', ['server' => $this->server]))
-            ->assertSuccessful()
-            ->assertJsonPath('current', null)
-            ->assertJsonPath('history', []);
-    }
-}
+    $this->getJson(route('monitoring.json', ['server' => $this->server]))
+        ->assertSuccessful()
+        ->assertJsonPath('current', null)
+        ->assertJsonPath('history', []);
+});

--- a/tests/Feature/ModernDeploymentTest.php
+++ b/tests/Feature/ModernDeploymentTest.php
@@ -1,144 +1,134 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Facades\SSH;
 use App\SiteTypes\Laravel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
-use Tests\TestCase;
 
-class ModernDeploymentTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_enable_modern_deployment(): void
-    {
-        SSH::fake();
+test('enable modern deployment', function () {
+    SSH::fake();
 
-        Http::fake([
-            'https://api.github.com/repos/*' => Http::response([
-            ], 201),
-        ]);
+    Http::fake([
+        'https://api.github.com/repos/*' => Http::response([
+        ], 201),
+    ]);
 
-        $this->site->update([
-            'type' => Laravel::id(),
-        ]);
+    $this->site->update([
+        'type' => Laravel::id(),
+    ]);
 
-        $this->actingAs($this->user)
-            ->post(route('site-features.action', [
-                'server' => $this->server,
-                'site' => $this->site,
-                'feature' => 'modern-deployment',
-                'action' => 'enable',
-            ]), [
-                'shared_resources' => '.env',
-                'history' => 10,
-            ])
-            ->assertRedirect();
+    $this->actingAs($this->user)
+        ->post(route('site-features.action', [
+            'server' => $this->server,
+            'site' => $this->site,
+            'feature' => 'modern-deployment',
+            'action' => 'enable',
+        ]), [
+            'shared_resources' => '.env',
+            'history' => 10,
+        ])
+        ->assertRedirect();
 
-        $this->site->refresh();
+    $this->site->refresh();
 
-        $this->assertTrue($this->site->type_data['modern_deployment']);
-        $this->assertEquals('10', $this->site->type_data['modern_deployment_history']);
-        $this->assertEquals(['.env'], $this->site->type_data['modern_deployment_shared_resources']);
-    }
+    expect($this->site->type_data['modern_deployment'])->toBeTrue();
+    expect($this->site->type_data['modern_deployment_history'])->toEqual('10');
+    expect($this->site->type_data['modern_deployment_shared_resources'])->toEqual(['.env']);
+});
 
-    public function test_enabling_modern_deployment_inherits_restart_workers_flag_into_pre_flight(): void
-    {
-        SSH::fake();
+test('enabling modern deployment inherits restart workers flag into pre flight', function () {
+    SSH::fake();
 
-        Http::fake([
-            'https://api.github.com/repos/*' => Http::response([], 201),
-        ]);
+    Http::fake([
+        'https://api.github.com/repos/*' => Http::response([], 201),
+    ]);
 
-        $this->site->update([
-            'type' => Laravel::id(),
-        ]);
-        $this->site->ensureDeploymentScriptsExist();
-        $this->site->deploymentScript->update(['configs' => ['restart_workers' => true]]);
+    $this->site->update([
+        'type' => Laravel::id(),
+    ]);
+    $this->site->ensureDeploymentScriptsExist();
+    $this->site->deploymentScript->update(['configs' => ['restart_workers' => true]]);
 
-        $this->actingAs($this->user)
-            ->post(route('site-features.action', [
-                'server' => $this->server,
-                'site' => $this->site,
-                'feature' => 'modern-deployment',
-                'action' => 'enable',
-            ]), [
-                'shared_resources' => '.env',
-                'history' => 10,
-            ])
-            ->assertRedirect();
+    $this->actingAs($this->user)
+        ->post(route('site-features.action', [
+            'server' => $this->server,
+            'site' => $this->site,
+            'feature' => 'modern-deployment',
+            'action' => 'enable',
+        ]), [
+            'shared_resources' => '.env',
+            'history' => 10,
+        ])
+        ->assertRedirect();
 
-        $this->site->refresh();
+    $this->site->refresh();
 
-        $this->assertNotNull($this->site->preFlightScript);
-        $this->assertTrue($this->site->preFlightScript->shouldRestartWorkers());
-        $this->assertTrue($this->site->deploymentScriptFor(true)->shouldRestartWorkers());
-        $this->assertTrue($this->site->deploymentScriptFor(false)->shouldRestartWorkers());
-    }
+    expect($this->site->preFlightScript)->not->toBeNull();
+    expect($this->site->preFlightScript->shouldRestartWorkers())->toBeTrue();
+    expect($this->site->deploymentScriptFor(true)->shouldRestartWorkers())->toBeTrue();
+    expect($this->site->deploymentScriptFor(false)->shouldRestartWorkers())->toBeTrue();
+});
 
-    public function test_disable_modern_deployment(): void
-    {
-        SSH::fake();
+test('disable modern deployment', function () {
+    SSH::fake();
 
-        Http::fake([
-            'https://api.github.com/repos/*' => Http::response([
-            ], 201),
-        ]);
+    Http::fake([
+        'https://api.github.com/repos/*' => Http::response([
+        ], 201),
+    ]);
 
-        $this->site->update([
-            'type' => Laravel::id(),
-            'type_data' => [
-                'modern_deployment' => true,
-                'modern_deployment_history' => 10,
-                'modern_deployment_shared_resources' => ['.env'],
-            ],
-        ]);
+    $this->site->update([
+        'type' => Laravel::id(),
+        'type_data' => [
+            'modern_deployment' => true,
+            'modern_deployment_history' => 10,
+            'modern_deployment_shared_resources' => ['.env'],
+        ],
+    ]);
 
-        $this->actingAs($this->user)
-            ->post(route('site-features.action', [
-                'server' => $this->server,
-                'site' => $this->site,
-                'feature' => 'modern-deployment',
-                'action' => 'disable',
-            ]))
-            ->assertRedirect();
+    $this->actingAs($this->user)
+        ->post(route('site-features.action', [
+            'server' => $this->server,
+            'site' => $this->site,
+            'feature' => 'modern-deployment',
+            'action' => 'disable',
+        ]))
+        ->assertRedirect();
 
-        $this->site->refresh();
+    $this->site->refresh();
 
-        $this->assertFalse($this->site->type_data['modern_deployment'] ?? false);
-        $this->assertArrayNotHasKey('modern_deployment_history', $this->site->type_data);
-        $this->assertArrayNotHasKey('modern_deployment_shared_resources', $this->site->type_data);
-    }
+    expect($this->site->type_data['modern_deployment'] ?? false)->toBeFalse();
+    $this->assertArrayNotHasKey('modern_deployment_history', $this->site->type_data);
+    $this->assertArrayNotHasKey('modern_deployment_shared_resources', $this->site->type_data);
+});
 
-    public function test_configure_modern_deployment(): void
-    {
-        $this->site->update([
-            'type' => Laravel::id(),
-            'type_data' => [
-                'modern_deployment' => true,
-                'modern_deployment_history' => 10,
-                'modern_deployment_shared_resources' => ['.env'],
-            ],
-        ]);
+test('configure modern deployment', function () {
+    $this->site->update([
+        'type' => Laravel::id(),
+        'type_data' => [
+            'modern_deployment' => true,
+            'modern_deployment_history' => 10,
+            'modern_deployment_shared_resources' => ['.env'],
+        ],
+    ]);
 
-        $this->actingAs($this->user)
-            ->post(route('site-features.action', [
-                'server' => $this->server,
-                'site' => $this->site,
-                'feature' => 'modern-deployment',
-                'action' => 'configuration',
-            ]), [
-                'shared_resources' => '.env,.env.local',
-                'history' => 5,
-            ])
-            ->assertRedirect();
+    $this->actingAs($this->user)
+        ->post(route('site-features.action', [
+            'server' => $this->server,
+            'site' => $this->site,
+            'feature' => 'modern-deployment',
+            'action' => 'configuration',
+        ]), [
+            'shared_resources' => '.env,.env.local',
+            'history' => 5,
+        ])
+        ->assertRedirect();
 
-        $this->site->refresh();
+    $this->site->refresh();
 
-        $this->assertTrue($this->site->type_data['modern_deployment']);
-        $this->assertEquals('5', $this->site->type_data['modern_deployment_history']);
-        $this->assertEquals(['.env', '.env.local'], $this->site->type_data['modern_deployment_shared_resources']);
-    }
-}
+    expect($this->site->type_data['modern_deployment'])->toBeTrue();
+    expect($this->site->type_data['modern_deployment_history'])->toEqual('5');
+    expect($this->site->type_data['modern_deployment_shared_resources'])->toEqual(['.env', '.env.local']);
+});

--- a/tests/Feature/NetworkFirewallTest.php
+++ b/tests/Feature/NetworkFirewallTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\FirewallRule\ManageRule;
 use App\Actions\Network\CreateNetwork;
 use App\Actions\Network\ManageNetworkFirewallRule;
@@ -22,606 +20,550 @@ use App\Models\ServerNetworkRule;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Validation\ValidationException;
 use Inertia\Testing\AssertableInertia;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class NetworkFirewallTest extends TestCase
+uses(RefreshDatabase::class);
+
+/**
+ * @param  array<int, int>  $servers
+ */
+function vitoPestFeatureNetworkFirewallTestWireguardNetwork(array $servers): Network
 {
-    use RefreshDatabase;
-
-    /**
-     * @param  array<int, int>  $servers
-     */
-    private function wireguardNetwork(array $servers): Network
-    {
-        return app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => $servers,
-        ]);
-    }
-
-    public function test_network_is_seeded_with_a_default_allow_all_rule(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = $this->wireguardNetwork([$this->server->id]);
-
-        $this->assertDatabaseHas('network_firewall_rules', [
-            'network_id' => $network->id,
-            'name' => 'Allow all',
-            'protocol' => null,
-            'port' => null,
-        ]);
-    }
-
-    public function test_wireguard_handshake_port_is_opened(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $peer = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
-
-        $this->wireguardNetwork([$this->server->id, $peer->id]);
-
-        SSH::assertExecutedContains('proto udp port 51820');
-    }
-
-    public function test_default_allow_all_rule_emits_catch_all(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $this->wireguardNetwork([$this->server->id]);
-
-        SSH::assertExecutedContains('allow from 100.64.0.0/24 to any');
-    }
-
-    public function test_allow_rule_is_emitted_scoped_to_the_network_cidr(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = $this->wireguardNetwork([$this->server->id]);
-
-        app(ManageNetworkFirewallRule::class)->create($network, [
-            'name' => 'mysql',
-            'protocol' => 'tcp',
-            'port' => '3306',
-        ]);
-
-        SSH::assertExecutedContains('allow from 100.64.0.0/24 to any proto tcp port 3306');
-        $this->assertDatabaseHas('network_firewall_rules', [
-            'network_id' => $network->id,
-            'name' => 'mysql',
-            'port' => '3306',
-        ]);
-    }
-
-    public function test_network_rules_are_not_stored_as_server_firewall_rules(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = $this->wireguardNetwork([$this->server->id]);
-        app(ManageNetworkFirewallRule::class)->create($network, [
-            'name' => 'mysql',
-            'protocol' => 'tcp',
-            'port' => '3306',
-        ]);
-
-        $this->assertSame(0, $this->server->firewallRules()->count());
-    }
-
-    public function test_server_firewall_page_exposes_managed_networks(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = $this->wireguardNetwork([$this->server->id]);
-
-        $this->actingAs($this->user);
-
-        $this->get(route('firewall', ['server' => $this->server]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('firewall/index')
-                ->where('networkRules.data.0.network_id', $network->id)
-                ->where('networkRules.data.0.name', 'Allow all'));
-    }
+    return app(CreateNetwork::class)->create(test()->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => $servers,
+    ]);
+}
+
+test('network is seeded with a default allow all rule', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id]);
+
+    $this->assertDatabaseHas('network_firewall_rules', [
+        'network_id' => $network->id,
+        'name' => 'Allow all',
+        'protocol' => null,
+        'port' => null,
+    ]);
+});
+
+test('wireguard handshake port is opened', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $peer = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
+
+    vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id, $peer->id]);
+
+    SSH::assertExecutedContains('proto udp port 51820');
+});
+
+test('default allow all rule emits catch all', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id]);
+
+    SSH::assertExecutedContains('allow from 100.64.0.0/24 to any');
+});
+
+test('allow rule is emitted scoped to the network cidr', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id]);
+
+    app(ManageNetworkFirewallRule::class)->create($network, [
+        'name' => 'mysql',
+        'protocol' => 'tcp',
+        'port' => '3306',
+    ]);
+
+    SSH::assertExecutedContains('allow from 100.64.0.0/24 to any proto tcp port 3306');
+    $this->assertDatabaseHas('network_firewall_rules', [
+        'network_id' => $network->id,
+        'name' => 'mysql',
+        'port' => '3306',
+    ]);
+});
+
+test('network rules are not stored as server firewall rules', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id]);
+    app(ManageNetworkFirewallRule::class)->create($network, [
+        'name' => 'mysql',
+        'protocol' => 'tcp',
+        'port' => '3306',
+    ]);
 
-    public function test_leaving_member_network_is_not_listed_as_managed(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
+    expect($this->server->firewallRules()->count())->toBe(0);
+});
 
-        $network = $this->wireguardNetwork([$this->server->id]);
-        $network->servers()->update(['status' => NetworkServerStatus::LEAVING]);
+test('server firewall page exposes managed networks', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
 
-        $this->actingAs($this->user);
-
-        $this->get(route('firewall', ['server' => $this->server]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('firewall/index')
-                ->count('networkRules.data', 0));
-    }
-
-    public function test_server_level_firewall_change_reapplies_network_rules(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $this->wireguardNetwork([$this->server->id]);
-
-        app(ManageRule::class)->create($this->server, [
-            'name' => 'ssh',
-            'type' => 'allow',
-            'protocol' => 'tcp',
-            'port' => '22',
-        ]);
-
-        SSH::assertExecutedContains('allow from 100.64.0.0/24 to any');
-    }
-
-    public function test_installing_ufw_opens_wireguard_handshake_for_existing_member(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $peer = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
-
-        $this->wireguardNetwork([$this->server->id, $peer->id]);
-
-        SSH::fake();
-        $this->server->firewall()->handler()->install();
-
-        SSH::assertExecutedContains('from '.$peer->ip.'/32 to any proto udp port 51820');
-    }
-
-    public function test_failed_firewall_apply_marks_member_failed(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = $this->wireguardNetwork([$this->server->id]);
-        $member = $network->servers()->firstOrFail();
-
-        (new ApplyNetworkFirewallJob($member))->failed(new \RuntimeException('boom'));
-
-        $this->assertSame(NetworkServerStatus::FAILED, $member->fresh()->status);
-    }
-
-    public function test_deleting_allow_all_locks_down_but_keeps_tunnel_handshake(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $peer = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
-
-        $network = $this->wireguardNetwork([$this->server->id, $peer->id]);
-
-        $allowAll = $network->firewallRules()->whereNull('protocol')->whereNull('port')->firstOrFail();
-        app(ManageNetworkFirewallRule::class)->delete($allowAll);
-
-        $rules = ServerNetworkRule::query()->where('server_id', $this->server->id);
-
-        $this->assertFalse((clone $rules)->where('kind', ServerNetworkRuleKind::RULE)->exists());
-        $this->assertTrue((clone $rules)->where('kind', ServerNetworkRuleKind::HANDSHAKE)->exists());
-    }
-
-    public function test_firewall_change_on_offline_server_marks_member_pending(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = $this->wireguardNetwork([$this->server->id]);
-
-        $this->server->update(['status' => ServerStatus::DISCONNECTED]);
-
-        app(ManageNetworkFirewallRule::class)->create($network, [
-            'name' => 'mysql',
-            'protocol' => 'tcp',
-            'port' => '3306',
-        ]);
-
-        $this->assertSame(NetworkServerStatus::PENDING, $network->servers()->firstOrFail()->status);
-        $this->assertSame(NetworkStatus::SYNCING, $network->fresh()->status);
-    }
-
-    public function test_custom_network_with_a_cidr_uses_the_range_as_the_rule_source(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $ip = ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'ip' => '10.0.0.5',
-            'type' => IpAddressType::PRIVATE,
-        ]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'custom-net',
-            'type' => 'custom',
-            'cidr' => '10.0.0.0/24',
-            'servers' => [$this->server->id],
-            'ip_addresses' => [$this->server->id => $ip->id],
-        ]);
-
-        app(ManageNetworkFirewallRule::class)->create($network, [
-            'name' => 'mysql',
-            'protocol' => 'tcp',
-            'port' => '3306',
-        ]);
-
-        SSH::assertExecutedContains('allow from 10.0.0.0/24 to any proto tcp port 3306');
-        SSH::assertNotExecutedContains(
-            "grep -q '^IPV6=yes'",
-            'An IPv4 rule must be applied unconditionally, not behind the IPv6 guard.'
-        );
-    }
-
-    public function test_custom_network_without_a_cidr_uses_each_member_private_ip(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $ip1 = ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'ip' => '10.0.0.5',
-            'type' => IpAddressType::PRIVATE,
-        ]);
-
-        $peer = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
-        $ip2 = ServerIpAddress::factory()->create([
-            'server_id' => $peer->id,
-            'ip' => '10.0.0.6',
-            'type' => IpAddressType::PRIVATE,
-        ]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'custom-net',
-            'type' => 'custom',
-            'servers' => [$this->server->id, $peer->id],
-            'ip_addresses' => [$this->server->id => $ip1->id, $peer->id => $ip2->id],
-        ]);
-
-        app(ManageNetworkFirewallRule::class)->create($network, [
-            'name' => 'mysql',
-            'protocol' => 'tcp',
-            'port' => '3306',
-        ]);
-
-        SSH::assertExecutedContains('from 10.0.0.6/32 to any');
-    }
-
-    public function test_custom_network_applies_the_catch_all_rule_on_create(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $ip = ServerIpAddress::factory()->create(['server_id' => $this->server->id, 'ip' => '10.0.0.5', 'type' => IpAddressType::PRIVATE]);
-
-        app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'custom-net',
-            'type' => 'custom',
-            'cidr' => '10.0.0.0/24',
-            'servers' => [$this->server->id],
-            'ip_addresses' => [$this->server->id => $ip->id],
-        ]);
-
-        SSH::assertExecutedContains('allow from 10.0.0.0/24 to any');
-    }
-
-    public function test_provider_network_never_uses_the_vpc_cidr_as_a_rule_source(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $peer = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
-
-        $network = Network::factory()->create([
-            'project_id' => $this->server->project_id,
-            'type' => NetworkType::PROVIDER,
-            'status' => NetworkStatus::ACTIVE,
-            'cidr' => '172.31.0.0/16',
-            'cidr_canonical' => '172.31.0.0/16',
-        ]);
-
-        $network->servers()->create([
-            'server_id' => $this->server->id,
-            'ip' => '172.31.0.5',
-            'status' => NetworkServerStatus::ACTIVE,
-        ]);
-        $network->servers()->create([
-            'server_id' => $peer->id,
-            'ip' => '172.31.0.6',
-            'status' => NetworkServerStatus::ACTIVE,
-        ]);
-
-        app(ManageNetworkFirewallRule::class)->create($network, [
-            'name' => 'mysql',
-            'protocol' => 'tcp',
-            'port' => '3306',
-        ]);
-
-        $sources = ServerNetworkRule::query()
-            ->where('server_id', $this->server->id)
-            ->where('network_id', $network->id)
-            ->pluck('source')
-            ->all();
-
-        $this->assertContains('172.31.0.6', $sources);
-        $this->assertNotContains('172.31.0.0', $sources, 'Provider networks must never widen the firewall to the whole VPC CIDR.');
-
-        $this->assertSame(
-            0,
-            ServerNetworkRule::query()
-                ->where('network_id', $network->id)
-                ->where('mask', 16)
-                ->count(),
-            'Provider network rules must be per-member /32s.'
-        );
-    }
-
-    public function test_server_with_zero_networks_has_no_materialized_rules(): void
-    {
-        $this->assertSame(0, ServerNetworkRule::query()->where('server_id', $this->server->id)->count());
-    }
-
-    public function test_network_create_materializes_handshake_and_catch_all_rows(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $peer = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
-
-        $network = $this->wireguardNetwork([$this->server->id, $peer->id]);
-        $allowAll = $network->firewallRules()->whereNull('protocol')->whereNull('port')->firstOrFail();
-
-        $this->assertDatabaseHas('server_network_rules', [
-            'server_id' => $this->server->id,
-            'network_id' => $network->id,
-            'kind' => ServerNetworkRuleKind::HANDSHAKE->value,
-            'protocol' => 'udp',
-            'port' => (string) $network->port,
-            'source' => $peer->ip,
-            'network_firewall_rule_id' => null,
-        ]);
-
-        $this->assertDatabaseHas('server_network_rules', [
-            'server_id' => $this->server->id,
-            'network_id' => $network->id,
-            'kind' => ServerNetworkRuleKind::RULE->value,
-            'protocol' => null,
-            'port' => null,
-            'source' => '100.64.0.0',
-            'network_firewall_rule_id' => $allowAll->id,
-        ]);
-    }
-
-    /**
-     * @return array<string, array{0: ?string, 1: ?string, 2: string}>
-     */
-    public static function protocolAndPortCombinations(): array
-    {
-        return [
-            'both' => ['tcp', '3306', 'to any proto tcp port 3306'],
-            'port only' => [null, '3306', 'to any port 3306'],
-            'protocol only' => ['udp', null, 'to any proto udp'],
-            'neither' => [null, null, 'to any'],
-        ];
-    }
-
-    /**
-     * Protocol and port are documented as independently optional, so all four combinations
-     * must validate and each must render a command `ufw` actually accepts — an empty `proto`
-     * or a silently dropped protocol are both wrong.
-     */
-    #[DataProvider('protocolAndPortCombinations')]
-    public function test_protocol_and_port_are_independently_optional(?string $protocol, ?string $port, string $expected): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $peer = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
-
-        $network = $this->wireguardNetwork([$this->server->id, $peer->id]);
-        $network->firewallRules()->delete();
-
-        SSH::fake();
-        app(ManageNetworkFirewallRule::class)->create($network, [
-            'name' => 'combo',
-            'protocol' => $protocol,
-            'port' => $port,
-        ]);
-
-        $this->assertDatabaseHas('network_firewall_rules', [
-            'network_id' => $network->id,
-            'name' => 'combo',
-            'protocol' => $protocol,
-            'port' => $port,
-        ]);
-
-        SSH::assertExecutedContains('allow from 100.64.0.0/24 '.$expected);
-    }
-
-    /**
-     * `ufw` refuses a multi-port rule that names no protocol. Accepting one would apply on every
-     * member and fail there, and because rules are reset and reapplied as a unit that failure
-     * takes the network's other rules — and the server's own — down with it.
-     */
-    public function test_port_range_without_a_protocol_is_rejected(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = $this->wireguardNetwork([$this->server->id]);
-
-        try {
-            app(ManageNetworkFirewallRule::class)->create($network, [
-                'name' => 'range',
-                'protocol' => null,
-                'port' => '3000:3010',
-            ]);
-            $this->fail('A port range without a protocol must be rejected.');
-        } catch (ValidationException $e) {
-            $this->assertArrayHasKey('protocol', $e->errors());
-        }
-
-        $this->assertDatabaseMissing('network_firewall_rules', [
-            'network_id' => $network->id,
-            'name' => 'range',
-        ]);
+    $network = vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id]);
 
+    $this->actingAs($this->user);
+
+    $this->get(route('firewall', ['server' => $this->server]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('firewall/index')
+            ->where('networkRules.data.0.network_id', $network->id)
+            ->where('networkRules.data.0.name', 'Allow all'));
+});
+
+test('leaving member network is not listed as managed', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id]);
+    $network->servers()->update(['status' => NetworkServerStatus::LEAVING]);
+
+    $this->actingAs($this->user);
+
+    $this->get(route('firewall', ['server' => $this->server]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('firewall/index')
+            ->count('networkRules.data', 0));
+});
+
+test('server level firewall change reapplies network rules', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id]);
+
+    app(ManageRule::class)->create($this->server, [
+        'name' => 'ssh',
+        'type' => 'allow',
+        'protocol' => 'tcp',
+        'port' => '22',
+    ]);
+
+    SSH::assertExecutedContains('allow from 100.64.0.0/24 to any');
+});
+
+test('installing ufw opens wireguard handshake for existing member', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $peer = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
+
+    vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id, $peer->id]);
+
+    SSH::fake();
+    $this->server->firewall()->handler()->install();
+
+    SSH::assertExecutedContains('from '.$peer->ip.'/32 to any proto udp port 51820');
+});
+
+test('failed firewall apply marks member failed', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id]);
+    $member = $network->servers()->firstOrFail();
+
+    (new ApplyNetworkFirewallJob($member))->failed(new RuntimeException('boom'));
+
+    expect($member->fresh()->status)->toBe(NetworkServerStatus::FAILED);
+});
+
+test('deleting allow all locks down but keeps tunnel handshake', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $peer = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
+
+    $network = vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id, $peer->id]);
+
+    $allowAll = $network->firewallRules()->whereNull('protocol')->whereNull('port')->firstOrFail();
+    app(ManageNetworkFirewallRule::class)->delete($allowAll);
+
+    $rules = ServerNetworkRule::query()->where('server_id', $this->server->id);
+
+    expect((clone $rules)->where('kind', ServerNetworkRuleKind::RULE)->exists())->toBeFalse();
+    expect((clone $rules)->where('kind', ServerNetworkRuleKind::HANDSHAKE)->exists())->toBeTrue();
+});
+
+test('firewall change on offline server marks member pending', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id]);
+
+    $this->server->update(['status' => ServerStatus::DISCONNECTED]);
+
+    app(ManageNetworkFirewallRule::class)->create($network, [
+        'name' => 'mysql',
+        'protocol' => 'tcp',
+        'port' => '3306',
+    ]);
+
+    expect($network->servers()->firstOrFail()->status)->toBe(NetworkServerStatus::PENDING);
+    expect($network->fresh()->status)->toBe(NetworkStatus::SYNCING);
+});
+
+test('custom network with a cidr uses the range as the rule source', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $ip = ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'ip' => '10.0.0.5',
+        'type' => IpAddressType::PRIVATE,
+    ]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'custom-net',
+        'type' => 'custom',
+        'cidr' => '10.0.0.0/24',
+        'servers' => [$this->server->id],
+        'ip_addresses' => [$this->server->id => $ip->id],
+    ]);
+
+    app(ManageNetworkFirewallRule::class)->create($network, [
+        'name' => 'mysql',
+        'protocol' => 'tcp',
+        'port' => '3306',
+    ]);
+
+    SSH::assertExecutedContains('allow from 10.0.0.0/24 to any proto tcp port 3306');
+    SSH::assertNotExecutedContains(
+        "grep -q '^IPV6=yes'",
+        'An IPv4 rule must be applied unconditionally, not behind the IPv6 guard.'
+    );
+});
+
+test('custom network without a cidr uses each member private ip', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $ip1 = ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'ip' => '10.0.0.5',
+        'type' => IpAddressType::PRIVATE,
+    ]);
+
+    $peer = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
+    $ip2 = ServerIpAddress::factory()->create([
+        'server_id' => $peer->id,
+        'ip' => '10.0.0.6',
+        'type' => IpAddressType::PRIVATE,
+    ]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'custom-net',
+        'type' => 'custom',
+        'servers' => [$this->server->id, $peer->id],
+        'ip_addresses' => [$this->server->id => $ip1->id, $peer->id => $ip2->id],
+    ]);
+
+    app(ManageNetworkFirewallRule::class)->create($network, [
+        'name' => 'mysql',
+        'protocol' => 'tcp',
+        'port' => '3306',
+    ]);
+
+    SSH::assertExecutedContains('from 10.0.0.6/32 to any');
+});
+
+test('custom network applies the catch all rule on create', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $ip = ServerIpAddress::factory()->create(['server_id' => $this->server->id, 'ip' => '10.0.0.5', 'type' => IpAddressType::PRIVATE]);
+
+    app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'custom-net',
+        'type' => 'custom',
+        'cidr' => '10.0.0.0/24',
+        'servers' => [$this->server->id],
+        'ip_addresses' => [$this->server->id => $ip->id],
+    ]);
+
+    SSH::assertExecutedContains('allow from 10.0.0.0/24 to any');
+});
+
+test('provider network never uses the vpc cidr as a rule source', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $peer = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
+
+    $network = Network::factory()->create([
+        'project_id' => $this->server->project_id,
+        'type' => NetworkType::PROVIDER,
+        'status' => NetworkStatus::ACTIVE,
+        'cidr' => '172.31.0.0/16',
+        'cidr_canonical' => '172.31.0.0/16',
+    ]);
+
+    $network->servers()->create([
+        'server_id' => $this->server->id,
+        'ip' => '172.31.0.5',
+        'status' => NetworkServerStatus::ACTIVE,
+    ]);
+    $network->servers()->create([
+        'server_id' => $peer->id,
+        'ip' => '172.31.0.6',
+        'status' => NetworkServerStatus::ACTIVE,
+    ]);
+
+    app(ManageNetworkFirewallRule::class)->create($network, [
+        'name' => 'mysql',
+        'protocol' => 'tcp',
+        'port' => '3306',
+    ]);
+
+    $sources = ServerNetworkRule::query()
+        ->where('server_id', $this->server->id)
+        ->where('network_id', $network->id)
+        ->pluck('source')
+        ->all();
+
+    expect($sources)->toContain('172.31.0.6');
+    expect($sources)->not->toContain('172.31.0.0');
+
+    expect(ServerNetworkRule::query()
+        ->where('network_id', $network->id)
+        ->where('mask', 16)
+        ->count())->toBe(0, 'Provider network rules must be per-member /32s.');
+});
+
+test('server with zero networks has no materialized rules', function () {
+    expect(ServerNetworkRule::query()->where('server_id', $this->server->id)->count())->toBe(0);
+});
+
+test('network create materializes handshake and catch all rows', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $peer = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
+
+    $network = vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id, $peer->id]);
+    $allowAll = $network->firewallRules()->whereNull('protocol')->whereNull('port')->firstOrFail();
+
+    $this->assertDatabaseHas('server_network_rules', [
+        'server_id' => $this->server->id,
+        'network_id' => $network->id,
+        'kind' => ServerNetworkRuleKind::HANDSHAKE->value,
+        'protocol' => 'udp',
+        'port' => (string) $network->port,
+        'source' => $peer->ip,
+        'network_firewall_rule_id' => null,
+    ]);
+
+    $this->assertDatabaseHas('server_network_rules', [
+        'server_id' => $this->server->id,
+        'network_id' => $network->id,
+        'kind' => ServerNetworkRuleKind::RULE->value,
+        'protocol' => null,
+        'port' => null,
+        'source' => '100.64.0.0',
+        'network_firewall_rule_id' => $allowAll->id,
+    ]);
+});
+
+/**
+ * @return array<string, array{0: ?string, 1: ?string, 2: string}>
+ */
+dataset('protocolAndPortCombinations', function () {
+    return [
+        'both' => ['tcp', '3306', 'to any proto tcp port 3306'],
+        'port only' => [null, '3306', 'to any port 3306'],
+        'protocol only' => ['udp', null, 'to any proto udp'],
+        'neither' => [null, null, 'to any'],
+    ];
+});
+
+test('protocol and port are independently optional', function (?string $protocol, ?string $port, string $expected) {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $peer = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
+
+    $network = vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id, $peer->id]);
+    $network->firewallRules()->delete();
+
+    SSH::fake();
+    app(ManageNetworkFirewallRule::class)->create($network, [
+        'name' => 'combo',
+        'protocol' => $protocol,
+        'port' => $port,
+    ]);
+
+    $this->assertDatabaseHas('network_firewall_rules', [
+        'network_id' => $network->id,
+        'name' => 'combo',
+        'protocol' => $protocol,
+        'port' => $port,
+    ]);
+
+    SSH::assertExecutedContains('allow from 100.64.0.0/24 '.$expected);
+})->with('protocolAndPortCombinations');
+
+test('port range without a protocol is rejected', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id]);
+
+    try {
         app(ManageNetworkFirewallRule::class)->create($network, [
             'name' => 'range',
-            'protocol' => 'tcp',
+            'protocol' => null,
             'port' => '3000:3010',
         ]);
-
-        SSH::assertExecutedContains('to any proto tcp port 3000:3010');
+        $this->fail('A port range without a protocol must be rejected.');
+    } catch (ValidationException $e) {
+        expect($e->errors())->toHaveKey('protocol');
     }
 
-    /**
-     * Every network type derives rules that name the other members, so deleting a server must
-     * clear its address from the remaining members' rules — a provider address in particular
-     * can be reassigned to an unrelated host later.
-     */
-    public function test_deleting_a_server_clears_its_rules_from_remaining_members_of_a_custom_network(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
+    $this->assertDatabaseMissing('network_firewall_rules', [
+        'network_id' => $network->id,
+        'name' => 'range',
+    ]);
 
-        $peer = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
+    app(ManageNetworkFirewallRule::class)->create($network, [
+        'name' => 'range',
+        'protocol' => 'tcp',
+        'port' => '3000:3010',
+    ]);
 
-        $mine = ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'ip' => '10.40.0.2',
-            'type' => IpAddressType::PRIVATE,
-        ]);
-        $theirs = ServerIpAddress::factory()->create([
-            'server_id' => $peer->id,
-            'ip' => '10.40.0.3',
-            'type' => IpAddressType::PRIVATE,
-        ]);
+    SSH::assertExecutedContains('to any proto tcp port 3000:3010');
+});
 
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'no-cidr-custom',
-            'type' => 'custom',
-            'servers' => [$this->server->id, $peer->id],
-            'ip_addresses' => [$this->server->id => $mine->id, $peer->id => $theirs->id],
-        ]);
+test('deleting a server clears its rules from remaining members of a custom network', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
 
-        $this->assertDatabaseHas('server_network_rules', [
-            'server_id' => $this->server->id,
-            'network_id' => $network->id,
-            'source' => '10.40.0.3',
-        ]);
+    $peer = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
 
-        $peer->delete();
+    $mine = ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'ip' => '10.40.0.2',
+        'type' => IpAddressType::PRIVATE,
+    ]);
+    $theirs = ServerIpAddress::factory()->create([
+        'server_id' => $peer->id,
+        'ip' => '10.40.0.3',
+        'type' => IpAddressType::PRIVATE,
+    ]);
 
-        $this->assertDatabaseMissing('server_network_rules', [
-            'server_id' => $this->server->id,
-            'network_id' => $network->id,
-            'source' => '10.40.0.3',
-        ]);
-    }
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'no-cidr-custom',
+        'type' => 'custom',
+        'servers' => [$this->server->id, $peer->id],
+        'ip_addresses' => [$this->server->id => $mine->id, $peer->id => $theirs->id],
+    ]);
 
-    /**
-     * @return array<string, array{0: string}>
-     */
-    public static function untrustedServerAddresses(): array
-    {
-        return [
-            'command chaining' => ['10.0.0.9; sudo ufw disable'],
-            'command substitution' => ['10.0.0.9 $(id)'],
-            'backticks' => ['`whoami`'],
-            'newline' => ["10.0.0.9\nsudo ufw disable"],
-            'not an address' => ['not-an-ip'],
-            'cidr not address' => ['10.0.0.0/24'],
-        ];
-    }
+    $this->assertDatabaseHas('server_network_rules', [
+        'server_id' => $this->server->id,
+        'network_id' => $network->id,
+        'source' => '10.40.0.3',
+    ]);
 
-    /**
-     * A server's public address becomes an unquoted `ufw` source on every WireGuard sibling,
-     * and Blade escapes HTML rather than shell metacharacters — so it must be rejected at the
-     * edge rather than reaching the template.
-     */
-    #[DataProvider('untrustedServerAddresses')]
-    public function test_server_address_that_is_not_an_ip_is_rejected(string $ip): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
+    $peer->delete();
 
-        $this->expectException(ValidationException::class);
+    $this->assertDatabaseMissing('server_network_rules', [
+        'server_id' => $this->server->id,
+        'network_id' => $network->id,
+        'source' => '10.40.0.3',
+    ]);
+});
 
-        app(EditServer::class)->edit($this->server, [
-            'name' => $this->server->name,
-            'ip' => $ip,
-            'port' => 22,
-        ]);
-    }
+/**
+ * @return array<string, array{0: string}>
+ */
+dataset('untrustedServerAddresses', function () {
+    return [
+        'command chaining' => ['10.0.0.9; sudo ufw disable'],
+        'command substitution' => ['10.0.0.9 $(id)'],
+        'backticks' => ['`whoami`'],
+        'newline' => ["10.0.0.9\nsudo ufw disable"],
+        'not an address' => ['not-an-ip'],
+        'cidr not address' => ['10.0.0.0/24'],
+    ];
+});
 
-    public function test_untrusted_address_never_reaches_the_firewall_template(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
+test('server address that is not an ip is rejected', function (string $ip) {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
 
-        $peer = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
+    $this->expectException(ValidationException::class);
 
-        $network = $this->wireguardNetwork([$this->server->id, $peer->id]);
+    app(EditServer::class)->edit($this->server, [
+        'name' => $this->server->name,
+        'ip' => $ip,
+        'port' => 22,
+    ]);
+})->with('untrustedServerAddresses');
 
-        Server::query()->whereKey($peer->id)->update(['ip' => '10.0.0.9; sudo ufw disable']);
+test('untrusted address never reaches the firewall template', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
 
-        SSH::fake();
-        app(MaterializeServerNetworkRules::class)->forServer($this->server->refresh());
-        $this->server->firewall()?->handler()->applyRules();
+    $peer = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
 
-        $this->assertDatabaseMissing('server_network_rules', [
-            'network_id' => $network->id,
-            'source' => '10.0.0.9; sudo ufw disable',
-        ]);
+    $network = vitoPestFeatureNetworkFirewallTestWireguardNetwork([$this->server->id, $peer->id]);
 
-        SSH::assertNotExecutedContains(
-            'sudo ufw disable',
-            'A non-address value must never be interpolated into the firewall script.'
-        );
-    }
-}
+    Server::query()->whereKey($peer->id)->update(['ip' => '10.0.0.9; sudo ufw disable']);
+
+    SSH::fake();
+    app(MaterializeServerNetworkRules::class)->forServer($this->server->refresh());
+    $this->server->firewall()?->handler()->applyRules();
+
+    $this->assertDatabaseMissing('server_network_rules', [
+        'network_id' => $network->id,
+        'source' => '10.0.0.9; sudo ufw disable',
+    ]);
+
+    SSH::assertNotExecutedContains(
+        'sudo ufw disable',
+        'A non-address value must never be interpolated into the firewall script.'
+    );
+});

--- a/tests/Feature/NetworkIpv6Test.php
+++ b/tests/Feature/NetworkIpv6Test.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\Network\AddServersToNetwork;
 use App\Actions\Network\CreateNetwork;
 use App\Actions\Network\CreateNetworkPeer;
@@ -18,307 +16,262 @@ use App\Models\ServerIpAddress;
 use App\Support\Cidr;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Validation\ValidationException;
-use Tests\TestCase;
 
-class NetworkIpv6Test extends TestCase
+uses(RefreshDatabase::class);
+
+function vitoPestFeatureNetworkIpv6TestReadyServer(string $ip): Server
 {
-    use RefreshDatabase;
-
-    private function readyServer(string $ip): Server
-    {
-        return Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'ip' => $ip,
-            'status' => ServerStatus::READY,
-        ]);
-    }
-
-    private function privateIp(Server $server, string $ip, int $prefix): ServerIpAddress
-    {
-        return ServerIpAddress::factory()->create([
-            'server_id' => $server->id,
-            'ip' => $ip,
-            'prefix_length' => $prefix,
-            'family' => str_contains($ip, ':') ? IpAddressFamily::V6 : IpAddressFamily::V4,
-            'type' => IpAddressType::PRIVATE,
-        ]);
-    }
-
-    public function test_cidr_helpers_handle_both_families(): void
-    {
-        $this->assertSame(32, Cidr::hostPrefix('10.0.0.1'));
-        $this->assertSame(128, Cidr::hostPrefix('fd00::1'));
-        $this->assertSame('fd00::/64', Cidr::canonical('fd00::dead:beef/64'));
-        $this->assertTrue(Cidr::contains('fd00::/64', 'fd00::9'));
-        $this->assertFalse(Cidr::contains('fd00::/64', 'fd00:1::9'));
-        $this->assertSame('fd00::2', Cidr::nextHost('fd00::/64', []));
-        $this->assertSame('fd00::3', Cidr::nextHost('fd00::/64', ['fd00::2']));
-    }
-
-    /**
-     * A family mismatch must never read as containment — an IPv4 pool and an IPv6 range
-     * would otherwise look like they overlap and block allocation.
-     */
-    public function test_cross_family_comparisons_never_match(): void
-    {
-        $this->assertFalse(Cidr::overlaps('10.0.0.0/8', 'fd00::/8'));
-        $this->assertFalse(Cidr::contains('10.0.0.0/8', 'fd00::1'));
-        $this->assertFalse(Cidr::contains('fd00::/8', '10.0.0.1'));
-    }
-
-    public function test_endpoint_brackets_ipv6_only(): void
-    {
-        $this->assertSame('1.2.3.4:51820', Cidr::endpoint('1.2.3.4', 51820));
-        $this->assertSame('[2001:db8::1]:51820', Cidr::endpoint('2001:db8::1', 51820));
-    }
-
-    /**
-     * WireGuard rejects a bare `host:port` for IPv6 — the address has to be bracketed or the
-     * config will not parse on the member or in a downloaded peer config.
-     */
-    public function test_ipv6_server_endpoint_is_bracketed_in_member_and_peer_configs(): void
-    {
-        SSH::fake();
-        $first = $this->readyServer('2001:db8::1');
-        $second = $this->readyServer('2001:db8::2');
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'v6-endpoints',
-            'type' => 'wireguard',
-            'servers' => [$first->id, $second->id],
-        ]);
-
-        $this->assertStringContainsString('Endpoint = [2001:db8::1]:'.$network->port, SSH::getUploadedContent());
-
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
-        $config = app(GetNetworkPeerConfig::class)->config($peer)['config'];
-
-        $this->assertMatchesRegularExpression('/^Endpoint = \[2001:db8::1\]:'.$network->port.'$/m', $config);
-        $this->assertStringNotContainsString('Endpoint = 2001:db8::1:', $config);
-    }
-
-    /**
-     * The handshake rule's source is the peer's public address, so an IPv6 endpoint needs a
-     * /128 host prefix rather than the IPv4 /32.
-     */
-    public function test_ipv6_handshake_rule_uses_a_128_prefix(): void
-    {
-        SSH::fake();
-        $this->server->update(['ip' => '2001:db8::1', 'status' => ServerStatus::READY]);
-        $peer = $this->readyServer('2001:db8::2');
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'v6-handshake',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id, $peer->id],
-        ]);
-
-        $this->assertDatabaseHas('server_network_rules', [
-            'network_id' => $network->id,
-            'server_id' => $this->server->id,
-            'source' => '2001:db8::2',
-            'mask' => 128,
-        ]);
-
-        SSH::assertExecutedContains('allow from 2001:db8::2/128 to any proto udp port '.$network->port);
-    }
-
-    /**
-     * ufw refuses a v6 rule when its own IPv6 support is off, and rules are applied as one
-     * reset-and-reapply batch — so an unguarded v6 rule would fail the whole batch on an
-     * IPv4-only member and leave it permanently `failed`. With IPv6 off the kernel table is
-     * unfiltered anyway, so skipping the rule loses nothing.
-     */
-    public function test_ipv6_rules_are_skipped_on_a_member_whose_ufw_has_no_ipv6(): void
-    {
-        SSH::fake();
-        $this->server->update(['ip' => '2001:db8::1', 'status' => ServerStatus::READY]);
-        $peer = $this->readyServer('2001:db8::2');
-
-        app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'v6-guard',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id, $peer->id],
-        ]);
-
-        SSH::assertExecutedContains("grep -q '^IPV6=yes' /etc/default/ufw");
-    }
-
-    public function test_custom_network_accepts_an_ipv6_range_and_members(): void
-    {
-        SSH::fake();
-        $server = $this->readyServer('2001:db8::10');
-        $ip = $this->privateIp($server, 'fd00:1::5', 64);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'v6-custom',
-            'type' => 'custom',
-            'cidr' => 'fd00:1::/64',
-            'servers' => [$server->id],
-            'ip_addresses' => [$server->id => $ip->id],
-        ]);
-
-        $this->assertSame('fd00:1::/64', $network->cidr);
-        $this->assertSame('fd00:1::/64', $network->cidr_canonical);
-    }
-
-    public function test_ipv6_custom_network_rule_uses_the_declared_range(): void
-    {
-        SSH::fake();
-        $this->server->update(['ip' => '2001:db8::21', 'status' => ServerStatus::READY]);
-        $peer = $this->readyServer('2001:db8::22');
-        $firstIp = $this->privateIp($this->server, 'fd00:2::5', 64);
-        $secondIp = $this->privateIp($peer, 'fd00:2::6', 64);
-
-        app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'v6-custom-rules',
-            'type' => 'custom',
-            'cidr' => 'fd00:2::/64',
-            'servers' => [$this->server->id, $peer->id],
-            'ip_addresses' => [$this->server->id => $firstIp->id, $peer->id => $secondIp->id],
-        ]);
-
-        SSH::assertExecutedContains('allow from fd00:2::/64 to any');
-    }
-
-    public function test_ufw_install_enables_ipv6(): void
-    {
-        SSH::fake();
-        $server = $this->readyServer('2001:db8::30');
-
-        $server->services()->where('type', 'firewall')->delete();
-        $service = $server->services()->create([
-            'type' => 'firewall',
-            'name' => 'ufw',
-            'version' => 'latest',
-            'status' => ServiceStatus::INSTALLING,
-        ]);
-
-        $service->handler()->install();
-
-        SSH::assertExecutedContains("sed -i '/^IPV6=/d' /etc/default/ufw");
-        SSH::assertExecutedContains("echo 'IPV6=yes' | sudo tee -a /etc/default/ufw");
-    }
-
-    /**
-     * The install allows SSH before enabling the firewall. Scoping that allow to an IPv4 source
-     * would leave a default-deny v6 table with no way in, locking Vito out of a server it
-     * reaches over IPv6 — and the very next thing install does is open a new connection.
-     */
-    public function test_ufw_install_opens_ssh_for_both_families(): void
-    {
-        SSH::fake();
-        $server = $this->readyServer('2001:db8::31');
-
-        $server->services()->where('type', 'firewall')->delete();
-        $service = $server->services()->create([
-            'type' => 'firewall',
-            'name' => 'ufw',
-            'version' => 'latest',
-            'status' => ServiceStatus::INSTALLING,
-        ]);
-
-        $service->handler()->install();
-
-        SSH::assertExecutedContains('ufw allow proto tcp to any port '.($server->port ?? 22));
-        SSH::assertNotExecutedContains('from 0.0.0.0/0', 'The install must not scope its own allows to IPv4.');
-    }
-
-    public function test_member_address_outside_the_declared_range_is_rejected(): void
-    {
-        SSH::fake();
-        $server = $this->readyServer('2001:db8::40');
-        $ip = $this->privateIp($server, '10.9.9.9', 32);
-
-        $this->expectException(ValidationException::class);
-
-        app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'mismatched',
-            'type' => 'custom',
-            'cidr' => '10.50.0.0/24',
-            'servers' => [$server->id],
-            'ip_addresses' => [$server->id => $ip->id],
-        ]);
-    }
-
-    public function test_member_address_outside_the_range_is_rejected_when_adding_and_updating(): void
-    {
-        SSH::fake();
-        $first = $this->readyServer('2001:db8::41');
-        $firstIp = $this->privateIp($first, '10.50.0.5', 24);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'contained',
-            'type' => 'custom',
-            'cidr' => '10.50.0.0/24',
-            'servers' => [$first->id],
-            'ip_addresses' => [$first->id => $firstIp->id],
-        ]);
-
-        $second = $this->readyServer('2001:db8::42');
-        $outside = $this->privateIp($second, '10.99.0.5', 24);
-
-        try {
-            app(AddServersToNetwork::class)->add($network, [
-                'servers' => [$second->id],
-                'ip_addresses' => [$second->id => $outside->id],
-            ]);
-            $this->fail('An address outside the declared range must be rejected.');
-        } catch (ValidationException) {
-            // expected
-        }
-
-        $member = $network->servers()->where('server_id', $first->id)->firstOrFail();
-        $alsoOutside = $this->privateIp($first, '10.99.0.6', 24);
-
-        $this->expectException(ValidationException::class);
-        app(UpdateNetworkServerIp::class)->update($member, ['server_ip_address_id' => $alsoOutside->id]);
-    }
-
-    /**
-     * A network with no declared range derives per-member host rules instead, so containment
-     * cannot be checked and any private address is allowed.
-     */
-    public function test_network_without_a_range_accepts_any_private_address(): void
-    {
-        SSH::fake();
-        $server = $this->readyServer('2001:db8::50');
-        $ip = $this->privateIp($server, '10.77.0.5', 24);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'no-range',
-            'type' => 'custom',
-            'cidr' => '',
-            'servers' => [$server->id],
-            'ip_addresses' => [$server->id => $ip->id],
-        ]);
-
-        $this->assertNull($network->cidr);
-        $this->assertSame(1, $network->servers()->count());
-    }
-
-    public function test_malformed_cidr_is_rejected_for_both_families(): void
-    {
-        SSH::fake();
-        $server = $this->readyServer('2001:db8::60');
-        $ip = $this->privateIp($server, '10.0.0.5', 24);
-
-        foreach (['10.0.0.0/33', 'fd00::/129', 'not-a-cidr', '10.0.0.0', '10.0.0.0/24; id'] as $cidr) {
-            try {
-                app(CreateNetwork::class)->create($this->server->project, [
-                    'name' => 'bad-'.md5($cidr),
-                    'type' => 'custom',
-                    'cidr' => $cidr,
-                    'servers' => [$server->id],
-                    'ip_addresses' => [$server->id => $ip->id],
-                ]);
-                $this->fail("Expected [$cidr] to be rejected.");
-            } catch (ValidationException) {
-                $this->assertTrue(true);
-            }
-        }
-
-        $this->assertSame(0, Network::query()->where('project_id', $this->server->project_id)->count());
-    }
+    return Server::factory()->create([
+        'project_id' => test()->server->project_id,
+        'user_id' => test()->user->id,
+        'ip' => $ip,
+        'status' => ServerStatus::READY,
+    ]);
 }
+
+function vitoPestFeatureNetworkIpv6TestPrivateIp(Server $server, string $ip, int $prefix): ServerIpAddress
+{
+    return ServerIpAddress::factory()->create([
+        'server_id' => $server->id,
+        'ip' => $ip,
+        'prefix_length' => $prefix,
+        'family' => str_contains($ip, ':') ? IpAddressFamily::V6 : IpAddressFamily::V4,
+        'type' => IpAddressType::PRIVATE,
+    ]);
+}
+
+test('cidr helpers handle both families', function () {
+    expect(Cidr::hostPrefix('10.0.0.1'))->toBe(32);
+    expect(Cidr::hostPrefix('fd00::1'))->toBe(128);
+    expect(Cidr::canonical('fd00::dead:beef/64'))->toBe('fd00::/64');
+    expect(Cidr::contains('fd00::/64', 'fd00::9'))->toBeTrue();
+    expect(Cidr::contains('fd00::/64', 'fd00:1::9'))->toBeFalse();
+    expect(Cidr::nextHost('fd00::/64', []))->toBe('fd00::2');
+    expect(Cidr::nextHost('fd00::/64', ['fd00::2']))->toBe('fd00::3');
+});
+
+test('cross family comparisons never match', function () {
+    expect(Cidr::overlaps('10.0.0.0/8', 'fd00::/8'))->toBeFalse();
+    expect(Cidr::contains('10.0.0.0/8', 'fd00::1'))->toBeFalse();
+    expect(Cidr::contains('fd00::/8', '10.0.0.1'))->toBeFalse();
+});
+
+test('endpoint brackets ipv6 only', function () {
+    expect(Cidr::endpoint('1.2.3.4', 51820))->toBe('1.2.3.4:51820');
+    expect(Cidr::endpoint('2001:db8::1', 51820))->toBe('[2001:db8::1]:51820');
+});
+
+test('ipv6 server endpoint is bracketed in member and peer configs', function () {
+    SSH::fake();
+    $first = vitoPestFeatureNetworkIpv6TestReadyServer('2001:db8::1');
+    $second = vitoPestFeatureNetworkIpv6TestReadyServer('2001:db8::2');
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'v6-endpoints',
+        'type' => 'wireguard',
+        'servers' => [$first->id, $second->id],
+    ]);
+
+    $this->assertStringContainsString('Endpoint = [2001:db8::1]:'.$network->port, SSH::getUploadedContent());
+
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+    $config = app(GetNetworkPeerConfig::class)->config($peer)['config'];
+
+    expect($config)->toMatch('/^Endpoint = \[2001:db8::1\]:'.$network->port.'$/m');
+    $this->assertStringNotContainsString('Endpoint = 2001:db8::1:', $config);
+});
+
+test('ipv6 handshake rule uses a 128 prefix', function () {
+    SSH::fake();
+    $this->server->update(['ip' => '2001:db8::1', 'status' => ServerStatus::READY]);
+    $peer = vitoPestFeatureNetworkIpv6TestReadyServer('2001:db8::2');
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'v6-handshake',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id, $peer->id],
+    ]);
+
+    $this->assertDatabaseHas('server_network_rules', [
+        'network_id' => $network->id,
+        'server_id' => $this->server->id,
+        'source' => '2001:db8::2',
+        'mask' => 128,
+    ]);
+
+    SSH::assertExecutedContains('allow from 2001:db8::2/128 to any proto udp port '.$network->port);
+});
+
+test('ipv6 rules are skipped on a member whose ufw has no ipv6', function () {
+    SSH::fake();
+    $this->server->update(['ip' => '2001:db8::1', 'status' => ServerStatus::READY]);
+    $peer = vitoPestFeatureNetworkIpv6TestReadyServer('2001:db8::2');
+
+    app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'v6-guard',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id, $peer->id],
+    ]);
+
+    SSH::assertExecutedContains("grep -q '^IPV6=yes' /etc/default/ufw");
+});
+
+test('custom network accepts an ipv6 range and members', function () {
+    SSH::fake();
+    $server = vitoPestFeatureNetworkIpv6TestReadyServer('2001:db8::10');
+    $ip = vitoPestFeatureNetworkIpv6TestPrivateIp($server, 'fd00:1::5', 64);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'v6-custom',
+        'type' => 'custom',
+        'cidr' => 'fd00:1::/64',
+        'servers' => [$server->id],
+        'ip_addresses' => [$server->id => $ip->id],
+    ]);
+
+    expect($network->cidr)->toBe('fd00:1::/64');
+    expect($network->cidr_canonical)->toBe('fd00:1::/64');
+});
+
+test('ipv6 custom network rule uses the declared range', function () {
+    SSH::fake();
+    $this->server->update(['ip' => '2001:db8::21', 'status' => ServerStatus::READY]);
+    $peer = vitoPestFeatureNetworkIpv6TestReadyServer('2001:db8::22');
+    $firstIp = vitoPestFeatureNetworkIpv6TestPrivateIp($this->server, 'fd00:2::5', 64);
+    $secondIp = vitoPestFeatureNetworkIpv6TestPrivateIp($peer, 'fd00:2::6', 64);
+
+    app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'v6-custom-rules',
+        'type' => 'custom',
+        'cidr' => 'fd00:2::/64',
+        'servers' => [$this->server->id, $peer->id],
+        'ip_addresses' => [$this->server->id => $firstIp->id, $peer->id => $secondIp->id],
+    ]);
+
+    SSH::assertExecutedContains('allow from fd00:2::/64 to any');
+});
+
+test('ufw install enables ipv6', function () {
+    SSH::fake();
+    $server = vitoPestFeatureNetworkIpv6TestReadyServer('2001:db8::30');
+
+    $server->services()->where('type', 'firewall')->delete();
+    $service = $server->services()->create([
+        'type' => 'firewall',
+        'name' => 'ufw',
+        'version' => 'latest',
+        'status' => ServiceStatus::INSTALLING,
+    ]);
+
+    $service->handler()->install();
+
+    SSH::assertExecutedContains("sed -i '/^IPV6=/d' /etc/default/ufw");
+    SSH::assertExecutedContains("echo 'IPV6=yes' | sudo tee -a /etc/default/ufw");
+});
+
+test('ufw install opens ssh for both families', function () {
+    SSH::fake();
+    $server = vitoPestFeatureNetworkIpv6TestReadyServer('2001:db8::31');
+
+    $server->services()->where('type', 'firewall')->delete();
+    $service = $server->services()->create([
+        'type' => 'firewall',
+        'name' => 'ufw',
+        'version' => 'latest',
+        'status' => ServiceStatus::INSTALLING,
+    ]);
+
+    $service->handler()->install();
+
+    SSH::assertExecutedContains('ufw allow proto tcp to any port '.($server->port ?? 22));
+    SSH::assertNotExecutedContains('from 0.0.0.0/0', 'The install must not scope its own allows to IPv4.');
+});
+
+test('member address outside the declared range is rejected', function () {
+    SSH::fake();
+    $server = vitoPestFeatureNetworkIpv6TestReadyServer('2001:db8::40');
+    $ip = vitoPestFeatureNetworkIpv6TestPrivateIp($server, '10.9.9.9', 32);
+
+    $this->expectException(ValidationException::class);
+
+    app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'mismatched',
+        'type' => 'custom',
+        'cidr' => '10.50.0.0/24',
+        'servers' => [$server->id],
+        'ip_addresses' => [$server->id => $ip->id],
+    ]);
+});
+
+test('member address outside the range is rejected when adding and updating', function () {
+    SSH::fake();
+    $first = vitoPestFeatureNetworkIpv6TestReadyServer('2001:db8::41');
+    $firstIp = vitoPestFeatureNetworkIpv6TestPrivateIp($first, '10.50.0.5', 24);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'contained',
+        'type' => 'custom',
+        'cidr' => '10.50.0.0/24',
+        'servers' => [$first->id],
+        'ip_addresses' => [$first->id => $firstIp->id],
+    ]);
+
+    $second = vitoPestFeatureNetworkIpv6TestReadyServer('2001:db8::42');
+    $outside = vitoPestFeatureNetworkIpv6TestPrivateIp($second, '10.99.0.5', 24);
+
+    try {
+        app(AddServersToNetwork::class)->add($network, [
+            'servers' => [$second->id],
+            'ip_addresses' => [$second->id => $outside->id],
+        ]);
+        $this->fail('An address outside the declared range must be rejected.');
+    } catch (ValidationException) {
+        // expected
+    }
+
+    $member = $network->servers()->where('server_id', $first->id)->firstOrFail();
+    $alsoOutside = vitoPestFeatureNetworkIpv6TestPrivateIp($first, '10.99.0.6', 24);
+
+    $this->expectException(ValidationException::class);
+    app(UpdateNetworkServerIp::class)->update($member, ['server_ip_address_id' => $alsoOutside->id]);
+});
+
+test('network without a range accepts any private address', function () {
+    SSH::fake();
+    $server = vitoPestFeatureNetworkIpv6TestReadyServer('2001:db8::50');
+    $ip = vitoPestFeatureNetworkIpv6TestPrivateIp($server, '10.77.0.5', 24);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'no-range',
+        'type' => 'custom',
+        'cidr' => '',
+        'servers' => [$server->id],
+        'ip_addresses' => [$server->id => $ip->id],
+    ]);
+
+    expect($network->cidr)->toBeNull();
+    expect($network->servers()->count())->toBe(1);
+});
+
+test('malformed cidr is rejected for both families', function () {
+    SSH::fake();
+    $server = vitoPestFeatureNetworkIpv6TestReadyServer('2001:db8::60');
+    $ip = vitoPestFeatureNetworkIpv6TestPrivateIp($server, '10.0.0.5', 24);
+
+    foreach (['10.0.0.0/33', 'fd00::/129', 'not-a-cidr', '10.0.0.0', '10.0.0.0/24; id'] as $cidr) {
+        try {
+            app(CreateNetwork::class)->create($this->server->project, [
+                'name' => 'bad-'.md5($cidr),
+                'type' => 'custom',
+                'cidr' => $cidr,
+                'servers' => [$server->id],
+                'ip_addresses' => [$server->id => $ip->id],
+            ]);
+            $this->fail("Expected [$cidr] to be rejected.");
+        } catch (ValidationException) {
+            expect(true)->toBeTrue();
+        }
+    }
+
+    expect(Network::query()->where('project_id', $this->server->project_id)->count())->toBe(0);
+});

--- a/tests/Feature/NetworkPeerTest.php
+++ b/tests/Feature/NetworkPeerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\Network\AddServersToNetwork;
 use App\Actions\Network\ConcealNetworkPeerKey;
 use App\Actions\Network\CreateNetwork;
@@ -23,483 +21,428 @@ use App\Models\Server;
 use App\Models\User;
 use App\Services\VPN\WireGuard;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class NetworkPeerTest extends TestCase
+uses(RefreshDatabase::class);
+
+/**
+ * @param  array<int, int>  $servers
+ */
+function vitoPestFeatureNetworkPeerTestWireguardNetwork(array $servers): Network
 {
-    use RefreshDatabase;
+    return app(CreateNetwork::class)->create(test()->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => $servers,
+    ]);
+}
 
-    /**
-     * @param  array<int, int>  $servers
-     */
-    private function wireguardNetwork(array $servers): Network
-    {
-        return app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => $servers,
-        ]);
-    }
+function vitoPestFeatureNetworkPeerTestReadyPeerServer(): Server
+{
+    return Server::factory()->create([
+        'project_id' => test()->server->project_id,
+        'user_id' => test()->user->id,
+        'status' => ServerStatus::READY,
+    ]);
+}
 
-    private function readyPeerServer(): Server
-    {
-        return Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
-    }
+test('peer on a member less network activates once a server joins', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
 
-    /**
-     * A network with no members has nothing to configure the peer on, so the peer waits rather
-     * than claiming to be connected. It must clear itself once a server joins — nothing else
-     * activates a pending peer.
-     */
-    public function test_peer_on_a_member_less_network_activates_once_a_server_joins(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
+    $network = Network::factory()->create([
+        'project_id' => $this->server->project_id,
+        'type' => NetworkType::WIREGUARD,
+    ]);
 
-        $network = Network::factory()->create([
-            'project_id' => $this->server->project_id,
-            'type' => NetworkType::WIREGUARD,
-        ]);
+    app(RecomputeNetworkStatus::class)->handle($network);
 
-        app(RecomputeNetworkStatus::class)->handle($network);
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+    expect($peer->fresh()?->status)->toBe(NetworkPeerStatus::PENDING);
 
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
-        $this->assertSame(NetworkPeerStatus::PENDING, $peer->fresh()?->status);
+    app(AddServersToNetwork::class)->add($network, ['servers' => [$this->server->id]]);
 
-        app(AddServersToNetwork::class)->add($network, ['servers' => [$this->server->id]]);
+    expect($peer->fresh()?->status)->toBe(NetworkPeerStatus::ACTIVE);
+});
 
-        $this->assertSame(NetworkPeerStatus::ACTIVE, $peer->fresh()?->status);
-    }
+test('create peer allocates next free ip', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
 
-    public function test_create_peer_allocates_next_free_ip(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
 
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+    $this->assertDatabaseHas('network_peers', [
+        'id' => $peer->id,
+        'network_id' => $network->id,
+        'ip' => '100.64.0.3',
+        'byo' => false,
+    ]);
+    expect($peer->private_key)->not->toBeNull();
+});
 
-        $this->assertDatabaseHas('network_peers', [
-            'id' => $peer->id,
-            'network_id' => $network->id,
-            'ip' => '100.64.0.3',
-            'byo' => false,
-        ]);
-        $this->assertNotNull($peer->private_key);
-    }
+test('server add skips peer ip', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
 
-    public function test_server_add_skips_peer_ip(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
+    app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
 
-        app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+    $other = vitoPestFeatureNetworkPeerTestReadyPeerServer();
+    app(AddServersToNetwork::class)->add($network, ['servers' => [$other->id]]);
 
-        $other = $this->readyPeerServer();
-        app(AddServersToNetwork::class)->add($network, ['servers' => [$other->id]]);
+    $this->assertDatabaseHas('network_servers', [
+        'network_id' => $network->id,
+        'server_id' => $other->id,
+        'ip' => '100.64.0.4',
+    ]);
+});
 
-        $this->assertDatabaseHas('network_servers', [
-            'network_id' => $network->id,
-            'server_id' => $other->id,
-            'ip' => '100.64.0.4',
-        ]);
-    }
+/**
+ * @return array<string, array{0: NetworkType}>
+ */
+dataset('nonWireGuardTypes', function () {
+    return [
+        'custom' => [NetworkType::CUSTOM],
+        'provider' => [NetworkType::PROVIDER],
+    ];
+});
 
-    /**
-     * @return array<string, array{0: NetworkType}>
-     */
-    public static function nonWireGuardTypes(): array
-    {
-        return [
-            'custom' => [NetworkType::CUSTOM],
-            'provider' => [NetworkType::PROVIDER],
-        ];
-    }
+test('peer routes 404 on non wireguard network', function (NetworkType $type) {
+    $network = Network::factory()->create([
+        'project_id' => $this->server->project_id,
+        'type' => $type,
+    ]);
 
-    #[DataProvider('nonWireGuardTypes')]
-    public function test_peer_routes_404_on_non_wireguard_network(NetworkType $type): void
-    {
-        $network = Network::factory()->create([
-            'project_id' => $this->server->project_id,
-            'type' => $type,
-        ]);
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $this->get(route('networks.peers', $network))->assertNotFound();
+    $this->post(route('networks.peers.store', $network), ['name' => 'laptop'])->assertNotFound();
+})->with('nonWireGuardTypes');
 
-        $this->get(route('networks.peers', $network))->assertNotFound();
-        $this->post(route('networks.peers.store', $network), ['name' => 'laptop'])->assertNotFound();
-    }
+test('peer appears in member config without endpoint', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
 
-    public function test_peer_appears_in_member_config_without_endpoint(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
 
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+    $conf = SSH::getUploadedContent();
+    $this->assertStringContainsString($peer->public_key, $conf);
+    $this->assertStringNotContainsString('Endpoint', $conf);
+});
 
-        $conf = SSH::getUploadedContent();
-        $this->assertStringContainsString($peer->public_key, $conf);
-        $this->assertStringNotContainsString('Endpoint', $conf);
-    }
+test('devices handshake rule is materialized and removed', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
 
-    public function test_devices_handshake_rule_is_materialized_and_removed(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
 
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+    SSH::assertExecutedContains('allow from any to any proto udp port 51820');
+    $this->assertDatabaseHas('server_network_rules', [
+        'network_id' => $network->id,
+        'name' => 'WireGuard handshake (devices)',
+        'source' => null,
+    ]);
 
-        SSH::assertExecutedContains('allow from any to any proto udp port 51820');
-        $this->assertDatabaseHas('server_network_rules', [
-            'network_id' => $network->id,
-            'name' => 'WireGuard handshake (devices)',
-            'source' => null,
-        ]);
+    app(DeleteNetworkPeer::class)->delete($peer);
 
-        app(DeleteNetworkPeer::class)->delete($peer);
+    $this->assertDatabaseMissing('server_network_rules', [
+        'network_id' => $network->id,
+        'name' => 'WireGuard handshake (devices)',
+    ]);
+});
 
-        $this->assertDatabaseMissing('server_network_rules', [
-            'network_id' => $network->id,
-            'name' => 'WireGuard handshake (devices)',
-        ]);
-    }
+test('peer config is valid wireguard ini format', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
 
-    /**
-     * WireGuard requires one directive per line — a reformatted blade template that
-     * collapses these onto a single line produces a config no client can parse.
-     */
-    public function test_peer_config_is_valid_wireguard_ini_format(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+    $config = app(GetNetworkPeerConfig::class)->config($peer)['config'];
 
-        $config = app(GetNetworkPeerConfig::class)->config($peer)['config'];
+    expect($config)->toMatch('/^\[Interface\]$/m');
+    expect($config)->toMatch('/^Address = '.preg_quote((string) $peer->ip, '/').'\/32$/m');
+    expect($config)->toMatch('/^PrivateKey = \S+$/m');
+    expect($config)->toMatch('/^\[Peer\]$/m');
+    expect($config)->toMatch('/^PublicKey = \S+$/m');
+    expect($config)->toMatch('/^AllowedIPs = \S+$/m');
+    expect($config)->toMatch('/^PersistentKeepalive = 25$/m');
+});
 
-        $this->assertMatchesRegularExpression('/^\[Interface\]$/m', $config);
-        $this->assertMatchesRegularExpression('/^Address = '.preg_quote((string) $peer->ip, '/').'\/32$/m', $config);
-        $this->assertMatchesRegularExpression('/^PrivateKey = \S+$/m', $config);
-        $this->assertMatchesRegularExpression('/^\[Peer\]$/m', $config);
-        $this->assertMatchesRegularExpression('/^PublicKey = \S+$/m', $config);
-        $this->assertMatchesRegularExpression('/^AllowedIPs = \S+$/m', $config);
-        $this->assertMatchesRegularExpression('/^PersistentKeepalive = 25$/m', $config);
-    }
+test('private key is revealed once but config remains available', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
 
-    /**
-     * The config is not a secret — it must stay available so it can be regenerated.
-     */
-    public function test_private_key_is_revealed_once_but_config_remains_available(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $url = route('networks.peers.config', ['network' => $network->id, 'networkPeer' => $peer->id]);
 
-        $url = route('networks.peers.config', ['network' => $network->id, 'networkPeer' => $peer->id]);
+    $this->getJson($url)
+        ->assertOk()
+        ->assertJsonPath('private_key', fn (?string $key): bool => filled($key))
+        ->assertJsonPath('config', fn (string $config): bool => str_contains($config, '[Interface]')
+            && ! str_contains($config, 'REPLACE_WITH_YOUR_PRIVATE_KEY'));
 
-        $this->getJson($url)
-            ->assertOk()
-            ->assertJsonPath('private_key', fn (?string $key): bool => filled($key))
-            ->assertJsonPath('config', fn (string $config): bool => str_contains($config, '[Interface]')
-                && ! str_contains($config, 'REPLACE_WITH_YOUR_PRIVATE_KEY'));
+    $this->post(route('networks.peers.conceal', ['network' => $network->id, 'networkPeer' => $peer->id]))
+        ->assertRedirect();
 
-        $this->post(route('networks.peers.conceal', ['network' => $network->id, 'networkPeer' => $peer->id]))
-            ->assertRedirect();
+    $this->assertDatabaseHas('network_peers', ['id' => $peer->id, 'private_key' => null]);
 
-        $this->assertDatabaseHas('network_peers', ['id' => $peer->id, 'private_key' => null]);
+    $this->getJson($url)
+        ->assertOk()
+        ->assertJsonPath('private_key', null)
+        ->assertJsonPath('config', fn (string $config): bool => str_contains($config, 'REPLACE_WITH_YOUR_PRIVATE_KEY'));
+});
 
-        $this->getJson($url)
-            ->assertOk()
-            ->assertJsonPath('private_key', null)
-            ->assertJsonPath('config', fn (string $config): bool => str_contains($config, 'REPLACE_WITH_YOUR_PRIVATE_KEY'));
-    }
+test('config reflects servers added after the key was concealed', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
 
-    public function test_config_reflects_servers_added_after_the_key_was_concealed(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+    app(ConcealNetworkPeerKey::class)->conceal($peer);
 
-        app(ConcealNetworkPeerKey::class)->conceal($peer);
+    $newServer = vitoPestFeatureNetworkPeerTestReadyPeerServer();
+    app(AddServersToNetwork::class)->add($network, ['servers' => [$newServer->id]]);
 
-        $newServer = $this->readyPeerServer();
-        app(AddServersToNetwork::class)->add($network, ['servers' => [$newServer->id]]);
+    $config = app(GetNetworkPeerConfig::class)->config($peer->fresh());
 
-        $config = app(GetNetworkPeerConfig::class)->config($peer->fresh());
+    expect($config['private_key'])->toBeNull();
+    $this->assertStringContainsString(
+        (string) $newServer->ip,
+        $config['config'],
+        'A peer must be able to regenerate its config to reach servers added after concealment.'
+    );
+});
 
-        $this->assertNull($config['private_key']);
-        $this->assertStringContainsString(
-            (string) $newServer->ip,
-            $config['config'],
-            'A peer must be able to regenerate its config to reach servers added after concealment.'
-        );
-    }
+test('peer config routes the subnet through a stable member', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $second = vitoPestFeatureNetworkPeerTestReadyPeerServer();
+    $third = vitoPestFeatureNetworkPeerTestReadyPeerServer();
 
-    /**
-     * The first member listed in a peer config carries the whole network range as its
-     * AllowedIPs, so it is the server the device routes the subnet through. That makes the
-     * order load-bearing: it must be stable across regenerations, not left to the database.
-     */
-    public function test_peer_config_routes_the_subnet_through_a_stable_member(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $second = $this->readyPeerServer();
-        $third = $this->readyPeerServer();
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
+    app(AddServersToNetwork::class)->add($network, ['servers' => [$second->id, $third->id]]);
 
-        $network = $this->wireguardNetwork([$this->server->id]);
-        app(AddServersToNetwork::class)->add($network, ['servers' => [$second->id, $third->id]]);
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
 
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+    $lowest = $network->servers()->orderBy('id')->firstOrFail();
 
-        $lowest = $network->servers()->orderBy('id')->firstOrFail();
+    for ($i = 0; $i < 3; $i++) {
+        $config = app(GetNetworkPeerConfig::class)->config($peer->refresh())['config'];
 
-        for ($i = 0; $i < 3; $i++) {
-            $config = app(GetNetworkPeerConfig::class)->config($peer->refresh())['config'];
+        $blocks = array_slice(preg_split('/^\[Peer\]$/m', $config) ?: [], 1);
+        expect($blocks)->toHaveCount(3);
 
-            $blocks = array_slice(preg_split('/^\[Peer\]$/m', $config) ?: [], 1);
-            $this->assertCount(3, $blocks);
+        $this->assertStringContainsString('AllowedIPs = '.$network->cidr, $blocks[0]);
+        $this->assertStringContainsString('PublicKey = '.$lowest->public_key, $blocks[0]);
 
-            $this->assertStringContainsString('AllowedIPs = '.$network->cidr, $blocks[0]);
-            $this->assertStringContainsString('PublicKey = '.$lowest->public_key, $blocks[0]);
-
-            foreach (array_slice($blocks, 1) as $block) {
-                $this->assertStringNotContainsString('AllowedIPs = '.$network->cidr, $block);
-                $this->assertMatchesRegularExpression('/AllowedIPs = \S+\/32/', $block);
-            }
+        foreach (array_slice($blocks, 1) as $block) {
+            $this->assertStringNotContainsString('AllowedIPs = '.$network->cidr, $block);
+            expect($block)->toMatch('/AllowedIPs = \S+\/32/');
         }
     }
+});
 
-    public function test_byo_peer_keeps_config_and_rejects_conceal(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
+test('byo peer keeps config and rejects conceal', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
 
-        $key = base64_encode(random_bytes(32));
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop', 'public_key' => $key]);
+    $key = base64_encode(random_bytes(32));
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop', 'public_key' => $key]);
 
-        $this->assertDatabaseHas('network_peers', ['id' => $peer->id, 'byo' => true, 'private_key' => null, 'public_key' => $key]);
+    $this->assertDatabaseHas('network_peers', ['id' => $peer->id, 'byo' => true, 'private_key' => null, 'public_key' => $key]);
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->getJson(route('networks.peers.config', ['network' => $network->id, 'networkPeer' => $peer->id]))
-            ->assertOk()
-            ->assertJsonPath('config', fn (string $config): bool => str_contains($config, 'REPLACE_WITH_YOUR_PRIVATE_KEY'));
+    $this->getJson(route('networks.peers.config', ['network' => $network->id, 'networkPeer' => $peer->id]))
+        ->assertOk()
+        ->assertJsonPath('config', fn (string $config): bool => str_contains($config, 'REPLACE_WITH_YOUR_PRIVATE_KEY'));
 
-        $this->post(route('networks.peers.conceal', ['network' => $network->id, 'networkPeer' => $peer->id]))
-            ->assertSessionHasErrors('peer');
-    }
+    $this->post(route('networks.peers.conceal', ['network' => $network->id, 'networkPeer' => $peer->id]))
+        ->assertSessionHasErrors('peer');
+});
 
-    public function test_byo_public_key_validation(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
+test('byo public key validation', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->post(route('networks.peers.store', $network), ['name' => 'bad', 'public_key' => 'not-base64!!'])
-            ->assertSessionHasErrors('public_key');
+    $this->post(route('networks.peers.store', $network), ['name' => 'bad', 'public_key' => 'not-base64!!'])
+        ->assertSessionHasErrors('public_key');
 
-        $memberKey = $network->servers()->first()->public_key;
-        $this->post(route('networks.peers.store', $network), ['name' => 'collide-member', 'public_key' => $memberKey])
-            ->assertSessionHasErrors('public_key');
+    $memberKey = $network->servers()->first()->public_key;
+    $this->post(route('networks.peers.store', $network), ['name' => 'collide-member', 'public_key' => $memberKey])
+        ->assertSessionHasErrors('public_key');
 
-        $existing = base64_encode(random_bytes(32));
-        app(CreateNetworkPeer::class)->create($network, ['name' => 'first', 'public_key' => $existing]);
-        $this->post(route('networks.peers.store', $network), ['name' => 'collide-peer', 'public_key' => $existing])
-            ->assertSessionHasErrors('public_key');
-    }
+    $existing = base64_encode(random_bytes(32));
+    app(CreateNetworkPeer::class)->create($network, ['name' => 'first', 'public_key' => $existing]);
+    $this->post(route('networks.peers.store', $network), ['name' => 'collide-peer', 'public_key' => $existing])
+        ->assertSessionHasErrors('public_key');
+});
 
-    /**
-     * @return array<string, array{0: string}>
-     */
-    public static function untrustedPublicKeys(): array
-    {
-        $valid = 'QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWY=';
+/**
+ * @return array<string, array{0: string}>
+ */
+dataset('untrustedPublicKeys', function () {
+    $valid = 'QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWY=';
 
-        return [
-            'embedded space' => ['QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZW Y='],
-            'embedded newline' => ["QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZW\nY="],
-            'trailing newline directive' => [$valid."\nAllowedIPs = 0.0.0.0/0"],
-            'embedded tab' => ["QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZW\tY="],
-            'command substitution' => ['$(id)'],
-            'command chaining' => [$valid.'; rm -rf /'],
-            'backticks' => ['`whoami`'],
-            'too short' => ['QUJDREVG'],
-            'wrong padding' => [str_repeat('A', 44)],
-        ];
-    }
+    return [
+        'embedded space' => ['QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZW Y='],
+        'embedded newline' => ["QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZW\nY="],
+        'trailing newline directive' => [$valid."\nAllowedIPs = 0.0.0.0/0"],
+        'embedded tab' => ["QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZW\tY="],
+        'command substitution' => ['$(id)'],
+        'command chaining' => [$valid.'; rm -rf /'],
+        'backticks' => ['`whoami`'],
+        'too short' => ['QUJDREVG'],
+        'wrong padding' => [str_repeat('A', 44)],
+    ];
+});
 
-    /**
-     * A bring-your-own public key is interpolated straight into the WireGuard config
-     * template, so anything but the exact 44-character wire form must be rejected.
-     */
-    #[DataProvider('untrustedPublicKeys')]
-    public function test_untrusted_byo_public_keys_are_rejected(string $publicKey): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
+test('untrusted byo public keys are rejected', function (string $publicKey) {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->post(route('networks.peers.store', $network), ['name' => 'laptop', 'public_key' => $publicKey])
-            ->assertSessionHasErrors('public_key');
+    $this->post(route('networks.peers.store', $network), ['name' => 'laptop', 'public_key' => $publicKey])
+        ->assertSessionHasErrors('public_key');
 
-        $this->assertDatabaseMissing('network_peers', ['network_id' => $network->id, 'public_key' => $publicKey]);
-    }
+    $this->assertDatabaseMissing('network_peers', ['network_id' => $network->id, 'public_key' => $publicKey]);
+})->with('untrustedPublicKeys');
 
-    public function test_regenerate_peer_keys(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
-        $original = $peer->public_key;
+test('regenerate peer keys', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+    $original = $peer->public_key;
 
-        $this->actingAs($this->user);
-        $this->post(route('networks.peers.regenerate', ['network' => $network->id, 'networkPeer' => $peer->id]))
-            ->assertRedirect();
+    $this->actingAs($this->user);
+    $this->post(route('networks.peers.regenerate', ['network' => $network->id, 'networkPeer' => $peer->id]))
+        ->assertRedirect();
 
-        $peer->refresh();
-        $this->assertNotSame($original, $peer->public_key);
-        $this->assertFalse($peer->byo);
-        $this->assertTrue($peer->hasPrivateKey());
-    }
+    $peer->refresh();
+    $this->assertNotSame($original, $peer->public_key);
+    expect($peer->byo)->toBeFalse();
+    expect($peer->hasPrivateKey())->toBeTrue();
+});
 
-    public function test_disable_removes_peer_from_config_and_enable_restores(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+test('disable removes peer from config and enable restores', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
 
-        app(UpdateNetworkPeer::class)->update($peer, ['name' => 'laptop', 'enabled' => false]);
-        $this->assertSame(NetworkPeerStatus::DISABLED, $peer->refresh()->status);
-        $this->assertStringNotContainsString($peer->public_key, SSH::getUploadedContent());
+    app(UpdateNetworkPeer::class)->update($peer, ['name' => 'laptop', 'enabled' => false]);
+    expect($peer->refresh()->status)->toBe(NetworkPeerStatus::DISABLED);
+    $this->assertStringNotContainsString($peer->public_key, SSH::getUploadedContent());
 
-        app(UpdateNetworkPeer::class)->update($peer, ['name' => 'laptop', 'enabled' => true]);
-        $this->assertStringContainsString($peer->public_key, SSH::getUploadedContent());
-    }
+    app(UpdateNetworkPeer::class)->update($peer, ['name' => 'laptop', 'enabled' => true]);
+    $this->assertStringContainsString($peer->public_key, SSH::getUploadedContent());
+});
 
-    /**
-     * The lowest-id member is polled first, but a member whose WireGuard service is not yet
-     * READY must not stop the poll — a later member with a ready service still serves it.
-     */
-    public function test_poll_peer_handshakes_falls_back_to_a_later_eligible_member(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $second = $this->readyPeerServer();
+test('poll peer handshakes falls back to a later eligible member', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $second = vitoPestFeatureNetworkPeerTestReadyPeerServer();
 
-        $network = $this->wireguardNetwork([$this->server->id]);
-        app(AddServersToNetwork::class)->add($network, ['servers' => [$second->id]]);
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
+    app(AddServersToNetwork::class)->add($network, ['servers' => [$second->id]]);
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
 
-        $first = $network->servers()->where('server_id', $this->server->id)->firstOrFail();
-        $first->server->service(WireGuard::type())->update(['status' => ServiceStatus::INSTALLING]);
+    $first = $network->servers()->where('server_id', $this->server->id)->firstOrFail();
+    $first->server->service(WireGuard::type())->update(['status' => ServiceStatus::INSTALLING]);
 
-        SSH::fake("{$peer->public_key}\t1700000000");
-        (new PollPeerHandshakesJob($network->refresh()))->handle();
+    SSH::fake("{$peer->public_key}\t1700000000");
+    (new PollPeerHandshakesJob($network->refresh()))->handle();
 
-        $this->assertNotNull($peer->refresh()->last_handshake_at);
-    }
+    expect($peer->refresh()->last_handshake_at)->not->toBeNull();
+});
 
-    public function test_poll_peer_handshakes_updates_last_handshake(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+test('poll peer handshakes updates last handshake', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
 
-        SSH::fake("{$peer->public_key}\t1700000000");
-        (new PollPeerHandshakesJob($network->refresh()))->handle();
-        $this->assertNotNull($peer->refresh()->last_handshake_at);
+    SSH::fake("{$peer->public_key}\t1700000000");
+    (new PollPeerHandshakesJob($network->refresh()))->handle();
+    expect($peer->refresh()->last_handshake_at)->not->toBeNull();
 
-        $peer->update(['last_handshake_at' => null]);
-        SSH::fake("{$peer->public_key}\t0");
-        (new PollPeerHandshakesJob($network->refresh()))->handle();
-        $this->assertNull($peer->refresh()->last_handshake_at);
-    }
+    $peer->update(['last_handshake_at' => null]);
+    SSH::fake("{$peer->public_key}\t0");
+    (new PollPeerHandshakesJob($network->refresh()))->handle();
+    expect($peer->refresh()->last_handshake_at)->toBeNull();
+});
 
-    public function test_duplicate_name_is_rejected(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
-        app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+test('duplicate name is rejected', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
+    app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
 
-        $this->actingAs($this->user);
-        $this->post(route('networks.peers.store', $network), ['name' => 'laptop'])
-            ->assertSessionHasErrors('name');
-    }
+    $this->actingAs($this->user);
+    $this->post(route('networks.peers.store', $network), ['name' => 'laptop'])
+        ->assertSessionHasErrors('name');
+});
 
-    public function test_config_endpoint_is_write_gated(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+test('config endpoint is write gated', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
 
-        $viewer = User::factory()->create();
-        $this->server->project->users()->create(['user_id' => $viewer->id, 'role' => UserRole::USER]);
-        $viewer->current_project_id = $this->server->project_id;
-        $viewer->save();
+    $viewer = User::factory()->create();
+    $this->server->project->users()->create(['user_id' => $viewer->id, 'role' => UserRole::USER]);
+    $viewer->current_project_id = $this->server->project_id;
+    $viewer->save();
 
-        $this->actingAs($viewer);
+    $this->actingAs($viewer);
 
-        $this->get(route('networks.peers', $network))->assertOk();
-        $this->getJson(route('networks.peers.config', ['network' => $network->id, 'networkPeer' => $peer->id]))
-            ->assertForbidden();
-        $this->post(route('networks.peers.store', $network), ['name' => 'nope'])->assertForbidden();
-    }
+    $this->get(route('networks.peers', $network))->assertOk();
+    $this->getJson(route('networks.peers.config', ['network' => $network->id, 'networkPeer' => $peer->id]))
+        ->assertForbidden();
+    $this->post(route('networks.peers.store', $network), ['name' => 'nope'])->assertForbidden();
+});
 
-    public function test_peer_from_another_project_is_not_found(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
+test('peer from another project is not found', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
 
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-        $otherNetwork = Network::factory()->create([
-            'project_id' => $otherUser->current_project_id,
-            'type' => NetworkType::WIREGUARD,
-        ]);
-        $foreignPeer = NetworkPeer::factory()->create(['network_id' => $otherNetwork->id]);
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+    $otherNetwork = Network::factory()->create([
+        'project_id' => $otherUser->current_project_id,
+        'type' => NetworkType::WIREGUARD,
+    ]);
+    $foreignPeer = NetworkPeer::factory()->create(['network_id' => $otherNetwork->id]);
 
-        $this->actingAs($this->user);
-        $this->getJson(route('networks.peers.config', ['network' => $network->id, 'networkPeer' => $foreignPeer->id]))
-            ->assertNotFound();
-    }
+    $this->actingAs($this->user);
+    $this->getJson(route('networks.peers.config', ['network' => $network->id, 'networkPeer' => $foreignPeer->id]))
+        ->assertNotFound();
+});
 
-    public function test_recompute_activates_pending_peers(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $network = $this->wireguardNetwork([$this->server->id]);
+test('recompute activates pending peers', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $network = vitoPestFeatureNetworkPeerTestWireguardNetwork([$this->server->id]);
 
-        $peer = NetworkPeer::factory()->create([
-            'network_id' => $network->id,
-            'status' => NetworkPeerStatus::PENDING,
-        ]);
+    $peer = NetworkPeer::factory()->create([
+        'network_id' => $network->id,
+        'status' => NetworkPeerStatus::PENDING,
+    ]);
 
-        app(RecomputeNetworkStatus::class)->handle($network);
+    app(RecomputeNetworkStatus::class)->handle($network);
 
-        $this->assertSame(NetworkPeerStatus::ACTIVE, $peer->refresh()->status);
-    }
-}
+    expect($peer->refresh()->status)->toBe(NetworkPeerStatus::ACTIVE);
+});

--- a/tests/Feature/NetworkPeerTest.php
+++ b/tests/Feature/NetworkPeerTest.php
@@ -277,7 +277,7 @@ test('byo public key validation', function () {
     $this->post(route('networks.peers.store', $network), ['name' => 'bad', 'public_key' => 'not-base64!!'])
         ->assertSessionHasErrors('public_key');
 
-    $memberKey = $network->servers()->first()->public_key;
+    $memberKey = $network->servers()->firstOrFail()->public_key;
     $this->post(route('networks.peers.store', $network), ['name' => 'collide-member', 'public_key' => $memberKey])
         ->assertSessionHasErrors('public_key');
 

--- a/tests/Feature/NetworkProviderSyncTest.php
+++ b/tests/Feature/NetworkProviderSyncTest.php
@@ -354,12 +354,8 @@ test('malformed provider response fails the sweep instead of pruning', function 
 
     $this->malformed = true;
 
-    try {
-        vitoPestFeatureNetworkProviderSyncTestSync();
-        $this->fail('A malformed provider response must fail the sweep.');
-    } catch (PrivateNetworkSyncError) {
-        // expected
-    }
+    expect(fn () => vitoPestFeatureNetworkProviderSyncTestSync())
+        ->toThrow(PrivateNetworkSyncError::class);
 
     expect(Network::query()->find($network->id))->not->toBeNull('A network must not be pruned on the strength of an unreadable response.');
 });
@@ -372,9 +368,8 @@ test('a network that cannot be persisted fails the sweep', function () {
         ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
     ]);
 
-    $this->expectException(PrivateNetworkPersistError::class);
-
-    vitoPestFeatureNetworkProviderSyncTestSync();
+    expect(fn () => vitoPestFeatureNetworkProviderSyncTestSync())
+        ->toThrow(PrivateNetworkPersistError::class);
 
     expect($peer)->not->toBeNull();
 });

--- a/tests/Feature/NetworkProviderSyncTest.php
+++ b/tests/Feature/NetworkProviderSyncTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\Network\RecomputeNetworkStatus;
 use App\Actions\Network\SyncProviderNetworks;
 use App\Enums\NetworkServerStatus;
@@ -29,812 +27,617 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Queue;
-use RuntimeException;
-use Tests\TestCase;
 
-class NetworkProviderSyncTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    private ServerProvider $connection;
+/**
+ * `Http::fake()` merges stubs rather than replacing them, so a per-call fake would let
+ * the first registration win for every later sync. One closure reading mutable state
+ * is the only way to vary the response across runs within a test.
+ */
+beforeEach(function () {
+    $this->networksPayload = [];
+    $this->serversPayload = [];
+    $this->failStatus = null;
+    $this->malformed = false;
 
-    /** @var array<int, array<string, mixed>> */
-    private array $networksPayload = [];
+    SSH::fake();
 
-    /** @var array<int, array<string, mixed>> */
-    private array $serversPayload = [];
+    Http::fake(function (Request $request): PromiseInterface {
+        if ($this->failStatus !== null) {
+            return Http::response(['error' => ['message' => 'nope']], $this->failStatus);
+        }
 
-    private ?int $failStatus = null;
+        if ($this->malformed) {
+            return Http::response(['unexpected' => 'shape']);
+        }
 
-    private bool $malformed = false;
-
-    /**
-     * `Http::fake()` merges stubs rather than replacing them, so a per-call fake would let
-     * the first registration win for every later sync. One closure reading mutable state
-     * is the only way to vary the response across runs within a test.
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        SSH::fake();
-
-        Http::fake(function (Request $request): PromiseInterface {
-            if ($this->failStatus !== null) {
-                return Http::response(['error' => ['message' => 'nope']], $this->failStatus);
-            }
-
-            if ($this->malformed) {
-                return Http::response(['unexpected' => 'shape']);
-            }
-
-            if (str_contains($request->url(), '/networks')) {
-                return Http::response([
-                    'networks' => $this->networksPayload,
-                    'meta' => ['pagination' => ['next_page' => null]],
-                ]);
-            }
-
+        if (str_contains($request->url(), '/networks')) {
             return Http::response([
-                'servers' => $this->serversPayload,
+                'networks' => $this->networksPayload,
                 'meta' => ['pagination' => ['next_page' => null]],
             ]);
-        });
-
-        $this->connection = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Hetzner::id(),
-            'profile' => 'hetzner-main',
-            'credentials' => ['token' => 'secret-token'],
-        ]);
-
-        $this->server->update([
-            'status' => ServerStatus::READY,
-            'provider_id' => $this->connection->id,
-            'provider_data' => ['hetzner_id' => 101, 'region' => 'nbg1'],
-        ]);
-    }
-
-    private function otherServer(int $hetznerId = 102): Server
-    {
-        return Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-            'provider_id' => $this->connection->id,
-            'provider_data' => ['hetzner_id' => $hetznerId, 'region' => 'nbg1'],
-        ]);
-    }
-
-    /**
-     * @param  array<int, array<string, mixed>>  $networks
-     * @param  array<int, array<string, mixed>>  $servers
-     */
-    private function fakeProvider(array $networks, array $servers): void
-    {
-        $this->networksPayload = $networks;
-        $this->serversPayload = $servers;
-        $this->failStatus = null;
-    }
-
-    private function sync(?Network $only = null): void
-    {
-        app(SyncProviderNetworks::class)->forProject($this->server->project, $only);
-    }
-
-    public function test_creates_network_and_members_from_provider(): void
-    {
-        $peer = $this->otherServer();
-
-        $this->fakeProvider(
-            [[
-                'id' => 4711,
-                'name' => 'prod',
-                'ip_range' => '10.0.0.0/16',
-                'subnets' => [['network_zone' => 'eu-central']],
-                'servers' => [101, 102],
-            ]],
-            [
-                ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
-                ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]],
-            ],
-        );
-
-        $this->sync();
-
-        $this->assertDatabaseHas('networks', [
-            'project_id' => $this->server->project_id,
-            'server_provider_id' => $this->connection->id,
-            'external_id' => '4711',
-            'name' => 'prod',
-            'type' => NetworkType::PROVIDER->value,
-            'cidr' => '10.0.0.0/16',
-            'region' => 'eu-central',
-        ]);
-
-        $network = Network::query()->where('external_id', '4711')->firstOrFail();
-
-        $this->assertDatabaseHas('network_servers', [
-            'network_id' => $network->id,
-            'server_id' => $this->server->id,
-            'ip' => '10.0.0.2',
-        ]);
-        $this->assertDatabaseHas('network_servers', [
-            'network_id' => $network->id,
-            'server_id' => $peer->id,
-            'ip' => '10.0.0.3',
-        ]);
-    }
-
-    public function test_second_run_creates_no_duplicates(): void
-    {
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
-            [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]],
-        );
-
-        $this->sync();
-        $this->sync();
-
-        $this->assertSame(1, Network::query()->where('external_id', '4711')->count());
-        $this->assertSame(1, Network::query()->where('type', NetworkType::PROVIDER)->count());
-    }
-
-    public function test_adds_and_removes_members_as_provider_changes(): void
-    {
-        $peer = $this->otherServer();
-
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101, 102]]],
-            [
-                ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
-                ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]],
-            ],
-        );
-        $this->sync();
-
-        $network = Network::query()->where('external_id', '4711')->firstOrFail();
-        $this->assertSame(2, $network->servers()->count());
-
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
-            [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]],
-        );
-        $this->sync();
-
-        $this->assertSame(
-            0,
-            $network->servers()->where('server_id', $peer->id)->whereNot('status', NetworkServerStatus::LEAVING)->count(),
-            'A detached server must no longer be a live member.'
-        );
-    }
-
-    public function test_reattached_server_revives_a_leaving_member_instead_of_throwing(): void
-    {
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
-            [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]],
-        );
-        $this->sync();
-
-        $network = Network::query()->where('external_id', '4711')->firstOrFail();
-        $member = $network->servers()->firstOrFail();
-        $member->update(['status' => NetworkServerStatus::LEAVING, 'sync_attempts' => 3]);
-
-        $this->sync();
-
-        $member->refresh();
-        $this->assertSame(NetworkServerStatus::ACTIVE, $member->status);
-        $this->assertSame(0, $member->sync_attempts);
-        $this->assertSame(1, $network->servers()->count(), 'Reviving must not insert a second member row.');
-    }
-
-    /**
-     * The peer keeps the network alive so this exercises member removal, not network prune.
-     */
-    public function test_already_leaving_member_is_not_torn_down_again(): void
-    {
-        $peer = $this->otherServer();
-
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101, 102]]],
-            [
-                ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
-                ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]],
-            ],
-        );
-        $this->sync();
-
-        $network = Network::query()->where('external_id', '4711')->firstOrFail();
-        $member = $network->servers()->where('server_id', $this->server->id)->firstOrFail();
-        $member->update(['status' => NetworkServerStatus::LEAVING, 'sync_attempts' => 3]);
-
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [102]]],
-            [['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]]],
-        );
-        $this->sync();
-
-        $member->refresh();
-        $this->assertSame(
-            3,
-            $member->sync_attempts,
-            'Re-driving teardown would reset sync_attempts and defeat forceConverge escalation.'
-        );
-        $this->assertNotNull($peer->id);
-    }
-
-    public function test_resurrects_a_deleting_network_that_reappears(): void
-    {
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
-            [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]],
-        );
-        $this->sync();
-
-        $network = Network::query()->where('external_id', '4711')->firstOrFail();
-        $network->update(['status' => NetworkStatus::DELETING]);
-        $network->servers()->update(['status' => NetworkServerStatus::LEAVING]);
-
-        $this->sync();
-
-        $network->refresh();
-        $this->assertNotSame(NetworkStatus::DELETING, $network->status);
-        $this->assertSame(
-            0,
-            $network->servers()->where('status', NetworkServerStatus::LEAVING)->count(),
-            'Resurrected networks must not keep LEAVING members that never converge.'
-        );
-    }
-
-    public function test_deletes_network_when_vpc_disappears(): void
-    {
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
-            [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]],
-        );
-        $this->sync();
-
-        $network = Network::query()->where('external_id', '4711')->firstOrFail();
-
-        $this->fakeProvider([], []);
-        $this->sync();
-
-        $this->assertNotSame(
-            NetworkStatus::ACTIVE,
-            $network->fresh()?->status,
-            'A removed VPC must start teardown.'
-        );
-    }
-
-    /**
-     * A failed connection must leave its networks untouched rather than pruning them, and the
-     * error must still reach the caller so the sync is not reported as a success.
-     */
-    public function test_provider_failure_never_prunes_and_is_rethrown(): void
-    {
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
-            [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]],
-        );
-        $this->sync();
-
-        $network = Network::query()->where('external_id', '4711')->firstOrFail();
-
-        $this->failStatus = 500;
-
-        $threw = false;
-        try {
-            $this->sync();
-        } catch (PrivateNetworkSyncError) {
-            $threw = true;
         }
 
-        $this->assertTrue($threw, 'A provider failure must not be reported as a successful sync.');
-
-        $network->refresh();
-        $this->assertSame(NetworkStatus::ACTIVE, $network->status);
-        $this->assertSame(1, $network->servers()->count());
-    }
-
-    /**
-     * Deleting the last server on a connection leaves its provider networks with no members,
-     * so nothing can reconcile them — and the policy refuses a manual delete while the network
-     * is provider-managed. The sweep therefore still has to visit the connection and prune.
-     */
-    public function test_provider_network_is_pruned_after_its_last_managed_server_is_deleted(): void
-    {
-        $other = $this->otherServer();
-
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101, 102]]],
-            [
-                ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
-                ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]],
-            ],
-        );
-        $this->sync();
-
-        $network = Network::query()->where('external_id', '4711')->firstOrFail();
-        $this->assertSame(2, $network->servers()->count());
-
-        $other->delete();
-        $this->server->delete();
-
-        $this->assertSame(0, $network->servers()->count());
-
-        $this->sync();
-
-        $this->assertNull(
-            Network::query()->find($network->id),
-            'A provider network with no managed servers left must be pruned, not stranded.'
-        );
-    }
-
-    /**
-     * A connection can yield no instance ids while its servers still exist — for example when
-     * `provider_data` is missing the id key. An empty result then says nothing about what is
-     * still at the provider, so a network that has members must survive rather than be reaped.
-     */
-    public function test_network_with_live_members_survives_when_no_instance_ids_can_be_queried(): void
-    {
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
-            [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]],
-        );
-        $this->sync();
-
-        $network = Network::query()->where('external_id', '4711')->firstOrFail();
-        $this->assertSame(1, $network->servers()->count());
-
-        $this->server->update(['provider_data' => ['region' => 'nbg1']]);
-
-        $this->sync();
-
-        $this->assertNotNull(
-            Network::query()->find($network->id),
-            'A network with live members must not be pruned when the provider could not be queried.'
-        );
-        $this->assertSame(1, $network->servers()->count());
-    }
-
-    /**
-     * EC2 is queried per region, so a connection whose servers carry no region cannot be asked
-     * at all. Reading that empty result as "the VPCs are gone" would delete every AWS network
-     * on the connection, with its firewall rules, on a single sync.
-     */
-    public function test_aws_networks_survive_when_no_region_is_known(): void
-    {
-        $connection = $this->awsConnection();
-        $server = $this->awsServer($connection, 'i-0abc');
-        $network = $this->awsNetwork($connection, 'vpc-0abc', $server);
-
-        $this->sync();
-
-        $this->assertNotNull(
-            Network::query()->find($network->id),
-            'An AWS network must not be pruned when no region was available to query.'
-        );
-        $this->assertSame(1, $network->servers()->count());
-    }
-
-    /**
-     * Only the regions actually collected are queried, so one server without a region leaves its
-     * VPC unasked-about while the rest of the connection answers normally. Treating that as a
-     * complete answer would delete precisely the network the guard exists to protect.
-     */
-    public function test_aws_networks_survive_when_one_server_has_no_region(): void
-    {
-        $connection = $this->awsConnection();
-        $this->awsServer($connection, 'i-known', 'eu-west-1');
-        $stranded = $this->awsServer($connection, 'i-unknown');
-        $network = $this->awsNetwork($connection, 'vpc-unknown', $stranded);
-
-        $this->sync();
-
-        $this->assertNotNull(
-            Network::query()->find($network->id),
-            'A network in an unqueried region must not be pruned because other servers answered.'
-        );
-        $this->assertSame(1, $network->servers()->count());
-    }
-
-    /**
-     * Sync spares a network it could not ask about, and the policy refuses to delete a network
-     * whose connection still exists. A network no member can be identified at the provider by
-     * falls into both, so it has to be deletable or it is stranded with no way out.
-     */
-    public function test_provider_network_no_member_can_be_identified_by_becomes_deletable(): void
-    {
-        $network = $this->providerNetwork($this->connection->id);
-        $network->servers()->create([
-            'server_id' => $this->server->id,
-            'ip' => '10.0.0.2',
-            'status' => NetworkServerStatus::ACTIVE,
+        return Http::response([
+            'servers' => $this->serversPayload,
+            'meta' => ['pagination' => ['next_page' => null]],
         ]);
-
-        $this->actingAs($this->user);
-
-        $this->delete(route('networks.destroy', $network))->assertForbidden();
-
-        $this->server->update(['provider_data' => ['region' => 'nbg1']]);
-
-        $this->sync();
-
-        $this->assertNotNull(
-            Network::query()->find($network->id),
-            'Sync cannot ask about this network, so it must not be pruned either.'
-        );
-
-        $this->delete(route('networks.destroy', $network))->assertRedirect();
-        $this->assertNotSame(NetworkStatus::ACTIVE, $network->fresh()?->status);
-    }
-
-    /**
-     * A 200 whose body is not the expected shape says nothing about the account's inventory.
-     * Reading it as "no networks" would make an API change, a proxy, or a captive portal delete
-     * every synced network on the connection.
-     */
-    public function test_malformed_provider_response_fails_the_sweep_instead_of_pruning(): void
-    {
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
-            [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]],
-        );
-        $this->sync();
-
-        $network = Network::query()->where('external_id', '4711')->firstOrFail();
-
-        $this->malformed = true;
-
-        try {
-            $this->sync();
-            $this->fail('A malformed provider response must fail the sweep.');
-        } catch (PrivateNetworkSyncError) {
-            // expected
-        }
-
-        $this->assertNotNull(
-            Network::query()->find($network->id),
-            'A network must not be pruned on the strength of an unreadable response.'
-        );
-    }
-
-    /**
-     * Discovered networks that cannot be written leave the sweep incomplete. Pruning still runs
-     * for the rest, but the job has to report failure rather than a silent partial sync.
-     */
-    public function test_a_network_that_cannot_be_persisted_fails_the_sweep(): void
-    {
-        $peer = $this->otherServer();
-
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101, 102]]],
-            [
-                ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
-                ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
-            ],
-        );
-
-        $this->expectException(PrivateNetworkPersistError::class);
-
-        $this->sync();
-
-        $this->assertNotNull($peer);
-    }
-
-    /**
-     * The client replaces its whole copy of the network from this payload, so a relation the
-     * initial page load included has to be present here too — otherwise Settings blanks the
-     * provider the moment any status change is broadcast.
-     */
-    public function test_status_broadcast_carries_the_provider_relation(): void
-    {
-        Event::fake([SocketEvent::class]);
-
-        $network = $this->providerNetwork($this->connection->id);
-
-        app(RecomputeNetworkStatus::class)->handle($network);
-
-        $payload = null;
-
-        Event::assertDispatched(SocketEvent::class, function (SocketEvent $event) use (&$payload): bool {
-            if ($event->data->type === 'network.updated' && is_array($event->data->data)) {
-                $payload = $event->data->data;
-            }
-
-            return true;
-        });
-
-        $this->assertIsArray($payload);
-        $this->assertSame(Hetzner::id(), $payload['provider'] ?? null);
-    }
-
-    /**
-     * Only the sweep's own exceptions are built credential-free; anything else can carry a token
-     * in its message, and this log is written verbatim.
-     */
-    public function test_failed_job_does_not_log_an_unexpected_exception_message(): void
-    {
-        Log::spy();
-        Notification::fake();
-
-        (new SyncProviderNetworksJob($this->server->project))->failed(new RuntimeException('token=super-secret'));
-
-        Log::shouldHaveReceived('warning')->withArgs(
-            fn (string $message, array $context): bool => $context['exception'] === RuntimeException::class
-                && $context['reason'] === null
-        );
-    }
-
-    private function awsConnection(): ServerProvider
-    {
-        return ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => AWS::id(),
-            'profile' => 'aws-main',
-            'credentials' => ['key' => 'key', 'secret' => 'secret'],
-        ]);
-    }
-
-    private function awsServer(ServerProvider $connection, string $instanceId, ?string $region = null): Server
-    {
-        return Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-            'provider_id' => $connection->id,
-            'provider_data' => $region === null
-                ? ['instance_id' => $instanceId]
-                : ['instance_id' => $instanceId, 'region' => $region],
-        ]);
-    }
-
-    private function awsNetwork(ServerProvider $connection, string $externalId, Server $member): Network
-    {
-        $network = Network::factory()->create([
-            'project_id' => $this->server->project_id,
-            'type' => NetworkType::PROVIDER,
-            'server_provider_id' => $connection->id,
-            'external_id' => $externalId,
-        ]);
-
-        $network->servers()->create([
-            'server_id' => $member->id,
-            'ip' => '172.31.0.5',
-            'status' => NetworkServerStatus::ACTIVE,
-        ]);
-
-        return $network;
-    }
-
-    public function test_vpc_without_managed_servers_is_not_imported(): void
-    {
-        $this->fakeProvider(
-            [['id' => 9999, 'name' => 'someone-elses', 'ip_range' => '10.9.0.0/16', 'servers' => [777]]],
-            [['id' => 777, 'private_net' => [['network' => 9999, 'ip' => '10.9.0.2']]]],
-        );
-
-        $this->sync();
-
-        $this->assertSame(0, Network::query()->where('type', NetworkType::PROVIDER)->count());
-    }
-
-    public function test_imported_network_firewall_uses_member_ips_not_vpc_cidr(): void
-    {
-        $peer = $this->otherServer();
-
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '172.31.0.0/16', 'servers' => [101, 102]]],
-            [
-                ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '172.31.0.2']]],
-                ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '172.31.0.3']]],
-            ],
-        );
-
-        $this->sync();
-
-        $network = Network::query()->where('external_id', '4711')->firstOrFail();
-
-        $this->assertSame(
-            0,
-            ServerNetworkRule::query()->where('network_id', $network->id)->where('mask', 16)->count(),
-            'Sync must never widen the firewall to the whole VPC.'
-        );
-
-        $sources = ServerNetworkRule::query()
-            ->where('network_id', $network->id)
-            ->where('server_id', $this->server->id)
-            ->pluck('source')
-            ->all();
-
-        $this->assertContains('172.31.0.3', $sources);
-        $this->assertNotContains('172.31.0.0', $sources);
-        $this->assertNotNull($peer->id);
-    }
-
-    public function test_name_collision_is_uniqued(): void
-    {
-        Network::factory()->create([
-            'project_id' => $this->server->project_id,
-            'name' => 'prod',
-            'type' => NetworkType::CUSTOM,
-        ]);
-
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
-            [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]],
-        );
-
-        $this->sync();
-
-        $this->assertDatabaseHas('networks', ['external_id' => '4711', 'name' => 'prod-2']);
-    }
-
-    public function test_provider_name_change_does_not_rename_the_local_network(): void
-    {
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
-            [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]],
-        );
-        $this->sync();
-
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'renamed-at-provider', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
-            [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]],
-        );
-        $this->sync();
-
-        $this->assertDatabaseHas('networks', ['external_id' => '4711', 'name' => 'prod']);
-    }
-
-    public function test_recycled_ip_between_members_does_not_violate_unique_index(): void
-    {
-        $peer = $this->otherServer();
-
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101, 102]]],
-            [
-                ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
-                ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]],
-            ],
-        );
-        $this->sync();
-
-        $this->fakeProvider(
-            [['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101, 102]]],
-            [
-                ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]],
-                ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
-            ],
-        );
-        $this->sync();
-
-        $network = Network::query()->where('external_id', '4711')->firstOrFail();
-
-        $this->assertSame('10.0.0.3', $network->servers()->where('server_id', $this->server->id)->value('ip'));
-        $this->assertSame('10.0.0.2', $network->servers()->where('server_id', $peer->id)->value('ip'));
-    }
-
-    private function providerNetwork(?int $connectionId = null): Network
-    {
-        return Network::factory()->create([
-            'project_id' => $this->server->project_id,
-            'type' => NetworkType::PROVIDER,
-            'server_provider_id' => $connectionId,
-            'external_id' => '4711',
-        ]);
-    }
-
-    public function test_provider_network_cannot_be_deleted(): void
-    {
-        $network = $this->providerNetwork($this->connection->id);
-
-        $this->actingAs($this->user)
-            ->delete(route('networks.destroy', $network))
-            ->assertForbidden();
-
-        $this->assertDatabaseHas('networks', ['id' => $network->id]);
-    }
-
-    public function test_orphaned_provider_network_can_be_deleted(): void
-    {
-        $network = $this->providerNetwork(null);
-
-        $this->actingAs($this->user)
-            ->delete(route('networks.destroy', $network))
-            ->assertRedirect();
-
-        $this->assertNotSame(NetworkStatus::ACTIVE, $network->fresh()?->status);
-    }
-
-    public function test_manual_member_routes_are_rejected_on_a_provider_network(): void
-    {
-        $network = $this->providerNetwork($this->connection->id);
-        $member = $network->servers()->create([
-            'server_id' => $this->server->id,
-            'ip' => '10.0.0.2',
-            'status' => NetworkServerStatus::ACTIVE,
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('networks.servers.store', $network), ['servers' => [$this->server->id]])
-            ->assertNotFound();
-
-        $this->put(route('networks.servers.update', ['network' => $network, 'networkServer' => $member]), [])
-            ->assertNotFound();
-
-        $this->post(route('networks.servers.sync', ['network' => $network, 'networkServer' => $member]))
-            ->assertNotFound();
-
-        $this->delete(route('networks.servers.destroy', ['network' => $network, 'networkServer' => $member]))
-            ->assertNotFound();
-
-        $this->assertDatabaseHas('network_servers', ['id' => $member->id, 'status' => NetworkServerStatus::ACTIVE->value]);
-    }
-
-    public function test_global_sync_route_dispatches_the_job(): void
-    {
-        Queue::fake();
-
-        $this->actingAs($this->user)
-            ->post(route('networks.sync-providers'))
-            ->assertRedirect();
-
-        Queue::assertPushed(SyncProviderNetworksJob::class);
-    }
-
-    public function test_repeated_sync_clicks_are_debounced(): void
-    {
-        Queue::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('networks.sync-providers'))->assertRedirect();
-        $this->post(route('networks.sync-providers'))->assertRedirect();
-
-        Queue::assertPushed(SyncProviderNetworksJob::class, 1);
-    }
-
-    public function test_viewer_cannot_trigger_a_provider_sync(): void
-    {
-        Queue::fake();
-
-        $viewer = User::factory()->create();
-        $this->server->project->users()->create(['user_id' => $viewer->id, 'role' => UserRole::USER]);
-        $viewer->current_project_id = $this->server->project_id;
-        $viewer->save();
-
-        $this->actingAs($viewer)
-            ->post(route('networks.sync-providers'))
-            ->assertForbidden();
-
-        Queue::assertNothingPushed();
-    }
-
-    public function test_sync_ignores_networks_of_another_project(): void
-    {
-        $other = Network::factory()->create([
-            'project_id' => $this->server->project_id,
-            'type' => NetworkType::PROVIDER,
-            'server_provider_id' => $this->connection->id,
-            'external_id' => '4711',
-        ]);
-
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-
-        $before = $other->only(['project_id', 'server_provider_id', 'external_id', 'name', 'status', 'cidr', 'last_synced_at']);
-
-        app(SyncProviderNetworks::class)->forProject($otherUser->currentProject, $other);
-
-        $this->assertDatabaseHas('networks', ['id' => $other->id]);
-        $this->assertSame(
-            $before,
-            $other->fresh()?->only(['project_id', 'server_provider_id', 'external_id', 'name', 'status', 'cidr', 'last_synced_at']),
-            'Syncing one project must not write to another project\'s network.'
-        );
-        $this->assertSame(0, $other->servers()->count());
-    }
+    });
+
+    $this->connection = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Hetzner::id(),
+        'profile' => 'hetzner-main',
+        'credentials' => ['token' => 'secret-token'],
+    ]);
+
+    $this->server->update([
+        'status' => ServerStatus::READY,
+        'provider_id' => $this->connection->id,
+        'provider_data' => ['hetzner_id' => 101, 'region' => 'nbg1'],
+    ]);
+});
+
+function vitoPestFeatureNetworkProviderSyncTestOtherServer(int $hetznerId = 102): Server
+{
+    return Server::factory()->create([
+        'project_id' => test()->server->project_id,
+        'user_id' => test()->user->id,
+        'status' => ServerStatus::READY,
+        'provider_id' => test()->connection->id,
+        'provider_data' => ['hetzner_id' => $hetznerId, 'region' => 'nbg1'],
+    ]);
 }
+
+/**
+ * @param  array<int, array<string, mixed>>  $networks
+ * @param  array<int, array<string, mixed>>  $servers
+ */
+function vitoPestFeatureNetworkProviderSyncTestFakeProvider(array $networks, array $servers): void
+{
+    test()->networksPayload = $networks;
+    test()->serversPayload = $servers;
+    test()->failStatus = null;
+}
+
+function vitoPestFeatureNetworkProviderSyncTestSync(?Network $only = null): void
+{
+    app(SyncProviderNetworks::class)->forProject(test()->server->project, $only);
+}
+
+test('creates network and members from provider', function () {
+    $peer = vitoPestFeatureNetworkProviderSyncTestOtherServer();
+
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([[
+        'id' => 4711,
+        'name' => 'prod',
+        'ip_range' => '10.0.0.0/16',
+        'subnets' => [['network_zone' => 'eu-central']],
+        'servers' => [101, 102],
+    ]], [
+        ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
+        ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]],
+    ]);
+
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $this->assertDatabaseHas('networks', [
+        'project_id' => $this->server->project_id,
+        'server_provider_id' => $this->connection->id,
+        'external_id' => '4711',
+        'name' => 'prod',
+        'type' => NetworkType::PROVIDER->value,
+        'cidr' => '10.0.0.0/16',
+        'region' => 'eu-central',
+    ]);
+
+    $network = Network::query()->where('external_id', '4711')->firstOrFail();
+
+    $this->assertDatabaseHas('network_servers', [
+        'network_id' => $network->id,
+        'server_id' => $this->server->id,
+        'ip' => '10.0.0.2',
+    ]);
+    $this->assertDatabaseHas('network_servers', [
+        'network_id' => $network->id,
+        'server_id' => $peer->id,
+        'ip' => '10.0.0.3',
+    ]);
+});
+
+test('second run creates no duplicates', function () {
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]], [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]]);
+
+    vitoPestFeatureNetworkProviderSyncTestSync();
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    expect(Network::query()->where('external_id', '4711')->count())->toBe(1);
+    expect(Network::query()->where('type', NetworkType::PROVIDER)->count())->toBe(1);
+});
+
+test('adds and removes members as provider changes', function () {
+    $peer = vitoPestFeatureNetworkProviderSyncTestOtherServer();
+
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101, 102]]], [
+        ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
+        ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]],
+    ]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $network = Network::query()->where('external_id', '4711')->firstOrFail();
+    expect($network->servers()->count())->toBe(2);
+
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]], [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    expect($network->servers()->where('server_id', $peer->id)->whereNot('status', NetworkServerStatus::LEAVING)->count())->toBe(0, 'A detached server must no longer be a live member.');
+});
+
+test('reattached server revives a leaving member instead of throwing', function () {
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]], [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $network = Network::query()->where('external_id', '4711')->firstOrFail();
+    $member = $network->servers()->firstOrFail();
+    $member->update(['status' => NetworkServerStatus::LEAVING, 'sync_attempts' => 3]);
+
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $member->refresh();
+    expect($member->status)->toBe(NetworkServerStatus::ACTIVE);
+    expect($member->sync_attempts)->toBe(0);
+    expect($network->servers()->count())->toBe(1, 'Reviving must not insert a second member row.');
+});
+
+test('already leaving member is not torn down again', function () {
+    $peer = vitoPestFeatureNetworkProviderSyncTestOtherServer();
+
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101, 102]]], [
+        ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
+        ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]],
+    ]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $network = Network::query()->where('external_id', '4711')->firstOrFail();
+    $member = $network->servers()->where('server_id', $this->server->id)->firstOrFail();
+    $member->update(['status' => NetworkServerStatus::LEAVING, 'sync_attempts' => 3]);
+
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [102]]], [['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]]]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $member->refresh();
+    expect($member->sync_attempts)->toBe(3, 'Re-driving teardown would reset sync_attempts and defeat forceConverge escalation.');
+    expect($peer->id)->not->toBeNull();
+});
+
+test('resurrects a deleting network that reappears', function () {
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]], [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $network = Network::query()->where('external_id', '4711')->firstOrFail();
+    $network->update(['status' => NetworkStatus::DELETING]);
+    $network->servers()->update(['status' => NetworkServerStatus::LEAVING]);
+
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $network->refresh();
+    $this->assertNotSame(NetworkStatus::DELETING, $network->status);
+    expect($network->servers()->where('status', NetworkServerStatus::LEAVING)->count())->toBe(0, 'Resurrected networks must not keep LEAVING members that never converge.');
+});
+
+test('deletes network when vpc disappears', function () {
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]], [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $network = Network::query()->where('external_id', '4711')->firstOrFail();
+
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([], []);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $this->assertNotSame(
+        NetworkStatus::ACTIVE,
+        $network->fresh()?->status,
+        'A removed VPC must start teardown.'
+    );
+});
+
+test('provider failure never prunes and is rethrown', function () {
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]], [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $network = Network::query()->where('external_id', '4711')->firstOrFail();
+
+    $this->failStatus = 500;
+
+    $threw = false;
+    try {
+        vitoPestFeatureNetworkProviderSyncTestSync();
+    } catch (PrivateNetworkSyncError) {
+        $threw = true;
+    }
+
+    expect($threw)->toBeTrue('A provider failure must not be reported as a successful sync.');
+
+    $network->refresh();
+    expect($network->status)->toBe(NetworkStatus::ACTIVE);
+    expect($network->servers()->count())->toBe(1);
+});
+
+test('provider network is pruned after its last managed server is deleted', function () {
+    $other = vitoPestFeatureNetworkProviderSyncTestOtherServer();
+
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101, 102]]], [
+        ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
+        ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]],
+    ]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $network = Network::query()->where('external_id', '4711')->firstOrFail();
+    expect($network->servers()->count())->toBe(2);
+
+    $other->delete();
+    $this->server->delete();
+
+    expect($network->servers()->count())->toBe(0);
+
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    expect(Network::query()->find($network->id))->toBeNull('A provider network with no managed servers left must be pruned, not stranded.');
+});
+
+test('network with live members survives when no instance ids can be queried', function () {
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]], [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $network = Network::query()->where('external_id', '4711')->firstOrFail();
+    expect($network->servers()->count())->toBe(1);
+
+    $this->server->update(['provider_data' => ['region' => 'nbg1']]);
+
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    expect(Network::query()->find($network->id))->not->toBeNull('A network with live members must not be pruned when the provider could not be queried.');
+    expect($network->servers()->count())->toBe(1);
+});
+
+test('aws networks survive when no region is known', function () {
+    $connection = vitoPestFeatureNetworkProviderSyncTestAwsConnection();
+    $server = vitoPestFeatureNetworkProviderSyncTestAwsServer($connection, 'i-0abc');
+    $network = vitoPestFeatureNetworkProviderSyncTestAwsNetwork($connection, 'vpc-0abc', $server);
+
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    expect(Network::query()->find($network->id))->not->toBeNull('An AWS network must not be pruned when no region was available to query.');
+    expect($network->servers()->count())->toBe(1);
+});
+
+test('aws networks survive when one server has no region', function () {
+    $connection = vitoPestFeatureNetworkProviderSyncTestAwsConnection();
+    vitoPestFeatureNetworkProviderSyncTestAwsServer($connection, 'i-known', 'eu-west-1');
+    $stranded = vitoPestFeatureNetworkProviderSyncTestAwsServer($connection, 'i-unknown');
+    $network = vitoPestFeatureNetworkProviderSyncTestAwsNetwork($connection, 'vpc-unknown', $stranded);
+
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    expect(Network::query()->find($network->id))->not->toBeNull('A network in an unqueried region must not be pruned because other servers answered.');
+    expect($network->servers()->count())->toBe(1);
+});
+
+test('provider network no member can be identified by becomes deletable', function () {
+    $network = vitoPestFeatureNetworkProviderSyncTestProviderNetwork($this->connection->id);
+    $network->servers()->create([
+        'server_id' => $this->server->id,
+        'ip' => '10.0.0.2',
+        'status' => NetworkServerStatus::ACTIVE,
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->delete(route('networks.destroy', $network))->assertForbidden();
+
+    $this->server->update(['provider_data' => ['region' => 'nbg1']]);
+
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    expect(Network::query()->find($network->id))->not->toBeNull('Sync cannot ask about this network, so it must not be pruned either.');
+
+    $this->delete(route('networks.destroy', $network))->assertRedirect();
+    $this->assertNotSame(NetworkStatus::ACTIVE, $network->fresh()?->status);
+});
+
+test('malformed provider response fails the sweep instead of pruning', function () {
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]], [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $network = Network::query()->where('external_id', '4711')->firstOrFail();
+
+    $this->malformed = true;
+
+    try {
+        vitoPestFeatureNetworkProviderSyncTestSync();
+        $this->fail('A malformed provider response must fail the sweep.');
+    } catch (PrivateNetworkSyncError) {
+        // expected
+    }
+
+    expect(Network::query()->find($network->id))->not->toBeNull('A network must not be pruned on the strength of an unreadable response.');
+});
+
+test('a network that cannot be persisted fails the sweep', function () {
+    $peer = vitoPestFeatureNetworkProviderSyncTestOtherServer();
+
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101, 102]]], [
+        ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
+        ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
+    ]);
+
+    $this->expectException(PrivateNetworkPersistError::class);
+
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    expect($peer)->not->toBeNull();
+});
+
+test('status broadcast carries the provider relation', function () {
+    Event::fake([SocketEvent::class]);
+
+    $network = vitoPestFeatureNetworkProviderSyncTestProviderNetwork($this->connection->id);
+
+    app(RecomputeNetworkStatus::class)->handle($network);
+
+    $payload = null;
+
+    Event::assertDispatched(SocketEvent::class, function (SocketEvent $event) use (&$payload): bool {
+        if ($event->data->type === 'network.updated' && is_array($event->data->data)) {
+            $payload = $event->data->data;
+        }
+
+        return true;
+    });
+
+    expect($payload)->toBeArray();
+    expect($payload['provider'] ?? null)->toBe(Hetzner::id());
+});
+
+test('failed job does not log an unexpected exception message', function () {
+    Log::spy();
+    Notification::fake();
+
+    (new SyncProviderNetworksJob($this->server->project))->failed(new RuntimeException('token=super-secret'));
+
+    Log::shouldHaveReceived('warning')->withArgs(
+        fn (string $message, array $context): bool => $context['exception'] === RuntimeException::class
+            && $context['reason'] === null
+    );
+});
+
+function vitoPestFeatureNetworkProviderSyncTestAwsConnection(): ServerProvider
+{
+    return ServerProvider::factory()->create([
+        'user_id' => test()->user->id,
+        'provider' => AWS::id(),
+        'profile' => 'aws-main',
+        'credentials' => ['key' => 'key', 'secret' => 'secret'],
+    ]);
+}
+
+function vitoPestFeatureNetworkProviderSyncTestAwsServer(ServerProvider $connection, string $instanceId, ?string $region = null): Server
+{
+    return Server::factory()->create([
+        'project_id' => test()->server->project_id,
+        'user_id' => test()->user->id,
+        'status' => ServerStatus::READY,
+        'provider_id' => $connection->id,
+        'provider_data' => $region === null
+            ? ['instance_id' => $instanceId]
+            : ['instance_id' => $instanceId, 'region' => $region],
+    ]);
+}
+
+function vitoPestFeatureNetworkProviderSyncTestAwsNetwork(ServerProvider $connection, string $externalId, Server $member): Network
+{
+    $network = Network::factory()->create([
+        'project_id' => test()->server->project_id,
+        'type' => NetworkType::PROVIDER,
+        'server_provider_id' => $connection->id,
+        'external_id' => $externalId,
+    ]);
+
+    $network->servers()->create([
+        'server_id' => $member->id,
+        'ip' => '172.31.0.5',
+        'status' => NetworkServerStatus::ACTIVE,
+    ]);
+
+    return $network;
+}
+
+test('vpc without managed servers is not imported', function () {
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 9999, 'name' => 'someone-elses', 'ip_range' => '10.9.0.0/16', 'servers' => [777]]], [['id' => 777, 'private_net' => [['network' => 9999, 'ip' => '10.9.0.2']]]]);
+
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    expect(Network::query()->where('type', NetworkType::PROVIDER)->count())->toBe(0);
+});
+
+test('imported network firewall uses member ips not vpc cidr', function () {
+    $peer = vitoPestFeatureNetworkProviderSyncTestOtherServer();
+
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '172.31.0.0/16', 'servers' => [101, 102]]], [
+        ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '172.31.0.2']]],
+        ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '172.31.0.3']]],
+    ]);
+
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $network = Network::query()->where('external_id', '4711')->firstOrFail();
+
+    expect(ServerNetworkRule::query()->where('network_id', $network->id)->where('mask', 16)->count())->toBe(0, 'Sync must never widen the firewall to the whole VPC.');
+
+    $sources = ServerNetworkRule::query()
+        ->where('network_id', $network->id)
+        ->where('server_id', $this->server->id)
+        ->pluck('source')
+        ->all();
+
+    expect($sources)->toContain('172.31.0.3');
+    expect($sources)->not->toContain('172.31.0.0');
+    expect($peer->id)->not->toBeNull();
+});
+
+test('name collision is uniqued', function () {
+    Network::factory()->create([
+        'project_id' => $this->server->project_id,
+        'name' => 'prod',
+        'type' => NetworkType::CUSTOM,
+    ]);
+
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]], [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]]);
+
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $this->assertDatabaseHas('networks', ['external_id' => '4711', 'name' => 'prod-2']);
+});
+
+test('provider name change does not rename the local network', function () {
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]], [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'renamed-at-provider', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]], [['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]]]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $this->assertDatabaseHas('networks', ['external_id' => '4711', 'name' => 'prod']);
+});
+
+test('recycled ip between members does not violate unique index', function () {
+    $peer = vitoPestFeatureNetworkProviderSyncTestOtherServer();
+
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101, 102]]], [
+        ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
+        ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]],
+    ]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    vitoPestFeatureNetworkProviderSyncTestFakeProvider([['id' => 4711, 'name' => 'prod', 'ip_range' => '10.0.0.0/16', 'servers' => [101, 102]]], [
+        ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]],
+        ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
+    ]);
+    vitoPestFeatureNetworkProviderSyncTestSync();
+
+    $network = Network::query()->where('external_id', '4711')->firstOrFail();
+
+    expect($network->servers()->where('server_id', $this->server->id)->value('ip'))->toBe('10.0.0.3');
+    expect($network->servers()->where('server_id', $peer->id)->value('ip'))->toBe('10.0.0.2');
+});
+
+function vitoPestFeatureNetworkProviderSyncTestProviderNetwork(?int $connectionId = null): Network
+{
+    return Network::factory()->create([
+        'project_id' => test()->server->project_id,
+        'type' => NetworkType::PROVIDER,
+        'server_provider_id' => $connectionId,
+        'external_id' => '4711',
+    ]);
+}
+
+test('provider network cannot be deleted', function () {
+    $network = vitoPestFeatureNetworkProviderSyncTestProviderNetwork($this->connection->id);
+
+    $this->actingAs($this->user)
+        ->delete(route('networks.destroy', $network))
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('networks', ['id' => $network->id]);
+});
+
+test('orphaned provider network can be deleted', function () {
+    $network = vitoPestFeatureNetworkProviderSyncTestProviderNetwork(null);
+
+    $this->actingAs($this->user)
+        ->delete(route('networks.destroy', $network))
+        ->assertRedirect();
+
+    $this->assertNotSame(NetworkStatus::ACTIVE, $network->fresh()?->status);
+});
+
+test('manual member routes are rejected on a provider network', function () {
+    $network = vitoPestFeatureNetworkProviderSyncTestProviderNetwork($this->connection->id);
+    $member = $network->servers()->create([
+        'server_id' => $this->server->id,
+        'ip' => '10.0.0.2',
+        'status' => NetworkServerStatus::ACTIVE,
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('networks.servers.store', $network), ['servers' => [$this->server->id]])
+        ->assertNotFound();
+
+    $this->put(route('networks.servers.update', ['network' => $network, 'networkServer' => $member]), [])
+        ->assertNotFound();
+
+    $this->post(route('networks.servers.sync', ['network' => $network, 'networkServer' => $member]))
+        ->assertNotFound();
+
+    $this->delete(route('networks.servers.destroy', ['network' => $network, 'networkServer' => $member]))
+        ->assertNotFound();
+
+    $this->assertDatabaseHas('network_servers', ['id' => $member->id, 'status' => NetworkServerStatus::ACTIVE->value]);
+});
+
+test('global sync route dispatches the job', function () {
+    Queue::fake();
+
+    $this->actingAs($this->user)
+        ->post(route('networks.sync-providers'))
+        ->assertRedirect();
+
+    Queue::assertPushed(SyncProviderNetworksJob::class);
+});
+
+test('repeated sync clicks are debounced', function () {
+    Queue::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('networks.sync-providers'))->assertRedirect();
+    $this->post(route('networks.sync-providers'))->assertRedirect();
+
+    Queue::assertPushed(SyncProviderNetworksJob::class, 1);
+});
+
+test('viewer cannot trigger a provider sync', function () {
+    Queue::fake();
+
+    $viewer = User::factory()->create();
+    $this->server->project->users()->create(['user_id' => $viewer->id, 'role' => UserRole::USER]);
+    $viewer->current_project_id = $this->server->project_id;
+    $viewer->save();
+
+    $this->actingAs($viewer)
+        ->post(route('networks.sync-providers'))
+        ->assertForbidden();
+
+    Queue::assertNothingPushed();
+});
+
+test('sync ignores networks of another project', function () {
+    $other = Network::factory()->create([
+        'project_id' => $this->server->project_id,
+        'type' => NetworkType::PROVIDER,
+        'server_provider_id' => $this->connection->id,
+        'external_id' => '4711',
+    ]);
+
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+
+    $before = $other->only(['project_id', 'server_provider_id', 'external_id', 'name', 'status', 'cidr', 'last_synced_at']);
+
+    app(SyncProviderNetworks::class)->forProject($otherUser->currentProject, $other);
+
+    $this->assertDatabaseHas('networks', ['id' => $other->id]);
+    expect($other->fresh()?->only(['project_id', 'server_provider_id', 'external_id', 'name', 'status', 'cidr', 'last_synced_at']))->toBe($before, 'Syncing one project must not write to another project\'s network.');
+    expect($other->servers()->count())->toBe(0);
+});

--- a/tests/Feature/NetworkSyncTest.php
+++ b/tests/Feature/NetworkSyncTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\Network\AddServersToNetwork;
 use App\Actions\Network\AllocateNetworkBlock;
 use App\Actions\Network\CreateNetwork;
@@ -29,707 +27,641 @@ use App\Support\Cidr;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Validation\ValidationException;
-use Tests\TestCase;
 
-class NetworkSyncTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_cidr_helpers(): void
-    {
-        $this->assertSame('100.64.0.0/24', Cidr::canonical('100.64.0.5/24'));
-        $this->assertTrue(Cidr::overlaps('10.0.0.0/16', '10.0.5.0/24'));
-        $this->assertFalse(Cidr::overlaps('10.0.0.0/24', '10.1.0.0/24'));
-        $this->assertSame('100.64.0.2', Cidr::nextHost('100.64.0.0/24', []));
-        $this->assertSame('100.64.0.3', Cidr::nextHost('100.64.0.0/24', ['100.64.0.2']));
+test('cidr helpers', function () {
+    expect(Cidr::canonical('100.64.0.5/24'))->toBe('100.64.0.0/24');
+    expect(Cidr::overlaps('10.0.0.0/16', '10.0.5.0/24'))->toBeTrue();
+    expect(Cidr::overlaps('10.0.0.0/24', '10.1.0.0/24'))->toBeFalse();
+    expect(Cidr::nextHost('100.64.0.0/24', []))->toBe('100.64.0.2');
+    expect(Cidr::nextHost('100.64.0.0/24', ['100.64.0.2']))->toBe('100.64.0.3');
+});
+
+test('block allocator skips member subnet', function () {
+    ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'ip' => '100.64.0.10',
+        'prefix_length' => 24,
+        'type' => IpAddressType::PUBLIC,
+    ]);
+
+    $cidr = app(AllocateNetworkBlock::class)->allocate(
+        NetworkAddressingPool::CGNAT,
+        24,
+        collect(),
+        collect([$this->server])
+    );
+
+    expect($cidr)->toBe('100.64.1.0/24');
+});
+
+test('create wireguard network allocates block and activates ready member', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    expect((string) $network->cidr)->toStartWith('100.64.');
+
+    $member = $network->servers()->firstOrFail();
+    expect($member->ip)->toBe('100.64.0.2');
+    expect($member->public_key)->not->toBeNull();
+    expect($member->fresh()->status)->toBe(NetworkServerStatus::ACTIVE);
+    expect($network->fresh()->status)->toBe(NetworkStatus::ACTIVE);
+    expect($this->server->fresh()->service('vpn'))->not->toBeNull();
+    SSH::assertExecutedContains('wg-quick@wg-vito-'.$network->id);
+});
+
+test('create wireguard member pending when server not ready then reconciler activates', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::DISCONNECTED]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    $member = $network->servers()->firstOrFail();
+    expect($member->status)->toBe(NetworkServerStatus::PENDING);
+    expect($network->fresh()->status)->toBe(NetworkStatus::SYNCING);
+
+    $this->server->update(['status' => ServerStatus::READY]);
+    Artisan::call('networks:reconcile');
+
+    expect($member->fresh()->status)->toBe(NetworkServerStatus::ACTIVE);
+    expect($network->fresh()->status)->toBe(NetworkStatus::ACTIVE);
+});
+
+test('custom network members are active without wireguard', function () {
+    SSH::fake();
+
+    $ip = ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'ip' => '10.0.0.5',
+        'type' => IpAddressType::PRIVATE,
+    ]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'prov-net',
+        'type' => 'custom',
+        'servers' => [$this->server->id],
+        'ip_addresses' => [$this->server->id => $ip->id],
+    ]);
+
+    $member = $network->servers()->firstOrFail();
+    expect($member->status)->toBe(NetworkServerStatus::ACTIVE);
+    expect($member->server_ip_address_id)->toBe($ip->id);
+    expect($network->fresh()->status)->toBe(NetworkStatus::ACTIVE);
+    expect($this->server->fresh()->service('vpn'))->toBeNull();
+    SSH::assertNotExecutedContains('wg-quick');
+});
+
+test('create rejects zero servers', function () {
+    $this->expectException(ValidationException::class);
+
+    app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'empty',
+        'type' => 'wireguard',
+        'servers' => [],
+    ]);
+});
+
+test('custom network rejects a public ip', function () {
+    $ip = ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'ip' => '1.2.3.4',
+        'type' => IpAddressType::PUBLIC,
+    ]);
+
+    $this->expectException(ValidationException::class);
+
+    app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'prov-net',
+        'type' => 'custom',
+        'servers' => [$this->server->id],
+        'ip_addresses' => [$this->server->id => $ip->id],
+    ]);
+});
+
+test('remove last wireguard member tears down and uninstalls', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+    $member = $network->servers()->firstOrFail();
+
+    app(RemoveServerFromNetwork::class)->remove($member->fresh());
+
+    $this->assertDatabaseMissing('network_servers', ['id' => $member->id]);
+    expect($this->server->fresh()->service('vpn'))->toBeNull();
+    SSH::assertExecutedContains('wg-quick down wg-vito-'.$network->id);
+    SSH::assertExecutedContains('apt-get remove -y wireguard');
+});
+
+test('delete network removes members and network', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    app(DeleteNetwork::class)->delete($network);
+
+    $this->assertDatabaseMissing('networks', ['id' => $network->id]);
+    $this->assertDatabaseMissing('network_servers', ['network_id' => $network->id]);
+});
+
+test('teardown failure recomputes network status', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+    $member = $network->servers()->firstOrFail();
+
+    NetworkServer::query()->whereKey($member->id)->update([
+        'status' => NetworkServerStatus::LEAVING,
+    ]);
+
+    (new SyncNetworkServerJob($member->fresh(), true))->failed(new Exception('boom'));
+
+    $this->assertDatabaseHas('network_servers', ['id' => $member->id]);
+    expect($network->fresh()->status)->toBe(NetworkStatus::SYNCING);
+});
+
+test('reconciler keeps retrying a leaving member past the fast attempts', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+    $member = $network->servers()->firstOrFail();
+
+    NetworkServer::query()->whereKey($member->id)->update([
+        'status' => NetworkServerStatus::LEAVING,
+        'sync_attempts' => 5,
+        'updated_at' => now()->subMinutes(3),
+    ]);
+
+    Artisan::call('networks:reconcile');
+
+    $this->assertDatabaseHas('network_servers', ['id' => $member->id]);
+
+    NetworkServer::query()->whereKey($member->id)->update([
+        'status' => NetworkServerStatus::LEAVING,
+        'updated_at' => now()->subMinutes(61),
+    ]);
+
+    Artisan::call('networks:reconcile');
+
+    $this->assertDatabaseMissing('network_servers', ['id' => $member->id]);
+    $this->assertDatabaseMissing('server_logs', [
+        'network_id' => $network->id,
+        'type' => 'network-leave-incomplete',
+    ]);
+});
+
+test('reconciler force converges a leaving member that never converges', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+    $member = $network->servers()->firstOrFail();
+
+    NetworkServer::query()->whereKey($member->id)->update([
+        'status' => NetworkServerStatus::LEAVING,
+        'sync_attempts' => 30,
+        'updated_at' => now()->subMinutes(3),
+    ]);
+
+    Artisan::call('networks:reconcile');
+
+    $this->assertDatabaseMissing('network_servers', ['id' => $member->id]);
+    $this->assertDatabaseHas('server_logs', [
+        'network_id' => $network->id,
+        'type' => 'network-leave-incomplete',
+    ]);
+});
+
+test('create wireguard rejects when block is full', function () {
+    SSH::fake();
+
+    $servers = [$this->server->id];
+    for ($i = 0; $i < 13; $i++) {
+        $servers[] = Server::factory()->create([
+            'project_id' => $this->server->project_id,
+            'user_id' => $this->user->id,
+            'status' => ServerStatus::DISCONNECTED,
+        ])->id;
     }
 
-    public function test_block_allocator_skips_member_subnet(): void
-    {
-        ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'ip' => '100.64.0.10',
-            'prefix_length' => 24,
-            'type' => IpAddressType::PUBLIC,
-        ]);
-
-        $cidr = app(AllocateNetworkBlock::class)->allocate(
-            NetworkAddressingPool::CGNAT,
-            24,
-            collect(),
-            collect([$this->server])
-        );
-
-        $this->assertSame('100.64.1.0/24', $cidr);
-    }
-
-    public function test_create_wireguard_network_allocates_block_and_activates_ready_member(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        $this->assertStringStartsWith('100.64.', (string) $network->cidr);
-
-        $member = $network->servers()->firstOrFail();
-        $this->assertSame('100.64.0.2', $member->ip);
-        $this->assertNotNull($member->public_key);
-        $this->assertSame(NetworkServerStatus::ACTIVE, $member->fresh()->status);
-        $this->assertSame(NetworkStatus::ACTIVE, $network->fresh()->status);
-        $this->assertNotNull($this->server->fresh()->service('vpn'));
-        SSH::assertExecutedContains('wg-quick@wg-vito-'.$network->id);
-    }
-
-    public function test_create_wireguard_member_pending_when_server_not_ready_then_reconciler_activates(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::DISCONNECTED]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        $member = $network->servers()->firstOrFail();
-        $this->assertSame(NetworkServerStatus::PENDING, $member->status);
-        $this->assertSame(NetworkStatus::SYNCING, $network->fresh()->status);
-
-        $this->server->update(['status' => ServerStatus::READY]);
-        Artisan::call('networks:reconcile');
-
-        $this->assertSame(NetworkServerStatus::ACTIVE, $member->fresh()->status);
-        $this->assertSame(NetworkStatus::ACTIVE, $network->fresh()->status);
-    }
-
-    public function test_custom_network_members_are_active_without_wireguard(): void
-    {
-        SSH::fake();
-
-        $ip = ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'ip' => '10.0.0.5',
-            'type' => IpAddressType::PRIVATE,
-        ]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'prov-net',
-            'type' => 'custom',
-            'servers' => [$this->server->id],
-            'ip_addresses' => [$this->server->id => $ip->id],
-        ]);
-
-        $member = $network->servers()->firstOrFail();
-        $this->assertSame(NetworkServerStatus::ACTIVE, $member->status);
-        $this->assertSame($ip->id, $member->server_ip_address_id);
-        $this->assertSame(NetworkStatus::ACTIVE, $network->fresh()->status);
-        $this->assertNull($this->server->fresh()->service('vpn'));
-        SSH::assertNotExecutedContains('wg-quick');
-    }
-
-    public function test_create_rejects_zero_servers(): void
-    {
-        $this->expectException(ValidationException::class);
-
+    try {
         app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'empty',
+            'name' => 'wg-full',
             'type' => 'wireguard',
-            'servers' => [],
+            'prefix' => 28,
+            'servers' => $servers,
         ]);
+        $this->fail('Expected a full-block ValidationException.');
+    } catch (ValidationException $e) {
+        expect($e->errors())->toHaveKey('servers');
     }
 
-    public function test_custom_network_rejects_a_public_ip(): void
-    {
-        $ip = ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'ip' => '1.2.3.4',
-            'type' => IpAddressType::PUBLIC,
-        ]);
-
-        $this->expectException(ValidationException::class);
-
-        app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'prov-net',
-            'type' => 'custom',
-            'servers' => [$this->server->id],
-            'ip_addresses' => [$this->server->id => $ip->id],
-        ]);
-    }
-
-    public function test_remove_last_wireguard_member_tears_down_and_uninstalls(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-        $member = $network->servers()->firstOrFail();
-
-        app(RemoveServerFromNetwork::class)->remove($member->fresh());
-
-        $this->assertDatabaseMissing('network_servers', ['id' => $member->id]);
-        $this->assertNull($this->server->fresh()->service('vpn'));
-        SSH::assertExecutedContains('wg-quick down wg-vito-'.$network->id);
-        SSH::assertExecutedContains('apt-get remove -y wireguard');
-    }
-
-    public function test_delete_network_removes_members_and_network(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        app(DeleteNetwork::class)->delete($network);
-
-        $this->assertDatabaseMissing('networks', ['id' => $network->id]);
-        $this->assertDatabaseMissing('network_servers', ['network_id' => $network->id]);
-    }
-
-    public function test_teardown_failure_recomputes_network_status(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-        $member = $network->servers()->firstOrFail();
-
-        NetworkServer::query()->whereKey($member->id)->update([
-            'status' => NetworkServerStatus::LEAVING,
-        ]);
-
-        (new SyncNetworkServerJob($member->fresh(), true))->failed(new \Exception('boom'));
-
-        $this->assertDatabaseHas('network_servers', ['id' => $member->id]);
-        $this->assertSame(NetworkStatus::SYNCING, $network->fresh()->status);
-    }
-
-    /**
-     * Cleanup on the server can only run while it is reachable, so a teardown that has burned
-     * its fast attempts keeps retrying on the slow cadence — abandoning it there would leave the
-     * tunnel configured on a server that was merely rebooting.
-     */
-    public function test_reconciler_keeps_retrying_a_leaving_member_past_the_fast_attempts(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-        $member = $network->servers()->firstOrFail();
-
-        NetworkServer::query()->whereKey($member->id)->update([
-            'status' => NetworkServerStatus::LEAVING,
-            'sync_attempts' => 5,
-            'updated_at' => now()->subMinutes(3),
-        ]);
-
-        Artisan::call('networks:reconcile');
-
-        $this->assertDatabaseHas('network_servers', ['id' => $member->id]);
-
-        NetworkServer::query()->whereKey($member->id)->update([
-            'status' => NetworkServerStatus::LEAVING,
-            'updated_at' => now()->subMinutes(61),
-        ]);
-
-        Artisan::call('networks:reconcile');
-
-        $this->assertDatabaseMissing('network_servers', ['id' => $member->id]);
-        $this->assertDatabaseMissing('server_logs', [
-            'network_id' => $network->id,
-            'type' => 'network-leave-incomplete',
-        ]);
-    }
-
-    /**
-     * The retries are bounded so a server that never comes back cannot strand the network in
-     * `deleting` forever. The membership goes; the log records that the server may still hold
-     * the tunnel configuration.
-     */
-    public function test_reconciler_force_converges_a_leaving_member_that_never_converges(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-        $member = $network->servers()->firstOrFail();
-
-        NetworkServer::query()->whereKey($member->id)->update([
-            'status' => NetworkServerStatus::LEAVING,
-            'sync_attempts' => 30,
-            'updated_at' => now()->subMinutes(3),
-        ]);
-
-        Artisan::call('networks:reconcile');
-
-        $this->assertDatabaseMissing('network_servers', ['id' => $member->id]);
-        $this->assertDatabaseHas('server_logs', [
-            'network_id' => $network->id,
-            'type' => 'network-leave-incomplete',
-        ]);
-    }
-
-    public function test_create_wireguard_rejects_when_block_is_full(): void
-    {
-        SSH::fake();
-
-        $servers = [$this->server->id];
-        for ($i = 0; $i < 13; $i++) {
-            $servers[] = Server::factory()->create([
-                'project_id' => $this->server->project_id,
-                'user_id' => $this->user->id,
-                'status' => ServerStatus::DISCONNECTED,
-            ])->id;
-        }
-
-        try {
-            app(CreateNetwork::class)->create($this->server->project, [
-                'name' => 'wg-full',
-                'type' => 'wireguard',
-                'prefix' => 28,
-                'servers' => $servers,
-            ]);
-            $this->fail('Expected a full-block ValidationException.');
-        } catch (ValidationException $e) {
-            $this->assertArrayHasKey('servers', $e->errors());
-        }
-
-        $this->assertDatabaseMissing('networks', ['name' => 'wg-full']);
-    }
-
-    public function test_add_server_to_wireguard_network_assigns_distinct_ip(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        $server2 = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
-
-        app(AddServersToNetwork::class)->add($network, ['servers' => [$server2->id]]);
-
-        $ips = $network->servers()->pluck('ip');
-        $this->assertSame(2, $ips->count());
-        $this->assertSame($ips->count(), $ips->unique()->count());
-        $this->assertContains('100.64.0.3', $ips->all());
-    }
-
-    public function test_add_server_rejects_cross_project_server(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-        $foreign = Server::factory()->create([
-            'project_id' => $otherUser->current_project_id,
-            'user_id' => $otherUser->id,
-            'status' => ServerStatus::READY,
-        ]);
-
-        $this->expectException(ValidationException::class);
-
-        app(AddServersToNetwork::class)->add($network, ['servers' => [$foreign->id]]);
-    }
-
-    public function test_sync_reinstalls_wireguard_when_service_not_ready(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $this->server->services()->create([
-            'type' => 'vpn',
-            'name' => 'wireguard',
-            'version' => 'latest',
-            'status' => ServiceStatus::INSTALLATION_FAILED,
-        ]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        SSH::assertExecutedContains('apt-get install -y wireguard');
-        $this->assertSame(ServiceStatus::READY, $this->server->fresh()->service('vpn')->status);
-        $this->assertSame(NetworkServerStatus::ACTIVE, $network->servers()->firstOrFail()->status);
-    }
-
-    public function test_reconciler_retries_failed_member_when_server_ready(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-        $member = $network->servers()->firstOrFail();
-
-        NetworkServer::query()->whereKey($member->id)->update([
-            'status' => NetworkServerStatus::FAILED,
-            'sync_attempts' => 1,
-        ]);
-
-        Artisan::call('networks:reconcile');
-
-        $fresh = $member->fresh();
-        $this->assertSame(NetworkServerStatus::ACTIVE, $fresh->status);
-        $this->assertSame(0, $fresh->sync_attempts);
-    }
-
-    /**
-     * A member that burns through its fast attempts drops to an hourly retry rather than being
-     * abandoned: giving up permanently would keep the network `failed` forever and would never
-     * pick up a later change, with nothing in the UI to say a manual sync is needed.
-     */
-    public function test_reconciler_retries_an_exhausted_member_on_the_slow_cadence(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-        $member = $network->servers()->firstOrFail();
-
-        NetworkServer::query()->whereKey($member->id)->update([
-            'status' => NetworkServerStatus::FAILED,
-            'sync_attempts' => 5,
-            'updated_at' => now()->subMinutes(5),
-        ]);
-
-        Artisan::call('networks:reconcile');
-
-        $this->assertSame(
-            NetworkServerStatus::FAILED,
-            $member->fresh()?->status,
-            'An exhausted member must not be retried again on the fast cadence.'
-        );
-
-        NetworkServer::query()->whereKey($member->id)->update(['updated_at' => now()->subMinutes(61)]);
-
-        Artisan::call('networks:reconcile');
-
-        $this->assertSame(NetworkServerStatus::ACTIVE, $member->fresh()?->status);
-    }
-
-    /**
-     * A custom membership is addressed solely by its IP row, so the membership has to go when
-     * the address does. The refresh used to drop these rows with a query-builder delete, which
-     * fires no model events, leaving the membership behind with a null address.
-     */
-    public function test_refresh_removes_a_custom_membership_when_its_address_disappears(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $address = ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'ip' => '10.70.0.5',
-            'prefix_length' => 24,
-            'family' => IpAddressFamily::V4,
-            'type' => IpAddressType::PRIVATE,
-            'is_managed' => false,
-        ]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'custom-net',
-            'type' => 'custom',
-            'cidr' => '10.70.0.0/24',
-            'servers' => [$this->server->id],
-            'ip_addresses' => [$this->server->id => $address->id],
-        ]);
-
-        $this->assertSame(1, $network->servers()->count());
-
-        SSH::fake(json_encode([[
-            'ifname' => 'eth0',
-            'addr_info' => [[
-                'family' => 'inet',
-                'local' => '10.70.0.9',
-                'prefixlen' => 24,
-                'scope' => 'global',
-            ]],
-        ]]));
-
-        app(RefreshServerIps::class)->handle($this->server);
-
-        $this->assertDatabaseMissing('server_ip_addresses', ['id' => $address->id]);
-        $this->assertSame(0, $network->servers()->where('status', '!=', NetworkServerStatus::LEAVING)->count());
-    }
-
-    /**
-     * A network losing its last member has no sibling left whose sync would recompute it, so the
-     * status has to be recomputed from the departure itself — otherwise the network reports
-     * `active` with no servers, and its peers report connected to nothing.
-     */
-    /**
-     * A peer's WireGuard endpoint is the server's public address, so promoting a different one
-     * has to push the change to the other members — the same resync an explicit IP edit does.
-     * Without it they keep dialling the old address.
-     */
-    public function test_promoting_a_public_ip_resyncs_wireguard_members(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $other = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id, $other->id],
-        ]);
-
-        $promoted = ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'ip' => '203.0.113.9',
-            'family' => IpAddressFamily::V4,
-            'type' => IpAddressType::PUBLIC,
-        ]);
-
-        SSH::fake();
-
-        app(ManageServerIp::class)->setPrimary($promoted);
-
-        $this->assertSame('203.0.113.9', $this->server->fresh()?->ip);
-        $this->assertStringContainsString(
-            'Endpoint = 203.0.113.9:'.$network->port,
-            SSH::getUploadedContent(),
-            "The other member's tunnel must point at the new address."
-        );
-    }
-
-    public function test_deleting_the_last_member_server_recomputes_the_network(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
-
-        $this->assertSame(NetworkStatus::ACTIVE, $network->fresh()?->status);
-        $this->assertSame(NetworkPeerStatus::ACTIVE, $peer->fresh()?->status);
-
-        $this->server->delete();
-
-        $this->assertSame(0, $network->servers()->count());
-        $this->assertSame(NetworkStatus::CREATING, $network->fresh()?->status);
-        $this->assertSame(NetworkPeerStatus::PENDING, $peer->fresh()?->status);
-    }
-
-    public function test_deleting_server_resyncs_wireguard_siblings(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $server2 = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id, $server2->id],
-        ]);
-        $sibling = $network->servers()->where('server_id', $server2->id)->firstOrFail();
-        $departingKey = (string) $network->servers()->where('server_id', $this->server->id)->firstOrFail()->public_key;
-
-        SSH::fake();
-
-        $this->server->deleteFromProvider = false;
-        $this->server->delete();
-
-        $this->assertDatabaseMissing('network_servers', ['server_id' => $this->server->id]);
-        $this->assertSame(1, $network->servers()->count());
-        $this->assertSame(NetworkServerStatus::ACTIVE, $sibling->fresh()->status);
-
-        SSH::assertExecutedContains('wg-quick@wg-vito-'.$network->id);
-        $this->assertStringNotContainsString(
-            $departingKey,
-            SSH::getUploadedContent(),
-            "The sibling's tunnel must be rewritten without the departed server's key."
-        );
-    }
-
-    public function test_leaving_one_of_two_wireguard_networks_keeps_service_installed(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $networkA = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-a',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-        app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-b',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        $memberA = $networkA->servers()->firstOrFail();
-        app(RemoveServerFromNetwork::class)->remove($memberA->fresh());
-
-        $this->assertDatabaseMissing('network_servers', ['id' => $memberA->id]);
-        $this->assertNotNull($this->server->fresh()->service('vpn'));
-    }
-
-    public function test_reconciler_recovers_stale_updating_member(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-        $member = $network->servers()->firstOrFail();
-
-        NetworkServer::query()->whereKey($member->id)->update([
-            'status' => NetworkServerStatus::UPDATING,
-            'updated_at' => now()->subMinutes(91),
-        ]);
-
-        Artisan::call('networks:reconcile');
-
-        $this->assertSame(NetworkServerStatus::ACTIVE, $member->fresh()->status);
-    }
-
-    public function test_allocator_ignores_ipv6_member_address(): void
-    {
-        ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'ip' => 'fe80::1',
-            'prefix_length' => 64,
-            'family' => IpAddressFamily::V6,
-            'type' => IpAddressType::PUBLIC,
-        ]);
-
-        $cidr = app(AllocateNetworkBlock::class)->allocate(
-            NetworkAddressingPool::CGNAT,
-            24,
-            collect(),
-            collect([$this->server])
-        );
-
-        $this->assertSame('100.64.0.0/24', $cidr);
-    }
-
-    public function test_two_wireguard_networks_sharing_a_server_get_distinct_ports(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $a = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-a',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-        $b = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-b',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        $this->assertSame(51820, $a->port);
-        $this->assertSame(51821, $b->port);
-    }
-
-    public function test_custom_network_accepts_a_second_server(): void
-    {
-        SSH::fake();
-        $ip1 = ServerIpAddress::factory()->create(['server_id' => $this->server->id, 'ip' => '10.0.0.5', 'type' => IpAddressType::PRIVATE]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'prov',
-            'type' => 'custom',
-            'servers' => [$this->server->id],
-            'ip_addresses' => [$this->server->id => $ip1->id],
-        ]);
-
-        $peer = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
-        $ip2 = ServerIpAddress::factory()->create(['server_id' => $peer->id, 'ip' => '10.0.0.6', 'type' => IpAddressType::PRIVATE]);
-
-        app(AddServersToNetwork::class)->add($network, ['servers' => [$peer->id], 'ip_addresses' => [$peer->id => $ip2->id]]);
-
-        $this->assertSame(2, $network->servers()->count());
-        $this->assertSame(NetworkServerStatus::ACTIVE, $network->servers()->where('server_id', $peer->id)->firstOrFail()->status);
-    }
-
-    public function test_sync_network_member_regenerates_config(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-        $member = $network->servers()->firstOrFail();
-
-        app(SyncNetwork::class)->member($member->fresh());
-
-        $this->assertSame(NetworkServerStatus::ACTIVE, $member->fresh()->status);
-        SSH::assertExecutedContains('wg-quick@wg-vito-'.$network->id);
-    }
-}
+    $this->assertDatabaseMissing('networks', ['name' => 'wg-full']);
+});
+
+test('add server to wireguard network assigns distinct ip', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    $server2 = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
+
+    app(AddServersToNetwork::class)->add($network, ['servers' => [$server2->id]]);
+
+    $ips = $network->servers()->pluck('ip');
+    expect($ips->count())->toBe(2);
+    expect($ips->unique()->count())->toBe($ips->count());
+    expect($ips->all())->toContain('100.64.0.3');
+});
+
+test('add server rejects cross project server', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+    $foreign = Server::factory()->create([
+        'project_id' => $otherUser->current_project_id,
+        'user_id' => $otherUser->id,
+        'status' => ServerStatus::READY,
+    ]);
+
+    $this->expectException(ValidationException::class);
+
+    app(AddServersToNetwork::class)->add($network, ['servers' => [$foreign->id]]);
+});
+
+test('sync reinstalls wireguard when service not ready', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $this->server->services()->create([
+        'type' => 'vpn',
+        'name' => 'wireguard',
+        'version' => 'latest',
+        'status' => ServiceStatus::INSTALLATION_FAILED,
+    ]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    SSH::assertExecutedContains('apt-get install -y wireguard');
+    expect($this->server->fresh()->service('vpn')->status)->toBe(ServiceStatus::READY);
+    expect($network->servers()->firstOrFail()->status)->toBe(NetworkServerStatus::ACTIVE);
+});
+
+test('reconciler retries failed member when server ready', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+    $member = $network->servers()->firstOrFail();
+
+    NetworkServer::query()->whereKey($member->id)->update([
+        'status' => NetworkServerStatus::FAILED,
+        'sync_attempts' => 1,
+    ]);
+
+    Artisan::call('networks:reconcile');
+
+    $fresh = $member->fresh();
+    expect($fresh->status)->toBe(NetworkServerStatus::ACTIVE);
+    expect($fresh->sync_attempts)->toBe(0);
+});
+
+test('reconciler retries an exhausted member on the slow cadence', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+    $member = $network->servers()->firstOrFail();
+
+    NetworkServer::query()->whereKey($member->id)->update([
+        'status' => NetworkServerStatus::FAILED,
+        'sync_attempts' => 5,
+        'updated_at' => now()->subMinutes(5),
+    ]);
+
+    Artisan::call('networks:reconcile');
+
+    expect($member->fresh()?->status)->toBe(NetworkServerStatus::FAILED, 'An exhausted member must not be retried again on the fast cadence.');
+
+    NetworkServer::query()->whereKey($member->id)->update(['updated_at' => now()->subMinutes(61)]);
+
+    Artisan::call('networks:reconcile');
+
+    expect($member->fresh()?->status)->toBe(NetworkServerStatus::ACTIVE);
+});
+
+test('refresh removes a custom membership when its address disappears', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $address = ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'ip' => '10.70.0.5',
+        'prefix_length' => 24,
+        'family' => IpAddressFamily::V4,
+        'type' => IpAddressType::PRIVATE,
+        'is_managed' => false,
+    ]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'custom-net',
+        'type' => 'custom',
+        'cidr' => '10.70.0.0/24',
+        'servers' => [$this->server->id],
+        'ip_addresses' => [$this->server->id => $address->id],
+    ]);
+
+    expect($network->servers()->count())->toBe(1);
+
+    SSH::fake(json_encode([[
+        'ifname' => 'eth0',
+        'addr_info' => [[
+            'family' => 'inet',
+            'local' => '10.70.0.9',
+            'prefixlen' => 24,
+            'scope' => 'global',
+        ]],
+    ]]));
+
+    app(RefreshServerIps::class)->handle($this->server);
+
+    $this->assertDatabaseMissing('server_ip_addresses', ['id' => $address->id]);
+    expect($network->servers()->where('status', '!=', NetworkServerStatus::LEAVING)->count())->toBe(0);
+});
+
+test('promoting a public ip resyncs wireguard members', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $other = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id, $other->id],
+    ]);
+
+    $promoted = ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'ip' => '203.0.113.9',
+        'family' => IpAddressFamily::V4,
+        'type' => IpAddressType::PUBLIC,
+    ]);
+
+    SSH::fake();
+
+    app(ManageServerIp::class)->setPrimary($promoted);
+
+    expect($this->server->fresh()?->ip)->toBe('203.0.113.9');
+    $this->assertStringContainsString(
+        'Endpoint = 203.0.113.9:'.$network->port,
+        SSH::getUploadedContent(),
+        "The other member's tunnel must point at the new address."
+    );
+});
+
+test('deleting the last member server recomputes the network', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    $peer = app(CreateNetworkPeer::class)->create($network, ['name' => 'laptop']);
+
+    expect($network->fresh()?->status)->toBe(NetworkStatus::ACTIVE);
+    expect($peer->fresh()?->status)->toBe(NetworkPeerStatus::ACTIVE);
+
+    $this->server->delete();
+
+    expect($network->servers()->count())->toBe(0);
+    expect($network->fresh()?->status)->toBe(NetworkStatus::CREATING);
+    expect($peer->fresh()?->status)->toBe(NetworkPeerStatus::PENDING);
+});
+
+test('deleting server resyncs wireguard siblings', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $server2 = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id, $server2->id],
+    ]);
+    $sibling = $network->servers()->where('server_id', $server2->id)->firstOrFail();
+    $departingKey = (string) $network->servers()->where('server_id', $this->server->id)->firstOrFail()->public_key;
+
+    SSH::fake();
+
+    $this->server->deleteFromProvider = false;
+    $this->server->delete();
+
+    $this->assertDatabaseMissing('network_servers', ['server_id' => $this->server->id]);
+    expect($network->servers()->count())->toBe(1);
+    expect($sibling->fresh()->status)->toBe(NetworkServerStatus::ACTIVE);
+
+    SSH::assertExecutedContains('wg-quick@wg-vito-'.$network->id);
+    $this->assertStringNotContainsString(
+        $departingKey,
+        SSH::getUploadedContent(),
+        "The sibling's tunnel must be rewritten without the departed server's key."
+    );
+});
+
+test('leaving one of two wireguard networks keeps service installed', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $networkA = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-a',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+    app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-b',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    $memberA = $networkA->servers()->firstOrFail();
+    app(RemoveServerFromNetwork::class)->remove($memberA->fresh());
+
+    $this->assertDatabaseMissing('network_servers', ['id' => $memberA->id]);
+    expect($this->server->fresh()->service('vpn'))->not->toBeNull();
+});
+
+test('reconciler recovers stale updating member', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+    $member = $network->servers()->firstOrFail();
+
+    NetworkServer::query()->whereKey($member->id)->update([
+        'status' => NetworkServerStatus::UPDATING,
+        'updated_at' => now()->subMinutes(91),
+    ]);
+
+    Artisan::call('networks:reconcile');
+
+    expect($member->fresh()->status)->toBe(NetworkServerStatus::ACTIVE);
+});
+
+test('allocator ignores ipv6 member address', function () {
+    ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'ip' => 'fe80::1',
+        'prefix_length' => 64,
+        'family' => IpAddressFamily::V6,
+        'type' => IpAddressType::PUBLIC,
+    ]);
+
+    $cidr = app(AllocateNetworkBlock::class)->allocate(
+        NetworkAddressingPool::CGNAT,
+        24,
+        collect(),
+        collect([$this->server])
+    );
+
+    expect($cidr)->toBe('100.64.0.0/24');
+});
+
+test('two wireguard networks sharing a server get distinct ports', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $a = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-a',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+    $b = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-b',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    expect($a->port)->toBe(51820);
+    expect($b->port)->toBe(51821);
+});
+
+test('custom network accepts a second server', function () {
+    SSH::fake();
+    $ip1 = ServerIpAddress::factory()->create(['server_id' => $this->server->id, 'ip' => '10.0.0.5', 'type' => IpAddressType::PRIVATE]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'prov',
+        'type' => 'custom',
+        'servers' => [$this->server->id],
+        'ip_addresses' => [$this->server->id => $ip1->id],
+    ]);
+
+    $peer = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
+    $ip2 = ServerIpAddress::factory()->create(['server_id' => $peer->id, 'ip' => '10.0.0.6', 'type' => IpAddressType::PRIVATE]);
+
+    app(AddServersToNetwork::class)->add($network, ['servers' => [$peer->id], 'ip_addresses' => [$peer->id => $ip2->id]]);
+
+    expect($network->servers()->count())->toBe(2);
+    expect($network->servers()->where('server_id', $peer->id)->firstOrFail()->status)->toBe(NetworkServerStatus::ACTIVE);
+});
+
+test('sync network member regenerates config', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+    $member = $network->servers()->firstOrFail();
+
+    app(SyncNetwork::class)->member($member->fresh());
+
+    expect($member->fresh()->status)->toBe(NetworkServerStatus::ACTIVE);
+    SSH::assertExecutedContains('wg-quick@wg-vito-'.$network->id);
+});

--- a/tests/Feature/NetworkTest.php
+++ b/tests/Feature/NetworkTest.php
@@ -45,7 +45,7 @@ test('network persists and casts enums', function () {
     $network->refresh();
     expect($network->type)->toBeInstanceOf(NetworkType::class);
     expect($network->status)->toBeInstanceOf(NetworkStatus::class);
-    expect($network->port === 51820)->toBeTrue();
+    expect($network->port)->toBe(51820);
 });
 
 test('network relations', function () {

--- a/tests/Feature/NetworkTest.php
+++ b/tests/Feature/NetworkTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\Network\AddServersToNetwork;
 use App\Actions\Network\CreateNetwork;
 use App\Actions\Network\CreateNetworkPeer;
@@ -29,771 +27,699 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class NetworkTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_network_persists_and_casts_enums(): void
-    {
-        $network = Network::factory()->create([
+test('network persists and casts enums', function () {
+    $network = Network::factory()->create([
+        'project_id' => $this->server->project_id,
+    ]);
+
+    $this->assertDatabaseHas('networks', [
+        'id' => $network->id,
+        'project_id' => $this->server->project_id,
+        'type' => NetworkType::WIREGUARD->value,
+        'status' => NetworkStatus::ACTIVE->value,
+    ]);
+
+    $network->refresh();
+    expect($network->type)->toBeInstanceOf(NetworkType::class);
+    expect($network->status)->toBeInstanceOf(NetworkStatus::class);
+    expect($network->port === 51820)->toBeTrue();
+});
+
+test('network relations', function () {
+    $network = Network::factory()->create([
+        'project_id' => $this->server->project_id,
+    ]);
+
+    $member = NetworkServer::factory()->create([
+        'network_id' => $network->id,
+        'server_id' => $this->server->id,
+        'ip' => '100.64.0.2',
+    ]);
+
+    $rule = NetworkFirewallRule::factory()->create([
+        'network_id' => $network->id,
+    ]);
+
+    expect($network->servers->contains($member))->toBeTrue();
+    expect($network->firewallRules->contains($rule))->toBeTrue();
+    expect($this->server->project->networks->contains($network))->toBeTrue();
+    expect($member->network->is($network))->toBeTrue();
+    expect($member->server->is($this->server))->toBeTrue();
+});
+
+test('network server private key is encrypted at rest', function () {
+    $member = NetworkServer::factory()->create([
+        'network_id' => Network::factory()->create([
             'project_id' => $this->server->project_id,
-        ]);
+        ])->id,
+        'server_id' => $this->server->id,
+        'ip' => '100.64.0.3',
+        'private_key' => 'super-secret-private-key',
+        'status' => NetworkServerStatus::PENDING,
+    ]);
 
-        $this->assertDatabaseHas('networks', [
-            'id' => $network->id,
-            'project_id' => $this->server->project_id,
-            'type' => NetworkType::WIREGUARD->value,
-            'status' => NetworkStatus::ACTIVE->value,
-        ]);
+    $raw = DB::table('network_servers')->where('id', $member->id)->value('private_key');
+    $this->assertNotSame('super-secret-private-key', $raw);
+    expect($member->fresh()->private_key)->toBe('super-secret-private-key');
+    expect($member->fresh()->status)->toBeInstanceOf(NetworkServerStatus::class);
+});
 
-        $network->refresh();
-        $this->assertInstanceOf(NetworkType::class, $network->type);
-        $this->assertInstanceOf(NetworkStatus::class, $network->status);
-        $this->assertTrue($network->port === 51820);
+test('generate wireguard keys produce valid curve25519 format', function () {
+    $keys = app(GenerateWireGuardKeys::class)->generate();
+
+    foreach (['private_key', 'public_key'] as $key) {
+        $decoded = base64_decode($keys[$key], true);
+        $this->assertNotFalse($decoded);
+        expect(strlen((string) $decoded))->toBe(32);
+        expect(strlen($keys[$key]))->toBe(44);
     }
 
-    public function test_network_relations(): void
-    {
-        $network = Network::factory()->create([
-            'project_id' => $this->server->project_id,
-        ]);
+    $private = base64_decode($keys['private_key']);
+    expect(ord($private[0]) & 7)->toBe(0);
+    expect(ord($private[31]) & 192)->toBe(64);
+});
 
-        $member = NetworkServer::factory()->create([
-            'network_id' => $network->id,
-            'server_id' => $this->server->id,
-            'ip' => '100.64.0.2',
-        ]);
+test('wireguard service installs and uninstalls via ssh', function () {
+    SSH::fake('v1.0.20210914');
 
-        $rule = NetworkFirewallRule::factory()->create([
-            'network_id' => $network->id,
-        ]);
+    $service = $this->server->services()->create([
+        'type' => WireGuard::type(),
+        'name' => WireGuard::id(),
+        'version' => 'latest',
+        'status' => ServiceStatus::INSTALLING,
+    ]);
 
-        $this->assertTrue($network->servers->contains($member));
-        $this->assertTrue($network->firewallRules->contains($rule));
-        $this->assertTrue($this->server->project->networks->contains($network));
-        $this->assertTrue($member->network->is($network));
-        $this->assertTrue($member->server->is($this->server));
-    }
+    $handler = $service->handler();
+    $handler->install();
+    SSH::assertExecutedContains('apt-get install -y wireguard');
+    expect($handler->version())->toBe('v1.0.20210914');
 
-    public function test_network_server_private_key_is_encrypted_at_rest(): void
-    {
-        $member = NetworkServer::factory()->create([
-            'network_id' => Network::factory()->create([
-                'project_id' => $this->server->project_id,
-            ])->id,
-            'server_id' => $this->server->id,
-            'ip' => '100.64.0.3',
-            'private_key' => 'super-secret-private-key',
-            'status' => NetworkServerStatus::PENDING,
-        ]);
+    $handler->uninstall();
+    SSH::assertExecutedContains('apt-get remove -y wireguard');
+});
 
-        $raw = DB::table('network_servers')->where('id', $member->id)->value('private_key');
-        $this->assertNotSame('super-secret-private-key', $raw);
-        $this->assertSame('super-secret-private-key', $member->fresh()->private_key);
-        $this->assertInstanceOf(NetworkServerStatus::class, $member->fresh()->status);
-    }
+test('wireguard cannot be installed via services store', function () {
+    SSH::fake();
 
-    public function test_generate_wireguard_keys_produce_valid_curve25519_format(): void
-    {
-        $keys = app(GenerateWireGuardKeys::class)->generate();
+    $this->actingAs($this->user);
 
-        foreach (['private_key', 'public_key'] as $key) {
-            $decoded = base64_decode($keys[$key], true);
-            $this->assertNotFalse($decoded);
-            $this->assertSame(32, strlen((string) $decoded));
-            $this->assertSame(44, strlen($keys[$key]));
+    $this->post(route('services.store', ['server' => $this->server]), [
+        'name' => WireGuard::id(),
+        'version' => 'latest',
+    ])->assertSessionHasErrors('name');
+
+    $this->assertDatabaseMissing('services', [
+        'server_id' => $this->server->id,
+        'name' => WireGuard::id(),
+    ]);
+});
+
+test('wireguard configure network uploads conf and starts interface', function () {
+    SSH::fake();
+
+    $network = Network::factory()->create([
+        'project_id' => $this->server->project_id,
+        'cidr' => '100.64.0.0/24',
+        'cidr_canonical' => '100.64.0.0/24',
+        'port' => 51820,
+    ]);
+
+    $peerServer = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+    ]);
+
+    NetworkServer::factory()->create([
+        'network_id' => $network->id,
+        'server_id' => $peerServer->id,
+        'ip' => '100.64.0.3',
+        'public_key' => 'PEERPUBLICKEYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+        'status' => NetworkServerStatus::ACTIVE,
+    ]);
+
+    $membership = NetworkServer::factory()->create([
+        'network_id' => $network->id,
+        'server_id' => $this->server->id,
+        'ip' => '100.64.0.2',
+        'private_key' => 'MYPRIVATEKEYBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=',
+        'public_key' => 'MYPUBLICKEYCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=',
+        'status' => NetworkServerStatus::UPDATING,
+    ]);
+
+    $service = $this->server->services()->create([
+        'type' => WireGuard::type(),
+        'name' => WireGuard::id(),
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+
+    /** @var WireGuard $handler */
+    $handler = $service->handler();
+    $handler->configureNetwork($membership);
+
+    SSH::assertFileUploaded("/etc/wireguard/wg-vito-{$network->id}.conf.tmp");
+    SSH::assertExecutedContains('install -m 600 -o root -g root /etc/wireguard/wg-vito-'.$network->id.'.conf.tmp');
+
+    $content = SSH::getUploadedContent();
+    $this->assertStringContainsString('[Interface]', $content);
+    $this->assertStringContainsString('Address = 100.64.0.2/24', $content);
+    $this->assertStringContainsString('ListenPort = 51820', $content);
+    $this->assertStringContainsString('[Peer]', $content);
+    $this->assertStringContainsString('PEERPUBLICKEYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=', $content);
+    $this->assertStringContainsString('AllowedIPs = 100.64.0.3/32', $content);
+    $this->assertStringContainsString('Endpoint = '.$peerServer->ip.':51820', $content);
+
+    SSH::assertExecutedContains("wg-quick@wg-vito-{$network->id}");
+});
+
+test('store creates wireguard network and redirects', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+    $this->actingAs($this->user);
+
+    $response = $this->post(route('networks.store'), [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    $response->assertRedirect();
+    $this->assertDatabaseHas('networks', [
+        'name' => 'wg-net',
+        'type' => NetworkType::WIREGUARD->value,
+        'project_id' => $this->server->project_id,
+    ]);
+});
+
+test('add server via http rejects cross project server', function () {
+    SSH::fake();
+    $network = Network::factory()->create(['project_id' => $this->server->project_id]);
+
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+    $foreign = Server::factory()->create([
+        'project_id' => $otherUser->current_project_id,
+        'user_id' => $otherUser->id,
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('networks.servers.store', $network), [
+        'servers' => [$foreign->id],
+    ])->assertSessionHasErrors('servers.0');
+
+    $this->assertDatabaseMissing('network_servers', ['server_id' => $foreign->id]);
+});
+
+test('destroy network via http', function () {
+    SSH::fake();
+    $network = Network::factory()->create(['project_id' => $this->server->project_id]);
+
+    $this->actingAs($this->user);
+
+    $this->delete(route('networks.destroy', $network))->assertRedirect(route('networks'));
+    $this->assertDatabaseMissing('networks', ['id' => $network->id]);
+});
+
+test('cannot view another projects network', function () {
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+    $network = Network::factory()->create(['project_id' => $otherUser->current_project_id]);
+
+    $this->actingAs($this->user);
+
+    $this->get(route('networks.show', $network))->assertForbidden();
+});
+
+test('network server resource never exposes private key', function () {
+    $network = Network::factory()->create(['project_id' => $this->server->project_id]);
+    $member = NetworkServer::factory()->create([
+        'network_id' => $network->id,
+        'server_id' => $this->server->id,
+        'ip' => '100.64.0.9',
+        'private_key' => 'top-secret',
+    ]);
+
+    $data = (new NetworkServerResource($member->load('server')))->toArray(request());
+
+    $this->assertArrayNotHasKey('private_key', $data);
+    expect($data)->toHaveKey('public_key');
+});
+
+test('network peer is never serialised with its private key', function () {
+    $network = Network::factory()->create(['project_id' => $this->server->project_id]);
+    $peer = NetworkPeer::factory()->create([
+        'network_id' => $network->id,
+        'private_key' => 'top-secret',
+    ]);
+
+    $this->assertArrayNotHasKey('private_key', (new NetworkPeerResource($peer))->toArray(request()));
+    $this->assertArrayNotHasKey('private_key', $peer->toArray());
+    expect($peer->private_key)->toBe('top-secret');
+});
+
+test('firewall rule update via http', function () {
+    SSH::fake();
+    $network = Network::factory()->create(['project_id' => $this->server->project_id]);
+    $rule = NetworkFirewallRule::factory()->create(['network_id' => $network->id, 'port' => '80']);
+
+    $this->actingAs($this->user);
+
+    $this->put(route('networks.firewall.update', ['network' => $network, 'networkFirewallRule' => $rule]), [
+        'name' => 'updated',
+        'protocol' => 'tcp',
+        'port' => '443',
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('network_firewall_rules', ['id' => $rule->id, 'name' => 'updated', 'port' => '443']);
+});
+
+test('empty cidr is stored as null not canonicalised', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $ip = ServerIpAddress::factory()->create(['server_id' => $this->server->id, 'ip' => '10.0.0.5', 'type' => IpAddressType::PRIVATE]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'no-cidr-net',
+        'type' => 'custom',
+        'cidr' => '',
+        'servers' => [$this->server->id],
+        'ip_addresses' => [$this->server->id => $ip->id],
+    ]);
+
+    $this->assertDatabaseHas('networks', [
+        'id' => $network->id,
+        'cidr' => null,
+        'cidr_canonical' => null,
+    ]);
+});
+
+test('update provider network server ip via http', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $ip1 = ServerIpAddress::factory()->create(['server_id' => $this->server->id, 'ip' => '10.0.0.5', 'type' => IpAddressType::PRIVATE]);
+    $ip2 = ServerIpAddress::factory()->create(['server_id' => $this->server->id, 'ip' => '10.0.0.6', 'type' => IpAddressType::PRIVATE]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'prov-net',
+        'type' => 'custom',
+        'cidr' => '10.0.0.0/24',
+        'servers' => [$this->server->id],
+        'ip_addresses' => [$this->server->id => $ip1->id],
+    ]);
+    $member = $network->servers()->firstOrFail();
+
+    $this->actingAs($this->user);
+
+    $this->put(route('networks.servers.update', ['network' => $network, 'networkServer' => $member]), [
+        'server_ip_address_id' => $ip2->id,
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('network_servers', ['id' => $member->id, 'server_ip_address_id' => $ip2->id]);
+});
+
+test('cannot update ip on wireguard network server', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $ip = ServerIpAddress::factory()->create(['server_id' => $this->server->id, 'ip' => '10.0.0.6', 'type' => IpAddressType::PRIVATE]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+    $member = $network->servers()->firstOrFail();
+
+    $this->actingAs($this->user);
+
+    $this->put(route('networks.servers.update', ['network' => $network, 'networkServer' => $member]), [
+        'server_ip_address_id' => $ip->id,
+    ])->assertNotFound();
+});
+
+test('adding a server moves the network off a port it already uses', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $other = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
+
+    $first = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-first',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    $second = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-second',
+        'type' => 'wireguard',
+        'servers' => [$other->id],
+    ]);
+
+    expect($first->port)->toBe(51820);
+    expect($second->port)->toBe(51820);
+
+    app(AddServersToNetwork::class)->add($second, ['servers' => [$this->server->id]]);
+
+    expect($second->fresh()?->port)->toBe(51821);
+    expect($first->fresh()?->port)->toBe(51820);
+    expect($second->servers()->count())->toBe(2);
+});
+
+test('port move warns that peers must download their config again', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $other = Server::factory()->create([
+        'project_id' => $this->server->project_id,
+        'user_id' => $this->user->id,
+        'status' => ServerStatus::READY,
+    ]);
+
+    app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-first',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    $second = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-second',
+        'type' => 'wireguard',
+        'servers' => [$other->id],
+    ]);
+
+    app(CreateNetworkPeer::class)->create($second, ['name' => 'laptop']);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('networks.servers.store', ['network' => $second]), [
+        'servers' => [$this->server->id],
+    ])->assertSessionHas('warning');
+
+    expect($second->fresh()?->port)->toBe(51821);
+});
+
+test('a range outside private address space is rejected', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $ip = ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'ip' => '10.80.0.5',
+        'type' => IpAddressType::PRIVATE,
+    ]);
+
+    foreach (['0.0.0.0/0', '::/0', '8.8.8.0/24', '10.0.0.0/7', '2001:db8::/32'] as $cidr) {
+        try {
+            app(CreateNetwork::class)->create($this->server->project, [
+                'name' => 'public-'.md5($cidr),
+                'type' => 'custom',
+                'cidr' => $cidr,
+                'servers' => [$this->server->id],
+                'ip_addresses' => [$this->server->id => $ip->id],
+            ]);
+            $this->fail("Expected [$cidr] to be rejected.");
+        } catch (ValidationException) {
+            // expected
         }
-
-        $private = base64_decode($keys['private_key']);
-        $this->assertSame(0, ord($private[0]) & 7);
-        $this->assertSame(64, ord($private[31]) & 192);
     }
 
-    public function test_wireguard_service_installs_and_uninstalls_via_ssh(): void
-    {
-        SSH::fake('v1.0.20210914');
-
-        $service = $this->server->services()->create([
-            'type' => WireGuard::type(),
-            'name' => WireGuard::id(),
-            'version' => 'latest',
-            'status' => ServiceStatus::INSTALLING,
-        ]);
-
-        $handler = $service->handler();
-        $handler->install();
-        SSH::assertExecutedContains('apt-get install -y wireguard');
-        $this->assertSame('v1.0.20210914', $handler->version());
-
-        $handler->uninstall();
-        SSH::assertExecutedContains('apt-get remove -y wireguard');
-    }
-
-    public function test_wireguard_cannot_be_installed_via_services_store(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('services.store', ['server' => $this->server]), [
-            'name' => WireGuard::id(),
-            'version' => 'latest',
-        ])->assertSessionHasErrors('name');
-
-        $this->assertDatabaseMissing('services', [
-            'server_id' => $this->server->id,
-            'name' => WireGuard::id(),
-        ]);
-    }
-
-    public function test_wireguard_configure_network_uploads_conf_and_starts_interface(): void
-    {
-        SSH::fake();
-
-        $network = Network::factory()->create([
-            'project_id' => $this->server->project_id,
-            'cidr' => '100.64.0.0/24',
-            'cidr_canonical' => '100.64.0.0/24',
-            'port' => 51820,
-        ]);
-
-        $peerServer = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-        ]);
-
-        NetworkServer::factory()->create([
-            'network_id' => $network->id,
-            'server_id' => $peerServer->id,
-            'ip' => '100.64.0.3',
-            'public_key' => 'PEERPUBLICKEYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
-            'status' => NetworkServerStatus::ACTIVE,
-        ]);
-
-        $membership = NetworkServer::factory()->create([
-            'network_id' => $network->id,
-            'server_id' => $this->server->id,
-            'ip' => '100.64.0.2',
-            'private_key' => 'MYPRIVATEKEYBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=',
-            'public_key' => 'MYPUBLICKEYCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=',
-            'status' => NetworkServerStatus::UPDATING,
-        ]);
-
-        $service = $this->server->services()->create([
-            'type' => WireGuard::type(),
-            'name' => WireGuard::id(),
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-
-        /** @var WireGuard $handler */
-        $handler = $service->handler();
-        $handler->configureNetwork($membership);
-
-        SSH::assertFileUploaded("/etc/wireguard/wg-vito-{$network->id}.conf.tmp");
-        SSH::assertExecutedContains('install -m 600 -o root -g root /etc/wireguard/wg-vito-'.$network->id.'.conf.tmp');
-
-        $content = SSH::getUploadedContent();
-        $this->assertStringContainsString('[Interface]', $content);
-        $this->assertStringContainsString('Address = 100.64.0.2/24', $content);
-        $this->assertStringContainsString('ListenPort = 51820', $content);
-        $this->assertStringContainsString('[Peer]', $content);
-        $this->assertStringContainsString('PEERPUBLICKEYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=', $content);
-        $this->assertStringContainsString('AllowedIPs = 100.64.0.3/32', $content);
-        $this->assertStringContainsString('Endpoint = '.$peerServer->ip.':51820', $content);
-
-        SSH::assertExecutedContains("wg-quick@wg-vito-{$network->id}");
-    }
-
-    public function test_store_creates_wireguard_network_and_redirects(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-        $this->actingAs($this->user);
-
-        $response = $this->post(route('networks.store'), [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        $response->assertRedirect();
-        $this->assertDatabaseHas('networks', [
-            'name' => 'wg-net',
-            'type' => NetworkType::WIREGUARD->value,
-            'project_id' => $this->server->project_id,
-        ]);
-    }
-
-    public function test_add_server_via_http_rejects_cross_project_server(): void
-    {
-        SSH::fake();
-        $network = Network::factory()->create(['project_id' => $this->server->project_id]);
-
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-        $foreign = Server::factory()->create([
-            'project_id' => $otherUser->current_project_id,
-            'user_id' => $otherUser->id,
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('networks.servers.store', $network), [
-            'servers' => [$foreign->id],
-        ])->assertSessionHasErrors('servers.0');
-
-        $this->assertDatabaseMissing('network_servers', ['server_id' => $foreign->id]);
-    }
-
-    public function test_destroy_network_via_http(): void
-    {
-        SSH::fake();
-        $network = Network::factory()->create(['project_id' => $this->server->project_id]);
-
-        $this->actingAs($this->user);
-
-        $this->delete(route('networks.destroy', $network))->assertRedirect(route('networks'));
-        $this->assertDatabaseMissing('networks', ['id' => $network->id]);
-    }
-
-    public function test_cannot_view_another_projects_network(): void
-    {
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-        $network = Network::factory()->create(['project_id' => $otherUser->current_project_id]);
-
-        $this->actingAs($this->user);
-
-        $this->get(route('networks.show', $network))->assertForbidden();
-    }
-
-    public function test_network_server_resource_never_exposes_private_key(): void
-    {
-        $network = Network::factory()->create(['project_id' => $this->server->project_id]);
-        $member = NetworkServer::factory()->create([
-            'network_id' => $network->id,
-            'server_id' => $this->server->id,
-            'ip' => '100.64.0.9',
-            'private_key' => 'top-secret',
-        ]);
-
-        $data = (new NetworkServerResource($member->load('server')))->toArray(request());
-
-        $this->assertArrayNotHasKey('private_key', $data);
-        $this->assertArrayHasKey('public_key', $data);
-    }
-
-    public function test_network_peer_is_never_serialised_with_its_private_key(): void
-    {
-        $network = Network::factory()->create(['project_id' => $this->server->project_id]);
-        $peer = NetworkPeer::factory()->create([
-            'network_id' => $network->id,
-            'private_key' => 'top-secret',
-        ]);
-
-        $this->assertArrayNotHasKey('private_key', (new NetworkPeerResource($peer))->toArray(request()));
-        $this->assertArrayNotHasKey('private_key', $peer->toArray());
-        $this->assertSame('top-secret', $peer->private_key);
-    }
-
-    public function test_firewall_rule_update_via_http(): void
-    {
-        SSH::fake();
-        $network = Network::factory()->create(['project_id' => $this->server->project_id]);
-        $rule = NetworkFirewallRule::factory()->create(['network_id' => $network->id, 'port' => '80']);
-
-        $this->actingAs($this->user);
-
-        $this->put(route('networks.firewall.update', ['network' => $network, 'networkFirewallRule' => $rule]), [
-            'name' => 'updated',
-            'protocol' => 'tcp',
-            'port' => '443',
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('network_firewall_rules', ['id' => $rule->id, 'name' => 'updated', 'port' => '443']);
-    }
-
-    /**
-     * The create dialog posts an empty string when the optional CIDR is left blank.
-     */
-    public function test_empty_cidr_is_stored_as_null_not_canonicalised(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $ip = ServerIpAddress::factory()->create(['server_id' => $this->server->id, 'ip' => '10.0.0.5', 'type' => IpAddressType::PRIVATE]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'no-cidr-net',
-            'type' => 'custom',
-            'cidr' => '',
-            'servers' => [$this->server->id],
-            'ip_addresses' => [$this->server->id => $ip->id],
-        ]);
-
-        $this->assertDatabaseHas('networks', [
-            'id' => $network->id,
-            'cidr' => null,
-            'cidr_canonical' => null,
-        ]);
-    }
-
-    public function test_update_provider_network_server_ip_via_http(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $ip1 = ServerIpAddress::factory()->create(['server_id' => $this->server->id, 'ip' => '10.0.0.5', 'type' => IpAddressType::PRIVATE]);
-        $ip2 = ServerIpAddress::factory()->create(['server_id' => $this->server->id, 'ip' => '10.0.0.6', 'type' => IpAddressType::PRIVATE]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'prov-net',
-            'type' => 'custom',
-            'cidr' => '10.0.0.0/24',
-            'servers' => [$this->server->id],
-            'ip_addresses' => [$this->server->id => $ip1->id],
-        ]);
-        $member = $network->servers()->firstOrFail();
-
-        $this->actingAs($this->user);
-
-        $this->put(route('networks.servers.update', ['network' => $network, 'networkServer' => $member]), [
-            'server_ip_address_id' => $ip2->id,
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('network_servers', ['id' => $member->id, 'server_ip_address_id' => $ip2->id]);
-    }
-
-    public function test_cannot_update_ip_on_wireguard_network_server(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $ip = ServerIpAddress::factory()->create(['server_id' => $this->server->id, 'ip' => '10.0.0.6', 'type' => IpAddressType::PRIVATE]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-        $member = $network->servers()->firstOrFail();
-
-        $this->actingAs($this->user);
-
-        $this->put(route('networks.servers.update', ['network' => $network, 'networkServer' => $member]), [
-            'server_ip_address_id' => $ip->id,
-        ])->assertNotFound();
-    }
-
-    /**
-     * Two WireGuard interfaces on one host cannot share a listen port. A server joining a second
-     * network on the port it already runs moves that network to the next free one — refusing the
-     * server instead would make "a server can belong to several networks" unreachable on the
-     * default port, with no way to change it.
-     */
-    public function test_adding_a_server_moves_the_network_off_a_port_it_already_uses(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $other = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
-
-        $first = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-first',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        $second = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-second',
-            'type' => 'wireguard',
-            'servers' => [$other->id],
-        ]);
-
-        $this->assertSame(51820, $first->port);
-        $this->assertSame(51820, $second->port);
-
-        app(AddServersToNetwork::class)->add($second, ['servers' => [$this->server->id]]);
-
-        $this->assertSame(51821, $second->fresh()?->port);
-        $this->assertSame(51820, $first->fresh()?->port);
-        $this->assertSame(2, $second->servers()->count());
-    }
-
-    /**
-     * A peer's endpoint port is fixed when its config is downloaded, so a config already imported
-     * on a laptop keeps pointing at the old port after the network moves. Nothing on the peer
-     * changes and no handshake failure surfaces, so the move has to be called out.
-     */
-    public function test_port_move_warns_that_peers_must_download_their_config_again(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $other = Server::factory()->create([
-            'project_id' => $this->server->project_id,
-            'user_id' => $this->user->id,
-            'status' => ServerStatus::READY,
-        ]);
-
-        app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-first',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        $second = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-second',
-            'type' => 'wireguard',
-            'servers' => [$other->id],
-        ]);
-
-        app(CreateNetworkPeer::class)->create($second, ['name' => 'laptop']);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('networks.servers.store', ['network' => $second]), [
-            'servers' => [$this->server->id],
-        ])->assertSessionHas('warning');
-
-        $this->assertSame(51821, $second->fresh()?->port);
-    }
-
-    /**
-     * The declared range is what the firewall rules are scoped to, so a range wider than private
-     * space would emit `allow from 0.0.0.0/0` on every member — opening those ports to the
-     * internet on servers that were default-deny.
-     */
-    public function test_a_range_outside_private_address_space_is_rejected(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $ip = ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'ip' => '10.80.0.5',
-            'type' => IpAddressType::PRIVATE,
-        ]);
-
-        foreach (['0.0.0.0/0', '::/0', '8.8.8.0/24', '10.0.0.0/7', '2001:db8::/32'] as $cidr) {
-            try {
-                app(CreateNetwork::class)->create($this->server->project, [
-                    'name' => 'public-'.md5($cidr),
-                    'type' => 'custom',
-                    'cidr' => $cidr,
-                    'servers' => [$this->server->id],
-                    'ip_addresses' => [$this->server->id => $ip->id],
-                ]);
-                $this->fail("Expected [$cidr] to be rejected.");
-            } catch (ValidationException) {
-                // expected
-            }
-        }
-
-        $this->assertSame(0, Network::query()->where('project_id', $this->server->project_id)->count());
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'private-range',
-            'type' => 'custom',
-            'cidr' => '10.80.0.0/24',
-            'servers' => [$this->server->id],
-            'ip_addresses' => [$this->server->id => $ip->id],
-        ]);
-
-        $this->assertSame('10.80.0.0/24', $network->cidr);
-    }
-
-    /**
-     * The per-server IP rules are keyed by server id, so building them from raw input turned a
-     * malformed `servers` entry into a 500 before the validator ever ran.
-     */
-    public function test_malformed_servers_input_is_a_validation_error(): void
-    {
-        $network = Network::factory()->create([
-            'project_id' => $this->server->project_id,
-            'type' => NetworkType::CUSTOM,
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('networks.store'), [
-            'name' => 'bad-input',
-            'type' => 'custom',
-            'servers' => [['nested']],
-            'ip_addresses' => [],
-        ])->assertSessionHasErrors('servers.0');
-
-        $this->post(route('networks.servers.store', ['network' => $network]), [
-            'servers' => [['nested']],
-            'ip_addresses' => [],
-        ])->assertSessionHasErrors('servers.0');
-
-        $this->assertDatabaseMissing('networks', ['name' => 'bad-input']);
-    }
-
-    public function test_sub_resource_404_when_not_belonging_to_network(): void
-    {
-        $network = Network::factory()->create(['project_id' => $this->server->project_id]);
-        $other = Network::factory()->create(['project_id' => $this->server->project_id]);
-        $rule = NetworkFirewallRule::factory()->create(['network_id' => $other->id]);
-
-        $this->actingAs($this->user);
-
-        $this->delete(route('networks.firewall.destroy', ['network' => $network, 'networkFirewallRule' => $rule]))
-            ->assertNotFound();
-    }
-
-    public function test_update_network_rename_via_http(): void
-    {
-        $network = Network::factory()->create(['project_id' => $this->server->project_id, 'name' => 'old-name']);
-
-        $this->actingAs($this->user);
-
-        $this->put(route('networks.update', $network), ['name' => 'new-name'])->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('networks', ['id' => $network->id, 'name' => 'new-name']);
-    }
-
-    public function test_viewer_role_cannot_create_network(): void
-    {
-        $viewer = User::factory()->create();
-        $this->server->project->users()->create(['user_id' => $viewer->id, 'role' => UserRole::USER]);
-        $viewer->current_project_id = $this->server->project_id;
-        $viewer->save();
-
-        $this->actingAs($viewer);
-
-        $this->post(route('networks.store'), [
-            'name' => 'denied',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ])->assertForbidden();
-    }
-
-    public function test_member_regenerate_via_http_resyncs_the_member(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = Network::factory()->create([
-            'project_id' => $this->server->project_id,
-            'cidr' => '100.64.0.0/24',
-            'cidr_canonical' => '100.64.0.0/24',
-        ]);
-        $member = NetworkServer::factory()->create([
-            'network_id' => $network->id,
-            'server_id' => $this->server->id,
-            'ip' => '100.64.0.5',
-            'status' => NetworkServerStatus::FAILED,
-            'sync_attempts' => 3,
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('networks.servers.sync', ['network' => $network, 'networkServer' => $member]))
-            ->assertSessionDoesntHaveErrors();
-
-        $fresh = $member->fresh();
-        $this->assertSame(NetworkServerStatus::ACTIVE, $fresh?->status);
-        $this->assertSame(0, $fresh?->sync_attempts);
-        SSH::assertExecutedContains('wg-quick@wg-vito-'.$network->id);
-    }
-
-    public function test_custom_network_duplicate_cidr_is_rejected(): void
-    {
-        $ip = ServerIpAddress::factory()->create(['server_id' => $this->server->id, 'ip' => '10.0.0.5', 'type' => IpAddressType::PRIVATE]);
-        Network::factory()->create([
-            'project_id' => $this->server->project_id,
-            'type' => NetworkType::CUSTOM,
-            'cidr' => '10.0.0.0/24',
-            'cidr_canonical' => '10.0.0.0/24',
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('networks.store'), [
-            'name' => 'dup',
-            'type' => 'custom',
-            'cidr' => '10.0.0.5/24',
-            'servers' => [$this->server->id],
-            'ip_addresses' => [$this->server->id => $ip->id],
-        ])->assertSessionHasErrors('cidr');
-    }
-
-    public function test_network_sync_logs_are_associated_to_the_network(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'network_id' => $network->id,
-            'type' => 'configure-wireguard-'.$network->id,
-        ]);
-        $this->assertDatabaseHas('server_logs', [
-            'network_id' => $network->id,
-            'type' => 'apply-rules',
-        ]);
-        $this->assertSame(0, DB::table('server_logs')->whereNull('network_id')->count());
-    }
-
-    /**
-     * `active` reads as "every server is configured and in sync", which a network with no
-     * servers at all has no business claiming.
-     */
-    public function test_network_without_servers_is_not_reported_as_active(): void
-    {
-        $network = Network::factory()->create([
-            'project_id' => $this->server->project_id,
-            'status' => NetworkStatus::ACTIVE,
-        ]);
-
-        app(RecomputeNetworkStatus::class)->handle($network);
-
-        $this->assertSame(NetworkStatus::CREATING, $network->fresh()?->status);
-    }
-
-    /**
-     * The create dialog reads `servers` as a bare list of options, each carrying the private
-     * addresses a custom network can be built from.
-     */
-    public function test_index_lists_servers_as_options_with_their_private_ips(): void
-    {
-        $ip = ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'ip' => '10.0.0.7',
-            'type' => IpAddressType::PRIVATE,
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->get(route('networks'))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('networks/index')
-                ->has('servers.0', fn (AssertableInertia $option) => $option
-                    ->where('id', $this->server->id)
-                    ->where('name', $this->server->name)
-                    ->has('is_ready')
-                    ->has('private_ips.0', fn (AssertableInertia $address) => $address
-                        ->where('id', $ip->id)
-                        ->where('ip', '10.0.0.7')
-                        ->has('is_primary')))
-                ->etc());
-    }
-
-    /**
-     * The servers tab of a custom network offers each member's other private addresses so the
-     * one it joined with can be changed.
-     */
-    public function test_servers_page_lists_member_ips_for_a_custom_network(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $ip = ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'ip' => '10.60.0.5',
-            'type' => IpAddressType::PRIVATE,
-        ]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'custom-members',
-            'type' => 'custom',
-            'cidr' => '10.60.0.0/24',
-            'servers' => [$this->server->id],
-            'ip_addresses' => [$this->server->id => $ip->id],
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->get(route('networks.servers', $network))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('networks/servers')
-                ->has('memberIps.0', fn (AssertableInertia $member) => $member
-                    ->where('server_id', $this->server->id)
-                    ->where('server_name', $this->server->name)
-                    ->where('ip_address_id', $ip->id)
-                    ->has('private_ips.0')
-                    ->etc())
-                ->etc());
-    }
-
-    public function test_overview_returns_stats_and_recent_logs(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->get(route('networks.show', $network))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('networks/show')
-                ->where('stats.servers', 1)
-                ->where('stats.peers', 0)
-                ->where('stats.firewall_rules', 1)
-                ->has('logs.data.0', fn (AssertableInertia $log) => $log
-                    ->where('network_id', $network->id)
-                    ->etc()));
-    }
-
-    public function test_logs_page_returns_network_logs_with_their_server(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $network = app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->get(route('networks.logs', $network))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('networks/logs')
-                ->has('logs.data.0', fn (AssertableInertia $log) => $log
-                    ->where('network_id', $network->id)
-                    ->where('server_id', $this->server->id)
-                    ->where('server_name', $this->server->name)
-                    ->etc()));
-    }
-
-    public function test_logs_page_is_not_visible_to_other_projects(): void
-    {
-        $network = Network::factory()->create([
-            'project_id' => $this->server->project_id,
-            'type' => NetworkType::CUSTOM,
-        ]);
-
-        $outsider = User::factory()->create();
-        $outsider->ensureHasDefaultProject();
-
-        $this->actingAs($outsider)
-            ->get(route('networks.logs', $network))
-            ->assertForbidden();
-    }
-}
+    expect(Network::query()->where('project_id', $this->server->project_id)->count())->toBe(0);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'private-range',
+        'type' => 'custom',
+        'cidr' => '10.80.0.0/24',
+        'servers' => [$this->server->id],
+        'ip_addresses' => [$this->server->id => $ip->id],
+    ]);
+
+    expect($network->cidr)->toBe('10.80.0.0/24');
+});
+
+test('malformed servers input is a validation error', function () {
+    $network = Network::factory()->create([
+        'project_id' => $this->server->project_id,
+        'type' => NetworkType::CUSTOM,
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('networks.store'), [
+        'name' => 'bad-input',
+        'type' => 'custom',
+        'servers' => [['nested']],
+        'ip_addresses' => [],
+    ])->assertSessionHasErrors('servers.0');
+
+    $this->post(route('networks.servers.store', ['network' => $network]), [
+        'servers' => [['nested']],
+        'ip_addresses' => [],
+    ])->assertSessionHasErrors('servers.0');
+
+    $this->assertDatabaseMissing('networks', ['name' => 'bad-input']);
+});
+
+test('sub resource 404 when not belonging to network', function () {
+    $network = Network::factory()->create(['project_id' => $this->server->project_id]);
+    $other = Network::factory()->create(['project_id' => $this->server->project_id]);
+    $rule = NetworkFirewallRule::factory()->create(['network_id' => $other->id]);
+
+    $this->actingAs($this->user);
+
+    $this->delete(route('networks.firewall.destroy', ['network' => $network, 'networkFirewallRule' => $rule]))
+        ->assertNotFound();
+});
+
+test('update network rename via http', function () {
+    $network = Network::factory()->create(['project_id' => $this->server->project_id, 'name' => 'old-name']);
+
+    $this->actingAs($this->user);
+
+    $this->put(route('networks.update', $network), ['name' => 'new-name'])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('networks', ['id' => $network->id, 'name' => 'new-name']);
+});
+
+test('viewer role cannot create network', function () {
+    $viewer = User::factory()->create();
+    $this->server->project->users()->create(['user_id' => $viewer->id, 'role' => UserRole::USER]);
+    $viewer->current_project_id = $this->server->project_id;
+    $viewer->save();
+
+    $this->actingAs($viewer);
+
+    $this->post(route('networks.store'), [
+        'name' => 'denied',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ])->assertForbidden();
+});
+
+test('member regenerate via http resyncs the member', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = Network::factory()->create([
+        'project_id' => $this->server->project_id,
+        'cidr' => '100.64.0.0/24',
+        'cidr_canonical' => '100.64.0.0/24',
+    ]);
+    $member = NetworkServer::factory()->create([
+        'network_id' => $network->id,
+        'server_id' => $this->server->id,
+        'ip' => '100.64.0.5',
+        'status' => NetworkServerStatus::FAILED,
+        'sync_attempts' => 3,
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('networks.servers.sync', ['network' => $network, 'networkServer' => $member]))
+        ->assertSessionDoesntHaveErrors();
+
+    $fresh = $member->fresh();
+    expect($fresh?->status)->toBe(NetworkServerStatus::ACTIVE);
+    expect($fresh?->sync_attempts)->toBe(0);
+    SSH::assertExecutedContains('wg-quick@wg-vito-'.$network->id);
+});
+
+test('custom network duplicate cidr is rejected', function () {
+    $ip = ServerIpAddress::factory()->create(['server_id' => $this->server->id, 'ip' => '10.0.0.5', 'type' => IpAddressType::PRIVATE]);
+    Network::factory()->create([
+        'project_id' => $this->server->project_id,
+        'type' => NetworkType::CUSTOM,
+        'cidr' => '10.0.0.0/24',
+        'cidr_canonical' => '10.0.0.0/24',
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('networks.store'), [
+        'name' => 'dup',
+        'type' => 'custom',
+        'cidr' => '10.0.0.5/24',
+        'servers' => [$this->server->id],
+        'ip_addresses' => [$this->server->id => $ip->id],
+    ])->assertSessionHasErrors('cidr');
+});
+
+test('network sync logs are associated to the network', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'network_id' => $network->id,
+        'type' => 'configure-wireguard-'.$network->id,
+    ]);
+    $this->assertDatabaseHas('server_logs', [
+        'network_id' => $network->id,
+        'type' => 'apply-rules',
+    ]);
+    expect(DB::table('server_logs')->whereNull('network_id')->count())->toBe(0);
+});
+
+test('network without servers is not reported as active', function () {
+    $network = Network::factory()->create([
+        'project_id' => $this->server->project_id,
+        'status' => NetworkStatus::ACTIVE,
+    ]);
+
+    app(RecomputeNetworkStatus::class)->handle($network);
+
+    expect($network->fresh()?->status)->toBe(NetworkStatus::CREATING);
+});
+
+test('index lists servers as options with their private ips', function () {
+    $ip = ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'ip' => '10.0.0.7',
+        'type' => IpAddressType::PRIVATE,
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->get(route('networks'))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('networks/index')
+            ->has('servers.0', fn (AssertableInertia $option) => $option
+                ->where('id', $this->server->id)
+                ->where('name', $this->server->name)
+                ->has('is_ready')
+                ->has('private_ips.0', fn (AssertableInertia $address) => $address
+                    ->where('id', $ip->id)
+                    ->where('ip', '10.0.0.7')
+                    ->has('is_primary')))
+            ->etc());
+});
+
+test('servers page lists member ips for a custom network', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $ip = ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'ip' => '10.60.0.5',
+        'type' => IpAddressType::PRIVATE,
+    ]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'custom-members',
+        'type' => 'custom',
+        'cidr' => '10.60.0.0/24',
+        'servers' => [$this->server->id],
+        'ip_addresses' => [$this->server->id => $ip->id],
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->get(route('networks.servers', $network))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('networks/servers')
+            ->has('memberIps.0', fn (AssertableInertia $member) => $member
+                ->where('server_id', $this->server->id)
+                ->where('server_name', $this->server->name)
+                ->where('ip_address_id', $ip->id)
+                ->has('private_ips.0')
+                ->etc())
+            ->etc());
+});
+
+test('overview returns stats and recent logs', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->get(route('networks.show', $network))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('networks/show')
+            ->where('stats.servers', 1)
+            ->where('stats.peers', 0)
+            ->where('stats.firewall_rules', 1)
+            ->has('logs.data.0', fn (AssertableInertia $log) => $log
+                ->where('network_id', $network->id)
+                ->etc()));
+});
+
+test('logs page returns network logs with their server', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $network = app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->get(route('networks.logs', $network))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('networks/logs')
+            ->has('logs.data.0', fn (AssertableInertia $log) => $log
+                ->where('network_id', $network->id)
+                ->where('server_id', $this->server->id)
+                ->where('server_name', $this->server->name)
+                ->etc()));
+});
+
+test('logs page is not visible to other projects', function () {
+    $network = Network::factory()->create([
+        'project_id' => $this->server->project_id,
+        'type' => NetworkType::CUSTOM,
+    ]);
+
+    $outsider = User::factory()->create();
+    $outsider->ensureHasDefaultProject();
+
+    $this->actingAs($outsider)
+        ->get(route('networks.logs', $network))
+        ->assertForbidden();
+});

--- a/tests/Feature/NotificationChannelsTest.php
+++ b/tests/Feature/NotificationChannelsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\NotificationChannel;
 use App\Models\User;
 use App\NotificationChannels\Discord;
@@ -12,351 +10,333 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Http;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class NotificationChannelsTest extends TestCase
-{
-    use RefreshDatabase;
-    use WithFaker;
+uses(RefreshDatabase::class);
 
-    public function test_add_email_channel(): void
-    {
-        $this->actingAs($this->user);
+uses(WithFaker::class);
 
-        $this->post(route('notification-channels.store'), [
-            'provider' => Email::id(),
-            'email' => 'email@example.com',
-            'name' => 'Email',
-            'global' => true,
-        ])
-            ->assertSessionDoesntHaveErrors();
+test('add email channel', function () {
+    $this->actingAs($this->user);
 
-        /** @var NotificationChannel $channel */
-        $channel = NotificationChannel::query()
-            ->where('provider', Email::id())
-            ->where('label', 'Email')
-            ->whereNull('project_id')
-            ->first();
+    $this->post(route('notification-channels.store'), [
+        'provider' => Email::id(),
+        'email' => 'email@example.com',
+        'name' => 'Email',
+        'global' => true,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertEquals('email@example.com', $channel->data['email']);
-        $this->assertTrue($channel->connected);
-    }
+    /** @var NotificationChannel $channel */
+    $channel = NotificationChannel::query()
+        ->where('provider', Email::id())
+        ->where('label', 'Email')
+        ->whereNull('project_id')
+        ->first();
 
-    public function test_cannot_add_email_channel(): void
-    {
-        config()->set('mail.default', 'smtp');
-        config()->set('mail.mailers.smtp.host', '127.0.0.1');
-        config()->set('mail.mailers.smtp.port', 1); // closed port so the SMTP connection fails even if a local mail catcher (e.g. Mailpit) is listening
+    expect($channel->data['email'])->toEqual('email@example.com');
+    expect($channel->connected)->toBeTrue();
+});
 
-        $this->actingAs($this->user);
+test('cannot add email channel', function () {
+    config()->set('mail.default', 'smtp');
+    config()->set('mail.mailers.smtp.host', '127.0.0.1');
+    config()->set('mail.mailers.smtp.port', 1);
 
-        $this->post(route('notification-channels.store'), [
-            'provider' => Email::id(),
-            'email' => 'email@example.com',
-            'name' => 'Email',
-            'global' => true,
+    // closed port so the SMTP connection fails even if a local mail catcher (e.g. Mailpit) is listening
+    $this->actingAs($this->user);
+
+    $this->post(route('notification-channels.store'), [
+        'provider' => Email::id(),
+        'email' => 'email@example.com',
+        'name' => 'Email',
+        'global' => true,
+    ]);
+
+    /** @var ?NotificationChannel $channel */
+    $channel = NotificationChannel::query()
+        ->where('provider', Email::id())
+        ->where('label', 'Email')
+        ->first();
+
+    expect($channel)->toBeNull();
+});
+
+test('add slack channel', function () {
+    $this->actingAs($this->user);
+
+    Http::fake();
+
+    $this->post(route('notification-channels.store'), [
+        'provider' => Slack::id(),
+        'webhook_url' => 'https://hooks.slack.com/services/123/token',
+        'name' => 'Slack',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    /** @var NotificationChannel $channel */
+    $channel = NotificationChannel::query()
+        ->where('provider', Slack::id())
+        ->first();
+
+    expect($channel->data['webhook_url'])->toEqual('https://hooks.slack.com/services/123/token');
+    expect($channel->connected)->toBeTrue();
+});
+
+test('cannot add slack channel', function () {
+    $this->actingAs($this->user);
+
+    Http::fake([
+        'slack.com/*' => Http::response(['ok' => false], 401),
+    ]);
+
+    $this->post(route('notification-channels.store'), [
+        'provider' => Slack::id(),
+        'webhook_url' => 'https://hooks.slack.com/services/123/token',
+        'name' => 'Slack',
+    ])
+        ->assertSessionHasErrors([
+            'provider' => 'Could not connect',
         ]);
 
-        /** @var ?NotificationChannel $channel */
-        $channel = NotificationChannel::query()
-            ->where('provider', Email::id())
-            ->where('label', 'Email')
-            ->first();
+    /** @var ?NotificationChannel $channel */
+    $channel = NotificationChannel::query()
+        ->where('provider', Slack::id())
+        ->first();
 
-        $this->assertNull($channel);
-    }
+    expect($channel)->toBeNull();
+});
 
-    public function test_add_slack_channel(): void
-    {
-        $this->actingAs($this->user);
+test('add discord channel', function () {
+    $this->actingAs($this->user);
 
-        Http::fake();
+    Http::fake();
 
-        $this->post(route('notification-channels.store'), [
-            'provider' => Slack::id(),
-            'webhook_url' => 'https://hooks.slack.com/services/123/token',
-            'name' => 'Slack',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('notification-channels.store'), [
+        'provider' => Discord::id(),
+        'webhook_url' => 'https://discord.com/api/webhooks/123/token',
+        'name' => 'Discord',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        /** @var NotificationChannel $channel */
-        $channel = NotificationChannel::query()
-            ->where('provider', Slack::id())
-            ->first();
+    /** @var NotificationChannel $channel */
+    $channel = NotificationChannel::query()
+        ->where('provider', Discord::id())
+        ->first();
 
-        $this->assertEquals('https://hooks.slack.com/services/123/token', $channel->data['webhook_url']);
-        $this->assertTrue($channel->connected);
-    }
+    expect($channel->data['webhook_url'])->toEqual('https://discord.com/api/webhooks/123/token');
+    expect($channel->connected)->toBeTrue();
+});
 
-    public function test_cannot_add_slack_channel(): void
-    {
-        $this->actingAs($this->user);
+test('cannot add discord channel', function () {
+    $this->actingAs($this->user);
 
-        Http::fake([
-            'slack.com/*' => Http::response(['ok' => false], 401),
+    Http::fake([
+        'discord.com/*' => Http::response(['ok' => false], 401),
+    ]);
+
+    $this->post(route('notification-channels.store'), [
+        'provider' => Discord::id(),
+        'webhook_url' => 'https://discord.com/api/webhooks/123/token',
+        'name' => 'Slack',
+    ])
+        ->assertSessionHasErrors([
+            'provider' => 'Could not connect',
         ]);
 
-        $this->post(route('notification-channels.store'), [
-            'provider' => Slack::id(),
-            'webhook_url' => 'https://hooks.slack.com/services/123/token',
-            'name' => 'Slack',
-        ])
-            ->assertSessionHasErrors([
-                'provider' => 'Could not connect',
-            ]);
+    /** @var ?NotificationChannel $channel */
+    $channel = NotificationChannel::query()
+        ->where('provider', Discord::id())
+        ->first();
 
-        /** @var ?NotificationChannel $channel */
-        $channel = NotificationChannel::query()
-            ->where('provider', Slack::id())
-            ->first();
+    expect($channel)->toBeNull();
+});
 
-        $this->assertNull($channel);
-    }
+test('add telegram channel', function () {
+    $this->actingAs($this->user);
 
-    public function test_add_discord_channel(): void
-    {
-        $this->actingAs($this->user);
+    Http::fake();
 
-        Http::fake();
+    $this->post(route('notification-channels.store'), [
+        'provider' => Telegram::id(),
+        'bot_token' => 'token',
+        'chat_id' => '123',
+        'name' => 'Telegram',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->post(route('notification-channels.store'), [
-            'provider' => Discord::id(),
-            'webhook_url' => 'https://discord.com/api/webhooks/123/token',
-            'name' => 'Discord',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    /** @var NotificationChannel $channel */
+    $channel = NotificationChannel::query()
+        ->where('provider', Telegram::id())
+        ->first();
 
-        /** @var NotificationChannel $channel */
-        $channel = NotificationChannel::query()
-            ->where('provider', Discord::id())
-            ->first();
+    expect($channel->data['chat_id'])->toEqual('123');
+    expect($channel->data['bot_token'])->toEqual('token');
+    expect($channel->connected)->toBeTrue();
+});
 
-        $this->assertEquals('https://discord.com/api/webhooks/123/token', $channel->data['webhook_url']);
-        $this->assertTrue($channel->connected);
-    }
+test('cannot add telegram channel', function () {
+    $this->actingAs($this->user);
 
-    public function test_cannot_add_discord_channel(): void
-    {
-        $this->actingAs($this->user);
+    Http::fake([
+        'api.telegram.org/*' => Http::response(['ok' => false], 401),
+    ]);
 
-        Http::fake([
-            'discord.com/*' => Http::response(['ok' => false], 401),
+    $this->post(route('notification-channels.store'), [
+        'provider' => Telegram::id(),
+        'bot_token' => 'token',
+        'chat_id' => '123',
+        'name' => 'Telegram',
+    ])
+        ->assertSessionHasErrors([
+            'provider' => 'Could not connect',
         ]);
 
-        $this->post(route('notification-channels.store'), [
-            'provider' => Discord::id(),
-            'webhook_url' => 'https://discord.com/api/webhooks/123/token',
-            'name' => 'Slack',
-        ])
-            ->assertSessionHasErrors([
-                'provider' => 'Could not connect',
-            ]);
+    /** @var ?NotificationChannel $channel */
+    $channel = NotificationChannel::query()
+        ->where('provider', Telegram::id())
+        ->first();
 
-        /** @var ?NotificationChannel $channel */
-        $channel = NotificationChannel::query()
-            ->where('provider', Discord::id())
-            ->first();
+    expect($channel)->toBeNull();
+});
 
-        $this->assertNull($channel);
-    }
+test('see channels list', function () {
+    $this->actingAs($this->user);
 
-    public function test_add_telegram_channel(): void
-    {
-        $this->actingAs($this->user);
+    NotificationChannel::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-        Http::fake();
+    $this->get(route('notification-channels'))
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('notification-channels/index'));
+});
 
-        $this->post(route('notification-channels.store'), [
-            'provider' => Telegram::id(),
-            'bot_token' => 'token',
-            'chat_id' => '123',
-            'name' => 'Telegram',
-        ])
-            ->assertSessionDoesntHaveErrors();
+test('delete channel', function () {
+    $this->actingAs($this->user);
 
-        /** @var NotificationChannel $channel */
-        $channel = NotificationChannel::query()
-            ->where('provider', Telegram::id())
-            ->first();
+    $channel = NotificationChannel::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-        $this->assertEquals('123', $channel->data['chat_id']);
-        $this->assertEquals('token', $channel->data['bot_token']);
-        $this->assertTrue($channel->connected);
-    }
+    $this->delete(route('notification-channels.destroy', [
+        'notificationChannel' => $channel->id,
+    ]));
 
-    public function test_cannot_add_telegram_channel(): void
-    {
-        $this->actingAs($this->user);
+    $this->assertDatabaseMissing('notification_channels', [
+        'id' => $channel->id,
+    ]);
+});
 
-        Http::fake([
-            'api.telegram.org/*' => Http::response(['ok' => false], 401),
-        ]);
+test('user cannot update other users notification channel', function () {
+    $this->actingAs($this->user);
 
-        $this->post(route('notification-channels.store'), [
-            'provider' => Telegram::id(),
-            'bot_token' => 'token',
-            'chat_id' => '123',
-            'name' => 'Telegram',
-        ])
-            ->assertSessionHasErrors([
-                'provider' => 'Could not connect',
-            ]);
+    $otherUser = User::factory()->create();
+    $channel = NotificationChannel::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
 
-        /** @var ?NotificationChannel $channel */
-        $channel = NotificationChannel::query()
-            ->where('provider', Telegram::id())
-            ->first();
+    $this->patch(route('notification-channels.update', $channel), [
+        'name' => 'hacked',
+    ])
+        ->assertForbidden();
+});
 
-        $this->assertNull($channel);
-    }
+test('user cannot delete other users notification channel', function () {
+    $this->actingAs($this->user);
 
-    public function test_see_channels_list(): void
-    {
-        $this->actingAs($this->user);
+    $otherUser = User::factory()->create();
+    $channel = NotificationChannel::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
 
-        NotificationChannel::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $this->delete(route('notification-channels.destroy', $channel))
+        ->assertForbidden();
+});
 
-        $this->get(route('notification-channels'))
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('notification-channels/index'));
-    }
+test('guest cannot access notification channels', function () {
+    $channel = NotificationChannel::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-    public function test_delete_channel(): void
-    {
-        $this->actingAs($this->user);
+    $this->get(route('notification-channels'))
+        ->assertRedirect('/');
 
-        $channel = NotificationChannel::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $this->post(route('notification-channels.store'), [])
+        ->assertRedirect('/');
 
-        $this->delete(route('notification-channels.destroy', [
-            'notificationChannel' => $channel->id,
-        ]));
+    $this->patch(route('notification-channels.update', $channel), [])
+        ->assertRedirect('/');
 
-        $this->assertDatabaseMissing('notification_channels', [
-            'id' => $channel->id,
-        ]);
-    }
+    $this->delete(route('notification-channels.destroy', $channel))
+        ->assertRedirect('/');
+});
 
-    public function test_user_cannot_update_other_users_notification_channel(): void
-    {
-        $this->actingAs($this->user);
+test('cannot manipulate user id on creation', function () {
+    $this->actingAs($this->user);
 
-        $otherUser = User::factory()->create();
-        $channel = NotificationChannel::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
+    $otherUser = User::factory()->create();
 
-        $this->patch(route('notification-channels.update', $channel), [
-            'name' => 'hacked',
-        ])
-            ->assertForbidden();
-    }
+    $this->post(route('notification-channels.store'), [
+        'provider' => Email::id(),
+        'email' => 'test@example.com',
+        'name' => 'test',
+        'user_id' => $otherUser->id,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-    public function test_user_cannot_delete_other_users_notification_channel(): void
-    {
-        $this->actingAs($this->user);
+    $this->assertDatabaseHas('notification_channels', [
+        'label' => 'test',
+        'provider' => Email::id(),
+        'user_id' => $this->user->id,
+    ]);
 
-        $otherUser = User::factory()->create();
-        $channel = NotificationChannel::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
+    $this->assertDatabaseMissing('notification_channels', [
+        'label' => 'test',
+        'provider' => Email::id(),
+        'user_id' => $otherUser->id,
+    ]);
+});
 
-        $this->delete(route('notification-channels.destroy', $channel))
-            ->assertForbidden();
-    }
+test('cannot transfer ownership via update', function () {
+    $this->actingAs($this->user);
 
-    public function test_guest_cannot_access_notification_channels(): void
-    {
-        $channel = NotificationChannel::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $otherUser = User::factory()->create();
+    $channel = NotificationChannel::factory()->create([
+        'user_id' => $this->user->id,
+        'label' => 'original',
+    ]);
 
-        $this->get(route('notification-channels'))
-            ->assertRedirect('/');
+    $this->patch(route('notification-channels.update', $channel), [
+        'name' => 'updated',
+        'user_id' => $otherUser->id,
+    ]);
 
-        $this->post(route('notification-channels.store'), [])
-            ->assertRedirect('/');
+    $channel->refresh();
 
-        $this->patch(route('notification-channels.update', $channel), [])
-            ->assertRedirect('/');
+    expect($channel->user_id)->toEqual($this->user->id);
+    $this->assertNotEquals($otherUser->id, $channel->user_id);
+});
 
-        $this->delete(route('notification-channels.destroy', $channel))
-            ->assertRedirect('/');
-    }
+test('user can only see own notification channels in list', function () {
+    $this->actingAs($this->user);
 
-    public function test_cannot_manipulate_user_id_on_creation(): void
-    {
-        $this->actingAs($this->user);
+    $otherUser = User::factory()->create();
 
-        $otherUser = User::factory()->create();
+    $ownChannel = NotificationChannel::factory()->create([
+        'user_id' => $this->user->id,
+        'label' => 'own-channel',
+    ]);
 
-        $this->post(route('notification-channels.store'), [
-            'provider' => Email::id(),
-            'email' => 'test@example.com',
-            'name' => 'test',
-            'user_id' => $otherUser->id,
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $otherChannel = NotificationChannel::factory()->create([
+        'user_id' => $otherUser->id,
+        'label' => 'other-channel',
+    ]);
 
-        $this->assertDatabaseHas('notification_channels', [
-            'label' => 'test',
-            'provider' => Email::id(),
-            'user_id' => $this->user->id,
-        ]);
+    $response = $this->get(route('notification-channels'))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('notification-channels/index'));
 
-        $this->assertDatabaseMissing('notification_channels', [
-            'label' => 'test',
-            'provider' => Email::id(),
-            'user_id' => $otherUser->id,
-        ]);
-    }
-
-    public function test_cannot_transfer_ownership_via_update(): void
-    {
-        $this->actingAs($this->user);
-
-        $otherUser = User::factory()->create();
-        $channel = NotificationChannel::factory()->create([
-            'user_id' => $this->user->id,
-            'label' => 'original',
-        ]);
-
-        $this->patch(route('notification-channels.update', $channel), [
-            'name' => 'updated',
-            'user_id' => $otherUser->id,
-        ]);
-
-        $channel->refresh();
-
-        $this->assertEquals($this->user->id, $channel->user_id);
-        $this->assertNotEquals($otherUser->id, $channel->user_id);
-    }
-
-    public function test_user_can_only_see_own_notification_channels_in_list(): void
-    {
-        $this->actingAs($this->user);
-
-        $otherUser = User::factory()->create();
-
-        $ownChannel = NotificationChannel::factory()->create([
-            'user_id' => $this->user->id,
-            'label' => 'own-channel',
-        ]);
-
-        $otherChannel = NotificationChannel::factory()->create([
-            'user_id' => $otherUser->id,
-            'label' => 'other-channel',
-        ]);
-
-        $response = $this->get(route('notification-channels'))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('notification-channels/index'));
-
-        $response->assertInertia(fn (AssertableInertia $page) => $page->has('notificationChannels.data')
-            ->where('notificationChannels.data.0.id', $ownChannel->id)
-            ->whereNot('notificationChannels.data.0.id', $otherChannel->id)
-        );
-    }
-}
+    $response->assertInertia(fn (AssertableInertia $page) => $page->has('notificationChannels.data')
+        ->where('notificationChannels.data.0.id', $ownChannel->id)
+        ->whereNot('notificationChannels.data.0.id', $otherChannel->id)
+    );
+});

--- a/tests/Feature/NotificationChannelsTest.php
+++ b/tests/Feature/NotificationChannelsTest.php
@@ -7,13 +7,10 @@ use App\NotificationChannels\Email;
 use App\NotificationChannels\Slack;
 use App\NotificationChannels\Telegram;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Http;
 use Inertia\Testing\AssertableInertia;
 
 uses(RefreshDatabase::class);
-
-uses(WithFaker::class);
 
 test('add email channel', function () {
     $this->actingAs($this->user);

--- a/tests/Feature/PHPTest.php
+++ b/tests/Feature/PHPTest.php
@@ -1,172 +1,156 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\PHPIniType;
 use App\Enums\ServiceStatus;
 use App\Facades\SSH;
 use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class PHPTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_install_does_not_install_global_composer(): void
-    {
-        SSH::fake();
-        Event::fake();
+test('install does not install global composer', function () {
+    SSH::fake();
+    Event::fake();
 
-        $php = Service::factory()->create([
-            'server_id' => $this->server->id,
-            'type' => 'php',
-            'type_data' => [
-                'extensions' => [],
-            ],
-            'name' => 'php',
-            'version' => '8.3',
-            'status' => ServiceStatus::READY,
-        ]);
+    $php = Service::factory()->create([
+        'server_id' => $this->server->id,
+        'type' => 'php',
+        'type_data' => [
+            'extensions' => [],
+        ],
+        'name' => 'php',
+        'version' => '8.3',
+        'status' => ServiceStatus::READY,
+    ]);
 
-        $php->handler()->install();
+    $php->handler()->install();
 
-        Event::assertDispatched('service.installed');
-        SSH::assertNotExecutedContains('getcomposer.org');
-    }
+    Event::assertDispatched('service.installed');
+    SSH::assertNotExecutedContains('getcomposer.org');
+});
 
-    public function test_change_default_php_cli(): void
-    {
-        SSH::fake();
+test('change default php cli', function () {
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $php = Service::factory()->create([
-            'server_id' => $this->server->id,
-            'type' => 'php',
-            'type_data' => [
-                'extensions' => [],
-            ],
-            'name' => 'php',
-            'version' => '8.1',
-            'status' => ServiceStatus::READY,
-            'is_default' => false,
-        ]);
+    $php = Service::factory()->create([
+        'server_id' => $this->server->id,
+        'type' => 'php',
+        'type_data' => [
+            'extensions' => [],
+        ],
+        'name' => 'php',
+        'version' => '8.1',
+        'status' => ServiceStatus::READY,
+        'is_default' => false,
+    ]);
 
-        $this->post(route('php.default-cli', [
-            'server' => $this->server,
-            'service' => $php->id,
-        ]), [
-            'version' => '8.1',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('php.default-cli', [
+        'server' => $this->server,
+        'service' => $php->id,
+    ]), [
+        'version' => '8.1',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $php->refresh();
+    $php->refresh();
 
-        $this->assertTrue($php->is_default);
-    }
+    expect($php->is_default)->toBeTrue();
+});
 
-    public function test_extensions_validation_array_extension(): void
-    {
-        SSH::fake('output... [PHP Modules] grcp');
+test('extensions validation array extension', function () {
+    SSH::fake('output... [PHP Modules] grcp');
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $php = $this->server->php('8.2');
+    $php = $this->server->php('8.2');
 
-        $php->type_data = [
-            'available_extensions' => ['grcp'],
-        ];
-        $php->save();
+    $php->type_data = [
+        'available_extensions' => ['grcp'],
+    ];
+    $php->save();
 
-        Event::listen('php.extensions.list', function (Service $service, array $availableExtensions) {
-            return [
-                'service' => $service,
-                'available_extensions' => $service->type_data['available_extensions'] ?? $availableExtensions,
-            ];
-        });
-
-        $this->post(route('php.install-extension', [
-            'server' => $this->server,
-            'service' => $php->id,
-        ]), [
-            'version' => '8.2',
-            'extension' => 'grcp',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertContains('grcp', $php->refresh()->type_data['extensions']);
-    }
-
-    public function test_invalid_extension_validation(): void
-    {
-        SSH::fake('output... [PHP Modules] invalid');
-
-        $this->actingAs($this->user);
-
-        $php = $this->server->php('8.2');
-
-        $this->post(route('php.install-extension', [
-            'server' => $this->server,
-            'service' => $php->id,
-        ]), [
-            'version' => '8.2',
-            'extension' => 'invalid',
-        ])
-            ->assertSessionHasErrors([
-                'extension' => 'The selected extension is invalid.',
-            ]);
-
-    }
-
-    public function test_install_extension(): void
-    {
-        SSH::fake('output... [PHP Modules] gmp');
-
-        $this->actingAs($this->user);
-
-        $php = $this->server->php('8.2');
-
-        $this->post(route('php.install-extension', [
-            'server' => $this->server,
-            'service' => $php->id,
-        ]), [
-            'version' => '8.2',
-            'extension' => 'gmp',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertContains('gmp', $php->refresh()->type_data['extensions']);
-    }
-
-    #[DataProvider('php_ini_data')]
-    public function test_get_php_ini(string $version, PHPIniType $type): void
-    {
-        SSH::fake('[PHP ini]');
-
-        $this->actingAs($this->user);
-
-        $php = $this->server->php('8.2');
-
-        $this->get(route('php.ini', [
-            'server' => $this->server,
-            'service' => $php->id,
-            'version' => '8.2',
-            'type' => $type->value,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-    }
-
-    /**
-     * @return array<array<int, string>>
-     */
-    public static function php_ini_data(): array
-    {
+    Event::listen('php.extensions.list', function (Service $service, array $availableExtensions) {
         return [
-            ['8.2', PHPIniType::FPM],
-            ['8.2', PHPIniType::CLI],
+            'service' => $service,
+            'available_extensions' => $service->type_data['available_extensions'] ?? $availableExtensions,
         ];
-    }
-}
+    });
+
+    $this->post(route('php.install-extension', [
+        'server' => $this->server,
+        'service' => $php->id,
+    ]), [
+        'version' => '8.2',
+        'extension' => 'grcp',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    expect($php->refresh()->type_data['extensions'])->toContain('grcp');
+});
+
+test('invalid extension validation', function () {
+    SSH::fake('output... [PHP Modules] invalid');
+
+    $this->actingAs($this->user);
+
+    $php = $this->server->php('8.2');
+
+    $this->post(route('php.install-extension', [
+        'server' => $this->server,
+        'service' => $php->id,
+    ]), [
+        'version' => '8.2',
+        'extension' => 'invalid',
+    ])
+        ->assertSessionHasErrors([
+            'extension' => 'The selected extension is invalid.',
+        ]);
+});
+
+test('install extension', function () {
+    SSH::fake('output... [PHP Modules] gmp');
+
+    $this->actingAs($this->user);
+
+    $php = $this->server->php('8.2');
+
+    $this->post(route('php.install-extension', [
+        'server' => $this->server,
+        'service' => $php->id,
+    ]), [
+        'version' => '8.2',
+        'extension' => 'gmp',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    expect($php->refresh()->type_data['extensions'])->toContain('gmp');
+});
+
+test('get php ini', function (string $version, PHPIniType $type) {
+    SSH::fake('[PHP ini]');
+
+    $this->actingAs($this->user);
+
+    $php = $this->server->php('8.2');
+
+    $this->get(route('php.ini', [
+        'server' => $this->server,
+        'service' => $php->id,
+        'version' => '8.2',
+        'type' => $type->value,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+})->with('php_ini_data');
+
+/**
+ * @return array<array<int, string>>
+ */
+dataset('php_ini_data', function () {
+    return [
+        ['8.2', PHPIniType::FPM],
+        ['8.2', PHPIniType::CLI],
+    ];
+});

--- a/tests/Feature/PHPTest.php
+++ b/tests/Feature/PHPTest.php
@@ -134,21 +134,18 @@ test('get php ini', function (string $version, PHPIniType $type) {
 
     $this->actingAs($this->user);
 
-    $php = $this->server->php('8.2');
+    $php = $this->server->php($version);
 
     $this->get(route('php.ini', [
         'server' => $this->server,
         'service' => $php->id,
-        'version' => '8.2',
+        'version' => $version,
         'type' => $type->value,
     ]))
         ->assertSessionDoesntHaveErrors();
 })->with('php_ini_data');
 
-/**
- * @return array<array<int, string>>
- */
-dataset('php_ini_data', function () {
+dataset('php_ini_data', /** @return array<int, array{0: string, 1: PHPIniType}> */ function (): array {
     return [
         ['8.2', PHPIniType::FPM],
         ['8.2', PHPIniType::CLI],

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -1,70 +1,60 @@
 <?php
 
-namespace Tests\Feature;
-
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Inertia\Testing\AssertableInertia as Assert;
-use Tests\TestCase;
 
-class ProfileTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_profile_page_is_displayed(): void
-    {
-        $this->actingAs($this->user);
+test('profile page is displayed', function () {
+    $this->actingAs($this->user);
 
-        $this
-            ->get(route('profile'))
-            ->assertSuccessful()
-            ->assertInertia(fn (Assert $page) => $page->component('profile/index'));
-    }
+    test()
+        ->get(route('profile'))
+        ->assertSuccessful()
+        ->assertInertia(fn (Assert $page) => $page->component('profile/index'));
+});
 
-    public function test_profile_information_can_be_updated(): void
-    {
-        $this->actingAs($this->user);
+test('profile information can be updated', function () {
+    $this->actingAs($this->user);
 
-        $this->patch(route('profile.update'), [
-            'name' => 'Test',
-            'email' => 'test@example.com',
-        ])
-            ->assertRedirect(route('profile'));
+    $this->patch(route('profile.update'), [
+        'name' => 'Test',
+        'email' => 'test@example.com',
+    ])
+        ->assertRedirect(route('profile'));
 
-        $this->user->refresh();
+    $this->user->refresh();
 
-        $this->assertSame('Test', $this->user->name);
-        $this->assertSame('test@example.com', $this->user->email);
-    }
+    expect($this->user->name)->toBe('Test');
+    expect($this->user->email)->toBe('test@example.com');
+});
 
-    public function test_password_can_be_updated(): void
-    {
-        $this->actingAs($this->user);
+test('password can be updated', function () {
+    $this->actingAs($this->user);
 
-        $this->put(route('profile.password'), [
-            'current_password' => 'password',
-            'password' => 'new-password',
-            'password_confirmation' => 'new-password',
-        ])
-            ->assertRedirect(route('profile'))
-            ->assertSessionDoesntHaveErrors();
+    $this->put(route('profile.password'), [
+        'current_password' => 'password',
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ])
+        ->assertRedirect(route('profile'))
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertTrue(Hash::check('new-password', $this->user->refresh()->password));
+    expect(Hash::check('new-password', $this->user->refresh()->password))->toBeTrue();
 
-        $this->user->refresh();
-        $this->assertNull($this->user->two_factor_secret);
-        $this->assertNull($this->user->two_factor_recovery_codes);
-        $this->assertNull($this->user->two_factor_confirmed_at);
-    }
+    $this->user->refresh();
+    expect($this->user->two_factor_secret)->toBeNull();
+    expect($this->user->two_factor_recovery_codes)->toBeNull();
+    expect($this->user->two_factor_confirmed_at)->toBeNull();
+});
 
-    public function test_correct_password_must_be_provided_to_update_password(): void
-    {
-        $this->actingAs($this->user);
-        $this->put(route('profile.password'), [
-            'current_password' => 'wrong-password',
-            'password' => 'new-password',
-            'password_confirmation' => 'new-password',
-        ])
-            ->assertSessionHasErrors('current_password');
-    }
-}
+test('correct password must be provided to update password', function () {
+    $this->actingAs($this->user);
+    $this->put(route('profile.password'), [
+        'current_password' => 'wrong-password',
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ])
+        ->assertSessionHasErrors('current_password');
+});

--- a/tests/Feature/ProjectsTest.php
+++ b/tests/Feature/ProjectsTest.php
@@ -1,149 +1,135 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\UserRole;
 use App\Models\Project;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class ProjectsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_project(): void
-    {
-        $this->actingAs($this->user);
+test('create project', function () {
+    $this->actingAs($this->user);
 
-        $this->post(route('projects.store'), [
-            'name' => 'create-project-test',
-        ])
-            ->assertSessionDoesntHaveErrors()
-            ->assertRedirect(route('projects'));
+    $this->post(route('projects.store'), [
+        'name' => 'create-project-test',
+    ])
+        ->assertSessionDoesntHaveErrors()
+        ->assertRedirect(route('projects'));
 
-        $this->assertDatabaseHas('projects', [
-            'name' => 'create-project-test',
+    $this->assertDatabaseHas('projects', [
+        'name' => 'create-project-test',
+    ]);
+
+    expect(Project::query()->where('name', 'create-project-test')->first()->id)->toEqual($this->user->refresh()->current_project_id);
+});
+
+test('see projects list', function () {
+    $this->actingAs($this->user);
+
+    $project = Project::factory()->create();
+
+    $project->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
+
+    $this->get(route('projects'))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('projects/index'));
+});
+
+test('no permission to delete project', function () {
+    $this->actingAs($this->user);
+
+    $project = Project::factory()->create();
+
+    $project->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
+
+    $this->delete(route('projects.destroy', $project), [
+        'name' => $project->name,
+    ])
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('projects', [
+        'id' => $project->id,
+    ]);
+});
+
+test('delete project', function () {
+    $this->actingAs($this->user);
+
+    $this->user->ensureHasDefaultProject();
+
+    $project = Project::factory()->create(['name' => 'new-project']);
+
+    $project->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::OWNER,
+    ]);
+
+    $this->delete(route('projects.destroy', $project), [
+        'name' => $project->name,
+    ])
+        ->assertSessionDoesntHaveErrors()
+        ->assertRedirect(route('projects'));
+
+    $this->assertDatabaseMissing('projects', [
+        'id' => $project->id,
+    ]);
+});
+
+test('no permission to edit project', function () {
+    $this->actingAs($this->user);
+
+    $project = Project::factory()->create();
+
+    $project->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::USER,
+    ]);
+
+    $this->patch(route('projects.update', $project), [
+        'name' => 'new-name',
+    ])
+        ->assertForbidden();
+});
+
+test('edit project', function () {
+    $this->actingAs($this->user);
+
+    $project = Project::factory()->create();
+
+    $project->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
+
+    $this->patch(route('projects.update', $project), [
+        'name' => 'new-name',
+    ])
+        ->assertSessionDoesntHaveErrors()
+        ->assertRedirect(route('projects'));
+
+    $this->assertDatabaseHas('projects', [
+        'id' => $project->id,
+        'name' => 'new-name',
+    ]);
+});
+
+test('cannot delete last project', function () {
+    $this->actingAs($this->user);
+
+    $this->delete(route('projects.destroy', $this->user->currentProject->id), [
+        'name' => $this->user->currentProject->name,
+    ])
+        ->assertSessionHasErrors([
+            'name' => 'Cannot delete the last project.',
         ]);
 
-        $this->assertEquals($this->user->refresh()->current_project_id, Project::query()->where('name', 'create-project-test')->first()->id);
-    }
-
-    public function test_see_projects_list(): void
-    {
-        $this->actingAs($this->user);
-
-        $project = Project::factory()->create();
-
-        $project->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
-
-        $this->get(route('projects'))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('projects/index'));
-
-    }
-
-    public function test_no_permission_to_delete_project(): void
-    {
-        $this->actingAs($this->user);
-
-        $project = Project::factory()->create();
-
-        $project->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
-
-        $this->delete(route('projects.destroy', $project), [
-            'name' => $project->name,
-        ])
-            ->assertForbidden();
-
-        $this->assertDatabaseHas('projects', [
-            'id' => $project->id,
-        ]);
-    }
-
-    public function test_delete_project(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->user->ensureHasDefaultProject();
-
-        $project = Project::factory()->create(['name' => 'new-project']);
-
-        $project->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::OWNER,
-        ]);
-
-        $this->delete(route('projects.destroy', $project), [
-            'name' => $project->name,
-        ])
-            ->assertSessionDoesntHaveErrors()
-            ->assertRedirect(route('projects'));
-
-        $this->assertDatabaseMissing('projects', [
-            'id' => $project->id,
-        ]);
-    }
-
-    public function test_no_permission_to_edit_project(): void
-    {
-        $this->actingAs($this->user);
-
-        $project = Project::factory()->create();
-
-        $project->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::USER,
-        ]);
-
-        $this->patch(route('projects.update', $project), [
-            'name' => 'new-name',
-        ])
-            ->assertForbidden();
-    }
-
-    public function test_edit_project(): void
-    {
-        $this->actingAs($this->user);
-
-        $project = Project::factory()->create();
-
-        $project->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
-
-        $this->patch(route('projects.update', $project), [
-            'name' => 'new-name',
-        ])
-            ->assertSessionDoesntHaveErrors()
-            ->assertRedirect(route('projects'));
-
-        $this->assertDatabaseHas('projects', [
-            'id' => $project->id,
-            'name' => 'new-name',
-        ]);
-    }
-
-    public function test_cannot_delete_last_project(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->delete(route('projects.destroy', $this->user->currentProject->id), [
-            'name' => $this->user->currentProject->name,
-        ])
-            ->assertSessionHasErrors([
-                'name' => 'Cannot delete the last project.',
-            ]);
-
-        $this->assertDatabaseHas('projects', [
-            'id' => $this->user->currentProject->id,
-        ]);
-    }
-}
+    $this->assertDatabaseHas('projects', [
+        'id' => $this->user->currentProject->id,
+    ]);
+});

--- a/tests/Feature/ProjectsUserTest.php
+++ b/tests/Feature/ProjectsUserTest.php
@@ -1,232 +1,216 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\UserRole;
 use App\Mail\ProjectInvitation;
 use App\Models\Project;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
-use Tests\TestCase;
 
-class ProjectsUserTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_user_can_invite_others(): void
-    {
-        Mail::fake();
+test('user can invite others', function () {
+    Mail::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        // make sure the user has default project
-        $project = $this->user->ensureHasDefaultProject();
+    // make sure the user has default project
+    $project = $this->user->ensureHasDefaultProject();
 
-        $this
-            ->from(route('projects'))
-            ->post(route('projects.users.store', ['project' => $project]), [
-                'email' => 'new-user@example.com',
-                'role' => UserRole::ADMIN->value,
-            ])
-            ->assertRedirect(route('projects'))
-            ->assertSessionDoesntHaveErrors()
-            ->assertSessionHas('success');
-
-        $this->assertDatabaseHas('user_project', [
-            'project_id' => $project->id,
+    test()
+        ->from(route('projects'))
+        ->post(route('projects.users.store', ['project' => $project]), [
             'email' => 'new-user@example.com',
+            'role' => UserRole::ADMIN->value,
+        ])
+        ->assertRedirect(route('projects'))
+        ->assertSessionDoesntHaveErrors()
+        ->assertSessionHas('success');
+
+    $this->assertDatabaseHas('user_project', [
+        'project_id' => $project->id,
+        'email' => 'new-user@example.com',
+    ]);
+
+    Mail::assertSent(ProjectInvitation::class);
+});
+
+test('can remove registered user from project', function () {
+    $this->actingAs($this->user);
+
+    // make sure the user has default project
+    $project = $this->user->ensureHasDefaultProject();
+
+    /** @var User $newUser */
+    $newUser = User::factory()->create();
+
+    $userProject = $project->users()->create([
+        'project_id' => $project->id,
+        'user_id' => $newUser->id,
+        'role' => UserRole::USER,
+    ]);
+
+    test()
+        ->from(route('projects'))
+        ->delete(route('projects.users.destroy', ['project' => $project, 'id' => $userProject->id]))
+        ->assertRedirect(route('projects'))
+        ->assertSessionDoesntHaveErrors()
+        ->assertSessionHas('success');
+
+    $this->assertDatabaseMissing('user_project', [
+        'project_id' => $project->id,
+        'user_id' => $newUser->id,
+    ]);
+});
+
+test('can remove owner from project', function () {
+    $this->actingAs($this->user);
+
+    // make sure the user has default project
+    $project = $this->user->ensureHasDefaultProject();
+
+    $id = $project->users()->where('user_id', $this->user->id)->first()->id;
+
+    test()
+        ->from(route('projects'))
+        ->delete(route('projects.users.destroy', ['project' => $project, 'id' => $id]))
+        ->assertSessionHas([
+            'error' => __('You cannot remove the project owner.'),
         ]);
+});
 
-        Mail::assertSent(ProjectInvitation::class);
-    }
+test('can remove invited user from project', function () {
+    $this->actingAs($this->user);
 
-    public function test_can_remove_registered_user_from_project(): void
-    {
-        $this->actingAs($this->user);
+    // make sure the user has default project
+    $project = $this->user->ensureHasDefaultProject();
 
-        // make sure the user has default project
-        $project = $this->user->ensureHasDefaultProject();
+    $userProject = $project->users()->create([
+        'project_id' => $project->id,
+        'email' => 'new-user@example.com',
+        'role' => UserRole::USER,
+    ]);
 
-        /** @var User $newUser */
-        $newUser = User::factory()->create();
+    test()
+        ->from(route('projects'))
+        ->delete(route('projects.users.destroy', ['project' => $project, 'id' => $userProject->id]))
+        ->assertRedirect(route('projects'))
+        ->assertSessionDoesntHaveErrors()
+        ->assertSessionHas('success');
 
-        $userProject = $project->users()->create([
-            'project_id' => $project->id,
-            'user_id' => $newUser->id,
-            'role' => UserRole::USER,
+    $this->assertDatabaseMissing('user_project', [
+        'project_id' => $project->id,
+        'email' => 'new-user@example.com',
+    ]);
+});
+
+test('user can accept invitation', function () {
+    /** @var User $owner */
+    $owner = User::factory()->create();
+    $ownerProject = $owner->ensureHasDefaultProject();
+
+    $this->actingAs($this->user);
+
+    $ownerProject->users()->create([
+        'email' => $this->user->email,
+        'role' => UserRole::USER,
+    ]);
+
+    test()
+        ->from(route('projects'))
+        ->get(route('projects.invitations.accept', ['project' => $ownerProject]))
+        ->assertRedirect(route('projects'))
+        ->assertSessionHas('success');
+
+    $this->assertDatabaseHas('user_project', [
+        'project_id' => $ownerProject->id,
+        'user_id' => $this->user->id,
+    ]);
+});
+
+test('user cannot join without invitation', function () {
+    /** @var User $owner */
+    $owner = User::factory()->create();
+    $ownerProject = $owner->ensureHasDefaultProject();
+
+    $this->actingAs($this->user);
+
+    test()
+        ->from(route('projects'))
+        ->get(route('projects.invitations.accept', ['project' => $ownerProject]))
+        ->assertNotFound();
+
+    $this->assertDatabaseMissing('user_project', [
+        'project_id' => $ownerProject->id,
+        'user_id' => $this->user->id,
+    ]);
+});
+
+test('user can leave project', function () {
+    /** @var User $owner */
+    $owner = User::factory()->create();
+    $ownerProject = $owner->ensureHasDefaultProject();
+
+    $this->actingAs($this->user);
+
+    $ownerProject->users()->create([
+        'email' => $this->user->email,
+        'role' => UserRole::USER,
+    ]);
+
+    test()
+        ->from(route('projects'))
+        ->delete(route('projects.leave', ['project' => $ownerProject]))
+        ->assertRedirect(route('projects'))
+        ->assertSessionHas('success');
+
+    $this->assertDatabaseMissing('user_project', [
+        'project_id' => $ownerProject->id,
+        'email' => $this->user->email,
+    ]);
+});
+
+test('user can leave project that is not invited', function () {
+    /** @var User $owner */
+    $owner = User::factory()->create();
+    $ownerProject = $owner->ensureHasDefaultProject();
+
+    $this->actingAs($this->user);
+
+    test()
+        ->from(route('projects'))
+        ->delete(route('projects.leave', ['project' => $ownerProject]))
+        ->assertNotFound();
+});
+
+test('cannot delete yourself from project', function () {
+    $this->actingAs($this->user);
+
+    $project = Project::factory()->create();
+
+    $userProject = $project->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
+
+    $this->delete(route('projects.users.destroy', ['project' => $project->id, 'id' => $userProject->id]))
+        ->assertSessionHas([
+            'error' => 'You cannot remove yourself from the project.',
         ]);
+});
 
-        $this
-            ->from(route('projects'))
-            ->delete(route('projects.users.destroy', ['project' => $project, 'id' => $userProject->id]))
-            ->assertRedirect(route('projects'))
-            ->assertSessionDoesntHaveErrors()
-            ->assertSessionHas('success');
+test('cannot delete the owner', function () {
+    $this->actingAs($this->user);
 
-        $this->assertDatabaseMissing('user_project', [
-            'project_id' => $project->id,
-            'user_id' => $newUser->id,
+    $project = Project::factory()->create();
+
+    $userProject = $project->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::OWNER,
+    ]);
+
+    $this->delete(route('projects.users.destroy', ['project' => $project->id, 'id' => $userProject->id]))
+        ->assertSessionHas([
+            'error' => 'You cannot remove the project owner.',
         ]);
-    }
-
-    public function test_can_remove_owner_from_project(): void
-    {
-        $this->actingAs($this->user);
-
-        // make sure the user has default project
-        $project = $this->user->ensureHasDefaultProject();
-
-        $id = $project->users()->where('user_id', $this->user->id)->first()->id;
-
-        $this
-            ->from(route('projects'))
-            ->delete(route('projects.users.destroy', ['project' => $project, 'id' => $id]))
-            ->assertSessionHas([
-                'error' => __('You cannot remove the project owner.'),
-            ]);
-    }
-
-    public function test_can_remove_invited_user_from_project(): void
-    {
-        $this->actingAs($this->user);
-
-        // make sure the user has default project
-        $project = $this->user->ensureHasDefaultProject();
-
-        $userProject = $project->users()->create([
-            'project_id' => $project->id,
-            'email' => 'new-user@example.com',
-            'role' => UserRole::USER,
-        ]);
-
-        $this
-            ->from(route('projects'))
-            ->delete(route('projects.users.destroy', ['project' => $project, 'id' => $userProject->id]))
-            ->assertRedirect(route('projects'))
-            ->assertSessionDoesntHaveErrors()
-            ->assertSessionHas('success');
-
-        $this->assertDatabaseMissing('user_project', [
-            'project_id' => $project->id,
-            'email' => 'new-user@example.com',
-        ]);
-    }
-
-    public function test_user_can_accept_invitation(): void
-    {
-        /** @var User $owner */
-        $owner = User::factory()->create();
-        $ownerProject = $owner->ensureHasDefaultProject();
-
-        $this->actingAs($this->user);
-
-        $ownerProject->users()->create([
-            'email' => $this->user->email,
-            'role' => UserRole::USER,
-        ]);
-
-        $this
-            ->from(route('projects'))
-            ->get(route('projects.invitations.accept', ['project' => $ownerProject]))
-            ->assertRedirect(route('projects'))
-            ->assertSessionHas('success');
-
-        $this->assertDatabaseHas('user_project', [
-            'project_id' => $ownerProject->id,
-            'user_id' => $this->user->id,
-        ]);
-    }
-
-    public function test_user_cannot_join_without_invitation(): void
-    {
-        /** @var User $owner */
-        $owner = User::factory()->create();
-        $ownerProject = $owner->ensureHasDefaultProject();
-
-        $this->actingAs($this->user);
-
-        $this
-            ->from(route('projects'))
-            ->get(route('projects.invitations.accept', ['project' => $ownerProject]))
-            ->assertNotFound();
-
-        $this->assertDatabaseMissing('user_project', [
-            'project_id' => $ownerProject->id,
-            'user_id' => $this->user->id,
-        ]);
-    }
-
-    public function test_user_can_leave_project(): void
-    {
-        /** @var User $owner */
-        $owner = User::factory()->create();
-        $ownerProject = $owner->ensureHasDefaultProject();
-
-        $this->actingAs($this->user);
-
-        $ownerProject->users()->create([
-            'email' => $this->user->email,
-            'role' => UserRole::USER,
-        ]);
-
-        $this
-            ->from(route('projects'))
-            ->delete(route('projects.leave', ['project' => $ownerProject]))
-            ->assertRedirect(route('projects'))
-            ->assertSessionHas('success');
-
-        $this->assertDatabaseMissing('user_project', [
-            'project_id' => $ownerProject->id,
-            'email' => $this->user->email,
-        ]);
-    }
-
-    public function test_user_can_leave_project_that_is_not_invited(): void
-    {
-        /** @var User $owner */
-        $owner = User::factory()->create();
-        $ownerProject = $owner->ensureHasDefaultProject();
-
-        $this->actingAs($this->user);
-
-        $this
-            ->from(route('projects'))
-            ->delete(route('projects.leave', ['project' => $ownerProject]))
-            ->assertNotFound();
-    }
-
-    public function test_cannot_delete_yourself_from_project(): void
-    {
-        $this->actingAs($this->user);
-
-        $project = Project::factory()->create();
-
-        $userProject = $project->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::ADMIN,
-        ]);
-
-        $this->delete(route('projects.users.destroy', ['project' => $project->id, 'id' => $userProject->id]))
-            ->assertSessionHas([
-                'error' => 'You cannot remove yourself from the project.',
-            ]);
-    }
-
-    public function test_cannot_delete_the_owner(): void
-    {
-        $this->actingAs($this->user);
-
-        $project = Project::factory()->create();
-
-        $userProject = $project->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::OWNER,
-        ]);
-
-        $this->delete(route('projects.users.destroy', ['project' => $project->id, 'id' => $userProject->id]))
-            ->assertSessionHas([
-                'error' => 'You cannot remove the project owner.',
-            ]);
-    }
-}
+});

--- a/tests/Feature/ProjectsUserTest.php
+++ b/tests/Feature/ProjectsUserTest.php
@@ -14,10 +14,9 @@ test('user can invite others', function () {
 
     $this->actingAs($this->user);
 
-    // make sure the user has default project
     $project = $this->user->ensureHasDefaultProject();
 
-    test()
+    $this
         ->from(route('projects'))
         ->post(route('projects.users.store', ['project' => $project]), [
             'email' => 'new-user@example.com',
@@ -38,7 +37,6 @@ test('user can invite others', function () {
 test('can remove registered user from project', function () {
     $this->actingAs($this->user);
 
-    // make sure the user has default project
     $project = $this->user->ensureHasDefaultProject();
 
     /** @var User $newUser */
@@ -50,7 +48,7 @@ test('can remove registered user from project', function () {
         'role' => UserRole::USER,
     ]);
 
-    test()
+    $this
         ->from(route('projects'))
         ->delete(route('projects.users.destroy', ['project' => $project, 'id' => $userProject->id]))
         ->assertRedirect(route('projects'))
@@ -66,12 +64,11 @@ test('can remove registered user from project', function () {
 test('can remove owner from project', function () {
     $this->actingAs($this->user);
 
-    // make sure the user has default project
     $project = $this->user->ensureHasDefaultProject();
 
     $id = $project->users()->where('user_id', $this->user->id)->first()->id;
 
-    test()
+    $this
         ->from(route('projects'))
         ->delete(route('projects.users.destroy', ['project' => $project, 'id' => $id]))
         ->assertSessionHas([
@@ -82,7 +79,6 @@ test('can remove owner from project', function () {
 test('can remove invited user from project', function () {
     $this->actingAs($this->user);
 
-    // make sure the user has default project
     $project = $this->user->ensureHasDefaultProject();
 
     $userProject = $project->users()->create([
@@ -91,7 +87,7 @@ test('can remove invited user from project', function () {
         'role' => UserRole::USER,
     ]);
 
-    test()
+    $this
         ->from(route('projects'))
         ->delete(route('projects.users.destroy', ['project' => $project, 'id' => $userProject->id]))
         ->assertRedirect(route('projects'))
@@ -116,7 +112,7 @@ test('user can accept invitation', function () {
         'role' => UserRole::USER,
     ]);
 
-    test()
+    $this
         ->from(route('projects'))
         ->get(route('projects.invitations.accept', ['project' => $ownerProject]))
         ->assertRedirect(route('projects'))
@@ -135,7 +131,7 @@ test('user cannot join without invitation', function () {
 
     $this->actingAs($this->user);
 
-    test()
+    $this
         ->from(route('projects'))
         ->get(route('projects.invitations.accept', ['project' => $ownerProject]))
         ->assertNotFound();
@@ -158,7 +154,7 @@ test('user can leave project', function () {
         'role' => UserRole::USER,
     ]);
 
-    test()
+    $this
         ->from(route('projects'))
         ->delete(route('projects.leave', ['project' => $ownerProject]))
         ->assertRedirect(route('projects'))
@@ -177,7 +173,7 @@ test('user can leave project that is not invited', function () {
 
     $this->actingAs($this->user);
 
-    test()
+    $this
         ->from(route('projects'))
         ->delete(route('projects.leave', ['project' => $ownerProject]))
         ->assertNotFound();

--- a/tests/Feature/ProviderPrivateNetworkTest.php
+++ b/tests/Feature/ProviderPrivateNetworkTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Exceptions\PrivateNetworkSyncError;
 use App\Models\ServerProvider;
 use App\ServerProviders\AWS;
@@ -11,619 +9,565 @@ use App\ServerProviders\Linode;
 use App\ServerProviders\Vultr;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class ProviderPrivateNetworkTest extends TestCase
+uses(RefreshDatabase::class);
+
+function vitoPestFeatureProviderPrivateNetworkTestHetznerConnection(): ServerProvider
 {
-    use RefreshDatabase;
-
-    private function hetznerConnection(): ServerProvider
-    {
-        return ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Hetzner::id(),
-            'profile' => 'hetzner-main',
-            'credentials' => ['token' => 'secret-token'],
-        ]);
-    }
-
-    public function test_hetzner_maps_networks_and_member_ips(): void
-    {
-        Http::fake([
-            'api.hetzner.cloud/v1/networks*' => Http::response([
-                'networks' => [
-                    [
-                        'id' => 4711,
-                        'name' => 'prod-net',
-                        'ip_range' => '10.0.0.0/16',
-                        'subnets' => [['network_zone' => 'eu-central']],
-                        'servers' => [101, 102, 999],
-                    ],
-                ],
-                'meta' => ['pagination' => ['next_page' => null]],
-            ]),
-            'api.hetzner.cloud/v1/servers*' => Http::response([
-                'servers' => [
-                    ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
-                    ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]],
-                    ['id' => 999, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.9']]],
-                ],
-                'meta' => ['pagination' => ['next_page' => null]],
-            ]),
-        ]);
-
-        /** @var Hetzner $provider */
-        $provider = $this->hetznerConnection()->provider();
-
-        $networks = $provider->privateNetworks(['101', '102'], []);
-
-        $this->assertCount(1, $networks);
-        $this->assertSame('4711', $networks[0]->externalId);
-        $this->assertSame('prod-net', $networks[0]->name);
-        $this->assertSame('10.0.0.0/16', $networks[0]->cidr);
-        $this->assertSame('eu-central', $networks[0]->region);
-
-        $this->assertCount(2, $networks[0]->members, 'Instances Vito does not manage must be ignored.');
-        $this->assertSame(['101', '102'], array_map(fn ($m): string => $m->instanceId, $networks[0]->members));
-        $this->assertSame(['10.0.0.2', '10.0.0.3'], array_map(fn ($m): ?string => $m->ip, $networks[0]->members));
-    }
-
-    public function test_hetzner_skips_networks_with_no_managed_members(): void
-    {
-        Http::fake([
-            'api.hetzner.cloud/v1/networks*' => Http::response([
-                'networks' => [
-                    ['id' => 1, 'name' => 'unrelated', 'ip_range' => '10.1.0.0/16', 'servers' => [777]],
-                ],
-                'meta' => ['pagination' => ['next_page' => null]],
-            ]),
-            'api.hetzner.cloud/v1/servers*' => Http::response([
-                'servers' => [],
-                'meta' => ['pagination' => ['next_page' => null]],
-            ]),
-        ]);
-
-        /** @var Hetzner $provider */
-        $provider = $this->hetznerConnection()->provider();
-
-        $this->assertSame([], $provider->privateNetworks(['101'], []));
-    }
-
-    public function test_hetzner_follows_pagination(): void
-    {
-        Http::fakeSequence('api.hetzner.cloud/v1/networks*')
-            ->push([
-                'networks' => [['id' => 1, 'name' => 'a', 'ip_range' => '10.1.0.0/16', 'servers' => []]],
-                'meta' => ['pagination' => ['next_page' => 2]],
-            ])
-            ->push([
-                'networks' => [['id' => 2, 'name' => 'b', 'ip_range' => '10.2.0.0/16', 'servers' => [101]]],
-                'meta' => ['pagination' => ['next_page' => null]],
-            ]);
-
-        Http::fake([
-            'api.hetzner.cloud/v1/servers*' => Http::response([
-                'servers' => [['id' => 101, 'private_net' => [['network' => 2, 'ip' => '10.2.0.4']]]],
-                'meta' => ['pagination' => ['next_page' => null]],
-            ]),
-        ]);
-
-        /** @var Hetzner $provider */
-        $provider = $this->hetznerConnection()->provider();
-
-        $networks = $provider->privateNetworks(['101'], []);
-
-        $this->assertCount(1, $networks);
-        $this->assertSame('2', $networks[0]->externalId);
-        $this->assertSame('10.2.0.4', $networks[0]->members[0]->ip);
-    }
-
-    public function test_hetzner_error_does_not_leak_credentials(): void
-    {
-        Http::fake([
-            'api.hetzner.cloud/v1/*' => Http::response(['error' => ['message' => 'forbidden']], 403),
-        ]);
-
-        /** @var Hetzner $provider */
-        $provider = $this->hetznerConnection()->provider();
-
-        try {
-            $provider->privateNetworks(['101'], []);
-            $this->fail('Expected PrivateNetworkSyncError.');
-        } catch (PrivateNetworkSyncError $e) {
-            $this->assertTrue($e->isPermissionError());
-            $this->assertStringNotContainsString('secret-token', $e->getMessage());
-            $this->assertStringNotContainsString('secret-token', (string) $e);
-            $this->assertSame('hetzner', $e->provider);
-            $this->assertSame('hetzner-main', $e->profile);
-        }
-    }
-
-    public function test_digitalocean_uses_droplet_vpc_uuid_and_private_address(): void
-    {
-        Http::fake([
-            'api.digitalocean.com/v2/vpcs*' => Http::response([
-                'vpcs' => [
-                    ['id' => 'vpc-abc', 'name' => 'default-lon1', 'ip_range' => '10.106.0.0/20', 'region' => 'lon1'],
-                ],
-            ]),
-            'api.digitalocean.com/v2/droplets*' => Http::response([
-                'droplets' => [
-                    [
-                        'id' => 3164444,
-                        'vpc_uuid' => 'vpc-abc',
-                        'networks' => ['v4' => [
-                            ['type' => 'public', 'ip_address' => '203.0.113.5'],
-                            ['type' => 'private', 'ip_address' => '10.106.0.4'],
-                        ]],
-                    ],
-                    ['id' => 999, 'vpc_uuid' => 'vpc-abc', 'networks' => ['v4' => []]],
-                ],
-            ]),
-        ]);
-
-        $connection = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => DigitalOcean::id(),
-            'credentials' => ['token' => 'secret-token'],
-        ]);
-
-        /** @var DigitalOcean $provider */
-        $provider = $connection->provider();
-
-        $networks = $provider->privateNetworks(['3164444'], []);
-
-        $this->assertCount(1, $networks);
-        $this->assertSame('vpc-abc', $networks[0]->externalId);
-        $this->assertSame('10.106.0.0/20', $networks[0]->cidr);
-        $this->assertCount(1, $networks[0]->members, 'Unmanaged droplets must be excluded.');
-        $this->assertSame('10.106.0.4', $networks[0]->members[0]->ip);
-    }
-
-    public function test_linode_reads_membership_from_subnets_and_ips_from_account_list(): void
-    {
-        Http::fake([
-            'api.linode.com/v4/vpcs/ips*' => Http::response([
-                'data' => [
-                    ['linode_id' => 555, 'vpc_id' => 77, 'address' => '10.0.1.4', 'active' => true],
-                    ['linode_id' => 555, 'vpc_id' => 77, 'address' => null, 'address_range' => '10.0.9.0/28'],
-                ],
-                'page' => 1,
-                'pages' => 1,
-            ]),
-            'api.linode.com/v4/vpcs*' => Http::response([
-                'data' => [
-                    [
-                        'id' => 77,
-                        'label' => 'prod-vpc',
-                        'region' => 'eu-west',
-                        'subnets' => [
-                            ['ipv4' => '10.0.1.0/24', 'linodes' => [['id' => 555], ['id' => 888]]],
-                        ],
-                    ],
-                ],
-                'page' => 1,
-                'pages' => 1,
-            ]),
-        ]);
-
-        $connection = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Linode::id(),
-            'credentials' => ['token' => 'secret-token'],
-        ]);
-
-        /** @var Linode $provider */
-        $provider = $connection->provider();
-
-        $networks = $provider->privateNetworks(['555'], []);
-
-        $this->assertCount(1, $networks);
-        $this->assertSame('prod-vpc', $networks[0]->name);
-        $this->assertSame('10.0.1.0/24', $networks[0]->cidr);
-        $this->assertCount(1, $networks[0]->members);
-        $this->assertSame('10.0.1.4', $networks[0]->members[0]->ip);
-    }
-
-    /**
-     * A page count the API never stops advancing past would otherwise be walked until the job's
-     * timeout. Failing beats returning what was collected so far: a partial view of the account
-     * would look like the missing VPCs are gone, and sync prunes on that.
-     */
-    public function test_linode_stops_and_fails_on_a_runaway_page_count(): void
-    {
-        Http::fake([
-            'api.linode.com/v4/*' => Http::response([
-                'data' => [],
-                'page' => 1,
-                'pages' => 100000,
-            ]),
-        ]);
-
-        $connection = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Linode::id(),
-            'credentials' => ['token' => 'secret-token'],
-        ]);
-
-        /** @var Linode $provider */
-        $provider = $connection->provider();
-
-        $this->expectException(PrivateNetworkSyncError::class);
-
-        $provider->privateNetworks(['555'], []);
-    }
-
-    public function test_linode_multi_subnet_vpc_reports_no_single_cidr(): void
-    {
-        Http::fake([
-            'api.linode.com/v4/vpcs/ips*' => Http::response(['data' => [], 'page' => 1, 'pages' => 1]),
-            'api.linode.com/v4/vpcs*' => Http::response([
-                'data' => [[
-                    'id' => 77,
-                    'label' => 'multi',
-                    'subnets' => [
-                        ['ipv4' => '10.0.1.0/24', 'linodes' => [['id' => 555]]],
-                        ['ipv4' => '10.0.2.0/24', 'linodes' => []],
-                    ],
-                ]],
-                'page' => 1,
-                'pages' => 1,
-            ]),
-        ]);
-
-        $connection = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Linode::id(),
-            'credentials' => ['token' => 'secret-token'],
-        ]);
-
-        /** @var Linode $provider */
-        $provider = $connection->provider();
-
-        $networks = $provider->privateNetworks(['555'], []);
-
-        $this->assertNull(
-            $networks[0]->cidr,
-            'A VPC with several subnets has no single CIDR; firewall rules fall back to member /32s.'
-        );
-    }
-
-    public function test_vultr_builds_cidr_from_v4_subnet_and_mask(): void
-    {
-        Http::fake([
-            'api.vultr.com/v2/instances/*/vpcs*' => Http::response([
-                'vpcs' => [['id' => 'vpc-1', 'ip_address' => '10.20.0.4', 'mac_address' => 'aa:bb']],
-            ]),
-            'api.vultr.com/v2/vpcs*' => Http::response([
-                'vpcs' => [[
-                    'id' => 'vpc-1',
-                    'description' => 'prod-vpc',
-                    'v4_subnet' => '10.20.0.0',
-                    'v4_subnet_mask' => 24,
-                    'region' => 'lhr',
-                ]],
-            ]),
-        ]);
-
-        $connection = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Vultr::id(),
-            'credentials' => ['token' => 'secret-token'],
-        ]);
-
-        /** @var Vultr $provider */
-        $provider = $connection->provider();
-
-        $networks = $provider->privateNetworks(['inst-1'], []);
-
-        $this->assertCount(1, $networks);
-        $this->assertSame('prod-vpc', $networks[0]->name);
-        $this->assertSame('10.20.0.0/24', $networks[0]->cidr);
-        $this->assertSame('10.20.0.4', $networks[0]->members[0]->ip);
-    }
-
-    public function test_vultr_stale_instance_id_does_not_abort_the_connection(): void
-    {
-        Http::fake([
-            'api.vultr.com/v2/instances/gone/vpcs*' => Http::response(['error' => 'not found'], 404),
-            'api.vultr.com/v2/instances/*/vpcs*' => Http::response([
-                'vpcs' => [['id' => 'vpc-1', 'ip_address' => '10.20.0.4']],
-            ]),
-            'api.vultr.com/v2/vpcs*' => Http::response([
-                'vpcs' => [['id' => 'vpc-1', 'description' => 'prod', 'v4_subnet' => '10.20.0.0', 'v4_subnet_mask' => 24]],
-            ]),
-        ]);
-
-        $connection = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Vultr::id(),
-            'credentials' => ['token' => 'secret-token'],
-        ]);
-
-        /** @var Vultr $provider */
-        $provider = $connection->provider();
-
-        $networks = $provider->privateNetworks(['gone', 'live'], []);
-
-        $this->assertCount(1, $networks, 'A deleted instance must not abort the whole connection.');
-        $this->assertSame('10.20.0.4', $networks[0]->members[0]->ip);
-        $this->assertSame('live', $networks[0]->members[0]->instanceId);
-    }
-
-    public function test_vultr_non_404_error_still_fails_the_connection(): void
-    {
-        Http::fake([
-            'api.vultr.com/v2/*' => Http::response(['error' => 'boom'], 500),
-        ]);
-
-        $connection = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Vultr::id(),
-            'credentials' => ['token' => 'secret-token'],
-        ]);
-
-        /** @var Vultr $provider */
-        $provider = $connection->provider();
-
-        $this->expectException(PrivateNetworkSyncError::class);
-        $provider->privateNetworks(['live'], []);
-    }
-
-    public function test_aws_mapper_prefers_network_interface_and_name_tag(): void
-    {
-        $connection = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => AWS::id(),
-            'credentials' => ['key' => 'k', 'secret' => 's'],
-        ]);
-
-        /** @var AWS $provider */
-        $provider = $connection->provider();
-
-        $reservations = [[
-            'Instances' => [
-                [
-                    'InstanceId' => 'i-123',
-                    'VpcId' => 'vpc-top',
-                    'PrivateIpAddress' => '172.31.9.9',
-                    'NetworkInterfaces' => [
-                        ['VpcId' => 'vpc-eni', 'PrivateIpAddress' => '172.31.0.5'],
-                    ],
-                ],
-                ['InstanceId' => 'i-unmanaged', 'VpcId' => 'vpc-eni', 'PrivateIpAddress' => '172.31.0.6'],
-            ],
-        ]];
-
-        $vpcs = [[
-            'VpcId' => 'vpc-eni',
-            'CidrBlock' => '172.31.0.0/16',
-            'Tags' => [['Key' => 'Name', 'Value' => 'production']],
-        ]];
-
-        $networks = $provider->mapPrivateNetworks($reservations, $vpcs, ['i-123'], 'eu-west-2');
-
-        $this->assertCount(1, $networks);
-        $this->assertSame('vpc-eni', $networks[0]->externalId);
-        $this->assertSame('production', $networks[0]->name);
-        $this->assertSame('172.31.0.0/16', $networks[0]->cidr);
-        $this->assertSame('eu-west-2', $networks[0]->region);
-        $this->assertCount(1, $networks[0]->members);
-        $this->assertSame('172.31.0.5', $networks[0]->members[0]->ip);
-    }
-
-    /**
-     * An IPv6-only VPC carries its range in the association set and its instances have no
-     * `PrivateIpAddress`. Reading only the IPv4 fields would sync the network with no range and
-     * its members with no address, leaving them outside every firewall rule derived from it.
-     */
-    public function test_aws_mapper_reads_ipv6_only_vpcs_and_members(): void
-    {
-        $connection = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => AWS::id(),
-            'credentials' => ['key' => 'k', 'secret' => 's'],
-        ]);
-
-        /** @var AWS $provider */
-        $provider = $connection->provider();
-
-        $networks = $provider->mapPrivateNetworks(
-            [['Instances' => [[
-                'InstanceId' => 'i-v6',
-                'NetworkInterfaces' => [[
-                    'VpcId' => 'vpc-v6',
-                    'Ipv6Addresses' => [['Ipv6Address' => '2001:db8:1::5']],
-                ]],
-            ]]]],
-            [[
-                'VpcId' => 'vpc-v6',
-                'Ipv6CidrBlockAssociationSet' => [['Ipv6CidrBlock' => '2001:db8:1::/56']],
-            ]],
-            ['i-v6'],
-            'eu-west-1',
-        );
-
-        $this->assertCount(1, $networks);
-        $this->assertSame('2001:db8:1::/56', $networks[0]->cidr);
-        $this->assertSame('2001:db8:1::5', $networks[0]->members[0]->ip);
-    }
-
-    /**
-     * A dual-stack VPC keeps its IPv4 identity — a network holds one range, and the members
-     * report their IPv4 addresses.
-     */
-    public function test_aws_mapper_prefers_ipv4_on_a_dual_stack_vpc(): void
-    {
-        $connection = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => AWS::id(),
-            'credentials' => ['key' => 'k', 'secret' => 's'],
-        ]);
-
-        /** @var AWS $provider */
-        $provider = $connection->provider();
-
-        $networks = $provider->mapPrivateNetworks(
-            [['Instances' => [[
-                'InstanceId' => 'i-dual',
-                'NetworkInterfaces' => [[
-                    'VpcId' => 'vpc-dual',
-                    'PrivateIpAddress' => '172.31.0.5',
-                    'Ipv6Addresses' => [['Ipv6Address' => '2001:db8:2::5']],
-                ]],
-            ]]]],
-            [[
-                'VpcId' => 'vpc-dual',
-                'CidrBlock' => '172.31.0.0/16',
-                'Ipv6CidrBlockAssociationSet' => [['Ipv6CidrBlock' => '2001:db8:2::/56']],
-            ]],
-            ['i-dual'],
-            'eu-west-1',
-        );
-
-        $this->assertSame('172.31.0.0/16', $networks[0]->cidr);
-        $this->assertSame('172.31.0.5', $networks[0]->members[0]->ip);
-    }
-
-    public function test_aws_mapper_falls_back_to_vpc_id_when_untagged(): void
-    {
-        $connection = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => AWS::id(),
-            'credentials' => ['key' => 'k', 'secret' => 's'],
-        ]);
-
-        /** @var AWS $provider */
-        $provider = $connection->provider();
-
-        $networks = $provider->mapPrivateNetworks(
-            [['Instances' => [['InstanceId' => 'i-1', 'VpcId' => 'vpc-9', 'PrivateIpAddress' => '10.0.0.2']]]],
-            [['VpcId' => 'vpc-9', 'CidrBlock' => '10.0.0.0/16']],
-            ['i-1'],
-            'us-east-1',
-        );
-
-        $this->assertSame('vpc-9', $networks[0]->name);
-    }
-
-    /**
-     * @return array<string, array{0: ?string}>
-     */
-    public static function untrustedAddresses(): array
-    {
-        return [
-            'command substitution' => ['10.0.0.2 $(id)'],
-            'command chaining' => ['10.0.0.2; rm -rf /'],
-            'backticks' => ['`whoami`'],
-            'newline injection' => ["10.0.0.2\nsudo ufw disable"],
-            'ipv6 with metacharacters' => ['fd00::1; id'],
-            'ipv6 with prefix' => ['fd00::1/64'],
-            'not an address' => ['not-an-ip'],
-            'empty' => [''],
-        ];
-    }
-
-    #[DataProvider('untrustedAddresses')]
-    public function test_member_addresses_that_are_not_literal_addresses_are_dropped(?string $address): void
-    {
-        Http::fake([
-            'api.hetzner.cloud/v1/networks*' => Http::response([
-                'networks' => [['id' => 1, 'name' => 'n', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
-                'meta' => ['pagination' => ['next_page' => null]],
-            ]),
-            'api.hetzner.cloud/v1/servers*' => Http::response([
-                'servers' => [['id' => 101, 'private_net' => [['network' => 1, 'ip' => $address]]]],
-                'meta' => ['pagination' => ['next_page' => null]],
-            ]),
-        ]);
-
-        /** @var Hetzner $provider */
-        $provider = $this->hetznerConnection()->provider();
-
-        $networks = $provider->privateNetworks(['101'], []);
-
-        $this->assertNull(
-            $networks[0]->members[0]->ip,
-            'Member addresses reach an unquoted shell interpolation in the ufw template.'
-        );
-    }
-
-    public function test_valid_member_address_survives_normalisation(): void
-    {
-        Http::fake([
-            'api.hetzner.cloud/v1/networks*' => Http::response([
-                'networks' => [['id' => 1, 'name' => 'n', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
-                'meta' => ['pagination' => ['next_page' => null]],
-            ]),
-            'api.hetzner.cloud/v1/servers*' => Http::response([
-                'servers' => [['id' => 101, 'private_net' => [['network' => 1, 'ip' => '10.0.0.42']]]],
-                'meta' => ['pagination' => ['next_page' => null]],
-            ]),
-        ]);
-
-        /** @var Hetzner $provider */
-        $provider = $this->hetznerConnection()->provider();
-
-        $this->assertSame('10.0.0.42', $provider->privateNetworks(['101'], [])[0]->members[0]->ip);
-    }
-
-    /**
-     * IPv6 ranges are supported and canonicalised like IPv4 ones; only ranges that are
-     * malformed — no prefix, out-of-range prefix, or not an address — are dropped, because
-     * they reach a shell template through the rules derived from them.
-     */
-    public function test_ipv6_ranges_are_kept_and_malformed_ranges_are_dropped(): void
-    {
-        Http::fake([
-            'api.hetzner.cloud/v1/networks*' => Http::response([
-                'networks' => [
-                    ['id' => 1, 'name' => 'v6', 'ip_range' => 'fd00::/64', 'servers' => [101]],
-                    ['id' => 2, 'name' => 'junk', 'ip_range' => 'not-a-cidr', 'servers' => [101]],
-                    ['id' => 3, 'name' => 'noprefix', 'ip_range' => '10.0.0.0', 'servers' => [101]],
-                    ['id' => 4, 'name' => 'ok', 'ip_range' => '10.5.0.0/16', 'servers' => [101]],
-                    ['id' => 5, 'name' => 'v6noncanonical', 'ip_range' => 'fd00:1:2:3:4::5/48', 'servers' => [101]],
-                    ['id' => 6, 'name' => 'v6overlong', 'ip_range' => 'fd00::/129', 'servers' => [101]],
-                    ['id' => 7, 'name' => 'v4overlong', 'ip_range' => '10.0.0.0/33', 'servers' => [101]],
-                ],
-                'meta' => ['pagination' => ['next_page' => null]],
-            ]),
-            'api.hetzner.cloud/v1/servers*' => Http::response([
-                'servers' => [['id' => 101, 'private_net' => []]],
-                'meta' => ['pagination' => ['next_page' => null]],
-            ]),
-        ]);
-
-        /** @var Hetzner $provider */
-        $provider = $this->hetznerConnection()->provider();
-
-        $cidrs = array_map(fn ($n): ?string => $n->cidr, $provider->privateNetworks(['101'], []));
-
-        $this->assertSame(
-            ['fd00::/64', null, null, '10.5.0.0/16', 'fd00:1:2::/48', null, null],
-            $cidrs
-        );
-    }
-
-    public function test_ipv6_member_address_survives_normalisation(): void
-    {
-        Http::fake([
-            'api.hetzner.cloud/v1/networks*' => Http::response([
-                'networks' => [['id' => 1, 'name' => 'n', 'ip_range' => 'fd00::/64', 'servers' => [101]]],
-                'meta' => ['pagination' => ['next_page' => null]],
-            ]),
-            'api.hetzner.cloud/v1/servers*' => Http::response([
-                'servers' => [['id' => 101, 'private_net' => [['network' => 1, 'ip' => 'fd00::5']]]],
-                'meta' => ['pagination' => ['next_page' => null]],
-            ]),
-        ]);
-
-        /** @var Hetzner $provider */
-        $provider = $this->hetznerConnection()->provider();
-
-        $networks = $provider->privateNetworks(['101'], []);
-
-        $this->assertSame('fd00::5', $networks[0]->members[0]->ip);
-    }
+    return ServerProvider::factory()->create([
+        'user_id' => test()->user->id,
+        'provider' => Hetzner::id(),
+        'profile' => 'hetzner-main',
+        'credentials' => ['token' => 'secret-token'],
+    ]);
 }
+
+test('hetzner maps networks and member ips', function () {
+    Http::fake([
+        'api.hetzner.cloud/v1/networks*' => Http::response([
+            'networks' => [
+                [
+                    'id' => 4711,
+                    'name' => 'prod-net',
+                    'ip_range' => '10.0.0.0/16',
+                    'subnets' => [['network_zone' => 'eu-central']],
+                    'servers' => [101, 102, 999],
+                ],
+            ],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ]),
+        'api.hetzner.cloud/v1/servers*' => Http::response([
+            'servers' => [
+                ['id' => 101, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.2']]],
+                ['id' => 102, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.3']]],
+                ['id' => 999, 'private_net' => [['network' => 4711, 'ip' => '10.0.0.9']]],
+            ],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ]),
+    ]);
+
+    /** @var Hetzner $provider */
+    $provider = vitoPestFeatureProviderPrivateNetworkTestHetznerConnection()->provider();
+
+    $networks = $provider->privateNetworks(['101', '102'], []);
+
+    expect($networks)->toHaveCount(1);
+    expect($networks[0]->externalId)->toBe('4711');
+    expect($networks[0]->name)->toBe('prod-net');
+    expect($networks[0]->cidr)->toBe('10.0.0.0/16');
+    expect($networks[0]->region)->toBe('eu-central');
+
+    expect($networks[0]->members)->toHaveCount(2, 'Instances Vito does not manage must be ignored.');
+    expect(array_map(fn ($m): string => $m->instanceId, $networks[0]->members))->toBe(['101', '102']);
+    expect(array_map(fn ($m): ?string => $m->ip, $networks[0]->members))->toBe(['10.0.0.2', '10.0.0.3']);
+});
+
+test('hetzner skips networks with no managed members', function () {
+    Http::fake([
+        'api.hetzner.cloud/v1/networks*' => Http::response([
+            'networks' => [
+                ['id' => 1, 'name' => 'unrelated', 'ip_range' => '10.1.0.0/16', 'servers' => [777]],
+            ],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ]),
+        'api.hetzner.cloud/v1/servers*' => Http::response([
+            'servers' => [],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ]),
+    ]);
+
+    /** @var Hetzner $provider */
+    $provider = vitoPestFeatureProviderPrivateNetworkTestHetznerConnection()->provider();
+
+    expect($provider->privateNetworks(['101'], []))->toBe([]);
+});
+
+test('hetzner follows pagination', function () {
+    Http::fakeSequence('api.hetzner.cloud/v1/networks*')
+        ->push([
+            'networks' => [['id' => 1, 'name' => 'a', 'ip_range' => '10.1.0.0/16', 'servers' => []]],
+            'meta' => ['pagination' => ['next_page' => 2]],
+        ])
+        ->push([
+            'networks' => [['id' => 2, 'name' => 'b', 'ip_range' => '10.2.0.0/16', 'servers' => [101]]],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ]);
+
+    Http::fake([
+        'api.hetzner.cloud/v1/servers*' => Http::response([
+            'servers' => [['id' => 101, 'private_net' => [['network' => 2, 'ip' => '10.2.0.4']]]],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ]),
+    ]);
+
+    /** @var Hetzner $provider */
+    $provider = vitoPestFeatureProviderPrivateNetworkTestHetznerConnection()->provider();
+
+    $networks = $provider->privateNetworks(['101'], []);
+
+    expect($networks)->toHaveCount(1);
+    expect($networks[0]->externalId)->toBe('2');
+    expect($networks[0]->members[0]->ip)->toBe('10.2.0.4');
+});
+
+test('hetzner error does not leak credentials', function () {
+    Http::fake([
+        'api.hetzner.cloud/v1/*' => Http::response(['error' => ['message' => 'forbidden']], 403),
+    ]);
+
+    /** @var Hetzner $provider */
+    $provider = vitoPestFeatureProviderPrivateNetworkTestHetznerConnection()->provider();
+
+    try {
+        $provider->privateNetworks(['101'], []);
+        $this->fail('Expected PrivateNetworkSyncError.');
+    } catch (PrivateNetworkSyncError $e) {
+        expect($e->isPermissionError())->toBeTrue();
+        $this->assertStringNotContainsString('secret-token', $e->getMessage());
+        $this->assertStringNotContainsString('secret-token', (string) $e);
+        expect($e->provider)->toBe('hetzner');
+        expect($e->profile)->toBe('hetzner-main');
+    }
+});
+
+test('digitalocean uses droplet vpc uuid and private address', function () {
+    Http::fake([
+        'api.digitalocean.com/v2/vpcs*' => Http::response([
+            'vpcs' => [
+                ['id' => 'vpc-abc', 'name' => 'default-lon1', 'ip_range' => '10.106.0.0/20', 'region' => 'lon1'],
+            ],
+        ]),
+        'api.digitalocean.com/v2/droplets*' => Http::response([
+            'droplets' => [
+                [
+                    'id' => 3164444,
+                    'vpc_uuid' => 'vpc-abc',
+                    'networks' => ['v4' => [
+                        ['type' => 'public', 'ip_address' => '203.0.113.5'],
+                        ['type' => 'private', 'ip_address' => '10.106.0.4'],
+                    ]],
+                ],
+                ['id' => 999, 'vpc_uuid' => 'vpc-abc', 'networks' => ['v4' => []]],
+            ],
+        ]),
+    ]);
+
+    $connection = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => DigitalOcean::id(),
+        'credentials' => ['token' => 'secret-token'],
+    ]);
+
+    /** @var DigitalOcean $provider */
+    $provider = $connection->provider();
+
+    $networks = $provider->privateNetworks(['3164444'], []);
+
+    expect($networks)->toHaveCount(1);
+    expect($networks[0]->externalId)->toBe('vpc-abc');
+    expect($networks[0]->cidr)->toBe('10.106.0.0/20');
+    expect($networks[0]->members)->toHaveCount(1, 'Unmanaged droplets must be excluded.');
+    expect($networks[0]->members[0]->ip)->toBe('10.106.0.4');
+});
+
+test('linode reads membership from subnets and ips from account list', function () {
+    Http::fake([
+        'api.linode.com/v4/vpcs/ips*' => Http::response([
+            'data' => [
+                ['linode_id' => 555, 'vpc_id' => 77, 'address' => '10.0.1.4', 'active' => true],
+                ['linode_id' => 555, 'vpc_id' => 77, 'address' => null, 'address_range' => '10.0.9.0/28'],
+            ],
+            'page' => 1,
+            'pages' => 1,
+        ]),
+        'api.linode.com/v4/vpcs*' => Http::response([
+            'data' => [
+                [
+                    'id' => 77,
+                    'label' => 'prod-vpc',
+                    'region' => 'eu-west',
+                    'subnets' => [
+                        ['ipv4' => '10.0.1.0/24', 'linodes' => [['id' => 555], ['id' => 888]]],
+                    ],
+                ],
+            ],
+            'page' => 1,
+            'pages' => 1,
+        ]),
+    ]);
+
+    $connection = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Linode::id(),
+        'credentials' => ['token' => 'secret-token'],
+    ]);
+
+    /** @var Linode $provider */
+    $provider = $connection->provider();
+
+    $networks = $provider->privateNetworks(['555'], []);
+
+    expect($networks)->toHaveCount(1);
+    expect($networks[0]->name)->toBe('prod-vpc');
+    expect($networks[0]->cidr)->toBe('10.0.1.0/24');
+    expect($networks[0]->members)->toHaveCount(1);
+    expect($networks[0]->members[0]->ip)->toBe('10.0.1.4');
+});
+
+test('linode stops and fails on a runaway page count', function () {
+    Http::fake([
+        'api.linode.com/v4/*' => Http::response([
+            'data' => [],
+            'page' => 1,
+            'pages' => 100000,
+        ]),
+    ]);
+
+    $connection = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Linode::id(),
+        'credentials' => ['token' => 'secret-token'],
+    ]);
+
+    /** @var Linode $provider */
+    $provider = $connection->provider();
+
+    $this->expectException(PrivateNetworkSyncError::class);
+
+    $provider->privateNetworks(['555'], []);
+});
+
+test('linode multi subnet vpc reports no single cidr', function () {
+    Http::fake([
+        'api.linode.com/v4/vpcs/ips*' => Http::response(['data' => [], 'page' => 1, 'pages' => 1]),
+        'api.linode.com/v4/vpcs*' => Http::response([
+            'data' => [[
+                'id' => 77,
+                'label' => 'multi',
+                'subnets' => [
+                    ['ipv4' => '10.0.1.0/24', 'linodes' => [['id' => 555]]],
+                    ['ipv4' => '10.0.2.0/24', 'linodes' => []],
+                ],
+            ]],
+            'page' => 1,
+            'pages' => 1,
+        ]),
+    ]);
+
+    $connection = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Linode::id(),
+        'credentials' => ['token' => 'secret-token'],
+    ]);
+
+    /** @var Linode $provider */
+    $provider = $connection->provider();
+
+    $networks = $provider->privateNetworks(['555'], []);
+
+    expect($networks[0]->cidr)->toBeNull('A VPC with several subnets has no single CIDR; firewall rules fall back to member /32s.');
+});
+
+test('vultr builds cidr from v4 subnet and mask', function () {
+    Http::fake([
+        'api.vultr.com/v2/instances/*/vpcs*' => Http::response([
+            'vpcs' => [['id' => 'vpc-1', 'ip_address' => '10.20.0.4', 'mac_address' => 'aa:bb']],
+        ]),
+        'api.vultr.com/v2/vpcs*' => Http::response([
+            'vpcs' => [[
+                'id' => 'vpc-1',
+                'description' => 'prod-vpc',
+                'v4_subnet' => '10.20.0.0',
+                'v4_subnet_mask' => 24,
+                'region' => 'lhr',
+            ]],
+        ]),
+    ]);
+
+    $connection = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Vultr::id(),
+        'credentials' => ['token' => 'secret-token'],
+    ]);
+
+    /** @var Vultr $provider */
+    $provider = $connection->provider();
+
+    $networks = $provider->privateNetworks(['inst-1'], []);
+
+    expect($networks)->toHaveCount(1);
+    expect($networks[0]->name)->toBe('prod-vpc');
+    expect($networks[0]->cidr)->toBe('10.20.0.0/24');
+    expect($networks[0]->members[0]->ip)->toBe('10.20.0.4');
+});
+
+test('vultr stale instance id does not abort the connection', function () {
+    Http::fake([
+        'api.vultr.com/v2/instances/gone/vpcs*' => Http::response(['error' => 'not found'], 404),
+        'api.vultr.com/v2/instances/*/vpcs*' => Http::response([
+            'vpcs' => [['id' => 'vpc-1', 'ip_address' => '10.20.0.4']],
+        ]),
+        'api.vultr.com/v2/vpcs*' => Http::response([
+            'vpcs' => [['id' => 'vpc-1', 'description' => 'prod', 'v4_subnet' => '10.20.0.0', 'v4_subnet_mask' => 24]],
+        ]),
+    ]);
+
+    $connection = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Vultr::id(),
+        'credentials' => ['token' => 'secret-token'],
+    ]);
+
+    /** @var Vultr $provider */
+    $provider = $connection->provider();
+
+    $networks = $provider->privateNetworks(['gone', 'live'], []);
+
+    expect($networks)->toHaveCount(1, 'A deleted instance must not abort the whole connection.');
+    expect($networks[0]->members[0]->ip)->toBe('10.20.0.4');
+    expect($networks[0]->members[0]->instanceId)->toBe('live');
+});
+
+test('vultr non 404 error still fails the connection', function () {
+    Http::fake([
+        'api.vultr.com/v2/*' => Http::response(['error' => 'boom'], 500),
+    ]);
+
+    $connection = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Vultr::id(),
+        'credentials' => ['token' => 'secret-token'],
+    ]);
+
+    /** @var Vultr $provider */
+    $provider = $connection->provider();
+
+    $this->expectException(PrivateNetworkSyncError::class);
+    $provider->privateNetworks(['live'], []);
+});
+
+test('aws mapper prefers network interface and name tag', function () {
+    $connection = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => AWS::id(),
+        'credentials' => ['key' => 'k', 'secret' => 's'],
+    ]);
+
+    /** @var AWS $provider */
+    $provider = $connection->provider();
+
+    $reservations = [[
+        'Instances' => [
+            [
+                'InstanceId' => 'i-123',
+                'VpcId' => 'vpc-top',
+                'PrivateIpAddress' => '172.31.9.9',
+                'NetworkInterfaces' => [
+                    ['VpcId' => 'vpc-eni', 'PrivateIpAddress' => '172.31.0.5'],
+                ],
+            ],
+            ['InstanceId' => 'i-unmanaged', 'VpcId' => 'vpc-eni', 'PrivateIpAddress' => '172.31.0.6'],
+        ],
+    ]];
+
+    $vpcs = [[
+        'VpcId' => 'vpc-eni',
+        'CidrBlock' => '172.31.0.0/16',
+        'Tags' => [['Key' => 'Name', 'Value' => 'production']],
+    ]];
+
+    $networks = $provider->mapPrivateNetworks($reservations, $vpcs, ['i-123'], 'eu-west-2');
+
+    expect($networks)->toHaveCount(1);
+    expect($networks[0]->externalId)->toBe('vpc-eni');
+    expect($networks[0]->name)->toBe('production');
+    expect($networks[0]->cidr)->toBe('172.31.0.0/16');
+    expect($networks[0]->region)->toBe('eu-west-2');
+    expect($networks[0]->members)->toHaveCount(1);
+    expect($networks[0]->members[0]->ip)->toBe('172.31.0.5');
+});
+
+test('aws mapper reads ipv6 only vpcs and members', function () {
+    $connection = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => AWS::id(),
+        'credentials' => ['key' => 'k', 'secret' => 's'],
+    ]);
+
+    /** @var AWS $provider */
+    $provider = $connection->provider();
+
+    $networks = $provider->mapPrivateNetworks(
+        [['Instances' => [[
+            'InstanceId' => 'i-v6',
+            'NetworkInterfaces' => [[
+                'VpcId' => 'vpc-v6',
+                'Ipv6Addresses' => [['Ipv6Address' => '2001:db8:1::5']],
+            ]],
+        ]]]],
+        [[
+            'VpcId' => 'vpc-v6',
+            'Ipv6CidrBlockAssociationSet' => [['Ipv6CidrBlock' => '2001:db8:1::/56']],
+        ]],
+        ['i-v6'],
+        'eu-west-1',
+    );
+
+    expect($networks)->toHaveCount(1);
+    expect($networks[0]->cidr)->toBe('2001:db8:1::/56');
+    expect($networks[0]->members[0]->ip)->toBe('2001:db8:1::5');
+});
+
+test('aws mapper prefers ipv4 on a dual stack vpc', function () {
+    $connection = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => AWS::id(),
+        'credentials' => ['key' => 'k', 'secret' => 's'],
+    ]);
+
+    /** @var AWS $provider */
+    $provider = $connection->provider();
+
+    $networks = $provider->mapPrivateNetworks(
+        [['Instances' => [[
+            'InstanceId' => 'i-dual',
+            'NetworkInterfaces' => [[
+                'VpcId' => 'vpc-dual',
+                'PrivateIpAddress' => '172.31.0.5',
+                'Ipv6Addresses' => [['Ipv6Address' => '2001:db8:2::5']],
+            ]],
+        ]]]],
+        [[
+            'VpcId' => 'vpc-dual',
+            'CidrBlock' => '172.31.0.0/16',
+            'Ipv6CidrBlockAssociationSet' => [['Ipv6CidrBlock' => '2001:db8:2::/56']],
+        ]],
+        ['i-dual'],
+        'eu-west-1',
+    );
+
+    expect($networks[0]->cidr)->toBe('172.31.0.0/16');
+    expect($networks[0]->members[0]->ip)->toBe('172.31.0.5');
+});
+
+test('aws mapper falls back to vpc id when untagged', function () {
+    $connection = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => AWS::id(),
+        'credentials' => ['key' => 'k', 'secret' => 's'],
+    ]);
+
+    /** @var AWS $provider */
+    $provider = $connection->provider();
+
+    $networks = $provider->mapPrivateNetworks(
+        [['Instances' => [['InstanceId' => 'i-1', 'VpcId' => 'vpc-9', 'PrivateIpAddress' => '10.0.0.2']]]],
+        [['VpcId' => 'vpc-9', 'CidrBlock' => '10.0.0.0/16']],
+        ['i-1'],
+        'us-east-1',
+    );
+
+    expect($networks[0]->name)->toBe('vpc-9');
+});
+
+/**
+ * @return array<string, array{0: ?string}>
+ */
+dataset('untrustedAddresses', function () {
+    return [
+        'command substitution' => ['10.0.0.2 $(id)'],
+        'command chaining' => ['10.0.0.2; rm -rf /'],
+        'backticks' => ['`whoami`'],
+        'newline injection' => ["10.0.0.2\nsudo ufw disable"],
+        'ipv6 with metacharacters' => ['fd00::1; id'],
+        'ipv6 with prefix' => ['fd00::1/64'],
+        'not an address' => ['not-an-ip'],
+        'empty' => [''],
+    ];
+});
+
+test('member addresses that are not literal addresses are dropped', function (?string $address) {
+    Http::fake([
+        'api.hetzner.cloud/v1/networks*' => Http::response([
+            'networks' => [['id' => 1, 'name' => 'n', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ]),
+        'api.hetzner.cloud/v1/servers*' => Http::response([
+            'servers' => [['id' => 101, 'private_net' => [['network' => 1, 'ip' => $address]]]],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ]),
+    ]);
+
+    /** @var Hetzner $provider */
+    $provider = vitoPestFeatureProviderPrivateNetworkTestHetznerConnection()->provider();
+
+    $networks = $provider->privateNetworks(['101'], []);
+
+    expect($networks[0]->members[0]->ip)->toBeNull('Member addresses reach an unquoted shell interpolation in the ufw template.');
+})->with('untrustedAddresses');
+
+test('valid member address survives normalisation', function () {
+    Http::fake([
+        'api.hetzner.cloud/v1/networks*' => Http::response([
+            'networks' => [['id' => 1, 'name' => 'n', 'ip_range' => '10.0.0.0/16', 'servers' => [101]]],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ]),
+        'api.hetzner.cloud/v1/servers*' => Http::response([
+            'servers' => [['id' => 101, 'private_net' => [['network' => 1, 'ip' => '10.0.0.42']]]],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ]),
+    ]);
+
+    /** @var Hetzner $provider */
+    $provider = vitoPestFeatureProviderPrivateNetworkTestHetznerConnection()->provider();
+
+    expect($provider->privateNetworks(['101'], [])[0]->members[0]->ip)->toBe('10.0.0.42');
+});
+
+test('ipv6 ranges are kept and malformed ranges are dropped', function () {
+    Http::fake([
+        'api.hetzner.cloud/v1/networks*' => Http::response([
+            'networks' => [
+                ['id' => 1, 'name' => 'v6', 'ip_range' => 'fd00::/64', 'servers' => [101]],
+                ['id' => 2, 'name' => 'junk', 'ip_range' => 'not-a-cidr', 'servers' => [101]],
+                ['id' => 3, 'name' => 'noprefix', 'ip_range' => '10.0.0.0', 'servers' => [101]],
+                ['id' => 4, 'name' => 'ok', 'ip_range' => '10.5.0.0/16', 'servers' => [101]],
+                ['id' => 5, 'name' => 'v6noncanonical', 'ip_range' => 'fd00:1:2:3:4::5/48', 'servers' => [101]],
+                ['id' => 6, 'name' => 'v6overlong', 'ip_range' => 'fd00::/129', 'servers' => [101]],
+                ['id' => 7, 'name' => 'v4overlong', 'ip_range' => '10.0.0.0/33', 'servers' => [101]],
+            ],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ]),
+        'api.hetzner.cloud/v1/servers*' => Http::response([
+            'servers' => [['id' => 101, 'private_net' => []]],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ]),
+    ]);
+
+    /** @var Hetzner $provider */
+    $provider = vitoPestFeatureProviderPrivateNetworkTestHetznerConnection()->provider();
+
+    $cidrs = array_map(fn ($n): ?string => $n->cidr, $provider->privateNetworks(['101'], []));
+
+    expect($cidrs)->toBe(['fd00::/64', null, null, '10.5.0.0/16', 'fd00:1:2::/48', null, null]);
+});
+
+test('ipv6 member address survives normalisation', function () {
+    Http::fake([
+        'api.hetzner.cloud/v1/networks*' => Http::response([
+            'networks' => [['id' => 1, 'name' => 'n', 'ip_range' => 'fd00::/64', 'servers' => [101]]],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ]),
+        'api.hetzner.cloud/v1/servers*' => Http::response([
+            'servers' => [['id' => 101, 'private_net' => [['network' => 1, 'ip' => 'fd00::5']]]],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ]),
+    ]);
+
+    /** @var Hetzner $provider */
+    $provider = vitoPestFeatureProviderPrivateNetworkTestHetznerConnection()->provider();
+
+    $networks = $provider->privateNetworks(['101'], []);
+
+    expect($networks[0]->members[0]->ip)->toBe('fd00::5');
+});

--- a/tests/Feature/ProviderPrivateNetworkTest.php
+++ b/tests/Feature/ProviderPrivateNetworkTest.php
@@ -470,10 +470,7 @@ test('aws mapper falls back to vpc id when untagged', function () {
     expect($networks[0]->name)->toBe('vpc-9');
 });
 
-/**
- * @return array<string, array{0: ?string}>
- */
-dataset('untrustedAddresses', function () {
+dataset('untrustedAddresses', /** @return array<string, array{0: string}> */ function (): array {
     return [
         'command substitution' => ['10.0.0.2 $(id)'],
         'command chaining' => ['10.0.0.2; rm -rf /'],

--- a/tests/Feature/RedirectsTest.php
+++ b/tests/Feature/RedirectsTest.php
@@ -1,221 +1,206 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\RedirectStatus;
 use App\Facades\SSH;
 use App\Models\Redirect;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class RedirectsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_see_redirects(): void
-    {
-        $this->actingAs($this->user);
+test('see redirects', function () {
+    $this->actingAs($this->user);
 
-        Redirect::factory()->create([
-            'site_id' => $this->site->id,
-        ]);
+    Redirect::factory()->create([
+        'site_id' => $this->site->id,
+    ]);
 
-        $this->get(route('redirects', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('redirects/index'));
+    $this->get(route('redirects', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('redirects/index'));
+});
 
-    }
+test('delete redirect', function () {
+    SSH::fake();
 
-    public function test_delete_redirect(): void
-    {
-        SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $redirect = Redirect::factory()->create([
+        'site_id' => $this->site->id,
+    ]);
 
-        $redirect = Redirect::factory()->create([
-            'site_id' => $this->site->id,
-        ]);
+    $this->delete(route('redirects.destroy', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'redirect' => $redirect,
+    ]))
+        ->assertSessionDoesntHaveErrors();
 
-        $this->delete(route('redirects.destroy', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'redirect' => $redirect,
-        ]))
-            ->assertSessionDoesntHaveErrors();
+    $this->assertDatabaseMissing('redirects', [
+        'id' => $redirect->id,
+    ]);
+});
 
-        $this->assertDatabaseMissing('redirects', [
-            'id' => $redirect->id,
-        ]);
-    }
+test('create redirect', function () {
+    SSH::fake();
 
-    public function test_create_redirect(): void
-    {
-        SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $this->post(route('redirects.store', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'from' => 'some-path',
+        'to' => 'https://example.com/redirect',
+        'mode' => 301,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->post(route('redirects.store', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'from' => 'some-path',
-            'to' => 'https://example.com/redirect',
-            'mode' => 301,
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->assertDatabaseHas('redirects', [
+        'from' => 'some-path',
+        'to' => 'https://example.com/redirect',
+        'mode' => 301,
+        'status' => RedirectStatus::READY,
+    ]);
+});
 
-        $this->assertDatabaseHas('redirects', [
-            'from' => 'some-path',
-            'to' => 'https://example.com/redirect',
-            'mode' => 301,
-            'status' => RedirectStatus::READY,
-        ]);
-    }
+test('create proxy redirect with websocket', function () {
+    SSH::fake();
 
-    public function test_create_proxy_redirect_with_websocket(): void
-    {
-        SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $this->post(route('redirects.store', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'from' => '/app',
+        'to' => 'https://backend.example.com',
+        'mode' => 1000,
+        'websocket' => true,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->post(route('redirects.store', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'from' => '/app',
-            'to' => 'https://backend.example.com',
-            'mode' => 1000,
-            'websocket' => true,
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->assertDatabaseHas('redirects', [
+        'from' => '/app',
+        'to' => 'https://backend.example.com',
+        'mode' => 1000,
+        'websocket' => true,
+        'status' => RedirectStatus::READY,
+    ]);
+});
 
-        $this->assertDatabaseHas('redirects', [
-            'from' => '/app',
-            'to' => 'https://backend.example.com',
-            'mode' => 1000,
-            'websocket' => true,
-            'status' => RedirectStatus::READY,
-        ]);
-    }
+test('websocket forced off when not proxy mode', function () {
+    SSH::fake();
 
-    public function test_websocket_forced_off_when_not_proxy_mode(): void
-    {
-        SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $this->post(route('redirects.store', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'from' => '/app',
+        'to' => 'https://example.com/redirect',
+        'mode' => 301,
+        'websocket' => true,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->post(route('redirects.store', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'from' => '/app',
-            'to' => 'https://example.com/redirect',
-            'mode' => 301,
-            'websocket' => true,
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->assertDatabaseHas('redirects', [
+        'from' => '/app',
+        'mode' => 301,
+        'websocket' => false,
+    ]);
+});
 
-        $this->assertDatabaseHas('redirects', [
-            'from' => '/app',
-            'mode' => 301,
-            'websocket' => false,
-        ]);
-    }
+test('update redirect', function () {
+    SSH::fake();
 
-    public function test_update_redirect(): void
-    {
-        SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $redirect = Redirect::factory()->create([
+        'site_id' => $this->site->id,
+        'mode' => 301,
+    ]);
 
-        $redirect = Redirect::factory()->create([
-            'site_id' => $this->site->id,
-            'mode' => 301,
-        ]);
+    $this->put(route('redirects.update', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'redirect' => $redirect,
+    ]), [
+        'from' => 'updated-path',
+        'to' => 'https://example.com/updated',
+        'mode' => 302,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->put(route('redirects.update', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'redirect' => $redirect,
-        ]), [
-            'from' => 'updated-path',
-            'to' => 'https://example.com/updated',
-            'mode' => 302,
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->assertDatabaseHas('redirects', [
+        'id' => $redirect->id,
+        'from' => 'updated-path',
+        'to' => 'https://example.com/updated',
+        'mode' => 302,
+        'status' => RedirectStatus::READY,
+    ]);
+});
 
-        $this->assertDatabaseHas('redirects', [
-            'id' => $redirect->id,
-            'from' => 'updated-path',
-            'to' => 'https://example.com/updated',
-            'mode' => 302,
-            'status' => RedirectStatus::READY,
-        ]);
-    }
+test('update redirect to proxy with websocket', function () {
+    SSH::fake();
 
-    public function test_update_redirect_to_proxy_with_websocket(): void
-    {
-        SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $redirect = Redirect::factory()->create([
+        'site_id' => $this->site->id,
+        'mode' => 301,
+        'websocket' => false,
+    ]);
 
-        $redirect = Redirect::factory()->create([
-            'site_id' => $this->site->id,
-            'mode' => 301,
-            'websocket' => false,
-        ]);
+    $this->put(route('redirects.update', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'redirect' => $redirect,
+    ]), [
+        'from' => 'ws-path',
+        'to' => 'https://backend.example.com',
+        'mode' => 1000,
+        'websocket' => true,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->put(route('redirects.update', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'redirect' => $redirect,
-        ]), [
-            'from' => 'ws-path',
-            'to' => 'https://backend.example.com',
-            'mode' => 1000,
-            'websocket' => true,
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->assertDatabaseHas('redirects', [
+        'id' => $redirect->id,
+        'mode' => 1000,
+        'websocket' => true,
+    ]);
+});
 
-        $this->assertDatabaseHas('redirects', [
-            'id' => $redirect->id,
-            'mode' => 1000,
-            'websocket' => true,
-        ]);
-    }
+test('update redirect away from proxy forces websocket off', function () {
+    SSH::fake();
 
-    public function test_update_redirect_away_from_proxy_forces_websocket_off(): void
-    {
-        SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $redirect = Redirect::factory()->create([
+        'site_id' => $this->site->id,
+        'mode' => 1000,
+        'websocket' => true,
+    ]);
 
-        $redirect = Redirect::factory()->create([
-            'site_id' => $this->site->id,
-            'mode' => 1000,
-            'websocket' => true,
-        ]);
+    $this->put(route('redirects.update', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'redirect' => $redirect,
+    ]), [
+        'from' => 'plain-path',
+        'to' => 'https://example.com/plain',
+        'mode' => 301,
+        'websocket' => true,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->put(route('redirects.update', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'redirect' => $redirect,
-        ]), [
-            'from' => 'plain-path',
-            'to' => 'https://example.com/plain',
-            'mode' => 301,
-            'websocket' => true,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('redirects', [
-            'id' => $redirect->id,
-            'mode' => 301,
-            'websocket' => false,
-        ]);
-    }
-}
+    $this->assertDatabaseHas('redirects', [
+        'id' => $redirect->id,
+        'mode' => 301,
+        'websocket' => false,
+    ]);
+});

--- a/tests/Feature/RenewSslCertificatesCommandTest.php
+++ b/tests/Feature/RenewSslCertificatesCommandTest.php
@@ -27,77 +27,23 @@ test('dispatches renewal for expiring wildcard ssl', function () {
     Bus::assertDispatched(CreateLetsEncryptWildcardSslJob::class);
 });
 
-test('does not dispatch for ssl not expiring soon', function () {
+test('does not dispatch renewal', function (array $attributes) {
     Bus::fake();
 
-    Ssl::factory()->create([
+    Ssl::factory()->create(array_merge([
         'server_id' => $this->server->id,
         'site_id' => null,
         'type' => SslType::LETSENCRYPT,
         'is_wildcard' => true,
         'status' => SslStatus::CREATED,
-        'expires_at' => now()->addDays(60),
-        'domains' => ['*.example.com'],
-    ]);
-
-    $this->artisan('ssl:renew-wildcards')->assertSuccessful();
-
-    Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
-});
-
-test('does not dispatch for non wildcard ssl', function () {
-    Bus::fake();
-
-    Ssl::factory()->create([
-        'server_id' => $this->server->id,
-        'site_id' => null,
-        'type' => SslType::LETSENCRYPT,
-        'is_wildcard' => false,
-        'status' => SslStatus::CREATED,
-        'expires_at' => now()->addDays(15),
-        'domains' => ['example.com'],
-    ]);
-
-    $this->artisan('ssl:renew-wildcards')->assertSuccessful();
-
-    Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
-});
-
-test('does not dispatch for creating ssl', function () {
-    Bus::fake();
-
-    Ssl::factory()->create([
-        'server_id' => $this->server->id,
-        'site_id' => null,
-        'type' => SslType::LETSENCRYPT,
-        'is_wildcard' => true,
-        'status' => SslStatus::CREATING,
         'expires_at' => now()->addDays(15),
         'domains' => ['*.example.com'],
-    ]);
+    ], $attributes));
 
     $this->artisan('ssl:renew-wildcards')->assertSuccessful();
 
     Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
-});
-
-test('does not dispatch for failed ssl', function () {
-    Bus::fake();
-
-    Ssl::factory()->create([
-        'server_id' => $this->server->id,
-        'site_id' => null,
-        'type' => SslType::LETSENCRYPT,
-        'is_wildcard' => true,
-        'status' => SslStatus::FAILED,
-        'expires_at' => now()->addDays(15),
-        'domains' => ['*.example.com'],
-    ]);
-
-    $this->artisan('ssl:renew-wildcards')->assertSuccessful();
-
-    Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
-});
+})->with('nonRenewableSsl');
 
 test('does not dispatch for site level ssl', function () {
     Bus::fake();
@@ -106,24 +52,6 @@ test('does not dispatch for site level ssl', function () {
         'server_id' => $this->server->id,
         'site_id' => $this->site->id,
         'type' => SslType::LETSENCRYPT,
-        'is_wildcard' => true,
-        'status' => SslStatus::CREATED,
-        'expires_at' => now()->addDays(15),
-        'domains' => ['*.example.com'],
-    ]);
-
-    $this->artisan('ssl:renew-wildcards')->assertSuccessful();
-
-    Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
-});
-
-test('does not dispatch for custom ssl type', function () {
-    Bus::fake();
-
-    Ssl::factory()->create([
-        'server_id' => $this->server->id,
-        'site_id' => null,
-        'type' => SslType::CUSTOM,
         'is_wildcard' => true,
         'status' => SslStatus::CREATED,
         'expires_at' => now()->addDays(15),
@@ -151,6 +79,16 @@ test('dispatches for ssl at exactly 30 days', function () {
     $this->artisan('ssl:renew-wildcards')->assertSuccessful();
 
     Bus::assertDispatched(CreateLetsEncryptWildcardSslJob::class);
+});
+
+dataset('nonRenewableSsl', /** @return array<string, array{0: array<string, mixed>}> */ function (): array {
+    return [
+        'not expiring soon' => [['expires_at' => now()->addDays(60)]],
+        'not wildcard' => [['is_wildcard' => false, 'domains' => ['example.com']]],
+        'creating' => [['status' => SslStatus::CREATING]],
+        'failed' => [['status' => SslStatus::FAILED]],
+        'custom type' => [['type' => SslType::CUSTOM]],
+    ];
 });
 
 test('dispatches multiple expiring ssls', function () {

--- a/tests/Feature/RenewSslCertificatesCommandTest.php
+++ b/tests/Feature/RenewSslCertificatesCommandTest.php
@@ -1,187 +1,172 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\SslStatus;
 use App\Enums\SslType;
 use App\Jobs\SSL\CreateLetsEncryptWildcardSslJob;
 use App\Models\Ssl;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
-use Tests\TestCase;
 
-class RenewSslCertificatesCommandTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_dispatches_renewal_for_expiring_wildcard_ssl(): void
-    {
-        Bus::fake();
+test('dispatches renewal for expiring wildcard ssl', function () {
+    Bus::fake();
 
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'type' => SslType::LETSENCRYPT,
-            'is_wildcard' => true,
-            'status' => SslStatus::CREATED,
-            'expires_at' => now()->addDays(15),
-            'domains' => ['*.example.com', 'example.com'],
-        ]);
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'type' => SslType::LETSENCRYPT,
+        'is_wildcard' => true,
+        'status' => SslStatus::CREATED,
+        'expires_at' => now()->addDays(15),
+        'domains' => ['*.example.com', 'example.com'],
+    ]);
 
-        $this->artisan('ssl:renew-wildcards')->assertSuccessful();
+    $this->artisan('ssl:renew-wildcards')->assertSuccessful();
 
-        Bus::assertDispatched(CreateLetsEncryptWildcardSslJob::class);
-    }
+    Bus::assertDispatched(CreateLetsEncryptWildcardSslJob::class);
+});
 
-    public function test_does_not_dispatch_for_ssl_not_expiring_soon(): void
-    {
-        Bus::fake();
+test('does not dispatch for ssl not expiring soon', function () {
+    Bus::fake();
 
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'type' => SslType::LETSENCRYPT,
-            'is_wildcard' => true,
-            'status' => SslStatus::CREATED,
-            'expires_at' => now()->addDays(60),
-            'domains' => ['*.example.com'],
-        ]);
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'type' => SslType::LETSENCRYPT,
+        'is_wildcard' => true,
+        'status' => SslStatus::CREATED,
+        'expires_at' => now()->addDays(60),
+        'domains' => ['*.example.com'],
+    ]);
 
-        $this->artisan('ssl:renew-wildcards')->assertSuccessful();
+    $this->artisan('ssl:renew-wildcards')->assertSuccessful();
 
-        Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
-    }
+    Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
+});
 
-    public function test_does_not_dispatch_for_non_wildcard_ssl(): void
-    {
-        Bus::fake();
+test('does not dispatch for non wildcard ssl', function () {
+    Bus::fake();
 
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'type' => SslType::LETSENCRYPT,
-            'is_wildcard' => false,
-            'status' => SslStatus::CREATED,
-            'expires_at' => now()->addDays(15),
-            'domains' => ['example.com'],
-        ]);
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'type' => SslType::LETSENCRYPT,
+        'is_wildcard' => false,
+        'status' => SslStatus::CREATED,
+        'expires_at' => now()->addDays(15),
+        'domains' => ['example.com'],
+    ]);
 
-        $this->artisan('ssl:renew-wildcards')->assertSuccessful();
+    $this->artisan('ssl:renew-wildcards')->assertSuccessful();
 
-        Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
-    }
+    Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
+});
 
-    public function test_does_not_dispatch_for_creating_ssl(): void
-    {
-        Bus::fake();
+test('does not dispatch for creating ssl', function () {
+    Bus::fake();
 
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'type' => SslType::LETSENCRYPT,
-            'is_wildcard' => true,
-            'status' => SslStatus::CREATING,
-            'expires_at' => now()->addDays(15),
-            'domains' => ['*.example.com'],
-        ]);
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'type' => SslType::LETSENCRYPT,
+        'is_wildcard' => true,
+        'status' => SslStatus::CREATING,
+        'expires_at' => now()->addDays(15),
+        'domains' => ['*.example.com'],
+    ]);
 
-        $this->artisan('ssl:renew-wildcards')->assertSuccessful();
+    $this->artisan('ssl:renew-wildcards')->assertSuccessful();
 
-        Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
-    }
+    Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
+});
 
-    public function test_does_not_dispatch_for_failed_ssl(): void
-    {
-        Bus::fake();
+test('does not dispatch for failed ssl', function () {
+    Bus::fake();
 
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'type' => SslType::LETSENCRYPT,
-            'is_wildcard' => true,
-            'status' => SslStatus::FAILED,
-            'expires_at' => now()->addDays(15),
-            'domains' => ['*.example.com'],
-        ]);
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'type' => SslType::LETSENCRYPT,
+        'is_wildcard' => true,
+        'status' => SslStatus::FAILED,
+        'expires_at' => now()->addDays(15),
+        'domains' => ['*.example.com'],
+    ]);
 
-        $this->artisan('ssl:renew-wildcards')->assertSuccessful();
+    $this->artisan('ssl:renew-wildcards')->assertSuccessful();
 
-        Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
-    }
+    Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
+});
 
-    public function test_does_not_dispatch_for_site_level_ssl(): void
-    {
-        Bus::fake();
+test('does not dispatch for site level ssl', function () {
+    Bus::fake();
 
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'type' => SslType::LETSENCRYPT,
-            'is_wildcard' => true,
-            'status' => SslStatus::CREATED,
-            'expires_at' => now()->addDays(15),
-            'domains' => ['*.example.com'],
-        ]);
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'type' => SslType::LETSENCRYPT,
+        'is_wildcard' => true,
+        'status' => SslStatus::CREATED,
+        'expires_at' => now()->addDays(15),
+        'domains' => ['*.example.com'],
+    ]);
 
-        $this->artisan('ssl:renew-wildcards')->assertSuccessful();
+    $this->artisan('ssl:renew-wildcards')->assertSuccessful();
 
-        Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
-    }
+    Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
+});
 
-    public function test_does_not_dispatch_for_custom_ssl_type(): void
-    {
-        Bus::fake();
+test('does not dispatch for custom ssl type', function () {
+    Bus::fake();
 
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'type' => SslType::CUSTOM,
-            'is_wildcard' => true,
-            'status' => SslStatus::CREATED,
-            'expires_at' => now()->addDays(15),
-            'domains' => ['*.example.com'],
-        ]);
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'type' => SslType::CUSTOM,
+        'is_wildcard' => true,
+        'status' => SslStatus::CREATED,
+        'expires_at' => now()->addDays(15),
+        'domains' => ['*.example.com'],
+    ]);
 
-        $this->artisan('ssl:renew-wildcards')->assertSuccessful();
+    $this->artisan('ssl:renew-wildcards')->assertSuccessful();
 
-        Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
-    }
+    Bus::assertNotDispatched(CreateLetsEncryptWildcardSslJob::class);
+});
 
-    public function test_dispatches_for_ssl_at_exactly_30_days(): void
-    {
-        Bus::fake();
+test('dispatches for ssl at exactly 30 days', function () {
+    Bus::fake();
 
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'type' => SslType::LETSENCRYPT,
-            'is_wildcard' => true,
-            'status' => SslStatus::CREATED,
-            'expires_at' => now()->addDays(30),
-            'domains' => ['*.example.com'],
-        ]);
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'type' => SslType::LETSENCRYPT,
+        'is_wildcard' => true,
+        'status' => SslStatus::CREATED,
+        'expires_at' => now()->addDays(30),
+        'domains' => ['*.example.com'],
+    ]);
 
-        $this->artisan('ssl:renew-wildcards')->assertSuccessful();
+    $this->artisan('ssl:renew-wildcards')->assertSuccessful();
 
-        Bus::assertDispatched(CreateLetsEncryptWildcardSslJob::class);
-    }
+    Bus::assertDispatched(CreateLetsEncryptWildcardSslJob::class);
+});
 
-    public function test_dispatches_multiple_expiring_ssls(): void
-    {
-        Bus::fake();
+test('dispatches multiple expiring ssls', function () {
+    Bus::fake();
 
-        Ssl::factory()->count(3)->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'type' => SslType::LETSENCRYPT,
-            'is_wildcard' => true,
-            'status' => SslStatus::CREATED,
-            'expires_at' => now()->addDays(10),
-            'domains' => ['*.example.com'],
-        ]);
+    Ssl::factory()->count(3)->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'type' => SslType::LETSENCRYPT,
+        'is_wildcard' => true,
+        'status' => SslStatus::CREATED,
+        'expires_at' => now()->addDays(10),
+        'domains' => ['*.example.com'],
+    ]);
 
-        $this->artisan('ssl:renew-wildcards')->assertSuccessful();
+    $this->artisan('ssl:renew-wildcards')->assertSuccessful();
 
-        Bus::assertDispatchedTimes(CreateLetsEncryptWildcardSslJob::class, 3);
-    }
-}
+    Bus::assertDispatchedTimes(CreateLetsEncryptWildcardSslJob::class, 3);
+});

--- a/tests/Feature/RestartSiteWorkersTest.php
+++ b/tests/Feature/RestartSiteWorkersTest.php
@@ -1,289 +1,260 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\Worker\RestartSiteWorkers;
 use App\Enums\WorkerStatus;
-use App\Exceptions\SSHCommandError;
 use App\Facades\SSH;
 use App\Models\ServerLog;
 use App\Models\Worker;
-use App\Services\ProcessManager\Supervisor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
-use Tests\TestCase;
+use Tests\Feature\ThrowingSupervisor;
 
-class RestartSiteWorkersTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_failed_worker_restart_is_non_fatal_and_records_error(): void
-    {
-        Storage::fake(config('core.logs_disk'));
+test('failed worker restart is non fatal and records error', function () {
+    Storage::fake(config('core.logs_disk'));
 
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
 
-        SSH::fake("{$worker->id}:{$worker->id}_00: ERROR (no such file)");
+    SSH::fake("{$worker->id}:{$worker->id}_00: ERROR (no such file)");
 
-        app(RestartSiteWorkers::class)->restart($this->site->fresh());
+    app(RestartSiteWorkers::class)->restart($this->site->fresh());
 
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::FAILED);
+    expect($worker->error)->toBe("{$worker->id}:{$worker->id}_00: ERROR (no such file)");
+});
+
+test('successful restart marks running and clears error', function () {
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::FAILED,
+        'error' => 'stale error',
+    ]);
+
+    SSH::fake(
+        "{$worker->id}:{$worker->id}_00: stopped\n".
+        "{$worker->id}:{$worker->id}_00: started"
+    );
+
+    app(RestartSiteWorkers::class)->restart($this->site->fresh());
+
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::RUNNING);
+    expect($worker->error)->toBeNull();
+});
+
+test('worker left stopped is marked stopped with generic error', function () {
+    Storage::fake(config('core.logs_disk'));
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    SSH::fake("{$worker->id}:{$worker->id}_00: stopped");
+
+    app(RestartSiteWorkers::class)->restart($this->site->fresh());
+
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::STOPPED);
+    expect($worker->error)->toBe('Unable to restart (stopped)');
+});
+
+test('worker absent from output is not marked running', function () {
+    Storage::fake(config('core.logs_disk'));
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    SSH::fake('error: some unexpected supervisor failure');
+
+    app(RestartSiteWorkers::class)->restart($this->site->fresh());
+
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::FAILED);
+    expect($worker->error)->toBe('Unable to restart');
+});
+
+test('worker with only benign statuses is not marked running', function () {
+    Storage::fake(config('core.logs_disk'));
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    SSH::fake("{$worker->id}:{$worker->id}_00: ERROR (not running)");
+
+    app(RestartSiteWorkers::class)->restart($this->site->fresh());
+
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::STOPPED);
+    expect($worker->error)->toBe('Unable to restart (stopped)');
+});
+
+test('multiprocess worker all started is running', function () {
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::FAILED,
+        'error' => 'stale error',
+    ]);
+
+    SSH::fake(
+        "{$worker->id}:{$worker->id}_00: stopped\n".
+        "{$worker->id}:{$worker->id}_00: started\n".
+        "{$worker->id}:{$worker->id}_01: stopped\n".
+        "{$worker->id}:{$worker->id}_01: started\n".
+        "{$worker->id}:{$worker->id}_02: stopped\n".
+        "{$worker->id}:{$worker->id}_02: started"
+    );
+
+    app(RestartSiteWorkers::class)->restart($this->site->fresh());
+
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::RUNNING);
+    expect($worker->error)->toBeNull();
+});
+
+test('multiprocess worker with one errored process records only that error', function () {
+    Storage::fake(config('core.logs_disk'));
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    SSH::fake(
+        "{$worker->id}:{$worker->id}_00: stopped\n".
+        "{$worker->id}:{$worker->id}_00: started\n".
+        "{$worker->id}:{$worker->id}_01: stopped\n".
+        "{$worker->id}:{$worker->id}_01: ERROR (abnormal termination)"
+    );
+
+    app(RestartSiteWorkers::class)->restart($this->site->fresh());
+
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::FAILED);
+    expect($worker->error)->toBe("{$worker->id}:{$worker->id}_01: ERROR (abnormal termination)");
+});
+
+test('multiprocess worker with one started one stopped is not running', function () {
+    Storage::fake(config('core.logs_disk'));
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    SSH::fake(
+        "{$worker->id}:{$worker->id}_00: started\n".
+        "{$worker->id}:{$worker->id}_01: stopped"
+    );
+
+    app(RestartSiteWorkers::class)->restart($this->site->fresh());
+
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::STOPPED);
+    expect($worker->error)->toBe('Unable to restart (stopped)');
+});
+
+test('restart attributes errors to the failing worker only', function () {
+    Storage::fake(config('core.logs_disk'));
+
+    $healthy = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+    $broken = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    SSH::fake(
+        "{$healthy->id}:{$healthy->id}_00: stopped\n".
+        "{$healthy->id}:{$healthy->id}_00: started\n".
+        "{$broken->id}:{$broken->id}_00: ERROR (abnormal termination)"
+    );
+
+    app(RestartSiteWorkers::class)->restart($this->site->fresh());
+
+    $healthy->refresh();
+    expect($healthy->status)->toBe(WorkerStatus::RUNNING);
+    expect($healthy->error)->toBeNull();
+
+    $broken->refresh();
+    expect($broken->status)->toBe(WorkerStatus::FAILED);
+    expect($broken->error)->toBe("{$broken->id}:{$broken->id}_00: ERROR (abnormal termination)");
+});
+
+test('thrown restart error marks all workers failed', function () {
+    SSH::fake();
+    Storage::fake(config('core.logs_disk'));
+    config(['service.services.supervisor.handler' => ThrowingSupervisor::class]);
+
+    $workers = Worker::factory()->count(2)->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    app(RestartSiteWorkers::class)->restart($this->site->fresh());
+
+    foreach ($workers as $worker) {
         $worker->refresh();
-        $this->assertSame(WorkerStatus::FAILED, $worker->status);
-        $this->assertSame("{$worker->id}:{$worker->id}_00: ERROR (no such file)", $worker->error);
+        expect($worker->status)->toBe(WorkerStatus::FAILED);
     }
+});
 
-    public function test_successful_restart_marks_running_and_clears_error(): void
-    {
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::FAILED,
-            'error' => 'stale error',
-        ]);
+test('restart rewrites worker config before restarting', function () {
+    Storage::fake(config('core.logs_disk'));
 
-        SSH::fake(
-            "{$worker->id}:{$worker->id}_00: stopped\n".
-            "{$worker->id}:{$worker->id}_00: started"
-        );
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
 
-        app(RestartSiteWorkers::class)->restart($this->site->fresh());
+    $ssh = SSH::fake(
+        "{$worker->id}:{$worker->id}_00: stopped\n".
+        "{$worker->id}:{$worker->id}_00: started"
+    );
 
-        $worker->refresh();
-        $this->assertSame(WorkerStatus::RUNNING, $worker->status);
-        $this->assertNull($worker->error);
-    }
+    app(RestartSiteWorkers::class)->restart($this->site->fresh());
 
-    public function test_worker_left_stopped_is_marked_stopped_with_generic_error(): void
-    {
-        Storage::fake(config('core.logs_disk'));
+    $ssh->assertExecutedContains("/etc/supervisor/conf.d/{$worker->id}.conf");
+});
 
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
+test('restart failure is written to the deploy log', function () {
+    Storage::fake(config('core.logs_disk'));
 
-        SSH::fake("{$worker->id}:{$worker->id}_00: stopped");
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
 
-        app(RestartSiteWorkers::class)->restart($this->site->fresh());
+    SSH::fake("{$worker->id}:{$worker->id}_00: ERROR (abnormal termination)");
 
-        $worker->refresh();
-        $this->assertSame(WorkerStatus::STOPPED, $worker->status);
-        $this->assertSame('Unable to restart (stopped)', $worker->error);
-    }
+    $log = ServerLog::newLog($this->server, 'deploy-test');
+    $log->save();
 
-    public function test_worker_absent_from_output_is_not_marked_running(): void
-    {
-        Storage::fake(config('core.logs_disk'));
+    app(RestartSiteWorkers::class)->restart($this->site->fresh(), $log);
 
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        SSH::fake('error: some unexpected supervisor failure');
-
-        app(RestartSiteWorkers::class)->restart($this->site->fresh());
-
-        $worker->refresh();
-        $this->assertSame(WorkerStatus::FAILED, $worker->status);
-        $this->assertSame('Unable to restart', $worker->error);
-    }
-
-    public function test_worker_with_only_benign_statuses_is_not_marked_running(): void
-    {
-        Storage::fake(config('core.logs_disk'));
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        SSH::fake("{$worker->id}:{$worker->id}_00: ERROR (not running)");
-
-        app(RestartSiteWorkers::class)->restart($this->site->fresh());
-
-        $worker->refresh();
-        $this->assertSame(WorkerStatus::STOPPED, $worker->status);
-        $this->assertSame('Unable to restart (stopped)', $worker->error);
-    }
-
-    public function test_multiprocess_worker_all_started_is_running(): void
-    {
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::FAILED,
-            'error' => 'stale error',
-        ]);
-
-        SSH::fake(
-            "{$worker->id}:{$worker->id}_00: stopped\n".
-            "{$worker->id}:{$worker->id}_00: started\n".
-            "{$worker->id}:{$worker->id}_01: stopped\n".
-            "{$worker->id}:{$worker->id}_01: started\n".
-            "{$worker->id}:{$worker->id}_02: stopped\n".
-            "{$worker->id}:{$worker->id}_02: started"
-        );
-
-        app(RestartSiteWorkers::class)->restart($this->site->fresh());
-
-        $worker->refresh();
-        $this->assertSame(WorkerStatus::RUNNING, $worker->status);
-        $this->assertNull($worker->error);
-    }
-
-    public function test_multiprocess_worker_with_one_errored_process_records_only_that_error(): void
-    {
-        Storage::fake(config('core.logs_disk'));
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        SSH::fake(
-            "{$worker->id}:{$worker->id}_00: stopped\n".
-            "{$worker->id}:{$worker->id}_00: started\n".
-            "{$worker->id}:{$worker->id}_01: stopped\n".
-            "{$worker->id}:{$worker->id}_01: ERROR (abnormal termination)"
-        );
-
-        app(RestartSiteWorkers::class)->restart($this->site->fresh());
-
-        $worker->refresh();
-        $this->assertSame(WorkerStatus::FAILED, $worker->status);
-        $this->assertSame("{$worker->id}:{$worker->id}_01: ERROR (abnormal termination)", $worker->error);
-    }
-
-    public function test_multiprocess_worker_with_one_started_one_stopped_is_not_running(): void
-    {
-        Storage::fake(config('core.logs_disk'));
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        SSH::fake(
-            "{$worker->id}:{$worker->id}_00: started\n".
-            "{$worker->id}:{$worker->id}_01: stopped"
-        );
-
-        app(RestartSiteWorkers::class)->restart($this->site->fresh());
-
-        $worker->refresh();
-        $this->assertSame(WorkerStatus::STOPPED, $worker->status);
-        $this->assertSame('Unable to restart (stopped)', $worker->error);
-    }
-
-    public function test_restart_attributes_errors_to_the_failing_worker_only(): void
-    {
-        Storage::fake(config('core.logs_disk'));
-
-        $healthy = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-        $broken = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        SSH::fake(
-            "{$healthy->id}:{$healthy->id}_00: stopped\n".
-            "{$healthy->id}:{$healthy->id}_00: started\n".
-            "{$broken->id}:{$broken->id}_00: ERROR (abnormal termination)"
-        );
-
-        app(RestartSiteWorkers::class)->restart($this->site->fresh());
-
-        $healthy->refresh();
-        $this->assertSame(WorkerStatus::RUNNING, $healthy->status);
-        $this->assertNull($healthy->error);
-
-        $broken->refresh();
-        $this->assertSame(WorkerStatus::FAILED, $broken->status);
-        $this->assertSame("{$broken->id}:{$broken->id}_00: ERROR (abnormal termination)", $broken->error);
-    }
-
-    public function test_thrown_restart_error_marks_all_workers_failed(): void
-    {
-        SSH::fake();
-        Storage::fake(config('core.logs_disk'));
-        config(['service.services.supervisor.handler' => ThrowingSupervisor::class]);
-
-        $workers = Worker::factory()->count(2)->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        app(RestartSiteWorkers::class)->restart($this->site->fresh());
-
-        foreach ($workers as $worker) {
-            $worker->refresh();
-            $this->assertSame(WorkerStatus::FAILED, $worker->status);
-        }
-    }
-
-    public function test_restart_rewrites_worker_config_before_restarting(): void
-    {
-        Storage::fake(config('core.logs_disk'));
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        $ssh = SSH::fake(
-            "{$worker->id}:{$worker->id}_00: stopped\n".
-            "{$worker->id}:{$worker->id}_00: started"
-        );
-
-        app(RestartSiteWorkers::class)->restart($this->site->fresh());
-
-        $ssh->assertExecutedContains("/etc/supervisor/conf.d/{$worker->id}.conf");
-    }
-
-    public function test_restart_failure_is_written_to_the_deploy_log(): void
-    {
-        Storage::fake(config('core.logs_disk'));
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        SSH::fake("{$worker->id}:{$worker->id}_00: ERROR (abnormal termination)");
-
-        $log = ServerLog::newLog($this->server, 'deploy-test');
-        $log->save();
-
-        app(RestartSiteWorkers::class)->restart($this->site->fresh(), $log);
-
-        $this->assertStringContainsString('Failed to restart worker(s): '.$worker->id, (string) $log->getContent());
-    }
-}
-
-class ThrowingSupervisor extends Supervisor
-{
-    public function restartMany(array $ids, ?int $siteId = null): string
-    {
-        $log = ServerLog::log($this->service->server, 'restart-workers', '');
-
-        throw new SSHCommandError(message: 'restart failed', log: $log);
-    }
-}
+    $this->assertStringContainsString('Failed to restart worker(s): '.$worker->id, (string) $log->getContent());
+});

--- a/tests/Feature/RetrySiteTest.php
+++ b/tests/Feature/RetrySiteTest.php
@@ -1,112 +1,101 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\SiteStatus;
 use App\Exceptions\FailedToDeployGitKey;
 use App\Facades\SSH;
 use App\Jobs\Site\CreateJob;
 use App\Models\Site;
-use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Queue;
-use Tests\TestCase;
 
-class RetrySiteTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_retry_failed_site_resets_state_and_dispatches_create_job(): void
-    {
-        Event::fake();
-        Queue::fake();
-        $this->actingAs($this->user);
+test('retry failed site resets state and dispatches create job', function () {
+    Event::fake();
+    Queue::fake();
+    $this->actingAs($this->user);
 
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => SiteStatus::INSTALLATION_FAILED,
-            'progress' => 40,
-            'progress_step' => 'cloning-repository',
-            'last_error' => '[SSHCommandError] SSH command failed with an error',
-        ]);
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => SiteStatus::INSTALLATION_FAILED,
+        'progress' => 40,
+        'progress_step' => 'cloning-repository',
+        'last_error' => '[SSHCommandError] SSH command failed with an error',
+    ]);
 
-        $this->post(route('sites.retry', ['server' => $this->server, 'site' => $site]))
-            ->assertSessionDoesntHaveErrors()
-            ->assertRedirect();
+    $this->post(route('sites.retry', ['server' => $this->server, 'site' => $site]))
+        ->assertSessionDoesntHaveErrors()
+        ->assertRedirect();
 
-        $site->refresh();
-        $this->assertEquals(SiteStatus::INSTALLING, $site->status);
-        $this->assertNull($site->last_error);
-        $this->assertNull($site->progress_step);
-        $this->assertEquals(0, $site->progress);
+    $site->refresh();
+    expect($site->status)->toEqual(SiteStatus::INSTALLING);
+    expect($site->last_error)->toBeNull();
+    expect($site->progress_step)->toBeNull();
+    expect($site->progress)->toEqual(0);
 
-        Queue::assertPushedOn('ssh', CreateJob::class);
-    }
+    Queue::assertPushedOn('ssh', CreateJob::class);
+});
 
-    public function test_retry_rejects_site_that_is_not_failed(): void
-    {
-        $this->actingAs($this->user);
+test('retry rejects site that is not failed', function () {
+    $this->actingAs($this->user);
 
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => SiteStatus::READY,
-        ]);
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => SiteStatus::READY,
+    ]);
 
-        $this->post(route('sites.retry', ['server' => $this->server, 'site' => $site]))
-            ->assertSessionHasErrors(['status']);
+    $this->post(route('sites.retry', ['server' => $this->server, 'site' => $site]))
+        ->assertSessionHasErrors(['status']);
 
-        $site->refresh();
-        $this->assertEquals(SiteStatus::READY, $site->status);
-    }
+    $site->refresh();
+    expect($site->status)->toEqual(SiteStatus::READY);
+});
 
-    public function test_create_job_failed_populates_safe_last_error_and_preserves_progress_step(): void
-    {
-        Notification::fake();
-        SSH::fake();
+test('create job failed populates safe last error and preserves progress step', function () {
+    Notification::fake();
+    SSH::fake();
 
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => SiteStatus::INSTALLING,
-            'progress' => 60,
-            'progress_step' => 'cloning-repository',
-        ]);
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => SiteStatus::INSTALLING,
+        'progress' => 60,
+        'progress_step' => 'cloning-repository',
+    ]);
 
-        $job = new CreateJob($site);
-        $job->failed(new Exception('raw provider response with possibly-sensitive payload'));
+    $job = new CreateJob($site);
+    $job->failed(new Exception('raw provider response with possibly-sensitive payload'));
 
-        $site->refresh();
-        $this->assertEquals(SiteStatus::INSTALLATION_FAILED, $site->status);
-        $this->assertNotNull($site->last_error);
-        $this->assertStringNotContainsString('raw provider response', $site->last_error);
-        $this->assertStringContainsString('Installation failed', $site->last_error);
-        $this->assertEquals('cloning-repository', $site->progress_step);
+    $site->refresh();
+    expect($site->status)->toEqual(SiteStatus::INSTALLATION_FAILED);
+    expect($site->last_error)->not->toBeNull();
+    $this->assertStringNotContainsString('raw provider response', $site->last_error);
+    $this->assertStringContainsString('Installation failed', $site->last_error);
+    expect($site->progress_step)->toEqual('cloning-repository');
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'site_id' => $site->id,
-            'type' => 'site-installation-failed',
-        ]);
-    }
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'site_id' => $site->id,
+        'type' => 'site-installation-failed',
+    ]);
+});
 
-    public function test_create_job_failed_uses_friendly_message_for_known_exceptions(): void
-    {
-        Notification::fake();
-        SSH::fake();
+test('create job failed uses friendly message for known exceptions', function () {
+    Notification::fake();
+    SSH::fake();
 
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => SiteStatus::INSTALLING,
-        ]);
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => SiteStatus::INSTALLING,
+    ]);
 
-        $job = new CreateJob($site);
-        $job->failed(new FailedToDeployGitKey('GitHub returned full key payload {"key": "ssh-rsa AAAA..."}'));
+    $job = new CreateJob($site);
+    $job->failed(new FailedToDeployGitKey('GitHub returned full key payload {"key": "ssh-rsa AAAA..."}'));
 
-        $site->refresh();
-        $this->assertNotNull($site->last_error);
-        $this->assertStringNotContainsString('ssh-rsa', $site->last_error);
-        $this->assertStringNotContainsString('AAAA', $site->last_error);
-        $this->assertStringContainsString('deploy key', $site->last_error);
-    }
-}
+    $site->refresh();
+    expect($site->last_error)->not->toBeNull();
+    $this->assertStringNotContainsString('ssh-rsa', $site->last_error);
+    $this->assertStringNotContainsString('AAAA', $site->last_error);
+    $this->assertStringContainsString('deploy key', $site->last_error);
+});

--- a/tests/Feature/ScriptTest.php
+++ b/tests/Feature/ScriptTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\ScriptExecutionStatus;
 use App\Facades\SSH;
 use App\Models\Script;
@@ -10,187 +8,175 @@ use App\Models\Server;
 use App\Models\Site;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class ScriptTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_see_scripts(): void
-    {
-        $this->actingAs($this->user);
+test('see scripts', function () {
+    $this->actingAs($this->user);
 
-        Script::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    Script::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-        $this->get(route('scripts'))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('scripts/index'));
-    }
+    $this->get(route('scripts'))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('scripts/index'));
+});
 
-    public function test_create_script(): void
-    {
-        $this->actingAs($this->user);
+test('create script', function () {
+    $this->actingAs($this->user);
 
-        $this->post(route('scripts.store'), [
-            'name' => 'Test Script',
-            'content' => 'echo "Hello, World!"',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('scripts.store'), [
+        'name' => 'Test Script',
+        'content' => 'echo "Hello, World!"',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('scripts', [
-            'name' => 'Test Script',
-            'content' => 'echo "Hello, World!"',
-        ]);
-    }
+    $this->assertDatabaseHas('scripts', [
+        'name' => 'Test Script',
+        'content' => 'echo "Hello, World!"',
+    ]);
+});
 
-    public function test_edit_script(): void
-    {
-        $this->actingAs($this->user);
+test('edit script', function () {
+    $this->actingAs($this->user);
 
-        $script = Script::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $script = Script::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-        $this->put(route('scripts.update', $script), [
-            'name' => 'New Name',
-            'content' => 'echo "Hello, new World!"',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->put(route('scripts.update', $script), [
+        'name' => 'New Name',
+        'content' => 'echo "Hello, new World!"',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('scripts', [
-            'id' => $script->id,
-            'name' => 'New Name',
-            'content' => 'echo "Hello, new World!"',
-        ]);
-    }
+    $this->assertDatabaseHas('scripts', [
+        'id' => $script->id,
+        'name' => 'New Name',
+        'content' => 'echo "Hello, new World!"',
+    ]);
+});
 
-    public function test_delete_script(): void
-    {
-        $this->actingAs($this->user);
+test('delete script', function () {
+    $this->actingAs($this->user);
 
-        $script = Script::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $script = Script::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-        $scriptExecution = ScriptExecution::factory()->create([
-            'script_id' => $script->id,
-            'status' => ScriptExecutionStatus::EXECUTING,
-        ]);
+    $scriptExecution = ScriptExecution::factory()->create([
+        'script_id' => $script->id,
+        'status' => ScriptExecutionStatus::EXECUTING,
+    ]);
 
-        $this->delete(route('scripts.destroy', $script->id));
+    $this->delete(route('scripts.destroy', $script->id));
 
-        $this->assertDatabaseMissing('scripts', [
-            'id' => $script->id,
-        ]);
+    $this->assertDatabaseMissing('scripts', [
+        'id' => $script->id,
+    ]);
 
-        $this->assertDatabaseMissing('script_executions', [
-            'id' => $scriptExecution->id,
-        ]);
-    }
+    $this->assertDatabaseMissing('script_executions', [
+        'id' => $scriptExecution->id,
+    ]);
+});
 
-    public function test_execute_script_and_view_log(): void
-    {
-        SSH::fake('script output');
+test('execute script and view log', function () {
+    SSH::fake('script output');
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $script = Script::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $script = Script::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-        $this->post(route('scripts.execute', $script), [
-            'server' => $this->server->id,
-            'user' => 'root',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('scripts.execute', $script), [
+        'server' => $this->server->id,
+        'user' => 'root',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('script_executions', [
-            'script_id' => $script->id,
-            'status' => ScriptExecutionStatus::COMPLETED,
-            'user' => 'root',
-        ]);
+    $this->assertDatabaseHas('script_executions', [
+        'script_id' => $script->id,
+        'status' => ScriptExecutionStatus::COMPLETED,
+        'user' => 'root',
+    ]);
 
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-        ]);
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+    ]);
 
-        $this->get(route('scripts.show', $script))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('scripts/show'));
-    }
+    $this->get(route('scripts.show', $script))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('scripts/show'));
+});
 
-    public function test_execute_script_as_isolated_user(): void
-    {
-        SSH::fake('script output');
+test('execute script as isolated user', function () {
+    SSH::fake('script output');
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $script = Script::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $script = Script::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-        Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'example',
-        ]);
+    Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'example',
+    ]);
 
-        $this->post(route('scripts.execute', $script), [
-            'server' => $this->server->id,
-            'user' => 'example',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('scripts.execute', $script), [
+        'server' => $this->server->id,
+        'user' => 'example',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('script_executions', [
-            'script_id' => $script->id,
-            'status' => ScriptExecutionStatus::COMPLETED,
-            'user' => 'example',
-        ]);
-    }
+    $this->assertDatabaseHas('script_executions', [
+        'script_id' => $script->id,
+        'status' => ScriptExecutionStatus::COMPLETED,
+        'user' => 'example',
+    ]);
+});
 
-    public function test_cannot_execute_script_as_non_existing_user(): void
-    {
-        $this->actingAs($this->user);
+test('cannot execute script as non existing user', function () {
+    $this->actingAs($this->user);
 
-        $script = Script::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $script = Script::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-        $this->post(route('scripts.execute', $script), [
-            'server' => $this->server->id,
-            'user' => 'example',
-        ])
-            ->assertSessionHasErrors();
+    $this->post(route('scripts.execute', $script), [
+        'server' => $this->server->id,
+        'user' => 'example',
+    ])
+        ->assertSessionHasErrors();
 
-        $this->assertDatabaseMissing('script_executions', [
-            'script_id' => $script->id,
-            'user' => 'example',
-        ]);
-    }
+    $this->assertDatabaseMissing('script_executions', [
+        'script_id' => $script->id,
+        'user' => 'example',
+    ]);
+});
 
-    public function test_cannot_execute_script_as_user_not_on_server(): void
-    {
-        $this->actingAs($this->user);
+test('cannot execute script as user not on server', function () {
+    $this->actingAs($this->user);
 
-        $script = Script::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $script = Script::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-        Site::factory()->create([
-            'server_id' => Server::factory()->create(['user_id' => 1])->id,
-            'user' => 'example',
-        ]);
+    Site::factory()->create([
+        'server_id' => Server::factory()->create(['user_id' => 1])->id,
+        'user' => 'example',
+    ]);
 
-        $this->post(route('scripts.execute', $script), [
-            'server' => $this->server->id,
-            'user' => 'example',
-        ])
-            ->assertSessionHasErrors();
+    $this->post(route('scripts.execute', $script), [
+        'server' => $this->server->id,
+        'user' => 'example',
+    ])
+        ->assertSessionHasErrors();
 
-        $this->assertDatabaseMissing('script_executions', [
-            'script_id' => $script->id,
-            'user' => 'example',
-        ]);
-    }
-}
+    $this->assertDatabaseMissing('script_executions', [
+        'script_id' => $script->id,
+        'user' => 'example',
+    ]);
+});

--- a/tests/Feature/SecurityTest.php
+++ b/tests/Feature/SecurityTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\SecurityControlStatus;
 use App\Enums\ServiceStatus;
 use App\Facades\SSH;
@@ -11,315 +9,293 @@ use App\Services\Fail2ban\Fail2ban;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class SecurityTest extends TestCase
+uses(RefreshDatabase::class);
+
+test('see security page', function () {
+    $this->actingAs($this->user);
+
+    $this->get(route('security', $this->server))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('security/index'));
+});
+
+test('enable auto update', function () {
+    $this->actingAs($this->user);
+
+    $this->post(route('security.auto-update', $this->server), [
+        'enabled' => true,
+        'schedule' => '0 2 * * *',
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'auto_update' => true,
+        'auto_update_schedule' => '0 2 * * *',
+    ]);
+});
+
+test('disable auto update clears schedule', function () {
+    $this->actingAs($this->user);
+    $this->server->update(['auto_update' => true, 'auto_update_schedule' => '0 2 * * *']);
+
+    $this->post(route('security.auto-update', $this->server), [
+        'enabled' => false,
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'auto_update' => false,
+        'auto_update_schedule' => null,
+    ]);
+});
+
+test('invalid schedule is rejected', function () {
+    $this->actingAs($this->user);
+
+    $this->post(route('security.auto-update', $this->server), [
+        'enabled' => true,
+        'schedule' => 'not-a-cron',
+    ])->assertSessionHasErrors('schedule');
+});
+
+test('disable password authentication', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->post(route('security.password-auth', $this->server), [
+        'enabled' => false,
+    ])->assertSessionDoesntHaveErrors();
+
+    SSH::assertExecutedContains('00-vito-hardening.conf');
+    SSH::assertExecutedContains('PasswordAuthentication no');
+
+    $state = $this->server->refresh()->securityState();
+    expect($state['password_authentication']['enabled'])->toBeFalse();
+    expect($state['password_authentication']['status'])->toBe(SecurityControlStatus::READY->value);
+});
+
+test('disable root login', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->server->update(['ssh_user' => 'vito']);
+
+    $this->post(route('security.root-login', $this->server), [
+        'enabled' => false,
+    ])->assertSessionDoesntHaveErrors();
+
+    SSH::assertExecutedContains('00-vito-root-login.conf');
+    SSH::assertExecutedContains('PermitRootLogin no');
+
+    $state = $this->server->refresh()->securityState();
+    expect($state['root_login']['enabled'])->toBeFalse();
+    expect($state['root_login']['status'])->toBe(SecurityControlStatus::READY->value);
+});
+
+test('disabling root login removes root from ssh login users', function () {
+    $this->actingAs($this->user);
+    $this->server->update(['ssh_user' => 'vito']);
+
+    expect($this->server->sshLoginUsers())->toContain('root');
+
+    $this->server->jsonUpdate('feature_data', 'security', ['root_login' => ['enabled' => false]]);
+    $server = $this->server->refresh();
+
+    expect($server->sshLoginUsers())->not->toContain('root');
+    expect($server->sshLoginUsers())->toContain('vito');
+    expect($server->getSshUsers())->toContain('root');
+});
+
+test('cannot disable root login when vito connects as root', function () {
+    $ssh = SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->server->update(['ssh_user' => 'root']);
+
+    $this->post(route('security.root-login', $this->server), [
+        'enabled' => false,
+    ])->assertSessionHasErrors('enabled');
+
+    $ssh->assertNotExecutedContains('PermitRootLogin no');
+    expect($this->server->refresh()->securityState()['root_login']['enabled'])->toBeTrue();
+});
+
+test('score counts controls only when complete', function () {
+    $this->actingAs($this->user);
+
+    $passwordCheck = fn () => collect($this->server->refresh()->securityScore()['checks'])->firstWhere('key', 'password_auth')['passed'];
+
+    $this->server->jsonUpdate('feature_data', 'security', [
+        'password_authentication' => ['enabled' => false, 'status' => SecurityControlStatus::UPDATING->value],
+    ]);
+    expect($passwordCheck())->toBeFalse('In-progress changes must not count toward the score.');
+
+    $this->server->jsonUpdate('feature_data', 'security', [
+        'password_authentication' => ['enabled' => false, 'status' => SecurityControlStatus::READY->value],
+    ]);
+    expect($passwordCheck())->toBeTrue('Completed changes count toward the score.');
+});
+
+test('firewall scores only when ready', function () {
+    $this->actingAs($this->user);
+
+    $firewallCheck = fn () => collect($this->server->refresh()->securityScore()['checks'])->firstWhere('key', 'firewall')['passed'];
+
+    $this->server->firewall()->update(['status' => ServiceStatus::INSTALLING]);
+    expect($firewallCheck())->toBeFalse();
+
+    $this->server->firewall()->update(['status' => ServiceStatus::READY]);
+    expect($firewallCheck())->toBeTrue();
+});
+
+test('root login excluded from score for root user servers', function () {
+    $this->actingAs($this->user);
+
+    $this->server->update(['ssh_user' => 'vito']);
+    expect($this->server->refresh()->securityScore()['total'])->toBe(5);
+
+    $this->server->update(['ssh_user' => 'root']);
+    $score = $this->server->refresh()->securityScore();
+    expect($score['total'])->toBe(4);
+    expect(collect($score['checks'])->firstWhere('key', 'root_login'))->toBeNull();
+});
+
+test('install fail2ban', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->post(route('security.fail2ban.install', $this->server), [
+        'maxretry' => 3,
+        'bantime' => '1h',
+    ])->assertSessionDoesntHaveErrors();
+
+    SSH::assertExecutedContains('apt-get install -y fail2ban');
+    SSH::assertExecutedContains('backend = systemd');
+    SSH::assertExecutedContains('jail.d/vito.local');
+
+    $this->assertDatabaseHas('services', [
+        'server_id' => $this->server->id,
+        'name' => 'fail2ban',
+        'type' => 'fail2ban',
+        'status' => ServiceStatus::READY,
+    ]);
+});
+
+test('fail2ban rejects shell injection in ignoreip', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->post(route('security.fail2ban.install', $this->server), [
+        'ignoreip' => '127.0.0.1 $(touch /tmp/pwned)',
+    ])->assertSessionHasErrors('ignoreip');
+
+    $this->assertDatabaseMissing('services', [
+        'server_id' => $this->server->id,
+        'name' => 'fail2ban',
+    ]);
+});
+
+test('fail2ban rejects newline injection in bantime', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->create([
+        'type' => Fail2ban::type(),
+        'name' => Fail2ban::id(),
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+
+    $this->patch(route('security.fail2ban.update', $this->server), [
+        'bantime' => "10m\nenabled",
+    ])->assertSessionHasErrors('bantime');
+
+    expect($service->fresh())->not->toBeNull();
+});
+
+test('uninstall fail2ban', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->create([
+        'type' => Fail2ban::type(),
+        'name' => Fail2ban::id(),
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+
+    $this->delete(route('security.fail2ban.destroy', $this->server))
+        ->assertSessionDoesntHaveErrors();
+
+    SSH::assertExecutedContains('purge -y fail2ban');
+    $this->assertDatabaseMissing('services', ['id' => $service->id]);
+});
+
+test('install firewall', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->server->services()->where('type', 'firewall')->delete();
+    expect($this->server->refresh()->firewall())->toBeNull();
+
+    $this->post(route('security.firewall.install', $this->server))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('services', [
+        'server_id' => $this->server->id,
+        'name' => 'ufw',
+        'type' => 'firewall',
+        'status' => ServiceStatus::READY,
+    ]);
+});
+
+test('security score reflects applied controls', function () {
+    $this->actingAs($this->user);
+
+    $score = $this->server->securityScore();
+    expect($score['total'])->toBe(5);
+    $firewallCheck = collect($score['checks'])->firstWhere('key', 'firewall');
+    expect($firewallCheck['passed'])->toBeTrue();
+
+    $this->server->update(['auto_update' => true]);
+    $this->server->jsonUpdate('feature_data', 'security', [
+        'password_authentication' => ['enabled' => false],
+    ]);
+
+    $after = $this->server->refresh()->securityScore();
+    expect($after['score'])->toBeGreaterThan($score['score']);
+});
+
+test('auto update runner dispatches only due servers', function () {
+    Queue::fake();
+    $this->travelTo(now()->startOfDay()->setTime(3, 0));
+
+    $this->server->update(['status' => 'ready', 'auto_update' => true, 'auto_update_schedule' => '0 3 * * *']);
+
+    $notDue = Server::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'status' => 'ready',
+        'auto_update' => true,
+        'auto_update_schedule' => '0 4 * * *',
+    ]);
+
+    $this->artisan('servers:auto-update')->assertSuccessful();
+
+    Queue::assertPushed(UpdateJob::class, 1);
+    Queue::assertPushed(UpdateJob::class, fn (UpdateJob $job) => vitoPestFeatureSecurityTestJobServerId($job) === $this->server->id);
+    $this->assertNotEquals($notDue->id, $this->server->id);
+});
+
+function vitoPestFeatureSecurityTestJobServerId(UpdateJob $job): int
 {
-    use RefreshDatabase;
+    $reflection = new ReflectionClass($job);
+    $property = $reflection->getProperty('server');
+    $property->setAccessible(true);
 
-    public function test_see_security_page(): void
-    {
-        $this->actingAs($this->user);
+    /** @var Server $server */
+    $server = $property->getValue($job);
 
-        $this->get(route('security', $this->server))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('security/index'));
-    }
-
-    public function test_enable_auto_update(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->post(route('security.auto-update', $this->server), [
-            'enabled' => true,
-            'schedule' => '0 2 * * *',
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-            'auto_update' => true,
-            'auto_update_schedule' => '0 2 * * *',
-        ]);
-    }
-
-    public function test_disable_auto_update_clears_schedule(): void
-    {
-        $this->actingAs($this->user);
-        $this->server->update(['auto_update' => true, 'auto_update_schedule' => '0 2 * * *']);
-
-        $this->post(route('security.auto-update', $this->server), [
-            'enabled' => false,
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-            'auto_update' => false,
-            'auto_update_schedule' => null,
-        ]);
-    }
-
-    public function test_invalid_schedule_is_rejected(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->post(route('security.auto-update', $this->server), [
-            'enabled' => true,
-            'schedule' => 'not-a-cron',
-        ])->assertSessionHasErrors('schedule');
-    }
-
-    public function test_disable_password_authentication(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->post(route('security.password-auth', $this->server), [
-            'enabled' => false,
-        ])->assertSessionDoesntHaveErrors();
-
-        SSH::assertExecutedContains('00-vito-hardening.conf');
-        SSH::assertExecutedContains('PasswordAuthentication no');
-
-        $state = $this->server->refresh()->securityState();
-        $this->assertFalse($state['password_authentication']['enabled']);
-        $this->assertSame(SecurityControlStatus::READY->value, $state['password_authentication']['status']);
-    }
-
-    public function test_disable_root_login(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->server->update(['ssh_user' => 'vito']);
-
-        $this->post(route('security.root-login', $this->server), [
-            'enabled' => false,
-        ])->assertSessionDoesntHaveErrors();
-
-        SSH::assertExecutedContains('00-vito-root-login.conf');
-        SSH::assertExecutedContains('PermitRootLogin no');
-
-        $state = $this->server->refresh()->securityState();
-        $this->assertFalse($state['root_login']['enabled']);
-        $this->assertSame(SecurityControlStatus::READY->value, $state['root_login']['status']);
-    }
-
-    public function test_disabling_root_login_removes_root_from_ssh_login_users(): void
-    {
-        $this->actingAs($this->user);
-        $this->server->update(['ssh_user' => 'vito']);
-
-        $this->assertContains('root', $this->server->sshLoginUsers());
-
-        $this->server->jsonUpdate('feature_data', 'security', ['root_login' => ['enabled' => false]]);
-        $server = $this->server->refresh();
-
-        $this->assertNotContains('root', $server->sshLoginUsers());
-        $this->assertContains('vito', $server->sshLoginUsers());
-        $this->assertContains('root', $server->getSshUsers());
-    }
-
-    public function test_cannot_disable_root_login_when_vito_connects_as_root(): void
-    {
-        $ssh = SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->server->update(['ssh_user' => 'root']);
-
-        $this->post(route('security.root-login', $this->server), [
-            'enabled' => false,
-        ])->assertSessionHasErrors('enabled');
-
-        $ssh->assertNotExecutedContains('PermitRootLogin no');
-        $this->assertTrue($this->server->refresh()->securityState()['root_login']['enabled']);
-    }
-
-    public function test_score_counts_controls_only_when_complete(): void
-    {
-        $this->actingAs($this->user);
-
-        $passwordCheck = fn () => collect($this->server->refresh()->securityScore()['checks'])->firstWhere('key', 'password_auth')['passed'];
-
-        $this->server->jsonUpdate('feature_data', 'security', [
-            'password_authentication' => ['enabled' => false, 'status' => SecurityControlStatus::UPDATING->value],
-        ]);
-        $this->assertFalse($passwordCheck(), 'In-progress changes must not count toward the score.');
-
-        $this->server->jsonUpdate('feature_data', 'security', [
-            'password_authentication' => ['enabled' => false, 'status' => SecurityControlStatus::READY->value],
-        ]);
-        $this->assertTrue($passwordCheck(), 'Completed changes count toward the score.');
-    }
-
-    public function test_firewall_scores_only_when_ready(): void
-    {
-        $this->actingAs($this->user);
-
-        $firewallCheck = fn () => collect($this->server->refresh()->securityScore()['checks'])->firstWhere('key', 'firewall')['passed'];
-
-        $this->server->firewall()->update(['status' => ServiceStatus::INSTALLING]);
-        $this->assertFalse($firewallCheck());
-
-        $this->server->firewall()->update(['status' => ServiceStatus::READY]);
-        $this->assertTrue($firewallCheck());
-    }
-
-    public function test_root_login_excluded_from_score_for_root_user_servers(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->server->update(['ssh_user' => 'vito']);
-        $this->assertSame(5, $this->server->refresh()->securityScore()['total']);
-
-        $this->server->update(['ssh_user' => 'root']);
-        $score = $this->server->refresh()->securityScore();
-        $this->assertSame(4, $score['total']);
-        $this->assertNull(collect($score['checks'])->firstWhere('key', 'root_login'));
-    }
-
-    public function test_install_fail2ban(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->post(route('security.fail2ban.install', $this->server), [
-            'maxretry' => 3,
-            'bantime' => '1h',
-        ])->assertSessionDoesntHaveErrors();
-
-        SSH::assertExecutedContains('apt-get install -y fail2ban');
-        SSH::assertExecutedContains('backend = systemd');
-        SSH::assertExecutedContains('jail.d/vito.local');
-
-        $this->assertDatabaseHas('services', [
-            'server_id' => $this->server->id,
-            'name' => 'fail2ban',
-            'type' => 'fail2ban',
-            'status' => ServiceStatus::READY,
-        ]);
-    }
-
-    public function test_fail2ban_rejects_shell_injection_in_ignoreip(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->post(route('security.fail2ban.install', $this->server), [
-            'ignoreip' => '127.0.0.1 $(touch /tmp/pwned)',
-        ])->assertSessionHasErrors('ignoreip');
-
-        $this->assertDatabaseMissing('services', [
-            'server_id' => $this->server->id,
-            'name' => 'fail2ban',
-        ]);
-    }
-
-    public function test_fail2ban_rejects_newline_injection_in_bantime(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->create([
-            'type' => Fail2ban::type(),
-            'name' => Fail2ban::id(),
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-
-        $this->patch(route('security.fail2ban.update', $this->server), [
-            'bantime' => "10m\nenabled",
-        ])->assertSessionHasErrors('bantime');
-
-        $this->assertNotNull($service->fresh());
-    }
-
-    public function test_uninstall_fail2ban(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->create([
-            'type' => Fail2ban::type(),
-            'name' => Fail2ban::id(),
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-
-        $this->delete(route('security.fail2ban.destroy', $this->server))
-            ->assertSessionDoesntHaveErrors();
-
-        SSH::assertExecutedContains('purge -y fail2ban');
-        $this->assertDatabaseMissing('services', ['id' => $service->id]);
-    }
-
-    public function test_install_firewall(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->server->services()->where('type', 'firewall')->delete();
-        $this->assertNull($this->server->refresh()->firewall());
-
-        $this->post(route('security.firewall.install', $this->server))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('services', [
-            'server_id' => $this->server->id,
-            'name' => 'ufw',
-            'type' => 'firewall',
-            'status' => ServiceStatus::READY,
-        ]);
-    }
-
-    public function test_security_score_reflects_applied_controls(): void
-    {
-        $this->actingAs($this->user);
-
-        $score = $this->server->securityScore();
-        $this->assertSame(5, $score['total']);
-        $firewallCheck = collect($score['checks'])->firstWhere('key', 'firewall');
-        $this->assertTrue($firewallCheck['passed']);
-
-        $this->server->update(['auto_update' => true]);
-        $this->server->jsonUpdate('feature_data', 'security', [
-            'password_authentication' => ['enabled' => false],
-        ]);
-
-        $after = $this->server->refresh()->securityScore();
-        $this->assertGreaterThan($score['score'], $after['score']);
-    }
-
-    public function test_auto_update_runner_dispatches_only_due_servers(): void
-    {
-        Queue::fake();
-        $this->travelTo(now()->startOfDay()->setTime(3, 0));
-
-        $this->server->update(['status' => 'ready', 'auto_update' => true, 'auto_update_schedule' => '0 3 * * *']);
-
-        $notDue = Server::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'status' => 'ready',
-            'auto_update' => true,
-            'auto_update_schedule' => '0 4 * * *',
-        ]);
-
-        $this->artisan('servers:auto-update')->assertSuccessful();
-
-        Queue::assertPushed(UpdateJob::class, 1);
-        Queue::assertPushed(UpdateJob::class, fn (UpdateJob $job) => $this->jobServerId($job) === $this->server->id);
-        $this->assertNotEquals($notDue->id, $this->server->id);
-    }
-
-    private function jobServerId(UpdateJob $job): int
-    {
-        $reflection = new \ReflectionClass($job);
-        $property = $reflection->getProperty('server');
-        $property->setAccessible(true);
-
-        /** @var Server $server */
-        $server = $property->getValue($job);
-
-        return $server->id;
-    }
+    return $server->id;
 }

--- a/tests/Feature/SecurityTest.php
+++ b/tests/Feature/SecurityTest.php
@@ -285,14 +285,13 @@ test('auto update runner dispatches only due servers', function () {
 
     Queue::assertPushed(UpdateJob::class, 1);
     Queue::assertPushed(UpdateJob::class, fn (UpdateJob $job) => vitoPestFeatureSecurityTestJobServerId($job) === $this->server->id);
-    $this->assertNotEquals($notDue->id, $this->server->id);
+    Queue::assertNotPushed(UpdateJob::class, fn (UpdateJob $job) => vitoPestFeatureSecurityTestJobServerId($job) === $notDue->id);
 });
 
 function vitoPestFeatureSecurityTestJobServerId(UpdateJob $job): int
 {
     $reflection = new ReflectionClass($job);
     $property = $reflection->getProperty('server');
-    $property->setAccessible(true);
 
     /** @var Server $server */
     $server = $property->getValue($job);

--- a/tests/Feature/ServerKeysTest.php
+++ b/tests/Feature/ServerKeysTest.php
@@ -1,132 +1,121 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\SshKeyStatus;
 use App\Facades\SSH;
 use App\Models\SshKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class ServerKeysTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_see_server_keys(): void
-    {
-        $this->actingAs($this->user);
+test('see server keys', function () {
+    $this->actingAs($this->user);
 
-        $sshKey = SshKey::factory()->create([
-            'user_id' => $this->user->id,
-            'name' => 'My first key',
-            'public_key' => 'public-key-content',
-        ]);
+    $sshKey = SshKey::factory()->create([
+        'user_id' => $this->user->id,
+        'name' => 'My first key',
+        'public_key' => 'public-key-content',
+    ]);
 
-        $this->server->sshKeys()->attach($sshKey, [
-            'status' => SshKeyStatus::ADDED,
-            'user' => $this->server->getSshUser(),
-        ]);
+    $this->server->sshKeys()->attach($sshKey, [
+        'status' => SshKeyStatus::ADDED,
+        'user' => $this->server->getSshUser(),
+    ]);
 
-        $this->get(route('server-ssh-keys', ['server' => $this->server->id]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('server-ssh-keys/index'));
-    }
+    $this->get(route('server-ssh-keys', ['server' => $this->server->id]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('server-ssh-keys/index'));
+});
 
-    public function test_delete_ssh_key(): void
-    {
-        SSH::fake();
+test('delete ssh key', function () {
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $sshKey = SshKey::factory()->create([
-            'user_id' => $this->user->id,
-            'name' => 'My first key',
-            'public_key' => 'public-key-content',
-        ]);
+    $sshKey = SshKey::factory()->create([
+        'user_id' => $this->user->id,
+        'name' => 'My first key',
+        'public_key' => 'public-key-content',
+    ]);
 
-        $this->server->sshKeys()->attach($sshKey, [
-            'status' => SshKeyStatus::ADDED,
-            'user' => $this->server->getSshUser(),
-        ]);
+    $this->server->sshKeys()->attach($sshKey, [
+        'status' => SshKeyStatus::ADDED,
+        'user' => $this->server->getSshUser(),
+    ]);
 
-        $this->delete(route('server-ssh-keys.destroy', ['server' => $this->server->id, 'sshKey' => $sshKey->id]))
-            ->assertSessionDoesntHaveErrors();
+    $this->delete(route('server-ssh-keys.destroy', ['server' => $this->server->id, 'sshKey' => $sshKey->id]))
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseMissing('server_ssh_keys', [
-            'server_id' => $this->server->id,
-            'ssh_key_id' => $sshKey->id,
-        ]);
-    }
+    $this->assertDatabaseMissing('server_ssh_keys', [
+        'server_id' => $this->server->id,
+        'ssh_key_id' => $sshKey->id,
+    ]);
+});
 
-    public function test_add_existing_key(): void
-    {
-        SSH::fake();
+test('add existing key', function () {
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $sshKey = SshKey::factory()->create([
-            'user_id' => $this->user->id,
-            'name' => 'My first key',
-            'public_key' => 'public-key-content',
-        ]);
+    $sshKey = SshKey::factory()->create([
+        'user_id' => $this->user->id,
+        'name' => 'My first key',
+        'public_key' => 'public-key-content',
+    ]);
 
-        $this->post(route('server-ssh-keys.store', ['server' => $this->server->id]), [
-            'key' => $sshKey->id,
-            'user' => $this->server->getSshUser(),
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('server-ssh-keys.store', ['server' => $this->server->id]), [
+        'key' => $sshKey->id,
+        'user' => $this->server->getSshUser(),
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('server_ssh_keys', [
-            'server_id' => $this->server->id,
-            'status' => SshKeyStatus::ADDED,
-            'user' => $this->server->getSshUser(),
-        ]);
-    }
+    $this->assertDatabaseHas('server_ssh_keys', [
+        'server_id' => $this->server->id,
+        'status' => SshKeyStatus::ADDED,
+        'user' => $this->server->getSshUser(),
+    ]);
+});
 
-    public function test_add_key_to_specific_user(): void
-    {
-        SSH::fake();
+test('add key to specific user', function () {
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $sshKey = SshKey::factory()->create([
-            'user_id' => $this->user->id,
-            'name' => 'My first key',
-            'public_key' => 'public-key-content',
-        ]);
+    $sshKey = SshKey::factory()->create([
+        'user_id' => $this->user->id,
+        'name' => 'My first key',
+        'public_key' => 'public-key-content',
+    ]);
 
-        $targetUser = 'root';
+    $targetUser = 'root';
 
-        $this->post(route('server-ssh-keys.store', ['server' => $this->server->id]), [
-            'key' => $sshKey->id,
-            'user' => $targetUser,
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('server-ssh-keys.store', ['server' => $this->server->id]), [
+        'key' => $sshKey->id,
+        'user' => $targetUser,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('server_ssh_keys', [
-            'server_id' => $this->server->id,
-            'status' => SshKeyStatus::ADDED,
-            'user' => $targetUser,
-        ]);
-    }
+    $this->assertDatabaseHas('server_ssh_keys', [
+        'server_id' => $this->server->id,
+        'status' => SshKeyStatus::ADDED,
+        'user' => $targetUser,
+    ]);
+});
 
-    public function test_add_key_to_invalid_user_fails(): void
-    {
-        SSH::fake();
+test('add key to invalid user fails', function () {
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $sshKey = SshKey::factory()->create([
-            'user_id' => $this->user->id,
-            'name' => 'My first key',
-            'public_key' => 'public-key-content',
-        ]);
+    $sshKey = SshKey::factory()->create([
+        'user_id' => $this->user->id,
+        'name' => 'My first key',
+        'public_key' => 'public-key-content',
+    ]);
 
-        $this->post(route('server-ssh-keys.store', ['server' => $this->server->id]), [
-            'key' => $sshKey->id,
-            'user' => 'invalid-user',
-        ])
-            ->assertSessionHasErrors(['user']);
-    }
-}
+    $this->post(route('server-ssh-keys.store', ['server' => $this->server->id]), [
+        'key' => $sshKey->id,
+        'user' => 'invalid-user',
+    ])
+        ->assertSessionHasErrors(['user']);
+});

--- a/tests/Feature/ServerNetworkTest.php
+++ b/tests/Feature/ServerNetworkTest.php
@@ -1,379 +1,357 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\IpAddressStatus;
 use App\Enums\IpAddressType;
 use App\Facades\SSH;
 use App\Models\ServerIpAddress;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class ServerNetworkTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_see_network_page(): void
-    {
-        $this->actingAs($this->user);
+test('see network page', function () {
+    $this->actingAs($this->user);
 
-        ServerIpAddress::factory()->create([
+    ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->get(route('servers.network', $this->server))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('server-network/index'));
+});
+
+test('add ip address', function () {
+    SSH::fake('[]');
+
+    $this->actingAs($this->user);
+
+    $this->post(route('servers.network.ips.store', ['server' => $this->server]), [
+        'ip' => '203.0.113.10',
+        'prefix_length' => '32',
+        'interface' => 'eth0',
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('server_ip_addresses', [
+        'server_id' => $this->server->id,
+        'ip' => '203.0.113.10',
+        'is_managed' => true,
+        'status' => IpAddressStatus::CONFIGURED,
+        'type' => IpAddressType::PUBLIC,
+    ]);
+
+    SSH::assertExecutedContains('netplan apply');
+});
+
+test('add ipv4 without prefix defaults to 32', function () {
+    SSH::fake('[]');
+
+    $this->actingAs($this->user);
+
+    $this->post(route('servers.network.ips.store', ['server' => $this->server]), [
+        'ip' => '203.0.113.20',
+        'interface' => 'eth0',
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('server_ip_addresses', [
+        'ip' => '203.0.113.20',
+        'prefix_length' => 32,
+    ]);
+});
+
+test('add ipv6 without prefix defaults to 64', function () {
+    SSH::fake('[]');
+
+    $this->actingAs($this->user);
+
+    $this->post(route('servers.network.ips.store', ['server' => $this->server]), [
+        'ip' => '2a01:4f9:c010:b550::2',
+        'interface' => 'eth0',
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('server_ip_addresses', [
+        'ip' => '2a01:4f9:c010:b550::2',
+        'prefix_length' => 64,
+    ]);
+});
+
+test('added ip is merged with existing static addresses', function () {
+    $this->server->update(['ip' => '203.0.113.10']);
+
+    SSH::fake(json_encode([
+        [
+            'ifname' => 'eth0',
+            'addr_info' => [
+                ['family' => 'inet', 'local' => '203.0.113.10', 'prefixlen' => 32, 'scope' => 'global', 'dynamic' => true],
+                ['family' => 'inet6', 'local' => '2a01:4f9:c010:b550::1', 'prefixlen' => 64, 'scope' => 'global'],
+            ],
+        ],
+    ]) ?: '');
+
+    $this->actingAs($this->user);
+
+    $this->post(route('servers.network.ips.store', ['server' => $this->server]), [
+        'ip' => '2a01:4f9:c010:b550::2',
+        'interface' => 'eth0',
+    ])->assertSessionDoesntHaveErrors();
+
+    $content = SSH::getUploadedContent();
+
+    $this->assertStringContainsString('2a01:4f9:c010:b550::2/64', $content);
+    $this->assertStringContainsString('2a01:4f9:c010:b550::1/64', $content);
+    $this->assertStringNotContainsString('203.0.113.10', $content);
+});
+
+test('add ip range creates a row per address', function () {
+    SSH::fake('[]');
+
+    $this->actingAs($this->user);
+
+    $this->post(route('servers.network.ips.store', ['server' => $this->server]), [
+        'ip' => '203.0.113.10',
+        'ip_last' => '203.0.113.13',
+        'interface' => 'eth0',
+    ])->assertSessionDoesntHaveErrors();
+
+    foreach (['203.0.113.10', '203.0.113.11', '203.0.113.12', '203.0.113.13'] as $ip) {
+        $this->assertDatabaseHas('server_ip_addresses', [
             'server_id' => $this->server->id,
+            'ip' => $ip,
+            'is_managed' => true,
         ]);
-
-        $this->get(route('servers.network', $this->server))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('server-network/index'));
     }
+});
 
-    public function test_add_ip_address(): void
-    {
-        SSH::fake('[]');
+test('add ip range rejects first after last', function () {
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $this->from(route('servers.network', $this->server))
+        ->post(route('servers.network.ips.store', ['server' => $this->server]), [
+            'ip' => '203.0.113.20',
+            'ip_last' => '203.0.113.10',
+            'interface' => 'eth0',
+        ])
+        ->assertSessionHasErrors(['ip_last']);
+});
 
-        $this->post(route('servers.network.ips.store', ['server' => $this->server]), [
-            'ip' => '203.0.113.10',
+test('add ip range rejects oversized range', function () {
+    $this->actingAs($this->user);
+
+    $this->from(route('servers.network', $this->server))
+        ->post(route('servers.network.ips.store', ['server' => $this->server]), [
+            'ip' => '10.0.0.0',
+            'ip_last' => '10.0.5.0',
+            'interface' => 'eth0',
+        ])
+        ->assertSessionHasErrors(['ip_last']);
+});
+
+test('add ip address rejects invalid ip', function () {
+    $this->actingAs($this->user);
+
+    $this->from(route('servers.network', $this->server))
+        ->post(route('servers.network.ips.store', ['server' => $this->server]), [
+            'ip' => 'not-an-ip',
             'prefix_length' => '32',
             'interface' => 'eth0',
-        ])->assertSessionDoesntHaveErrors();
+        ])
+        ->assertSessionHasErrors(['ip']);
+});
 
-        $this->assertDatabaseHas('server_ip_addresses', [
-            'server_id' => $this->server->id,
+test('add ipv4 rejects prefix over 32', function () {
+    $this->actingAs($this->user);
+
+    $this->from(route('servers.network', $this->server))
+        ->post(route('servers.network.ips.store', ['server' => $this->server]), [
             'ip' => '203.0.113.10',
-            'is_managed' => true,
-            'status' => IpAddressStatus::CONFIGURED,
-            'type' => IpAddressType::PUBLIC,
-        ]);
-
-        SSH::assertExecutedContains('netplan apply');
-    }
-
-    public function test_add_ipv4_without_prefix_defaults_to_32(): void
-    {
-        SSH::fake('[]');
-
-        $this->actingAs($this->user);
-
-        $this->post(route('servers.network.ips.store', ['server' => $this->server]), [
-            'ip' => '203.0.113.20',
+            'prefix_length' => '40',
             'interface' => 'eth0',
-        ])->assertSessionDoesntHaveErrors();
+        ])
+        ->assertSessionHasErrors(['prefix_length']);
+});
 
-        $this->assertDatabaseHas('server_ip_addresses', [
-            'ip' => '203.0.113.20',
-            'prefix_length' => 32,
-        ]);
-    }
+test('delete managed ip address', function () {
+    SSH::fake('[]');
 
-    public function test_add_ipv6_without_prefix_defaults_to_64(): void
-    {
-        SSH::fake('[]');
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $address = ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'is_managed' => true,
+    ]);
 
-        $this->post(route('servers.network.ips.store', ['server' => $this->server]), [
-            'ip' => '2a01:4f9:c010:b550::2',
-            'interface' => 'eth0',
-        ])->assertSessionDoesntHaveErrors();
+    $this->delete(route('servers.network.ips.destroy', [
+        'server' => $this->server,
+        'serverIpAddress' => $address,
+    ]))->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('server_ip_addresses', [
-            'ip' => '2a01:4f9:c010:b550::2',
-            'prefix_length' => 64,
-        ]);
-    }
+    $this->assertDatabaseMissing('server_ip_addresses', [
+        'id' => $address->id,
+    ]);
+});
 
-    public function test_added_ip_is_merged_with_existing_static_addresses(): void
-    {
-        $this->server->update(['ip' => '203.0.113.10']);
+test('set ip as primary updates server ip', function () {
+    $this->actingAs($this->user);
 
-        SSH::fake(json_encode([
-            [
-                'ifname' => 'eth0',
-                'addr_info' => [
-                    ['family' => 'inet', 'local' => '203.0.113.10', 'prefixlen' => 32, 'scope' => 'global', 'dynamic' => true],
-                    ['family' => 'inet6', 'local' => '2a01:4f9:c010:b550::1', 'prefixlen' => 64, 'scope' => 'global'],
-                ],
-            ],
-        ]) ?: '');
+    $address = ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'ip' => '203.0.113.50',
+        'type' => IpAddressType::PUBLIC,
+        'is_primary' => false,
+    ]);
 
-        $this->actingAs($this->user);
+    $this->post(route('servers.network.ips.primary', [
+        'server' => $this->server,
+        'serverIpAddress' => $address,
+    ]))->assertSessionDoesntHaveErrors();
 
-        $this->post(route('servers.network.ips.store', ['server' => $this->server]), [
-            'ip' => '2a01:4f9:c010:b550::2',
-            'interface' => 'eth0',
-        ])->assertSessionDoesntHaveErrors();
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'ip' => '203.0.113.50',
+    ]);
 
-        $content = SSH::getUploadedContent();
+    $this->assertDatabaseHas('server_ip_addresses', [
+        'id' => $address->id,
+        'is_primary' => true,
+    ]);
+});
 
-        $this->assertStringContainsString('2a01:4f9:c010:b550::2/64', $content);
-        $this->assertStringContainsString('2a01:4f9:c010:b550::1/64', $content);
-        $this->assertStringNotContainsString('203.0.113.10', $content);
-    }
+test('cannot delete discovered ip address', function () {
+    $this->actingAs($this->user);
 
-    public function test_add_ip_range_creates_a_row_per_address(): void
-    {
-        SSH::fake('[]');
+    $address = ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'is_managed' => false,
+    ]);
 
-        $this->actingAs($this->user);
-
-        $this->post(route('servers.network.ips.store', ['server' => $this->server]), [
-            'ip' => '203.0.113.10',
-            'ip_last' => '203.0.113.13',
-            'interface' => 'eth0',
-        ])->assertSessionDoesntHaveErrors();
-
-        foreach (['203.0.113.10', '203.0.113.11', '203.0.113.12', '203.0.113.13'] as $ip) {
-            $this->assertDatabaseHas('server_ip_addresses', [
-                'server_id' => $this->server->id,
-                'ip' => $ip,
-                'is_managed' => true,
-            ]);
-        }
-    }
-
-    public function test_add_ip_range_rejects_first_after_last(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->from(route('servers.network', $this->server))
-            ->post(route('servers.network.ips.store', ['server' => $this->server]), [
-                'ip' => '203.0.113.20',
-                'ip_last' => '203.0.113.10',
-                'interface' => 'eth0',
-            ])
-            ->assertSessionHasErrors(['ip_last']);
-    }
-
-    public function test_add_ip_range_rejects_oversized_range(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->from(route('servers.network', $this->server))
-            ->post(route('servers.network.ips.store', ['server' => $this->server]), [
-                'ip' => '10.0.0.0',
-                'ip_last' => '10.0.5.0',
-                'interface' => 'eth0',
-            ])
-            ->assertSessionHasErrors(['ip_last']);
-    }
-
-    public function test_add_ip_address_rejects_invalid_ip(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->from(route('servers.network', $this->server))
-            ->post(route('servers.network.ips.store', ['server' => $this->server]), [
-                'ip' => 'not-an-ip',
-                'prefix_length' => '32',
-                'interface' => 'eth0',
-            ])
-            ->assertSessionHasErrors(['ip']);
-    }
-
-    public function test_add_ipv4_rejects_prefix_over_32(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->from(route('servers.network', $this->server))
-            ->post(route('servers.network.ips.store', ['server' => $this->server]), [
-                'ip' => '203.0.113.10',
-                'prefix_length' => '40',
-                'interface' => 'eth0',
-            ])
-            ->assertSessionHasErrors(['prefix_length']);
-    }
-
-    public function test_delete_managed_ip_address(): void
-    {
-        SSH::fake('[]');
-
-        $this->actingAs($this->user);
-
-        $address = ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'is_managed' => true,
-        ]);
-
-        $this->delete(route('servers.network.ips.destroy', [
+    $this->from(route('servers.network', $this->server))
+        ->delete(route('servers.network.ips.destroy', [
             'server' => $this->server,
             'serverIpAddress' => $address,
-        ]))->assertSessionDoesntHaveErrors();
+        ]))
+        ->assertSessionHasErrors(['ip']);
 
-        $this->assertDatabaseMissing('server_ip_addresses', [
-            'id' => $address->id,
-        ]);
-    }
+    $this->assertDatabaseHas('server_ip_addresses', [
+        'id' => $address->id,
+    ]);
+});
 
-    public function test_set_ip_as_primary_updates_server_ip(): void
-    {
-        $this->actingAs($this->user);
+test('refresh pulls ips from server', function () {
+    $this->server->update(['ip' => '203.0.113.10']);
 
-        $address = ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'ip' => '203.0.113.50',
-            'type' => IpAddressType::PUBLIC,
-            'is_primary' => false,
-        ]);
+    SSH::fake(vitoPestFeatureServerNetworkTestIpAddrJson());
 
-        $this->post(route('servers.network.ips.primary', [
-            'server' => $this->server,
-            'serverIpAddress' => $address,
-        ]))->assertSessionDoesntHaveErrors();
+    $this->actingAs($this->user);
 
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-            'ip' => '203.0.113.50',
-        ]);
+    $this->post(route('servers.network.refresh', ['server' => $this->server]))
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('server_ip_addresses', [
-            'id' => $address->id,
-            'is_primary' => true,
-        ]);
-    }
+    $this->assertDatabaseHas('server_ip_addresses', [
+        'server_id' => $this->server->id,
+        'ip' => '203.0.113.10',
+        'interface' => 'eth0',
+        'is_managed' => false,
+        'is_primary' => true,
+        'type' => IpAddressType::PUBLIC,
+    ]);
 
-    public function test_cannot_delete_discovered_ip_address(): void
-    {
-        $this->actingAs($this->user);
+    $this->assertDatabaseHas('server_ip_addresses', [
+        'server_id' => $this->server->id,
+        'ip' => '10.0.0.5',
+        'type' => IpAddressType::PRIVATE,
+    ]);
 
-        $address = ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'is_managed' => false,
-        ]);
+    $this->assertDatabaseMissing('server_ip_addresses', [
+        'server_id' => $this->server->id,
+        'ip' => '127.0.0.1',
+    ]);
 
-        $this->from(route('servers.network', $this->server))
-            ->delete(route('servers.network.ips.destroy', [
-                'server' => $this->server,
-                'serverIpAddress' => $address,
-            ]))
-            ->assertSessionHasErrors(['ip']);
+    $this->assertDatabaseMissing('server_ip_addresses', [
+        'server_id' => $this->server->id,
+        'ip' => 'fe80::1',
+    ]);
+});
 
-        $this->assertDatabaseHas('server_ip_addresses', [
-            'id' => $address->id,
-        ]);
-    }
+test('refresh resyncs managed row fields but not status', function () {
+    $address = ServerIpAddress::factory()->create([
+        'server_id' => $this->server->id,
+        'ip' => '203.0.113.77',
+        'interface' => 'old0',
+        'prefix_length' => 24,
+        'status' => IpAddressStatus::CONFIGURING,
+        'is_managed' => true,
+    ]);
 
-    public function test_refresh_pulls_ips_from_server(): void
-    {
-        $this->server->update(['ip' => '203.0.113.10']);
-
-        SSH::fake($this->ipAddrJson());
-
-        $this->actingAs($this->user);
-
-        $this->post(route('servers.network.refresh', ['server' => $this->server]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('server_ip_addresses', [
-            'server_id' => $this->server->id,
-            'ip' => '203.0.113.10',
-            'interface' => 'eth0',
-            'is_managed' => false,
-            'is_primary' => true,
-            'type' => IpAddressType::PUBLIC,
-        ]);
-
-        $this->assertDatabaseHas('server_ip_addresses', [
-            'server_id' => $this->server->id,
-            'ip' => '10.0.0.5',
-            'type' => IpAddressType::PRIVATE,
-        ]);
-
-        $this->assertDatabaseMissing('server_ip_addresses', [
-            'server_id' => $this->server->id,
-            'ip' => '127.0.0.1',
-        ]);
-
-        $this->assertDatabaseMissing('server_ip_addresses', [
-            'server_id' => $this->server->id,
-            'ip' => 'fe80::1',
-        ]);
-    }
-
-    public function test_refresh_resyncs_managed_row_fields_but_not_status(): void
-    {
-        $address = ServerIpAddress::factory()->create([
-            'server_id' => $this->server->id,
-            'ip' => '203.0.113.77',
-            'interface' => 'old0',
-            'prefix_length' => 24,
-            'status' => IpAddressStatus::CONFIGURING,
-            'is_managed' => true,
-        ]);
-
-        SSH::fake(json_encode([
-            [
-                'ifname' => 'eth0',
-                'addr_info' => [
-                    ['family' => 'inet', 'local' => '203.0.113.77', 'prefixlen' => 32, 'scope' => 'global'],
-                ],
+    SSH::fake(json_encode([
+        [
+            'ifname' => 'eth0',
+            'addr_info' => [
+                ['family' => 'inet', 'local' => '203.0.113.77', 'prefixlen' => 32, 'scope' => 'global'],
             ],
-        ]) ?: '');
+        ],
+    ]) ?: '');
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->post(route('servers.network.refresh', ['server' => $this->server]))
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('servers.network.refresh', ['server' => $this->server]))
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('server_ip_addresses', [
-            'id' => $address->id,
-            'interface' => 'eth0',
-            'prefix_length' => 32,
-            'is_managed' => true,
-            'status' => IpAddressStatus::CONFIGURING,
-        ]);
-    }
+    $this->assertDatabaseHas('server_ip_addresses', [
+        'id' => $address->id,
+        'interface' => 'eth0',
+        'prefix_length' => 32,
+        'is_managed' => true,
+        'status' => IpAddressStatus::CONFIGURING,
+    ]);
+});
 
-    public function test_refresh_marks_vito_managed_ips_from_marker(): void
-    {
-        $output = (json_encode([
-            [
-                'ifname' => 'eth0',
-                'addr_info' => [
-                    ['family' => 'inet', 'local' => '203.0.113.50', 'prefixlen' => 32, 'scope' => 'global'],
-                    ['family' => 'inet', 'local' => '203.0.113.99', 'prefixlen' => 32, 'scope' => 'global'],
-                ],
+test('refresh marks vito managed ips from marker', function () {
+    $output = (json_encode([
+        [
+            'ifname' => 'eth0',
+            'addr_info' => [
+                ['family' => 'inet', 'local' => '203.0.113.50', 'prefixlen' => 32, 'scope' => 'global'],
+                ['family' => 'inet', 'local' => '203.0.113.99', 'prefixlen' => 32, 'scope' => 'global'],
             ],
-        ]) ?: '')."\n===VITO-MANAGED===\n# vito-managed: 203.0.113.50\n";
+        ],
+    ]) ?: '')."\n===VITO-MANAGED===\n# vito-managed: 203.0.113.50\n";
 
-        SSH::fake($output);
+    SSH::fake($output);
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->post(route('servers.network.refresh', ['server' => $this->server]))
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('servers.network.refresh', ['server' => $this->server]))
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('server_ip_addresses', [
-            'server_id' => $this->server->id,
-            'ip' => '203.0.113.50',
-            'is_managed' => true,
-        ]);
+    $this->assertDatabaseHas('server_ip_addresses', [
+        'server_id' => $this->server->id,
+        'ip' => '203.0.113.50',
+        'is_managed' => true,
+    ]);
 
-        $this->assertDatabaseHas('server_ip_addresses', [
-            'server_id' => $this->server->id,
-            'ip' => '203.0.113.99',
-            'is_managed' => false,
-        ]);
-    }
+    $this->assertDatabaseHas('server_ip_addresses', [
+        'server_id' => $this->server->id,
+        'ip' => '203.0.113.99',
+        'is_managed' => false,
+    ]);
+});
 
-    private function ipAddrJson(): string
-    {
-        return json_encode([
-            [
-                'ifname' => 'lo',
-                'addr_info' => [
-                    ['family' => 'inet', 'local' => '127.0.0.1', 'prefixlen' => 8, 'scope' => 'host'],
-                ],
+function vitoPestFeatureServerNetworkTestIpAddrJson(): string
+{
+    return json_encode([
+        [
+            'ifname' => 'lo',
+            'addr_info' => [
+                ['family' => 'inet', 'local' => '127.0.0.1', 'prefixlen' => 8, 'scope' => 'host'],
             ],
-            [
-                'ifname' => 'eth0',
-                'addr_info' => [
-                    ['family' => 'inet', 'local' => '203.0.113.10', 'prefixlen' => 32, 'scope' => 'global'],
-                    ['family' => 'inet', 'local' => '10.0.0.5', 'prefixlen' => 24, 'scope' => 'global'],
-                    ['family' => 'inet6', 'local' => 'fe80::1', 'prefixlen' => 64, 'scope' => 'link'],
-                ],
+        ],
+        [
+            'ifname' => 'eth0',
+            'addr_info' => [
+                ['family' => 'inet', 'local' => '203.0.113.10', 'prefixlen' => 32, 'scope' => 'global'],
+                ['family' => 'inet', 'local' => '10.0.0.5', 'prefixlen' => 24, 'scope' => 'global'],
+                ['family' => 'inet6', 'local' => 'fe80::1', 'prefixlen' => 64, 'scope' => 'link'],
             ],
-        ]) ?: '';
-    }
+        ],
+    ]) ?: '';
 }

--- a/tests/Feature/ServerProvidersTest.php
+++ b/tests/Feature/ServerProvidersTest.php
@@ -478,18 +478,8 @@ test('linode plans grey classes unsupported by region', function () {
     $this->assertStringNotContainsString('/mo', $plans['g7-premium-2']['label']);
 });
 
-/**
- * @return array<string, array<int, array<string, mixed>>>
- */
-dataset('data', function () {
+dataset('data', /** @return array<int, array{0: string, 1: array<string, mixed>}> */ function (): array {
     return [
-        // [
-        //     ServerProvider::AWS,
-        //     [
-        //         'key' => 'key',
-        //         'secret' => 'secret',
-        //     ],
-        // ],
         [
             Linode::id(),
             [

--- a/tests/Feature/ServerProvidersTest.php
+++ b/tests/Feature/ServerProvidersTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Events\SocketEvent;
 use App\Models\ServerProvider;
 use App\Models\User;
@@ -13,549 +11,515 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Inertia\Testing\AssertableInertia;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class ServerProvidersTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    /**
-     * @param  array<string, mixed>  $input
-     */
-    #[DataProvider('data')]
-    public function test_connect_provider(string $provider, array $input): void
-    {
-        $this->actingAs($this->user);
+test('connect provider', function (string $provider, array $input) {
+    $this->actingAs($this->user);
 
-        Http::fake();
+    Http::fake();
 
-        $data = array_merge(
-            [
-                'provider' => $provider,
-                'name' => 'profile',
-            ],
-            $input
-        );
-        $this->post(route('server-providers.store'), $data)
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('server_providers', [
+    $data = array_merge(
+        [
             'provider' => $provider,
-            'profile' => 'profile',
-            'project_id' => isset($input['global']) ? null : $this->user->current_project_id,
-        ]);
-    }
+            'name' => 'profile',
+        ],
+        $input
+    );
+    $this->post(route('server-providers.store'), $data)
+        ->assertSessionDoesntHaveErrors();
 
-    /**
-     * @param  array<string, mixed>  $input
-     */
-    #[DataProvider('data')]
-    public function test_cannot_connect_to_provider(string $provider, array $input): void
-    {
-        $this->actingAs($this->user);
+    $this->assertDatabaseHas('server_providers', [
+        'provider' => $provider,
+        'profile' => 'profile',
+        'project_id' => isset($input['global']) ? null : $this->user->current_project_id,
+    ]);
+})->with('data');
 
-        Http::fake([
-            '*' => Http::response([], 401),
-        ]);
+test('cannot connect to provider', function (string $provider, array $input) {
+    $this->actingAs($this->user);
 
-        $data = array_merge(
-            [
-                'provider' => $provider,
-                'name' => 'profile',
-            ],
-            $input
-        );
-        $this->post(route('server-providers.store'), $data)
-            ->assertSessionHasErrors('provider');
+    Http::fake([
+        '*' => Http::response([], 401),
+    ]);
 
-        $this->assertDatabaseMissing('server_providers', [
+    $data = array_merge(
+        [
             'provider' => $provider,
-            'profile' => 'profile',
-        ]);
-    }
+            'name' => 'profile',
+        ],
+        $input
+    );
+    $this->post(route('server-providers.store'), $data)
+        ->assertSessionHasErrors('provider');
 
-    public function test_see_providers_list(): void
-    {
-        $this->actingAs($this->user);
+    $this->assertDatabaseMissing('server_providers', [
+        'provider' => $provider,
+        'profile' => 'profile',
+    ]);
+})->with('data');
 
-        ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+test('see providers list', function () {
+    $this->actingAs($this->user);
 
-        $this->get(route('server-providers'))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('server-providers/index'));
-    }
+    ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-    #[DataProvider('data')]
-    public function test_delete_provider(string $provider, array $input): void
-    {
-        unset($input);
+    $this->get(route('server-providers'))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('server-providers/index'));
+});
 
-        $this->actingAs($this->user);
+test('delete provider', function (string $provider, array $input) {
+    unset($input);
 
-        $provider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => $provider,
-        ]);
+    $this->actingAs($this->user);
 
-        $this->delete(route('server-providers.destroy', $provider))
-            ->assertSessionDoesntHaveErrors()
-            ->assertRedirect(route('server-providers'));
+    $provider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => $provider,
+    ]);
 
-        $this->assertDatabaseMissing('server_providers', [
-            'id' => $provider->id,
-        ]);
-    }
+    $this->delete(route('server-providers.destroy', $provider))
+        ->assertSessionDoesntHaveErrors()
+        ->assertRedirect(route('server-providers'));
 
-    #[DataProvider('data')]
-    public function test_cannot_delete_provider(string $provider, array $input): void
-    {
-        unset($input);
+    $this->assertDatabaseMissing('server_providers', [
+        'id' => $provider->id,
+    ]);
+})->with('data');
 
-        $this->actingAs($this->user);
+test('cannot delete provider', function (string $provider, array $input) {
+    unset($input);
 
-        $provider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => $provider,
-        ]);
+    $this->actingAs($this->user);
 
-        $this->server->update([
-            'provider_id' => $provider->id,
-        ]);
+    $provider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => $provider,
+    ]);
 
-        $this->delete(route('server-providers.destroy', $provider))
-            ->assertSessionHasErrors([
-                'provider' => 'This server provider is being used by a server.',
-            ]);
+    $this->server->update([
+        'provider_id' => $provider->id,
+    ]);
 
-        $this->assertDatabaseHas('server_providers', [
-            'id' => $provider->id,
-        ]);
-    }
-
-    public function test_user_cannot_access_other_users_server_provider(): void
-    {
-        $this->actingAs($this->user);
-
-        $otherUser = User::factory()->create();
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $otherUser->id,
+    $this->delete(route('server-providers.destroy', $provider))
+        ->assertSessionHasErrors([
+            'provider' => 'This server provider is being used by a server.',
         ]);
 
-        $this->get(route('server-providers.regions', $serverProvider))
-            ->assertForbidden();
-    }
+    $this->assertDatabaseHas('server_providers', [
+        'id' => $provider->id,
+    ]);
+})->with('data');
 
-    public function test_user_cannot_update_other_users_server_provider(): void
-    {
-        $this->actingAs($this->user);
+test('user cannot access other users server provider', function () {
+    $this->actingAs($this->user);
 
-        $otherUser = User::factory()->create();
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
+    $otherUser = User::factory()->create();
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
 
-        $this->patch(route('server-providers.update', $serverProvider), [
-            'name' => 'hacked',
-        ])
-            ->assertForbidden();
-    }
+    $this->get(route('server-providers.regions', $serverProvider))
+        ->assertForbidden();
+});
 
-    public function test_user_cannot_delete_other_users_server_provider(): void
-    {
-        $this->actingAs($this->user);
+test('user cannot update other users server provider', function () {
+    $this->actingAs($this->user);
 
-        $otherUser = User::factory()->create();
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
+    $otherUser = User::factory()->create();
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
 
-        $this->delete(route('server-providers.destroy', $serverProvider))
-            ->assertForbidden();
-    }
+    $this->patch(route('server-providers.update', $serverProvider), [
+        'name' => 'hacked',
+    ])
+        ->assertForbidden();
+});
 
-    public function test_guest_cannot_access_server_providers(): void
-    {
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+test('user cannot delete other users server provider', function () {
+    $this->actingAs($this->user);
 
-        $this->get(route('server-providers'))
-            ->assertRedirect('/');
+    $otherUser = User::factory()->create();
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
 
-        $this->get(route('server-providers.regions', $serverProvider))
-            ->assertRedirect('/');
+    $this->delete(route('server-providers.destroy', $serverProvider))
+        ->assertForbidden();
+});
 
-        $this->post(route('server-providers.store'), [])
-            ->assertRedirect('/');
+test('guest cannot access server providers', function () {
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-        $this->patch(route('server-providers.update', $serverProvider), [])
-            ->assertRedirect('/');
+    $this->get(route('server-providers'))
+        ->assertRedirect('/');
 
-        $this->delete(route('server-providers.destroy', $serverProvider))
-            ->assertRedirect('/');
-    }
+    $this->get(route('server-providers.regions', $serverProvider))
+        ->assertRedirect('/');
 
-    public function test_cannot_manipulate_user_id_on_creation(): void
-    {
-        $this->actingAs($this->user);
+    $this->post(route('server-providers.store'), [])
+        ->assertRedirect('/');
 
-        $otherUser = User::factory()->create();
+    $this->patch(route('server-providers.update', $serverProvider), [])
+        ->assertRedirect('/');
 
-        Http::fake();
+    $this->delete(route('server-providers.destroy', $serverProvider))
+        ->assertRedirect('/');
+});
 
-        $data = [
-            'provider' => DigitalOcean::id(),
-            'name' => 'test',
-            'token' => 'fake-token',
-            'user_id' => $otherUser->id,
-        ];
+test('cannot manipulate user id on creation', function () {
+    $this->actingAs($this->user);
 
-        $this->post(route('server-providers.store'), $data)
-            ->assertSessionDoesntHaveErrors();
+    $otherUser = User::factory()->create();
 
-        $this->assertDatabaseHas('server_providers', [
-            'profile' => 'test',
-            'provider' => DigitalOcean::id(),
-            'user_id' => $this->user->id,
-        ]);
+    Http::fake();
 
-        $this->assertDatabaseMissing('server_providers', [
-            'profile' => 'test',
-            'provider' => DigitalOcean::id(),
-            'user_id' => $otherUser->id,
-        ]);
-    }
+    $data = [
+        'provider' => DigitalOcean::id(),
+        'name' => 'test',
+        'token' => 'fake-token',
+        'user_id' => $otherUser->id,
+    ];
 
-    public function test_cannot_transfer_ownership_via_update(): void
-    {
-        $this->actingAs($this->user);
+    $this->post(route('server-providers.store'), $data)
+        ->assertSessionDoesntHaveErrors();
 
-        $otherUser = User::factory()->create();
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'profile' => 'original',
-        ]);
+    $this->assertDatabaseHas('server_providers', [
+        'profile' => 'test',
+        'provider' => DigitalOcean::id(),
+        'user_id' => $this->user->id,
+    ]);
 
-        $this->patch(route('server-providers.update', $serverProvider), [
-            'name' => 'updated',
-            'user_id' => $otherUser->id,
-        ]);
+    $this->assertDatabaseMissing('server_providers', [
+        'profile' => 'test',
+        'provider' => DigitalOcean::id(),
+        'user_id' => $otherUser->id,
+    ]);
+});
 
-        $serverProvider->refresh();
+test('cannot transfer ownership via update', function () {
+    $this->actingAs($this->user);
 
-        $this->assertEquals($this->user->id, $serverProvider->user_id);
-        $this->assertNotEquals($otherUser->id, $serverProvider->user_id);
-    }
+    $otherUser = User::factory()->create();
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'profile' => 'original',
+    ]);
 
-    public function test_user_can_only_see_own_server_providers_in_list(): void
-    {
-        $this->actingAs($this->user);
+    $this->patch(route('server-providers.update', $serverProvider), [
+        'name' => 'updated',
+        'user_id' => $otherUser->id,
+    ]);
 
-        $otherUser = User::factory()->create();
+    $serverProvider->refresh();
 
-        $ownProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'profile' => 'own-provider',
-        ]);
+    expect($serverProvider->user_id)->toEqual($this->user->id);
+    $this->assertNotEquals($otherUser->id, $serverProvider->user_id);
+});
 
-        $otherProvider = ServerProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'profile' => 'other-provider',
-        ]);
+test('user can only see own server providers in list', function () {
+    $this->actingAs($this->user);
 
-        $response = $this->get(route('server-providers'))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('server-providers/index'));
+    $otherUser = User::factory()->create();
 
-        $response->assertInertia(fn (AssertableInertia $page) => $page->has('serverProviders.data')
-            ->where('serverProviders.data.0.id', $ownProvider->id)
-            ->whereNot('serverProviders.data.0.id', $otherProvider->id)
-        );
-    }
+    $ownProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'profile' => 'own-provider',
+    ]);
 
-    public function test_creating_server_provider_dispatches_socket_event(): void
-    {
-        Event::fake([SocketEvent::class]);
-        $this->actingAs($this->user);
-        Http::fake();
+    $otherProvider = ServerProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'profile' => 'other-provider',
+    ]);
 
-        $this->post(route('server-providers.store'), [
-            'provider' => Hetzner::id(),
-            'name' => 'hetty',
-            'token' => 'token',
-        ])->assertSessionDoesntHaveErrors();
+    $response = $this->get(route('server-providers'))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('server-providers/index'));
 
-        Event::assertDispatched(SocketEvent::class, fn (SocketEvent $event): bool => $event->data->type === 'server-provider.created'
-            && $event->data->data['name'] === 'hetty');
-    }
+    $response->assertInertia(fn (AssertableInertia $page) => $page->has('serverProviders.data')
+        ->where('serverProviders.data.0.id', $ownProvider->id)
+        ->whereNot('serverProviders.data.0.id', $otherProvider->id)
+    );
+});
 
-    public function test_deleting_server_provider_dispatches_socket_event(): void
-    {
-        Event::fake([SocketEvent::class]);
-        $this->actingAs($this->user);
+test('creating server provider dispatches socket event', function () {
+    Event::fake([SocketEvent::class]);
+    $this->actingAs($this->user);
+    Http::fake();
 
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    $this->post(route('server-providers.store'), [
+        'provider' => Hetzner::id(),
+        'name' => 'hetty',
+        'token' => 'token',
+    ])->assertSessionDoesntHaveErrors();
 
-        $this->delete(route('server-providers.destroy', $serverProvider))->assertSessionDoesntHaveErrors();
+    Event::assertDispatched(SocketEvent::class, fn (SocketEvent $event): bool => $event->data->type === 'server-provider.created'
+        && $event->data->data['name'] === 'hetty');
+});
 
-        Event::assertDispatched(SocketEvent::class, fn (SocketEvent $event): bool => $event->data->type === 'server-provider.deleted'
-            && $event->data->data['id'] === $serverProvider->id);
-    }
+test('deleting server provider dispatches socket event', function () {
+    Event::fake([SocketEvent::class]);
+    $this->actingAs($this->user);
 
-    public function test_hetzner_plans_expose_availability_and_order_available_first(): void
-    {
-        $this->actingAs($this->user);
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        Http::fake([
-            '*' => Http::response([
-                'server_types' => [
-                    [
-                        'name' => 'cpx22', 'cores' => 2, 'memory' => 4, 'disk' => 80,
-                        'prices' => [['location' => 'fsn1', 'price_monthly' => ['net' => '9.4900000000']]],
-                        'locations' => [
-                            ['name' => 'fsn1', 'available' => true, 'deprecation' => null],
-                        ],
-                    ],
-                    [
-                        'name' => 'ccx13', 'cores' => 2, 'memory' => 8, 'disk' => 80,
-                        'prices' => [['location' => 'fsn1', 'price_monthly' => ['net' => '18.4900000000']]],
-                        'locations' => [
-                            ['name' => 'fsn1', 'available' => true, 'deprecation' => null],
-                        ],
-                    ],
-                    [
-                        'name' => 'cax11', 'cores' => 2, 'memory' => 4, 'disk' => 40,
-                        'prices' => [['location' => 'fsn1', 'price_monthly' => ['net' => '5.4900000000']]],
-                        'locations' => [
-                            ['name' => 'fsn1', 'available' => false, 'deprecation' => null],
-                        ],
-                    ],
-                    [
-                        'name' => 'cpx12', 'cores' => 1, 'memory' => 2, 'disk' => 40,
-                        'prices' => [['location' => 'sin', 'price_monthly' => ['net' => '9.4900000000']]],
-                        'locations' => [
-                            ['name' => 'sin', 'available' => true, 'deprecation' => null],
-                        ],
-                    ],
-                ],
-            ], 200),
-        ]);
+    $this->delete(route('server-providers.destroy', $serverProvider))->assertSessionDoesntHaveErrors();
 
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'provider' => Hetzner::id(),
-            'credentials' => ['token' => 'token'],
-        ]);
+    Event::assertDispatched(SocketEvent::class, fn (SocketEvent $event): bool => $event->data->type === 'server-provider.deleted'
+        && $event->data->data['id'] === $serverProvider->id);
+});
 
-        $plans = $this->get(route('server-providers.plans', [
-            'serverProvider' => $serverProvider->id,
-            'region' => 'fsn1',
-        ]))
-            ->assertSuccessful()
-            ->json();
+test('hetzner plans expose availability and order available first', function () {
+    $this->actingAs($this->user);
 
-        $this->assertSame(['cpx22', 'ccx13', 'cax11'], array_keys($plans));
-        $this->assertTrue($plans['ccx13']['available']);
-        $this->assertStringContainsString('(18.49/mo)', $plans['ccx13']['label']);
-        $this->assertFalse($plans['cax11']['available']);
-        $this->assertStringNotContainsString('/mo', $plans['cax11']['label']);
-        $this->assertArrayNotHasKey('cpx12', $plans);
-    }
-
-    public function test_digital_ocean_plans_show_every_size_and_grey_unavailable(): void
-    {
-        $this->actingAs($this->user);
-
-        Http::fake([
-            '*' => Http::response([
-                'sizes' => [
-                    [
-                        'slug' => 's-1vcpu-1gb', 'description' => 'Basic', 'vcpus' => 1, 'memory' => 1024, 'disk' => 25,
-                        'price_monthly' => 6, 'available' => true, 'regions' => ['lon1', 'nyc1'],
-                    ],
-                    [
-                        'slug' => 's-2vcpu-4gb', 'description' => 'Basic', 'vcpus' => 2, 'memory' => 4096, 'disk' => 80,
-                        'price_monthly' => 24, 'available' => true, 'regions' => ['lon1'],
-                    ],
-                    [
-                        'slug' => 's-1vcpu-512mb-10gb', 'description' => 'Basic', 'vcpus' => 1, 'memory' => 512, 'disk' => 10,
-                        'price_monthly' => 4, 'available' => true, 'regions' => ['nyc1'],
-                    ],
-                ],
-            ], 200),
-        ]);
-
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'provider' => DigitalOcean::id(),
-            'credentials' => ['token' => 'token'],
-        ]);
-
-        $plans = $this->get(route('server-providers.plans', [
-            'serverProvider' => $serverProvider->id,
-            'region' => 'lon1',
-        ]))
-            ->assertSuccessful()
-            ->json();
-
-        $this->assertSame(['s-1vcpu-1gb', 's-2vcpu-4gb', 's-1vcpu-512mb-10gb'], array_keys($plans));
-        $this->assertTrue($plans['s-1vcpu-1gb']['available']);
-        $this->assertStringContainsString('(6.00/mo)', $plans['s-1vcpu-1gb']['label']);
-        $this->assertFalse($plans['s-1vcpu-512mb-10gb']['available']);
-        $this->assertStringNotContainsString('/mo', $plans['s-1vcpu-512mb-10gb']['label']);
-    }
-
-    public function test_vultr_plans_show_every_plan_and_grey_unavailable(): void
-    {
-        $this->actingAs($this->user);
-
-        Http::fake([
-            '*' => Http::response([
-                'plans' => [
-                    [
-                        'id' => 'vc2-1c-1gb', 'type' => 'vc2', 'vcpu_count' => 1, 'ram' => 1024, 'disk' => 25,
-                        'monthly_cost' => 5, 'locations' => ['ams', 'ewr'],
-                    ],
-                    [
-                        'id' => 'vc2-2c-4gb', 'type' => 'vc2', 'vcpu_count' => 2, 'ram' => 4096, 'disk' => 80,
-                        'monthly_cost' => 20, 'locations' => ['ams'],
-                    ],
-                    [
-                        'id' => 'vc2-1c-0.5gb', 'type' => 'vc2', 'vcpu_count' => 1, 'ram' => 512, 'disk' => 10,
-                        'monthly_cost' => 2.5, 'locations' => ['ewr'],
-                    ],
-                ],
-            ], 200),
-        ]);
-
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'provider' => Vultr::id(),
-            'credentials' => ['token' => 'token'],
-        ]);
-
-        $plans = $this->get(route('server-providers.plans', [
-            'serverProvider' => $serverProvider->id,
-            'region' => 'ams',
-        ]))
-            ->assertSuccessful()
-            ->json();
-
-        $this->assertSame(['vc2-1c-1gb', 'vc2-2c-4gb', 'vc2-1c-0.5gb'], array_keys($plans));
-        $this->assertTrue($plans['vc2-1c-1gb']['available']);
-        $this->assertStringContainsString('(5.00/mo)', $plans['vc2-1c-1gb']['label']);
-        $this->assertFalse($plans['vc2-1c-0.5gb']['available']);
-        $this->assertStringNotContainsString('/mo', $plans['vc2-1c-0.5gb']['label']);
-    }
-
-    public function test_linode_plans_grey_classes_unsupported_by_region(): void
-    {
-        $this->actingAs($this->user);
-
-        Http::fake([
-            'api.linode.com/v4/linode/types*' => Http::response([
-                'data' => [
-                    [
-                        'id' => 'g6-standard-1', 'label' => 'Linode 2GB', 'class' => 'standard',
-                        'vcpus' => 1, 'memory' => 2048, 'disk' => 51200,
-                        'price' => ['monthly' => 12.0, 'hourly' => 0.018], 'region_prices' => [],
-                    ],
-                    [
-                        'id' => 'g1-gpu-rtx6000-1', 'label' => 'RTX6000 GPU', 'class' => 'gpu',
-                        'vcpus' => 8, 'memory' => 32768, 'disk' => 655360,
-                        'price' => ['monthly' => 1000.0, 'hourly' => 1.5], 'region_prices' => [],
-                    ],
-                    [
-                        'id' => 'g7-premium-2', 'label' => 'Premium 4GB', 'class' => 'premium',
-                        'vcpus' => 2, 'memory' => 4096, 'disk' => 81920,
-                        'price' => ['monthly' => 36.0, 'hourly' => 0.054],
-                        'region_prices' => [['id' => 'eu-test', 'monthly' => 40.0, 'hourly' => 0.06]],
-                    ],
-                ],
-            ], 200),
-            'api.linode.com/v4/regions*' => Http::response([
-                'data' => [
-                    ['id' => 'eu-test', 'label' => 'Test', 'capabilities' => ['Linodes']],
-                ],
-            ], 200),
-        ]);
-
-        $serverProvider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'provider' => Linode::id(),
-            'credentials' => ['token' => 'token'],
-        ]);
-
-        $plans = $this->get(route('server-providers.plans', [
-            'serverProvider' => $serverProvider->id,
-            'region' => 'eu-test',
-        ]))
-            ->assertSuccessful()
-            ->json();
-
-        $this->assertSame(['g6-standard-1', 'g1-gpu-rtx6000-1', 'g7-premium-2'], array_keys($plans));
-        $this->assertTrue($plans['g6-standard-1']['available']);
-        $this->assertStringContainsString('50 Disk', $plans['g6-standard-1']['label']);
-        $this->assertStringContainsString('(12.00/mo)', $plans['g6-standard-1']['label']);
-        $this->assertFalse($plans['g1-gpu-rtx6000-1']['available']);
-        $this->assertFalse($plans['g7-premium-2']['available']);
-        $this->assertStringNotContainsString('/mo', $plans['g7-premium-2']['label']);
-    }
-
-    /**
-     * @return array<string, array<int, array<string, mixed>>>
-     */
-    public static function data(): array
-    {
-        return [
-            // [
-            //     ServerProvider::AWS,
-            //     [
-            //         'key' => 'key',
-            //         'secret' => 'secret',
-            //     ],
-            // ],
-            [
-                Linode::id(),
+    Http::fake([
+        '*' => Http::response([
+            'server_types' => [
                 [
-                    'token' => 'token',
+                    'name' => 'cpx22', 'cores' => 2, 'memory' => 4, 'disk' => 80,
+                    'prices' => [['location' => 'fsn1', 'price_monthly' => ['net' => '9.4900000000']]],
+                    'locations' => [
+                        ['name' => 'fsn1', 'available' => true, 'deprecation' => null],
+                    ],
+                ],
+                [
+                    'name' => 'ccx13', 'cores' => 2, 'memory' => 8, 'disk' => 80,
+                    'prices' => [['location' => 'fsn1', 'price_monthly' => ['net' => '18.4900000000']]],
+                    'locations' => [
+                        ['name' => 'fsn1', 'available' => true, 'deprecation' => null],
+                    ],
+                ],
+                [
+                    'name' => 'cax11', 'cores' => 2, 'memory' => 4, 'disk' => 40,
+                    'prices' => [['location' => 'fsn1', 'price_monthly' => ['net' => '5.4900000000']]],
+                    'locations' => [
+                        ['name' => 'fsn1', 'available' => false, 'deprecation' => null],
+                    ],
+                ],
+                [
+                    'name' => 'cpx12', 'cores' => 1, 'memory' => 2, 'disk' => 40,
+                    'prices' => [['location' => 'sin', 'price_monthly' => ['net' => '9.4900000000']]],
+                    'locations' => [
+                        ['name' => 'sin', 'available' => true, 'deprecation' => null],
+                    ],
                 ],
             ],
-            [
-                Linode::id(),
+        ], 200),
+    ]);
+
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'provider' => Hetzner::id(),
+        'credentials' => ['token' => 'token'],
+    ]);
+
+    $plans = $this->get(route('server-providers.plans', [
+        'serverProvider' => $serverProvider->id,
+        'region' => 'fsn1',
+    ]))
+        ->assertSuccessful()
+        ->json();
+
+    expect(array_keys($plans))->toBe(['cpx22', 'ccx13', 'cax11']);
+    expect($plans['ccx13']['available'])->toBeTrue();
+    $this->assertStringContainsString('(18.49/mo)', $plans['ccx13']['label']);
+    expect($plans['cax11']['available'])->toBeFalse();
+    $this->assertStringNotContainsString('/mo', $plans['cax11']['label']);
+    $this->assertArrayNotHasKey('cpx12', $plans);
+});
+
+test('digital ocean plans show every size and grey unavailable', function () {
+    $this->actingAs($this->user);
+
+    Http::fake([
+        '*' => Http::response([
+            'sizes' => [
                 [
-                    'token' => 'token',
-                    'global' => 1,
+                    'slug' => 's-1vcpu-1gb', 'description' => 'Basic', 'vcpus' => 1, 'memory' => 1024, 'disk' => 25,
+                    'price_monthly' => 6, 'available' => true, 'regions' => ['lon1', 'nyc1'],
+                ],
+                [
+                    'slug' => 's-2vcpu-4gb', 'description' => 'Basic', 'vcpus' => 2, 'memory' => 4096, 'disk' => 80,
+                    'price_monthly' => 24, 'available' => true, 'regions' => ['lon1'],
+                ],
+                [
+                    'slug' => 's-1vcpu-512mb-10gb', 'description' => 'Basic', 'vcpus' => 1, 'memory' => 512, 'disk' => 10,
+                    'price_monthly' => 4, 'available' => true, 'regions' => ['nyc1'],
                 ],
             ],
-            [
-                DigitalOcean::id(),
+        ], 200),
+    ]);
+
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'provider' => DigitalOcean::id(),
+        'credentials' => ['token' => 'token'],
+    ]);
+
+    $plans = $this->get(route('server-providers.plans', [
+        'serverProvider' => $serverProvider->id,
+        'region' => 'lon1',
+    ]))
+        ->assertSuccessful()
+        ->json();
+
+    expect(array_keys($plans))->toBe(['s-1vcpu-1gb', 's-2vcpu-4gb', 's-1vcpu-512mb-10gb']);
+    expect($plans['s-1vcpu-1gb']['available'])->toBeTrue();
+    $this->assertStringContainsString('(6.00/mo)', $plans['s-1vcpu-1gb']['label']);
+    expect($plans['s-1vcpu-512mb-10gb']['available'])->toBeFalse();
+    $this->assertStringNotContainsString('/mo', $plans['s-1vcpu-512mb-10gb']['label']);
+});
+
+test('vultr plans show every plan and grey unavailable', function () {
+    $this->actingAs($this->user);
+
+    Http::fake([
+        '*' => Http::response([
+            'plans' => [
                 [
-                    'token' => 'token',
+                    'id' => 'vc2-1c-1gb', 'type' => 'vc2', 'vcpu_count' => 1, 'ram' => 1024, 'disk' => 25,
+                    'monthly_cost' => 5, 'locations' => ['ams', 'ewr'],
+                ],
+                [
+                    'id' => 'vc2-2c-4gb', 'type' => 'vc2', 'vcpu_count' => 2, 'ram' => 4096, 'disk' => 80,
+                    'monthly_cost' => 20, 'locations' => ['ams'],
+                ],
+                [
+                    'id' => 'vc2-1c-0.5gb', 'type' => 'vc2', 'vcpu_count' => 1, 'ram' => 512, 'disk' => 10,
+                    'monthly_cost' => 2.5, 'locations' => ['ewr'],
                 ],
             ],
-            [
-                Vultr::id(),
+        ], 200),
+    ]);
+
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'provider' => Vultr::id(),
+        'credentials' => ['token' => 'token'],
+    ]);
+
+    $plans = $this->get(route('server-providers.plans', [
+        'serverProvider' => $serverProvider->id,
+        'region' => 'ams',
+    ]))
+        ->assertSuccessful()
+        ->json();
+
+    expect(array_keys($plans))->toBe(['vc2-1c-1gb', 'vc2-2c-4gb', 'vc2-1c-0.5gb']);
+    expect($plans['vc2-1c-1gb']['available'])->toBeTrue();
+    $this->assertStringContainsString('(5.00/mo)', $plans['vc2-1c-1gb']['label']);
+    expect($plans['vc2-1c-0.5gb']['available'])->toBeFalse();
+    $this->assertStringNotContainsString('/mo', $plans['vc2-1c-0.5gb']['label']);
+});
+
+test('linode plans grey classes unsupported by region', function () {
+    $this->actingAs($this->user);
+
+    Http::fake([
+        'api.linode.com/v4/linode/types*' => Http::response([
+            'data' => [
                 [
-                    'token' => 'token',
+                    'id' => 'g6-standard-1', 'label' => 'Linode 2GB', 'class' => 'standard',
+                    'vcpus' => 1, 'memory' => 2048, 'disk' => 51200,
+                    'price' => ['monthly' => 12.0, 'hourly' => 0.018], 'region_prices' => [],
+                ],
+                [
+                    'id' => 'g1-gpu-rtx6000-1', 'label' => 'RTX6000 GPU', 'class' => 'gpu',
+                    'vcpus' => 8, 'memory' => 32768, 'disk' => 655360,
+                    'price' => ['monthly' => 1000.0, 'hourly' => 1.5], 'region_prices' => [],
+                ],
+                [
+                    'id' => 'g7-premium-2', 'label' => 'Premium 4GB', 'class' => 'premium',
+                    'vcpus' => 2, 'memory' => 4096, 'disk' => 81920,
+                    'price' => ['monthly' => 36.0, 'hourly' => 0.054],
+                    'region_prices' => [['id' => 'eu-test', 'monthly' => 40.0, 'hourly' => 0.06]],
                 ],
             ],
-            [
-                Hetzner::id(),
-                [
-                    'token' => 'token',
-                ],
+        ], 200),
+        'api.linode.com/v4/regions*' => Http::response([
+            'data' => [
+                ['id' => 'eu-test', 'label' => 'Test', 'capabilities' => ['Linodes']],
             ],
-        ];
-    }
-}
+        ], 200),
+    ]);
+
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'provider' => Linode::id(),
+        'credentials' => ['token' => 'token'],
+    ]);
+
+    $plans = $this->get(route('server-providers.plans', [
+        'serverProvider' => $serverProvider->id,
+        'region' => 'eu-test',
+    ]))
+        ->assertSuccessful()
+        ->json();
+
+    expect(array_keys($plans))->toBe(['g6-standard-1', 'g1-gpu-rtx6000-1', 'g7-premium-2']);
+    expect($plans['g6-standard-1']['available'])->toBeTrue();
+    $this->assertStringContainsString('50 Disk', $plans['g6-standard-1']['label']);
+    $this->assertStringContainsString('(12.00/mo)', $plans['g6-standard-1']['label']);
+    expect($plans['g1-gpu-rtx6000-1']['available'])->toBeFalse();
+    expect($plans['g7-premium-2']['available'])->toBeFalse();
+    $this->assertStringNotContainsString('/mo', $plans['g7-premium-2']['label']);
+});
+
+/**
+ * @return array<string, array<int, array<string, mixed>>>
+ */
+dataset('data', function () {
+    return [
+        // [
+        //     ServerProvider::AWS,
+        //     [
+        //         'key' => 'key',
+        //         'secret' => 'secret',
+        //     ],
+        // ],
+        [
+            Linode::id(),
+            [
+                'token' => 'token',
+            ],
+        ],
+        [
+            Linode::id(),
+            [
+                'token' => 'token',
+                'global' => 1,
+            ],
+        ],
+        [
+            DigitalOcean::id(),
+            [
+                'token' => 'token',
+            ],
+        ],
+        [
+            Vultr::id(),
+            [
+                'token' => 'token',
+            ],
+        ],
+        [
+            Hetzner::id(),
+            [
+                'token' => 'token',
+            ],
+        ],
+    ];
+});

--- a/tests/Feature/ServerSslTest.php
+++ b/tests/Feature/ServerSslTest.php
@@ -1,265 +1,247 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\SslStatus;
 use App\Facades\SSH;
 use App\Models\Ssl;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class ServerSslTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_see_server_ssls_list(): void
-    {
-        $this->actingAs($this->user);
+test('see server ssls list', function () {
+    $this->actingAs($this->user);
 
-        Ssl::factory()->serverLevel()->create([
-            'server_id' => $this->server->id,
-        ]);
+    Ssl::factory()->serverLevel()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        $this->get(route('server-ssls', ['server' => $this->server->id]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('server-ssls/index')
-                ->has('ssls.data', 1)
-                ->has('domains')
-            );
-    }
+    $this->get(route('server-ssls', ['server' => $this->server->id]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('server-ssls/index')
+            ->has('ssls.data', 1)
+            ->has('domains')
+        );
+});
 
-    public function test_create_csr(): void
-    {
-        SSH::fake('CSR GENERATED SUCCESSFULLY');
+test('create csr', function () {
+    SSH::fake('CSR GENERATED SUCCESSFULLY');
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->post(route('server-ssls.store', ['server' => $this->server->id]), [
-            'type' => 'csr',
+    $this->post(route('server-ssls.store', ['server' => $this->server->id]), [
+        'type' => 'csr',
+        'common_name' => 'example.com',
+        'organization' => 'Test Org',
+        'organizational_unit' => 'IT',
+        'city' => 'San Francisco',
+        'state' => 'California',
+        'country' => 'US',
+        'email' => 'admin@example.com',
+        'key_size' => '2048',
+    ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('ssls', [
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'type' => 'csr',
+        'status' => SslStatus::CREATED,
+        'has_csr' => true,
+        'domains' => $this->castAsJson(['example.com']),
+    ]);
+});
+
+test('create csr validation', function () {
+    $this->actingAs($this->user);
+
+    $this->post(route('server-ssls.store', ['server' => $this->server->id]), [
+        'type' => 'csr',
+    ])
+        ->assertSessionHasErrors(['common_name', 'organization', 'city', 'state', 'country']);
+});
+
+test('create csr invalid type', function () {
+    $this->actingAs($this->user);
+
+    $this->post(route('server-ssls.store', ['server' => $this->server->id]), [
+        'type' => 'invalid',
+    ])
+        ->assertSessionHasErrors('type');
+});
+
+test('create custom ssl', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $cert = vitoPestFeatureServerSslTestGenerateSelfSignedCert();
+
+    $this->post(route('server-ssls.store', ['server' => $this->server->id]), [
+        'type' => 'custom',
+        'certificate' => $cert['certificate'],
+        'private_key' => $cert['private_key'],
+    ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('ssls', [
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'type' => 'custom',
+        'status' => SslStatus::CREATED,
+    ]);
+});
+
+test('create custom ssl validation', function () {
+    $this->actingAs($this->user);
+
+    $this->post(route('server-ssls.store', ['server' => $this->server->id]), [
+        'type' => 'custom',
+    ])
+        ->assertSessionHasErrors(['certificate', 'private_key']);
+});
+
+test('activate csr', function () {
+    SSH::fake('SSL ACTIVATED SUCCESSFULLY');
+
+    $this->actingAs($this->user);
+
+    $cert = vitoPestFeatureServerSslTestGenerateSelfSignedCert();
+
+    $ssl = Ssl::factory()->serverLevel()->create([
+        'server_id' => $this->server->id,
+        'status' => SslStatus::CREATED,
+        'has_csr' => true,
+        'csr_data' => [
             'common_name' => 'example.com',
             'organization' => 'Test Org',
-            'organizational_unit' => 'IT',
             'city' => 'San Francisco',
             'state' => 'California',
             'country' => 'US',
-            'email' => 'admin@example.com',
-            'key_size' => '2048',
-        ])
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
+            'key_size' => 2048,
+            'pk_path' => '/etc/ssl/vito/'.$this->server->id.'/private.key',
+        ],
+    ]);
 
-        $this->assertDatabaseHas('ssls', [
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'type' => 'csr',
-            'status' => SslStatus::CREATED,
-            'has_csr' => true,
-            'domains' => $this->castAsJson(['example.com']),
-        ]);
-    }
+    $this->post(route('server-ssls.activate', ['server' => $this->server->id, 'ssl' => $ssl->id]), [
+        'certificate' => $cert['certificate'],
+    ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
 
-    public function test_create_csr_validation(): void
-    {
-        $this->actingAs($this->user);
+    $this->assertDatabaseHas('ssls', [
+        'id' => $ssl->id,
+        'type' => 'custom',
+        'status' => SslStatus::CREATED,
+    ]);
+});
 
-        $this->post(route('server-ssls.store', ['server' => $this->server->id]), [
-            'type' => 'csr',
-        ])
-            ->assertSessionHasErrors(['common_name', 'organization', 'city', 'state', 'country']);
-    }
+test('delete server ssl', function () {
+    SSH::fake('SSL DELETED SUCCESSFULLY');
 
-    public function test_create_csr_invalid_type(): void
-    {
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->post(route('server-ssls.store', ['server' => $this->server->id]), [
-            'type' => 'invalid',
-        ])
-            ->assertSessionHasErrors('type');
-    }
+    $ssl = Ssl::factory()->serverLevel()->create([
+        'server_id' => $this->server->id,
+        'status' => SslStatus::CREATED,
+    ]);
 
-    public function test_create_custom_ssl(): void
-    {
-        SSH::fake();
+    $this->delete(route('server-ssls.destroy', ['server' => $this->server->id, 'ssl' => $ssl->id]))
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
 
-        $this->actingAs($this->user);
+    $this->assertDatabaseMissing('ssls', [
+        'id' => $ssl->id,
+    ]);
+});
 
-        $cert = $this->generateSelfSignedCert();
+test('delete wildcard ssl runs certbot delete', function () {
+    SSH::fake('SSL DELETED SUCCESSFULLY');
 
-        $this->post(route('server-ssls.store', ['server' => $this->server->id]), [
-            'type' => 'custom',
-            'certificate' => $cert['certificate'],
-            'private_key' => $cert['private_key'],
-        ])
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
+    $this->actingAs($this->user);
 
-        $this->assertDatabaseHas('ssls', [
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'type' => 'custom',
-            'status' => SslStatus::CREATED,
-        ]);
-    }
+    $ssl = Ssl::factory()->serverLevel()->create([
+        'server_id' => $this->server->id,
+        'type' => 'letsencrypt',
+        'status' => SslStatus::CREATED,
+        'is_wildcard' => true,
+    ]);
 
-    public function test_create_custom_ssl_validation(): void
-    {
-        $this->actingAs($this->user);
+    $this->delete(route('server-ssls.destroy', ['server' => $this->server->id, 'ssl' => $ssl->id]))
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
 
-        $this->post(route('server-ssls.store', ['server' => $this->server->id]), [
-            'type' => 'custom',
-        ])
-            ->assertSessionHasErrors(['certificate', 'private_key']);
-    }
+    $this->assertDatabaseMissing('ssls', [
+        'id' => $ssl->id,
+    ]);
 
-    public function test_activate_csr(): void
-    {
-        SSH::fake('SSL ACTIVATED SUCCESSFULLY');
+    SSH::assertExecutedContains('certbot delete');
+});
 
-        $this->actingAs($this->user);
+test('download csr not found without csr path', function () {
+    $this->actingAs($this->user);
 
-        $cert = $this->generateSelfSignedCert();
+    $ssl = Ssl::factory()->serverLevel()->create([
+        'server_id' => $this->server->id,
+        'status' => SslStatus::CREATED,
+        'has_csr' => true,
+        'csr_data' => [
+            'common_name' => 'example.com',
+        ],
+    ]);
 
-        $ssl = Ssl::factory()->serverLevel()->create([
-            'server_id' => $this->server->id,
-            'status' => SslStatus::CREATED,
-            'has_csr' => true,
-            'csr_data' => [
-                'common_name' => 'example.com',
-                'organization' => 'Test Org',
-                'city' => 'San Francisco',
-                'state' => 'California',
-                'country' => 'US',
-                'key_size' => 2048,
-                'pk_path' => '/etc/ssl/vito/'.$this->server->id.'/private.key',
-            ],
-        ]);
+    $this->get(route('server-ssls.download', ['server' => $this->server->id, 'ssl' => $ssl->id]))
+        ->assertNotFound();
+});
 
-        $this->post(route('server-ssls.activate', ['server' => $this->server->id, 'ssl' => $ssl->id]), [
-            'certificate' => $cert['certificate'],
-        ])
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
+test('download csr not available without has csr', function () {
+    $this->actingAs($this->user);
 
-        $this->assertDatabaseHas('ssls', [
-            'id' => $ssl->id,
-            'type' => 'custom',
-            'status' => SslStatus::CREATED,
-        ]);
-    }
+    $ssl = Ssl::factory()->serverLevel()->create([
+        'server_id' => $this->server->id,
+        'status' => SslStatus::CREATED,
+        'has_csr' => false,
+    ]);
 
-    public function test_delete_server_ssl(): void
-    {
-        SSH::fake('SSL DELETED SUCCESSFULLY');
+    $this->get(route('server-ssls.download', ['server' => $this->server->id, 'ssl' => $ssl->id]))
+        ->assertNotFound();
+});
 
-        $this->actingAs($this->user);
+test('cannot access other servers ssl', function () {
+    $this->actingAs($this->user);
 
-        $ssl = Ssl::factory()->serverLevel()->create([
-            'server_id' => $this->server->id,
-            'status' => SslStatus::CREATED,
-        ]);
+    $ssl = Ssl::factory()->serverLevel()->create([
+        'status' => SslStatus::CREATED,
+    ]);
 
-        $this->delete(route('server-ssls.destroy', ['server' => $this->server->id, 'ssl' => $ssl->id]))
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
+    $this->delete(route('server-ssls.destroy', ['server' => $this->server->id, 'ssl' => $ssl->id]))
+        ->assertForbidden();
+});
 
-        $this->assertDatabaseMissing('ssls', [
-            'id' => $ssl->id,
-        ]);
-    }
+/**
+ * Generate a self-signed certificate for testing.
+ *
+ * @return array{certificate: string, private_key: string}
+ */
+function vitoPestFeatureServerSslTestGenerateSelfSignedCert(): array
+{
+    $key = openssl_pkey_new(['private_key_bits' => 2048]);
+    $csr = openssl_csr_new([
+        'commonName' => 'example.com',
+        'organizationName' => 'Test',
+        'countryName' => 'US',
+        'stateOrProvinceName' => 'CA',
+        'localityName' => 'SF',
+    ], $key);
+    $cert = openssl_csr_sign($csr, null, $key, 365);
 
-    public function test_delete_wildcard_ssl_runs_certbot_delete(): void
-    {
-        SSH::fake('SSL DELETED SUCCESSFULLY');
+    openssl_x509_export($cert, $certPem);
+    openssl_pkey_export($key, $keyPem);
 
-        $this->actingAs($this->user);
-
-        $ssl = Ssl::factory()->serverLevel()->create([
-            'server_id' => $this->server->id,
-            'type' => 'letsencrypt',
-            'status' => SslStatus::CREATED,
-            'is_wildcard' => true,
-        ]);
-
-        $this->delete(route('server-ssls.destroy', ['server' => $this->server->id, 'ssl' => $ssl->id]))
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('ssls', [
-            'id' => $ssl->id,
-        ]);
-
-        SSH::assertExecutedContains('certbot delete');
-    }
-
-    public function test_download_csr_not_found_without_csr_path(): void
-    {
-        $this->actingAs($this->user);
-
-        $ssl = Ssl::factory()->serverLevel()->create([
-            'server_id' => $this->server->id,
-            'status' => SslStatus::CREATED,
-            'has_csr' => true,
-            'csr_data' => [
-                'common_name' => 'example.com',
-            ],
-        ]);
-
-        $this->get(route('server-ssls.download', ['server' => $this->server->id, 'ssl' => $ssl->id]))
-            ->assertNotFound();
-    }
-
-    public function test_download_csr_not_available_without_has_csr(): void
-    {
-        $this->actingAs($this->user);
-
-        $ssl = Ssl::factory()->serverLevel()->create([
-            'server_id' => $this->server->id,
-            'status' => SslStatus::CREATED,
-            'has_csr' => false,
-        ]);
-
-        $this->get(route('server-ssls.download', ['server' => $this->server->id, 'ssl' => $ssl->id]))
-            ->assertNotFound();
-    }
-
-    public function test_cannot_access_other_servers_ssl(): void
-    {
-        $this->actingAs($this->user);
-
-        $ssl = Ssl::factory()->serverLevel()->create([
-            'status' => SslStatus::CREATED,
-        ]);
-
-        $this->delete(route('server-ssls.destroy', ['server' => $this->server->id, 'ssl' => $ssl->id]))
-            ->assertForbidden();
-    }
-
-    /**
-     * Generate a self-signed certificate for testing.
-     *
-     * @return array{certificate: string, private_key: string}
-     */
-    private function generateSelfSignedCert(): array
-    {
-        $key = openssl_pkey_new(['private_key_bits' => 2048]);
-        $csr = openssl_csr_new([
-            'commonName' => 'example.com',
-            'organizationName' => 'Test',
-            'countryName' => 'US',
-            'stateOrProvinceName' => 'CA',
-            'localityName' => 'SF',
-        ], $key);
-        $cert = openssl_csr_sign($csr, null, $key, 365);
-
-        openssl_x509_export($cert, $certPem);
-        openssl_pkey_export($key, $keyPem);
-
-        return [
-            'certificate' => $certPem,
-            'private_key' => $keyPem,
-        ];
-    }
+    return [
+        'certificate' => $certPem,
+        'private_key' => $keyPem,
+    ];
 }

--- a/tests/Feature/ServerTemplateTest.php
+++ b/tests/Feature/ServerTemplateTest.php
@@ -1,377 +1,351 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\ServerTemplate;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class ServerTemplateTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->user->ensureHasDefaultProject();
+});
 
-        $this->user = User::factory()->create();
-        $this->user->ensureHasDefaultProject();
-    }
+test('index returns user server templates', function () {
+    // Create some server templates for the user
+    $templates = ServerTemplate::factory()->count(3)->create([
+        'user_id' => $this->user->id,
+    ]);
 
-    public function test_index_returns_user_server_templates(): void
-    {
-        // Create some server templates for the user
-        $templates = ServerTemplate::factory()->count(3)->create([
-            'user_id' => $this->user->id,
+    // Create a template for another user (should not be returned)
+    $otherUser = User::factory()->create();
+    ServerTemplate::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->getJson(route('server-templates.index'));
+
+    $response->assertStatus(200)
+        ->assertJson([
+            'templates' => $templates->map(function ($template) {
+                return [
+                    'id' => $template->id,
+                    'name' => $template->name,
+                    'services' => $template->services,
+                    'user_id' => $template->user_id,
+                ];
+            })->toArray(),
         ]);
 
-        // Create a template for another user (should not be returned)
-        $otherUser = User::factory()->create();
-        ServerTemplate::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
-
-        $response = $this->actingAs($this->user)
-            ->getJson(route('server-templates.index'));
-
-        $response->assertStatus(200)
-            ->assertJson([
-                'templates' => $templates->map(function ($template) {
-                    return [
-                        'id' => $template->id,
-                        'name' => $template->name,
-                        'services' => $template->services,
-                        'user_id' => $template->user_id,
-                    ];
-                })->toArray(),
-            ]);
-
-        // Ensure only user's templates are returned
-        $this->assertCount(3, $response->json('templates'));
-    }
-
-    public function test_index_requires_authentication(): void
-    {
-        $response = $this->getJson(route('server-templates.index'));
-
-        $response->assertStatus(401);
-    }
-
-    public function test_store_creates_server_template(): void
-    {
-        $data = [
-            'name' => 'My Web Server Template',
-            'services' => [
-                'php' => '8.4',
-                'nginx' => 'latest',
-                'mysql' => '8.4',
-            ],
-        ];
-
-        $response = $this->actingAs($this->user)
-            ->post(route('server-templates.store'), $data);
-
-        $response->assertRedirect()
-            ->assertSessionHas('success', 'Server template created successfully.');
-
-        $this->assertDatabaseHas('server_templates', [
-            'user_id' => $this->user->id,
-            'name' => 'My Web Server Template',
-            'services' => $this->castAsJson([
-                'php' => '8.4',
-                'nginx' => 'latest',
-                'mysql' => '8.4',
-            ]),
-        ]);
-    }
-
-    public function test_store_validates_required_fields(): void
-    {
-        $response = $this->actingAs($this->user)
-            ->post(route('server-templates.store'), []);
-
-        $response->assertSessionHasErrors(['name', 'services']);
-    }
-
-    public function test_store_validates_name_is_string(): void
-    {
-        $data = [
-            'name' => 123,
-            'services' => ['php' => '8.4'],
-        ];
-
-        $response = $this->actingAs($this->user)
-            ->post(route('server-templates.store'), $data);
-
-        $response->assertSessionHasErrors(['name']);
-    }
-
-    public function test_store_validates_name_max_length(): void
-    {
-        $data = [
-            'name' => str_repeat('a', 256), // 256 characters (over the 255 limit)
-            'services' => ['php' => '8.4'],
-        ];
-
-        $response = $this->actingAs($this->user)
-            ->post(route('server-templates.store'), $data);
-
-        $response->assertSessionHasErrors(['name']);
-    }
-
-    public function test_store_validates_services_is_array(): void
-    {
-        $data = [
-            'name' => 'Test Template',
-            'services' => 'not-an-array',
-        ];
-
-        $response = $this->actingAs($this->user)
-            ->post(route('server-templates.store'), $data);
-
-        $response->assertSessionHasErrors(['services']);
-    }
-
-    public function test_store_requires_authentication(): void
-    {
-        $data = [
-            'name' => 'Test Template',
-            'services' => ['php' => '8.4'],
-        ];
-
-        $response = $this->post(route('server-templates.store'), $data);
-
-        $response->assertStatus(302); // Redirect to login
-    }
-
-    public function test_update_modifies_existing_server_template(): void
-    {
-        $template = ServerTemplate::factory()->create([
-            'user_id' => $this->user->id,
-            'name' => 'Original Name',
-            'services' => ['php' => '8.2'],
-        ]);
-
-        $updateData = [
-            'name' => 'Updated Name',
-            'services' => [
-                'php' => '8.4',
-                'nginx' => 'latest',
-            ],
-        ];
-
-        $response = $this->actingAs($this->user)
-            ->put(route('server-templates.update', $template->id), $updateData);
-
-        $response->assertRedirect()
-            ->assertSessionHas('success', 'Server template updated successfully.');
-
-        $template->refresh();
-        $this->assertEquals('Updated Name', $template->name);
-        $this->assertEquals([
-            'php' => '8.4',
-            'nginx' => 'latest',
-        ], $template->services);
-    }
-
-    public function test_update_allows_partial_updates(): void
-    {
-        $template = ServerTemplate::factory()->create([
-            'user_id' => $this->user->id,
-            'name' => 'Original Name',
-            'services' => ['php' => '8.2'],
-        ]);
-
-        // Update only the name
-        $response = $this->actingAs($this->user)
-            ->put(route('server-templates.update', $template->id), [
-                'name' => 'New Name Only',
-            ]);
-
-        $response->assertRedirect()
-            ->assertSessionHas('success', 'Server template updated successfully.');
-
-        $template->refresh();
-        $this->assertEquals('New Name Only', $template->name);
-        $this->assertEquals(['php' => '8.2'], $template->services); // Should remain unchanged
-
-        // Update only the services
-        $response = $this->actingAs($this->user)
-            ->put(route('server-templates.update', $template->id), [
-                'services' => ['nginx' => 'latest'],
-            ]);
-
-        $response->assertRedirect()
-            ->assertSessionHas('success', 'Server template updated successfully.');
-
-        $template->refresh();
-        $this->assertEquals('New Name Only', $template->name); // Should remain unchanged
-        $this->assertEquals(['nginx' => 'latest'], $template->services);
-    }
-
-    public function test_update_validates_fields_when_provided(): void
-    {
-        $template = ServerTemplate::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $response = $this->actingAs($this->user)
-            ->put(route('server-templates.update', $template->id), [
-                'name' => '', // Invalid: empty string
-                'services' => 'not-an-array', // Invalid: not an array
-            ]);
-
-        $response->assertSessionHasErrors(['name', 'services']);
-    }
-
-    public function test_update_prevents_access_to_other_users_templates(): void
-    {
-        $otherUser = User::factory()->create();
-        $template = ServerTemplate::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
-
-        $response = $this->actingAs($this->user)
-            ->put(route('server-templates.update', $template->id), [
-                'name' => 'Hacked Name',
-            ]);
-
-        $response->assertStatus(404);
-    }
-
-    public function test_update_returns_404_for_nonexistent_template(): void
-    {
-        $response = $this->actingAs($this->user)
-            ->put(route('server-templates.update', 99999), [
-                'name' => 'Test Name',
-            ]);
-
-        $response->assertStatus(404);
-    }
-
-    public function test_update_requires_authentication(): void
-    {
-        $template = ServerTemplate::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $response = $this->put(route('server-templates.update', $template->id), [
-            'name' => 'Test Name',
-        ]);
-
-        $response->assertStatus(302); // Redirect to login
-    }
-
-    public function test_destroy_deletes_server_template(): void
-    {
-        $template = ServerTemplate::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $response = $this->actingAs($this->user)
-            ->delete(route('server-templates.destroy', $template->id));
-
-        $response->assertRedirect()
-            ->assertSessionHas('success', 'Server template deleted successfully.');
-
-        $this->assertDatabaseMissing('server_templates', [
-            'id' => $template->id,
-        ]);
-    }
-
-    public function test_destroy_prevents_access_to_other_users_templates(): void
-    {
-        $otherUser = User::factory()->create();
-        $template = ServerTemplate::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
-
-        $response = $this->actingAs($this->user)
-            ->delete(route('server-templates.destroy', $template->id));
-
-        $response->assertStatus(404);
-
-        // Ensure the template still exists
-        $this->assertDatabaseHas('server_templates', [
-            'id' => $template->id,
-        ]);
-    }
-
-    public function test_destroy_returns_404_for_nonexistent_template(): void
-    {
-        $response = $this->actingAs($this->user)
-            ->delete(route('server-templates.destroy', 99999));
-
-        $response->assertStatus(404);
-    }
-
-    public function test_destroy_requires_authentication(): void
-    {
-        $template = ServerTemplate::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $response = $this->delete(route('server-templates.destroy', $template->id));
-
-        $response->assertStatus(302); // Redirect to login
-    }
-
-    public function test_server_template_belongs_to_user(): void
-    {
-        $template = ServerTemplate::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->assertEquals($this->user->id, $template->user->id);
-        $this->assertInstanceOf(User::class, $template->user);
-    }
-
-    public function test_user_has_many_server_templates(): void
-    {
-        $templates = ServerTemplate::factory()->count(3)->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $userTemplates = $this->user->serverTemplates()->get();
-
-        $this->assertCount(3, $userTemplates);
-        $this->assertEquals($templates->pluck('id')->sort()->values(), $userTemplates->pluck('id')->sort()->values());
-    }
-
-    public function test_server_template_casts_services_to_array(): void
-    {
-        $services = [
+    // Ensure only user's templates are returned
+    expect($response->json('templates'))->toHaveCount(3);
+});
+
+test('index requires authentication', function () {
+    $response = $this->getJson(route('server-templates.index'));
+
+    $response->assertStatus(401);
+});
+
+test('store creates server template', function () {
+    $data = [
+        'name' => 'My Web Server Template',
+        'services' => [
             'php' => '8.4',
             'nginx' => 'latest',
             'mysql' => '8.4',
-        ];
+        ],
+    ];
 
-        $template = ServerTemplate::factory()->create([
-            'user_id' => $this->user->id,
-            'services' => $services,
+    $response = $this->actingAs($this->user)
+        ->post(route('server-templates.store'), $data);
+
+    $response->assertRedirect()
+        ->assertSessionHas('success', 'Server template created successfully.');
+
+    $this->assertDatabaseHas('server_templates', [
+        'user_id' => $this->user->id,
+        'name' => 'My Web Server Template',
+        'services' => $this->castAsJson([
+            'php' => '8.4',
+            'nginx' => 'latest',
+            'mysql' => '8.4',
+        ]),
+    ]);
+});
+
+test('store validates required fields', function () {
+    $response = $this->actingAs($this->user)
+        ->post(route('server-templates.store'), []);
+
+    $response->assertSessionHasErrors(['name', 'services']);
+});
+
+test('store validates name is string', function () {
+    $data = [
+        'name' => 123,
+        'services' => ['php' => '8.4'],
+    ];
+
+    $response = $this->actingAs($this->user)
+        ->post(route('server-templates.store'), $data);
+
+    $response->assertSessionHasErrors(['name']);
+});
+
+test('store validates name max length', function () {
+    $data = [
+        'name' => str_repeat('a', 256), // 256 characters (over the 255 limit)
+        'services' => ['php' => '8.4'],
+    ];
+
+    $response = $this->actingAs($this->user)
+        ->post(route('server-templates.store'), $data);
+
+    $response->assertSessionHasErrors(['name']);
+});
+
+test('store validates services is array', function () {
+    $data = [
+        'name' => 'Test Template',
+        'services' => 'not-an-array',
+    ];
+
+    $response = $this->actingAs($this->user)
+        ->post(route('server-templates.store'), $data);
+
+    $response->assertSessionHasErrors(['services']);
+});
+
+test('store requires authentication', function () {
+    $data = [
+        'name' => 'Test Template',
+        'services' => ['php' => '8.4'],
+    ];
+
+    $response = $this->post(route('server-templates.store'), $data);
+
+    $response->assertStatus(302);
+    // Redirect to login
+});
+
+test('update modifies existing server template', function () {
+    $template = ServerTemplate::factory()->create([
+        'user_id' => $this->user->id,
+        'name' => 'Original Name',
+        'services' => ['php' => '8.2'],
+    ]);
+
+    $updateData = [
+        'name' => 'Updated Name',
+        'services' => [
+            'php' => '8.4',
+            'nginx' => 'latest',
+        ],
+    ];
+
+    $response = $this->actingAs($this->user)
+        ->put(route('server-templates.update', $template->id), $updateData);
+
+    $response->assertRedirect()
+        ->assertSessionHas('success', 'Server template updated successfully.');
+
+    $template->refresh();
+    expect($template->name)->toEqual('Updated Name');
+    expect($template->services)->toEqual([
+        'php' => '8.4',
+        'nginx' => 'latest',
+    ]);
+});
+
+test('update allows partial updates', function () {
+    $template = ServerTemplate::factory()->create([
+        'user_id' => $this->user->id,
+        'name' => 'Original Name',
+        'services' => ['php' => '8.2'],
+    ]);
+
+    // Update only the name
+    $response = $this->actingAs($this->user)
+        ->put(route('server-templates.update', $template->id), [
+            'name' => 'New Name Only',
         ]);
 
-        $this->assertIsArray($template->services);
-        $this->assertEquals($services, $template->services);
+    $response->assertRedirect()
+        ->assertSessionHas('success', 'Server template updated successfully.');
 
-        // Test with fresh instance from database
-        $template = ServerTemplate::find($template->id);
-        $this->assertIsArray($template->services);
-        $this->assertEquals($services, $template->services);
-    }
+    $template->refresh();
+    expect($template->name)->toEqual('New Name Only');
+    expect($template->services)->toEqual(['php' => '8.2']);
 
-    public function test_server_template_factory_creates_valid_instance(): void
-    {
-        $template = ServerTemplate::factory()->create([
-            'user_id' => $this->user->id,
+    // Should remain unchanged
+    // Update only the services
+    $response = $this->actingAs($this->user)
+        ->put(route('server-templates.update', $template->id), [
+            'services' => ['nginx' => 'latest'],
         ]);
 
-        $this->assertInstanceOf(ServerTemplate::class, $template);
-        $this->assertEquals($this->user->id, $template->user_id);
-        $this->assertIsString($template->name);
-        $this->assertIsArray($template->services);
-        $this->assertNotEmpty($template->name);
-        $this->assertNotEmpty($template->services);
-    }
-}
+    $response->assertRedirect()
+        ->assertSessionHas('success', 'Server template updated successfully.');
+
+    $template->refresh();
+    expect($template->name)->toEqual('New Name Only');
+    // Should remain unchanged
+    expect($template->services)->toEqual(['nginx' => 'latest']);
+});
+
+test('update validates fields when provided', function () {
+    $template = ServerTemplate::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->put(route('server-templates.update', $template->id), [
+            'name' => '', // Invalid: empty string
+            'services' => 'not-an-array', // Invalid: not an array
+        ]);
+
+    $response->assertSessionHasErrors(['name', 'services']);
+});
+
+test('update prevents access to other users templates', function () {
+    $otherUser = User::factory()->create();
+    $template = ServerTemplate::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->put(route('server-templates.update', $template->id), [
+            'name' => 'Hacked Name',
+        ]);
+
+    $response->assertStatus(404);
+});
+
+test('update returns 404 for nonexistent template', function () {
+    $response = $this->actingAs($this->user)
+        ->put(route('server-templates.update', 99999), [
+            'name' => 'Test Name',
+        ]);
+
+    $response->assertStatus(404);
+});
+
+test('update requires authentication', function () {
+    $template = ServerTemplate::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $response = $this->put(route('server-templates.update', $template->id), [
+        'name' => 'Test Name',
+    ]);
+
+    $response->assertStatus(302);
+    // Redirect to login
+});
+
+test('destroy deletes server template', function () {
+    $template = ServerTemplate::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->delete(route('server-templates.destroy', $template->id));
+
+    $response->assertRedirect()
+        ->assertSessionHas('success', 'Server template deleted successfully.');
+
+    $this->assertDatabaseMissing('server_templates', [
+        'id' => $template->id,
+    ]);
+});
+
+test('destroy prevents access to other users templates', function () {
+    $otherUser = User::factory()->create();
+    $template = ServerTemplate::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->delete(route('server-templates.destroy', $template->id));
+
+    $response->assertStatus(404);
+
+    // Ensure the template still exists
+    $this->assertDatabaseHas('server_templates', [
+        'id' => $template->id,
+    ]);
+});
+
+test('destroy returns 404 for nonexistent template', function () {
+    $response = $this->actingAs($this->user)
+        ->delete(route('server-templates.destroy', 99999));
+
+    $response->assertStatus(404);
+});
+
+test('destroy requires authentication', function () {
+    $template = ServerTemplate::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $response = $this->delete(route('server-templates.destroy', $template->id));
+
+    $response->assertStatus(302);
+    // Redirect to login
+});
+
+test('server template belongs to user', function () {
+    $template = ServerTemplate::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    expect($template->user->id)->toEqual($this->user->id);
+    expect($template->user)->toBeInstanceOf(User::class);
+});
+
+test('user has many server templates', function () {
+    $templates = ServerTemplate::factory()->count(3)->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $userTemplates = $this->user->serverTemplates()->get();
+
+    expect($userTemplates)->toHaveCount(3);
+    expect($userTemplates->pluck('id')->sort()->values())->toEqual($templates->pluck('id')->sort()->values());
+});
+
+test('server template casts services to array', function () {
+    $services = [
+        'php' => '8.4',
+        'nginx' => 'latest',
+        'mysql' => '8.4',
+    ];
+
+    $template = ServerTemplate::factory()->create([
+        'user_id' => $this->user->id,
+        'services' => $services,
+    ]);
+
+    expect($template->services)->toBeArray();
+    expect($template->services)->toEqual($services);
+
+    // Test with fresh instance from database
+    $template = ServerTemplate::find($template->id);
+    expect($template->services)->toBeArray();
+    expect($template->services)->toEqual($services);
+});
+
+test('server template factory creates valid instance', function () {
+    $template = ServerTemplate::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    expect($template)->toBeInstanceOf(ServerTemplate::class);
+    expect($template->user_id)->toEqual($this->user->id);
+    expect($template->name)->toBeString();
+    expect($template->services)->toBeArray();
+    expect($template->name)->not->toBeEmpty();
+    expect($template->services)->not->toBeEmpty();
+});

--- a/tests/Feature/ServerTest.php
+++ b/tests/Feature/ServerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\Server\Update;
 use App\Enums\OperatingSystem;
 use App\Enums\ServerStatus;
@@ -22,996 +20,949 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Sanctum\Sanctum;
-use Tests\TestCase;
 
-class ServerTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_server(): void
-    {
-        $this->actingAs($this->user);
+test('create server', function () {
+    $this->actingAs($this->user);
 
-        Storage::fake();
-        SSH::fake('user_not_found'); // fake output for vito user check and service installations
+    Storage::fake();
+    SSH::fake('user_not_found');
 
-        $this->post(route('servers.store', [
-            'provider' => Custom::id(),
-            'name' => 'test',
-            'ip' => '1.1.1.1',
-            'port' => '22',
-            'os' => OperatingSystem::UBUNTU22->value,
-            'services' => [
-                [
-                    'name' => 'ufw',
-                    'type' => 'firewall',
-                    'version' => 'latest',
-                ],
+    // fake output for vito user check and service installations
+    $this->post(route('servers.store', [
+        'provider' => Custom::id(),
+        'name' => 'test',
+        'ip' => '1.1.1.1',
+        'port' => '22',
+        'os' => OperatingSystem::UBUNTU22->value,
+        'services' => [
+            [
+                'name' => 'ufw',
+                'type' => 'firewall',
+                'version' => 'latest',
             ],
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('servers', [
-            'name' => 'test',
-            'ip' => '1.1.1.1',
-            'status' => ServerStatus::READY,
-        ]);
-
-        /** @var Server $server */
-        $server = Server::where('name', 'test')->where('ip', '1.1.1.1')->first();
-
-        $this->assertDatabaseHas('services', [
-            'server_id' => $server->id,
-            'type' => 'firewall',
-            'name' => 'ufw',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-    }
-
-    public function test_delete_server(): void
-    {
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $this->delete(route('servers.destroy', $this->server), [
-            'name' => $this->server->name,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('servers', [
-            'id' => $this->server->id,
-        ]);
-    }
-
-    public function test_cannot_delete_on_provider(): void
-    {
-        Mail::fake();
-        Http::fake([
-            '*' => Http::response([], 401),
-        ]);
-
-        $this->actingAs($this->user);
-
-        $provider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Hetzner::id(),
-            'credentials' => [
-                'token' => 'token',
-            ],
-        ]);
-
-        $this->server->update([
-            'provider' => Hetzner::id(),
-            'provider_id' => $provider->id,
-            'provider_data' => [
-                'hetzner_id' => 1,
-                'ssh_key_id' => 1,
-            ],
-        ]);
-
-        $this->delete(route('servers.destroy', $this->server), [
-            'name' => $this->server->name,
-            'delete_from_provider' => true,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('servers', [
-            'id' => $this->server->id,
-        ]);
-
-        Mail::assertSent(NotificationMail::class);
-    }
-
-    public function test_delete_server_destroys_provider_vm_when_opted_in(): void
-    {
-        Http::fake();
-
-        $this->actingAs($this->user);
-
-        $provider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Hetzner::id(),
-            'credentials' => [
-                'token' => 'token',
-            ],
-        ]);
-
-        $this->server->update([
-            'provider' => Hetzner::id(),
-            'provider_id' => $provider->id,
-            'provider_data' => [
-                'hetzner_id' => 42,
-                'ssh_key_id' => 1,
-            ],
-        ]);
-
-        $this->delete(route('servers.destroy', $this->server), [
-            'name' => $this->server->name,
-            'delete_from_provider' => true,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('servers', [
-            'id' => $this->server->id,
-        ]);
-
-        Http::assertSent(fn ($request): bool => $request->method() === 'DELETE'
-            && str_contains($request->url(), '/servers/42'));
-    }
-
-    public function test_delete_server_keeps_provider_vm_when_opted_out(): void
-    {
-        Http::fake();
-
-        $this->actingAs($this->user);
-
-        $provider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Hetzner::id(),
-            'credentials' => [
-                'token' => 'token',
-            ],
-        ]);
-
-        $this->server->update([
-            'provider' => Hetzner::id(),
-            'provider_id' => $provider->id,
-            'provider_data' => [
-                'hetzner_id' => 42,
-                'ssh_key_id' => 1,
-            ],
-        ]);
-
-        $this->delete(route('servers.destroy', $this->server), [
-            'name' => $this->server->name,
-            'delete_from_provider' => false,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('servers', [
-            'id' => $this->server->id,
-        ]);
-
-        Http::assertNothingSent();
-    }
-
-    public function test_delete_server_requires_delete_from_provider_for_non_custom(): void
-    {
-        $this->actingAs($this->user);
-
-        $provider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Hetzner::id(),
-            'credentials' => [
-                'token' => 'token',
-            ],
-        ]);
-
-        $this->server->update([
-            'provider' => Hetzner::id(),
-            'provider_id' => $provider->id,
-            'provider_data' => [
-                'hetzner_id' => 42,
-                'ssh_key_id' => 1,
-            ],
-        ]);
-
-        $this->delete(route('servers.destroy', $this->server), [
-            'name' => $this->server->name,
-        ])
-            ->assertSessionHasErrors('delete_from_provider');
-
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-        ]);
-    }
-
-    public function test_api_delete_server_defaults_to_destroying_provider_vm(): void
-    {
-        Http::fake();
-
-        $provider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Hetzner::id(),
-            'credentials' => [
-                'token' => 'token',
-            ],
-        ]);
-
-        $this->server->update([
-            'provider' => Hetzner::id(),
-            'provider_id' => $provider->id,
-            'provider_data' => [
-                'hetzner_id' => 99,
-                'ssh_key_id' => 1,
-            ],
-        ]);
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $this->deleteJson(route('api.projects.servers.delete', [
-            'project' => $this->server->project_id,
-            'server' => $this->server->id,
-        ]))
-            ->assertNoContent();
-
-        $this->assertDatabaseMissing('servers', [
-            'id' => $this->server->id,
-        ]);
-
-        Http::assertSent(fn ($request): bool => $request->method() === 'DELETE'
-            && str_contains($request->url(), '/servers/99'));
-    }
-
-    public function test_api_delete_server_can_opt_out_of_provider_destruction(): void
-    {
-        Http::fake();
-
-        $provider = ServerProvider::factory()->create([
-            'user_id' => $this->user->id,
-            'provider' => Hetzner::id(),
-            'credentials' => [
-                'token' => 'token',
-            ],
-        ]);
-
-        $this->server->update([
-            'provider' => Hetzner::id(),
-            'provider_id' => $provider->id,
-            'provider_data' => [
-                'hetzner_id' => 99,
-                'ssh_key_id' => 1,
-            ],
-        ]);
-
-        Sanctum::actingAs($this->user, ['read', 'write']);
-
-        $this->deleteJson(route('api.projects.servers.delete', [
-            'project' => $this->server->project_id,
-            'server' => $this->server->id,
-        ]), ['delete_from_provider' => false])
-            ->assertNoContent();
-
-        $this->assertDatabaseMissing('servers', [
-            'id' => $this->server->id,
-        ]);
-
-        Http::assertNothingSent();
-    }
-
-    public function test_check_connection_is_ready(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->server->update(['status' => ServerStatus::DISCONNECTED]);
-
-        $this->patch(route('servers.status', $this->server))
-            ->assertSessionHas('success', 'Server status is '.ServerStatus::READY->getText());
-
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-            'status' => ServerStatus::READY,
-        ]);
-    }
-
-    public function test_connection_failed(): void
-    {
-        SSH::fake()->connectionWillFail();
-
-        $this->actingAs($this->user);
-
-        $this->server->update(['status' => ServerStatus::READY]);
-
-        $this->patch(route('servers.status', $this->server))
-            ->assertSessionHas('gray', 'Server status is '.ServerStatus::DISCONNECTED->getText());
-
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-            'status' => ServerStatus::DISCONNECTED,
-        ]);
-    }
-
-    public function test_reboot_server(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('servers.reboot', $this->server))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-            'status' => ServerStatus::DISCONNECTED,
-        ]);
-    }
-
-    public function test_edit_server(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->patch(route('server-settings.update', $this->server), [
-            'name' => 'new-name',
-            'ip' => $this->server->ip,
-            'port' => $this->server->port,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-            'name' => 'new-name',
-        ]);
-    }
-
-    public function test_edit_server_ip_address(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->patch(route('server-settings.update', $this->server), [
-            'name' => $this->server->name,
-            'ip' => '2.2.2.2',
-            'port' => $this->server->port,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-            'ip' => '2.2.2.2',
-            'status' => ServerStatus::READY,
-        ]);
-    }
-
-    public function test_edit_server_ip_address_and_disconnect(): void
-    {
-        SSH::fake()->connectionWillFail();
-
-        $this->actingAs($this->user);
-
-        $this->patch(route('server-settings.update', $this->server), [
-            'name' => $this->server->name,
-            'ip' => '2.2.2.2',
-            'port' => 2222,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-            'ip' => '2.2.2.2',
-            'port' => 2222,
-            'status' => ServerStatus::DISCONNECTED,
-        ]);
-    }
-
-    public function test_check_updates(): void
-    {
-        SSH::fake('Available updates:10');
-
-        $this->actingAs($this->user);
-
-        $this->post(route('servers.check-for-updates', $this->server))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->server->refresh();
-        $this->assertEquals(10, $this->server->updates);
-    }
-
-    public function test_check_updates_splits_kernel_updates(): void
-    {
-        SSH::fake("Available updates:5\nKernel updates:2");
-
-        $this->actingAs($this->user);
-
-        $this->post(route('servers.check-for-updates', $this->server))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->server->refresh();
-        $this->assertEquals(5, $this->server->updates);
-        $this->assertEquals(2, $this->server->kernel_updates);
-    }
-
-    public function test_kernel_update_warning_is_exposed(): void
-    {
-        $this->server->update(['kernel_updates' => 1]);
-
-        $warnings = collect($this->server->getWarnings());
-
-        $this->assertTrue($warnings->contains(fn (array $w): bool => $w['key'] === 'kernel_update_available' && $w['count'] === 1));
-    }
-
-    public function test_update_server(): void
-    {
-        SSH::fake('Available updates:0');
-
-        $this->actingAs($this->user);
-
-        $this->post(route('servers.update', $this->server))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->server->refresh();
-
-        $this->assertEquals(ServerStatus::READY, $this->server->status);
-        $this->assertEquals(0, $this->server->updates);
-    }
-
-    public function test_os_upgrade_parses_markers(): void
-    {
-        SSH::fake("Packages upgraded:7\nReboot required:1");
-
-        $result = $this->server->os()->upgrade();
-
-        $this->assertSame(7, $result['upgraded']);
-        $this->assertTrue($result['reboot_required']);
-    }
-
-    public function test_auto_update_notifies_when_packages_upgraded(): void
-    {
-        SSH::fake("Packages upgraded:3\nReboot required:1\nAvailable updates:0\nKernel updates:2");
-        Notifier::spy();
-
-        app(Update::class)->update($this->server, notify: true);
-
-        Notifier::shouldHaveReceived('send')->withArgs(
-            function (object $notifiable, object $notification): bool {
-                if (! $notification instanceof ServerAutoUpdateCompleted) {
-                    return false;
-                }
-
-                $text = $notification->rawText();
-
-                return str_contains($text, 'Packages upgraded: 3')
-                    && str_contains($text, 'Kernel updates available: 2')
-                    && str_contains($text, 'rebooted');
+        ],
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('servers', [
+        'name' => 'test',
+        'ip' => '1.1.1.1',
+        'status' => ServerStatus::READY,
+    ]);
+
+    /** @var Server $server */
+    $server = Server::where('name', 'test')->where('ip', '1.1.1.1')->first();
+
+    $this->assertDatabaseHas('services', [
+        'server_id' => $server->id,
+        'type' => 'firewall',
+        'name' => 'ufw',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+});
+
+test('delete server', function () {
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $this->delete(route('servers.destroy', $this->server), [
+        'name' => $this->server->name,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseMissing('servers', [
+        'id' => $this->server->id,
+    ]);
+});
+
+test('cannot delete on provider', function () {
+    Mail::fake();
+    Http::fake([
+        '*' => Http::response([], 401),
+    ]);
+
+    $this->actingAs($this->user);
+
+    $provider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Hetzner::id(),
+        'credentials' => [
+            'token' => 'token',
+        ],
+    ]);
+
+    $this->server->update([
+        'provider' => Hetzner::id(),
+        'provider_id' => $provider->id,
+        'provider_data' => [
+            'hetzner_id' => 1,
+            'ssh_key_id' => 1,
+        ],
+    ]);
+
+    $this->delete(route('servers.destroy', $this->server), [
+        'name' => $this->server->name,
+        'delete_from_provider' => true,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseMissing('servers', [
+        'id' => $this->server->id,
+    ]);
+
+    Mail::assertSent(NotificationMail::class);
+});
+
+test('delete server destroys provider vm when opted in', function () {
+    Http::fake();
+
+    $this->actingAs($this->user);
+
+    $provider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Hetzner::id(),
+        'credentials' => [
+            'token' => 'token',
+        ],
+    ]);
+
+    $this->server->update([
+        'provider' => Hetzner::id(),
+        'provider_id' => $provider->id,
+        'provider_data' => [
+            'hetzner_id' => 42,
+            'ssh_key_id' => 1,
+        ],
+    ]);
+
+    $this->delete(route('servers.destroy', $this->server), [
+        'name' => $this->server->name,
+        'delete_from_provider' => true,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseMissing('servers', [
+        'id' => $this->server->id,
+    ]);
+
+    Http::assertSent(fn ($request): bool => $request->method() === 'DELETE'
+        && str_contains($request->url(), '/servers/42'));
+});
+
+test('delete server keeps provider vm when opted out', function () {
+    Http::fake();
+
+    $this->actingAs($this->user);
+
+    $provider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Hetzner::id(),
+        'credentials' => [
+            'token' => 'token',
+        ],
+    ]);
+
+    $this->server->update([
+        'provider' => Hetzner::id(),
+        'provider_id' => $provider->id,
+        'provider_data' => [
+            'hetzner_id' => 42,
+            'ssh_key_id' => 1,
+        ],
+    ]);
+
+    $this->delete(route('servers.destroy', $this->server), [
+        'name' => $this->server->name,
+        'delete_from_provider' => false,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseMissing('servers', [
+        'id' => $this->server->id,
+    ]);
+
+    Http::assertNothingSent();
+});
+
+test('delete server requires delete from provider for non custom', function () {
+    $this->actingAs($this->user);
+
+    $provider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Hetzner::id(),
+        'credentials' => [
+            'token' => 'token',
+        ],
+    ]);
+
+    $this->server->update([
+        'provider' => Hetzner::id(),
+        'provider_id' => $provider->id,
+        'provider_data' => [
+            'hetzner_id' => 42,
+            'ssh_key_id' => 1,
+        ],
+    ]);
+
+    $this->delete(route('servers.destroy', $this->server), [
+        'name' => $this->server->name,
+    ])
+        ->assertSessionHasErrors('delete_from_provider');
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+    ]);
+});
+
+test('api delete server defaults to destroying provider vm', function () {
+    Http::fake();
+
+    $provider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Hetzner::id(),
+        'credentials' => [
+            'token' => 'token',
+        ],
+    ]);
+
+    $this->server->update([
+        'provider' => Hetzner::id(),
+        'provider_id' => $provider->id,
+        'provider_data' => [
+            'hetzner_id' => 99,
+            'ssh_key_id' => 1,
+        ],
+    ]);
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $this->deleteJson(route('api.projects.servers.delete', [
+        'project' => $this->server->project_id,
+        'server' => $this->server->id,
+    ]))
+        ->assertNoContent();
+
+    $this->assertDatabaseMissing('servers', [
+        'id' => $this->server->id,
+    ]);
+
+    Http::assertSent(fn ($request): bool => $request->method() === 'DELETE'
+        && str_contains($request->url(), '/servers/99'));
+});
+
+test('api delete server can opt out of provider destruction', function () {
+    Http::fake();
+
+    $provider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => Hetzner::id(),
+        'credentials' => [
+            'token' => 'token',
+        ],
+    ]);
+
+    $this->server->update([
+        'provider' => Hetzner::id(),
+        'provider_id' => $provider->id,
+        'provider_data' => [
+            'hetzner_id' => 99,
+            'ssh_key_id' => 1,
+        ],
+    ]);
+
+    Sanctum::actingAs($this->user, ['read', 'write']);
+
+    $this->deleteJson(route('api.projects.servers.delete', [
+        'project' => $this->server->project_id,
+        'server' => $this->server->id,
+    ]), ['delete_from_provider' => false])
+        ->assertNoContent();
+
+    $this->assertDatabaseMissing('servers', [
+        'id' => $this->server->id,
+    ]);
+
+    Http::assertNothingSent();
+});
+
+test('check connection is ready', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->server->update(['status' => ServerStatus::DISCONNECTED]);
+
+    $this->patch(route('servers.status', $this->server))
+        ->assertSessionHas('success', 'Server status is '.ServerStatus::READY->getText());
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'status' => ServerStatus::READY,
+    ]);
+});
+
+test('connection failed', function () {
+    SSH::fake()->connectionWillFail();
+
+    $this->actingAs($this->user);
+
+    $this->server->update(['status' => ServerStatus::READY]);
+
+    $this->patch(route('servers.status', $this->server))
+        ->assertSessionHas('gray', 'Server status is '.ServerStatus::DISCONNECTED->getText());
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'status' => ServerStatus::DISCONNECTED,
+    ]);
+});
+
+test('reboot server', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('servers.reboot', $this->server))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'status' => ServerStatus::DISCONNECTED,
+    ]);
+});
+
+test('edit server', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->patch(route('server-settings.update', $this->server), [
+        'name' => 'new-name',
+        'ip' => $this->server->ip,
+        'port' => $this->server->port,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'name' => 'new-name',
+    ]);
+});
+
+test('edit server ip address', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->patch(route('server-settings.update', $this->server), [
+        'name' => $this->server->name,
+        'ip' => '2.2.2.2',
+        'port' => $this->server->port,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'ip' => '2.2.2.2',
+        'status' => ServerStatus::READY,
+    ]);
+});
+
+test('edit server ip address and disconnect', function () {
+    SSH::fake()->connectionWillFail();
+
+    $this->actingAs($this->user);
+
+    $this->patch(route('server-settings.update', $this->server), [
+        'name' => $this->server->name,
+        'ip' => '2.2.2.2',
+        'port' => 2222,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'ip' => '2.2.2.2',
+        'port' => 2222,
+        'status' => ServerStatus::DISCONNECTED,
+    ]);
+});
+
+test('check updates', function () {
+    SSH::fake('Available updates:10');
+
+    $this->actingAs($this->user);
+
+    $this->post(route('servers.check-for-updates', $this->server))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->server->refresh();
+    expect($this->server->updates)->toEqual(10);
+});
+
+test('check updates splits kernel updates', function () {
+    SSH::fake("Available updates:5\nKernel updates:2");
+
+    $this->actingAs($this->user);
+
+    $this->post(route('servers.check-for-updates', $this->server))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->server->refresh();
+    expect($this->server->updates)->toEqual(5);
+    expect($this->server->kernel_updates)->toEqual(2);
+});
+
+test('kernel update warning is exposed', function () {
+    $this->server->update(['kernel_updates' => 1]);
+
+    $warnings = collect($this->server->getWarnings());
+
+    expect($warnings->contains(fn (array $w): bool => $w['key'] === 'kernel_update_available' && $w['count'] === 1))->toBeTrue();
+});
+
+test('update server', function () {
+    SSH::fake('Available updates:0');
+
+    $this->actingAs($this->user);
+
+    $this->post(route('servers.update', $this->server))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->server->refresh();
+
+    expect($this->server->status)->toEqual(ServerStatus::READY);
+    expect($this->server->updates)->toEqual(0);
+});
+
+test('os upgrade parses markers', function () {
+    SSH::fake("Packages upgraded:7\nReboot required:1");
+
+    $result = $this->server->os()->upgrade();
+
+    expect($result['upgraded'])->toBe(7);
+    expect($result['reboot_required'])->toBeTrue();
+});
+
+test('auto update notifies when packages upgraded', function () {
+    SSH::fake("Packages upgraded:3\nReboot required:1\nAvailable updates:0\nKernel updates:2");
+    Notifier::spy();
+
+    app(Update::class)->update($this->server, notify: true);
+
+    Notifier::shouldHaveReceived('send')->withArgs(
+        function (object $notifiable, object $notification): bool {
+            if (! $notification instanceof ServerAutoUpdateCompleted) {
+                return false;
             }
-        )->once();
-    }
 
-    public function test_manual_update_does_not_notify(): void
-    {
-        SSH::fake("Packages upgraded:3\nReboot required:1\nAvailable updates:0\nKernel updates:2");
-        Notifier::spy();
+            $text = $notification->rawText();
 
-        app(Update::class)->update($this->server);
+            return str_contains($text, 'Packages upgraded: 3')
+                && str_contains($text, 'Kernel updates available: 2')
+                && str_contains($text, 'rebooted');
+        }
+    )->once();
+});
 
-        Notifier::shouldNotHaveReceived('send');
-    }
+test('manual update does not notify', function () {
+    SSH::fake("Packages upgraded:3\nReboot required:1\nAvailable updates:0\nKernel updates:2");
+    Notifier::spy();
 
-    public function test_auto_update_is_silent_when_nothing_changed(): void
-    {
-        SSH::fake("Packages upgraded:0\nReboot required:0\nAvailable updates:0\nKernel updates:0");
-        Notifier::spy();
+    app(Update::class)->update($this->server);
 
-        app(Update::class)->update($this->server, notify: true);
+    Notifier::shouldNotHaveReceived('send');
+});
 
-        Notifier::shouldNotHaveReceived('send');
-    }
+test('auto update is silent when nothing changed', function () {
+    SSH::fake("Packages upgraded:0\nReboot required:0\nAvailable updates:0\nKernel updates:0");
+    Notifier::spy();
 
-    public function test_update_kernel(): void
-    {
-        SSH::fake("Available updates:0\nKernel updates:0");
+    app(Update::class)->update($this->server, notify: true);
 
-        $this->actingAs($this->user);
+    Notifier::shouldNotHaveReceived('send');
+});
 
-        $this->post(route('servers.update-kernel', $this->server))
-            ->assertSessionDoesntHaveErrors();
+test('update kernel', function () {
+    SSH::fake("Available updates:0\nKernel updates:0");
 
-        $this->server->refresh();
+    $this->actingAs($this->user);
 
-        $this->assertEquals(ServerStatus::DISCONNECTED, $this->server->status);
-        $this->assertEquals(0, $this->server->kernel_updates);
-    }
+    $this->post(route('servers.update-kernel', $this->server))
+        ->assertSessionDoesntHaveErrors();
 
-    public function test_only_owner_can_transfer_server(): void
-    {
-        $this->actingAs($this->user);
+    $this->server->refresh();
 
-        $oldProject = $this->server->project;
-        $oldProject->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::ADMIN,
-        ]);
+    expect($this->server->status)->toEqual(ServerStatus::DISCONNECTED);
+    expect($this->server->kernel_updates)->toEqual(0);
+});
 
-        /** @var Project $newProject */
-        $newProject = $this->user->projects()->create([
-            'name' => 'New Project',
-        ]);
-        $newProject->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::OWNER,
-        ]);
+test('only owner can transfer server', function () {
+    $this->actingAs($this->user);
 
-        $this->post(route('servers.transfer', $this->server), [
-            'project_id' => $newProject->id,
-        ])
-            ->assertForbidden();
-    }
+    $oldProject = $this->server->project;
+    $oldProject->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::ADMIN,
+    ]);
 
-    public function test_transfer_server(): void
-    {
-        $this->actingAs($this->user);
+    /** @var Project $newProject */
+    $newProject = $this->user->projects()->create([
+        'name' => 'New Project',
+    ]);
+    $newProject->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::OWNER,
+    ]);
 
-        $oldProject = $this->server->project;
-        $oldProject->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::OWNER,
-        ]);
+    $this->post(route('servers.transfer', $this->server), [
+        'project_id' => $newProject->id,
+    ])
+        ->assertForbidden();
+});
 
-        /** @var Project $newProject */
-        $newProject = $this->user->projects()->create([
-            'name' => 'New Project',
-        ]);
-        $newProject->users()->create([
-            'user_id' => $this->user->id,
-            'role' => UserRole::OWNER,
-        ]);
+test('transfer server', function () {
+    $this->actingAs($this->user);
 
-        $this->post(route('servers.transfer', $this->server), [
-            'project_id' => $newProject->id,
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $oldProject = $this->server->project;
+    $oldProject->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::OWNER,
+    ]);
 
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-            'project_id' => $newProject->id,
-        ]);
+    /** @var Project $newProject */
+    $newProject = $this->user->projects()->create([
+        'name' => 'New Project',
+    ]);
+    $newProject->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::OWNER,
+    ]);
 
-        $this->assertEquals($newProject->id, $this->user->refresh()->current_project_id);
-    }
+    $this->post(route('servers.transfer', $this->server), [
+        'project_id' => $newProject->id,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-    public function test_user_role_can_view_server(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::USER,
-        ]);
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'project_id' => $newProject->id,
+    ]);
 
-        $this->actingAs($this->user);
+    expect($this->user->refresh()->current_project_id)->toEqual($newProject->id);
+});
 
-        $this->get(route('servers.show', $this->server))
-            ->assertOk();
-    }
+test('user role can view server', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::USER,
+    ]);
 
-    public function test_admin_role_can_view_server(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::ADMIN,
-        ]);
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $this->get(route('servers.show', $this->server))
+        ->assertOk();
+});
 
-        $this->get(route('servers.show', $this->server))
-            ->assertOk();
-    }
+test('admin role can view server', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::ADMIN,
+    ]);
 
-    public function test_owner_role_can_view_server(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::OWNER,
-        ]);
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $this->get(route('servers.show', $this->server))
+        ->assertOk();
+});
 
-        $this->get(route('servers.show', $this->server))
-            ->assertOk();
-    }
+test('owner role can view server', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::OWNER,
+    ]);
 
-    public function test_user_role_cannot_create_server(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::USER,
-        ]);
+    $this->actingAs($this->user);
 
-        $this->actingAs($this->user);
+    $this->get(route('servers.show', $this->server))
+        ->assertOk();
+});
 
-        Storage::fake();
-        SSH::fake('user_not_found');
+test('user role cannot create server', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::USER,
+    ]);
 
-        $this->post(route('servers.store'), [
-            'provider' => Custom::id(),
-            'name' => 'test-user-server',
-            'ip' => '2.2.2.2',
-            'port' => '22',
-            'os' => OperatingSystem::UBUNTU22->value,
-            'services' => [
-                [
-                    'name' => 'ufw',
-                    'type' => 'firewall',
-                    'version' => 'latest',
-                ],
+    $this->actingAs($this->user);
+
+    Storage::fake();
+    SSH::fake('user_not_found');
+
+    $this->post(route('servers.store'), [
+        'provider' => Custom::id(),
+        'name' => 'test-user-server',
+        'ip' => '2.2.2.2',
+        'port' => '22',
+        'os' => OperatingSystem::UBUNTU22->value,
+        'services' => [
+            [
+                'name' => 'ufw',
+                'type' => 'firewall',
+                'version' => 'latest',
             ],
-        ])
-            ->assertForbidden();
-    }
+        ],
+    ])
+        ->assertForbidden();
+});
 
-    public function test_admin_role_can_create_server(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::ADMIN,
-        ]);
+test('admin role can create server', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::ADMIN,
+    ]);
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        Storage::fake();
-        SSH::fake('user_not_found');
+    Storage::fake();
+    SSH::fake('user_not_found');
 
-        $this->post(route('servers.store'), [
-            'provider' => Custom::id(),
-            'name' => 'test-admin-server',
-            'ip' => '3.3.3.3',
-            'port' => '22',
-            'os' => OperatingSystem::UBUNTU22->value,
-            'services' => [
-                [
-                    'name' => 'ufw',
-                    'type' => 'firewall',
-                    'version' => 'latest',
-                ],
+    $this->post(route('servers.store'), [
+        'provider' => Custom::id(),
+        'name' => 'test-admin-server',
+        'ip' => '3.3.3.3',
+        'port' => '22',
+        'os' => OperatingSystem::UBUNTU22->value,
+        'services' => [
+            [
+                'name' => 'ufw',
+                'type' => 'firewall',
+                'version' => 'latest',
             ],
-        ])
-            ->assertSessionDoesntHaveErrors();
+        ],
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('servers', [
-            'name' => 'test-admin-server',
-            'ip' => '3.3.3.3',
-        ]);
-    }
+    $this->assertDatabaseHas('servers', [
+        'name' => 'test-admin-server',
+        'ip' => '3.3.3.3',
+    ]);
+});
 
-    public function test_owner_role_can_create_server(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::OWNER,
-        ]);
+test('owner role can create server', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::OWNER,
+    ]);
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        Storage::fake();
-        SSH::fake('user_not_found');
+    Storage::fake();
+    SSH::fake('user_not_found');
 
-        $this->post(route('servers.store'), [
-            'provider' => Custom::id(),
-            'name' => 'test-owner-server',
-            'ip' => '4.4.4.4',
-            'port' => '22',
-            'os' => OperatingSystem::UBUNTU22->value,
-            'services' => [
-                [
-                    'name' => 'ufw',
-                    'type' => 'firewall',
-                    'version' => 'latest',
-                ],
+    $this->post(route('servers.store'), [
+        'provider' => Custom::id(),
+        'name' => 'test-owner-server',
+        'ip' => '4.4.4.4',
+        'port' => '22',
+        'os' => OperatingSystem::UBUNTU22->value,
+        'services' => [
+            [
+                'name' => 'ufw',
+                'type' => 'firewall',
+                'version' => 'latest',
             ],
-        ])
-            ->assertSessionDoesntHaveErrors();
+        ],
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('servers', [
-            'name' => 'test-owner-server',
-            'ip' => '4.4.4.4',
-        ]);
-    }
+    $this->assertDatabaseHas('servers', [
+        'name' => 'test-owner-server',
+        'ip' => '4.4.4.4',
+    ]);
+});
 
-    public function test_user_role_cannot_update_server(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::USER,
-        ]);
+test('user role cannot update server', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::USER,
+    ]);
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->patch(route('server-settings.update', $this->server), [
-            'name' => 'new-name',
-            'ip' => $this->server->ip,
-            'port' => $this->server->port,
-        ])
-            ->assertForbidden();
-    }
+    $this->patch(route('server-settings.update', $this->server), [
+        'name' => 'new-name',
+        'ip' => $this->server->ip,
+        'port' => $this->server->port,
+    ])
+        ->assertForbidden();
+});
 
-    public function test_admin_role_can_update_server(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::ADMIN,
-        ]);
+test('admin role can update server', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::ADMIN,
+    ]);
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->patch(route('server-settings.update', $this->server), [
-            'name' => 'new-name',
-            'ip' => $this->server->ip,
-            'port' => $this->server->port,
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->patch(route('server-settings.update', $this->server), [
+        'name' => 'new-name',
+        'ip' => $this->server->ip,
+        'port' => $this->server->port,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-            'name' => 'new-name',
-        ]);
-    }
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'name' => 'new-name',
+    ]);
+});
 
-    public function test_owner_role_can_update_server(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::OWNER,
-        ]);
+test('owner role can update server', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::OWNER,
+    ]);
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->patch(route('server-settings.update', $this->server), [
-            'name' => 'new-name',
-            'ip' => $this->server->ip,
-            'port' => $this->server->port,
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->patch(route('server-settings.update', $this->server), [
+        'name' => 'new-name',
+        'ip' => $this->server->ip,
+        'port' => $this->server->port,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-            'name' => 'new-name',
-        ]);
-    }
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'name' => 'new-name',
+    ]);
+});
 
-    public function test_user_role_cannot_delete_server(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::USER,
-        ]);
+test('user role cannot delete server', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::USER,
+    ]);
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->delete(route('servers.destroy', $this->server), [
-            'name' => $this->server->name,
-        ])
-            ->assertForbidden();
-    }
+    $this->delete(route('servers.destroy', $this->server), [
+        'name' => $this->server->name,
+    ])
+        ->assertForbidden();
+});
 
-    public function test_admin_role_cannot_delete_server(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::ADMIN,
-        ]);
+test('admin role cannot delete server', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::ADMIN,
+    ]);
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->delete(route('servers.destroy', $this->server), [
-            'name' => $this->server->name,
-        ])
-            ->assertForbidden();
-    }
+    $this->delete(route('servers.destroy', $this->server), [
+        'name' => $this->server->name,
+    ])
+        ->assertForbidden();
+});
 
-    public function test_owner_role_can_delete_server(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::OWNER,
-        ]);
+test('owner role can delete server', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::OWNER,
+    ]);
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->delete(route('servers.destroy', $this->server), [
-            'name' => $this->server->name,
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->delete(route('servers.destroy', $this->server), [
+        'name' => $this->server->name,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseMissing('servers', [
-            'id' => $this->server->id,
-        ]);
-    }
+    $this->assertDatabaseMissing('servers', [
+        'id' => $this->server->id,
+    ]);
+});
 
-    public function test_user_role_cannot_manage_server_operations(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::USER,
-        ]);
+test('user role cannot manage server operations', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::USER,
+    ]);
 
-        SSH::fake();
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        // Test reboot
-        $this->post(route('servers.reboot', $this->server))
-            ->assertForbidden();
+    // Test reboot
+    $this->post(route('servers.reboot', $this->server))
+        ->assertForbidden();
 
-        // Test check updates
-        $this->post(route('servers.check-for-updates', $this->server))
-            ->assertForbidden();
+    // Test check updates
+    $this->post(route('servers.check-for-updates', $this->server))
+        ->assertForbidden();
 
-        // Test update server
-        $this->post(route('servers.update', $this->server))
-            ->assertForbidden();
+    // Test update server
+    $this->post(route('servers.update', $this->server))
+        ->assertForbidden();
 
-        // Test update kernel
-        $this->post(route('servers.update-kernel', $this->server))
-            ->assertForbidden();
-    }
+    // Test update kernel
+    $this->post(route('servers.update-kernel', $this->server))
+        ->assertForbidden();
+});
 
-    public function test_admin_role_can_manage_server_operations(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::ADMIN,
-        ]);
+test('admin role can manage server operations', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::ADMIN,
+    ]);
 
-        SSH::fake('Available updates:10');
+    SSH::fake('Available updates:10');
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        // Test reboot
-        $this->post(route('servers.reboot', $this->server))
-            ->assertSessionDoesntHaveErrors();
+    // Test reboot
+    $this->post(route('servers.reboot', $this->server))
+        ->assertSessionDoesntHaveErrors();
 
-        // Reset server status for next test
-        $this->server->update(['status' => ServerStatus::READY]);
+    // Reset server status for next test
+    $this->server->update(['status' => ServerStatus::READY]);
 
-        // Test check updates
-        $this->post(route('servers.check-for-updates', $this->server))
-            ->assertSessionDoesntHaveErrors();
+    // Test check updates
+    $this->post(route('servers.check-for-updates', $this->server))
+        ->assertSessionDoesntHaveErrors();
 
-        // Test update server
-        SSH::fake('Available updates:0');
-        $this->post(route('servers.update', $this->server))
-            ->assertSessionDoesntHaveErrors();
-    }
+    // Test update server
+    SSH::fake('Available updates:0');
+    $this->post(route('servers.update', $this->server))
+        ->assertSessionDoesntHaveErrors();
+});
 
-    public function test_owner_role_can_manage_server_operations(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::OWNER,
-        ]);
+test('owner role can manage server operations', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::OWNER,
+    ]);
 
-        SSH::fake('Available updates:10');
+    SSH::fake('Available updates:10');
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        // Test reboot
-        $this->post(route('servers.reboot', $this->server))
-            ->assertSessionDoesntHaveErrors();
+    // Test reboot
+    $this->post(route('servers.reboot', $this->server))
+        ->assertSessionDoesntHaveErrors();
 
-        // Reset server status for next test
-        $this->server->update(['status' => ServerStatus::READY]);
+    // Reset server status for next test
+    $this->server->update(['status' => ServerStatus::READY]);
 
-        // Test check updates
-        $this->post(route('servers.check-for-updates', $this->server))
-            ->assertSessionDoesntHaveErrors();
+    // Test check updates
+    $this->post(route('servers.check-for-updates', $this->server))
+        ->assertSessionDoesntHaveErrors();
 
-        // Test update server
-        SSH::fake('Available updates:0');
-        $this->post(route('servers.update', $this->server))
-            ->assertSessionDoesntHaveErrors();
-    }
+    // Test update server
+    SSH::fake('Available updates:0');
+    $this->post(route('servers.update', $this->server))
+        ->assertSessionDoesntHaveErrors();
+});
 
-    public function test_cannot_create_server_with_unauthorized_provider(): void
-    {
-        $this->actingAs($this->user);
+test('cannot create server with unauthorized provider', function () {
+    $this->actingAs($this->user);
 
-        // Create a server provider that belongs to a different user
-        $otherUser = User::factory()->create();
-        $unauthorizedProvider = ServerProvider::factory()->create([
-            'user_id' => $otherUser->id,
-            'provider' => Hetzner::id(),
-            'credentials' => ['token' => 'test-token'],
-        ]);
+    // Create a server provider that belongs to a different user
+    $otherUser = User::factory()->create();
+    $unauthorizedProvider = ServerProvider::factory()->create([
+        'user_id' => $otherUser->id,
+        'provider' => Hetzner::id(),
+        'credentials' => ['token' => 'test-token'],
+    ]);
 
-        Storage::fake();
-        SSH::fake('user_not_found');
+    Storage::fake();
+    SSH::fake('user_not_found');
 
-        $this->post(route('servers.store'), [
-            'provider' => Hetzner::id(),
-            'server_provider' => $unauthorizedProvider->id,
-            'name' => 'test-unauthorized-server',
-            'os' => OperatingSystem::UBUNTU22->value,
-            'plan' => 'cx11',
-            'region' => 'nbg1',
-            'services' => [
-                [
-                    'name' => 'ufw',
-                    'type' => 'firewall',
-                    'version' => 'latest',
-                ],
+    $this->post(route('servers.store'), [
+        'provider' => Hetzner::id(),
+        'server_provider' => $unauthorizedProvider->id,
+        'name' => 'test-unauthorized-server',
+        'os' => OperatingSystem::UBUNTU22->value,
+        'plan' => 'cx11',
+        'region' => 'nbg1',
+        'services' => [
+            [
+                'name' => 'ufw',
+                'type' => 'firewall',
+                'version' => 'latest',
             ],
-        ])
-            ->assertStatus(403)
-            ->assertSee('You do not have permission to use this server provider.');
+        ],
+    ])
+        ->assertStatus(403)
+        ->assertSee('You do not have permission to use this server provider.');
 
-        $this->assertDatabaseMissing('servers', [
-            'name' => 'test-unauthorized-server',
-        ]);
-    }
+    $this->assertDatabaseMissing('servers', [
+        'name' => 'test-unauthorized-server',
+    ]);
+});
 
-    public function test_cannot_create_server_with_ssh_connection_failure(): void
-    {
-        $this->actingAs($this->user);
+test('cannot create server with ssh connection failure', function () {
+    $this->actingAs($this->user);
 
-        Storage::fake();
-        SSH::fake()->connectionWillFail();
+    Storage::fake();
+    SSH::fake()->connectionWillFail();
 
-        $this->post(route('servers.store'), [
-            'provider' => Custom::id(),
-            'name' => 'test-connection-fail',
-            'ip' => '5.5.5.5',
-            'port' => '22',
-            'os' => OperatingSystem::UBUNTU22->value,
-            'services' => [],
-        ])
-            ->assertSessionHasErrors();
+    $this->post(route('servers.store'), [
+        'provider' => Custom::id(),
+        'name' => 'test-connection-fail',
+        'ip' => '5.5.5.5',
+        'port' => '22',
+        'os' => OperatingSystem::UBUNTU22->value,
+        'services' => [],
+    ])
+        ->assertSessionHasErrors();
 
-        $this->assertDatabaseMissing('servers', [
-            'name' => 'test-connection-fail',
-        ]);
-    }
+    $this->assertDatabaseMissing('servers', [
+        'name' => 'test-connection-fail',
+    ]);
+});
 
-    public function test_cannot_create_server_on_vito_server(): void
-    {
-        $this->actingAs($this->user);
+test('cannot create server on vito server', function () {
+    $this->actingAs($this->user);
 
-        Storage::fake();
-        SSH::fake('vito_managed_host');
+    Storage::fake();
+    SSH::fake('vito_managed_host');
 
-        $this->post(route('servers.store'), [
-            'provider' => Custom::id(),
-            'name' => 'test-vito-server',
-            'ip' => '6.6.6.6',
-            'port' => '22',
-            'os' => OperatingSystem::UBUNTU22->value,
-            'services' => [],
-        ])
-            ->assertSessionHasErrors();
+    $this->post(route('servers.store'), [
+        'provider' => Custom::id(),
+        'name' => 'test-vito-server',
+        'ip' => '6.6.6.6',
+        'port' => '22',
+        'os' => OperatingSystem::UBUNTU22->value,
+        'services' => [],
+    ])
+        ->assertSessionHasErrors();
 
-        $this->assertDatabaseMissing('servers', [
-            'name' => 'test-vito-server',
-        ]);
-    }
+    $this->assertDatabaseMissing('servers', [
+        'name' => 'test-vito-server',
+    ]);
+});
 
-    public function test_can_create_server_when_host_has_unrelated_vito_user(): void
-    {
-        $this->actingAs($this->user);
+test('can create server when host has unrelated vito user', function () {
+    $this->actingAs($this->user);
 
-        Storage::fake();
-        SSH::fake('ok');
+    Storage::fake();
+    SSH::fake('ok');
 
-        $this->post(route('servers.store'), [
-            'provider' => Custom::id(),
-            'name' => 'unrelated-vito-user',
-            'ip' => '7.7.7.7',
-            'port' => '22',
-            'os' => OperatingSystem::UBUNTU22->value,
-            'services' => [],
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('servers.store'), [
+        'provider' => Custom::id(),
+        'name' => 'unrelated-vito-user',
+        'ip' => '7.7.7.7',
+        'port' => '22',
+        'os' => OperatingSystem::UBUNTU22->value,
+        'services' => [],
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('servers', [
-            'name' => 'unrelated-vito-user',
-            'ip' => '7.7.7.7',
-        ]);
-    }
-}
+    $this->assertDatabaseHas('servers', [
+        'name' => 'unrelated-vito-user',
+        'ip' => '7.7.7.7',
+    ]);
+});

--- a/tests/Feature/ServiceConfigFileTest.php
+++ b/tests/Feature/ServiceConfigFileTest.php
@@ -1,119 +1,108 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Facades\SSH;
 use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class ServiceConfigFileTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_get_config_file(): void
-    {
-        $this->actingAs($this->user);
+test('get config file', function () {
+    $this->actingAs($this->user);
 
-        $service = Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'mysql',
-            'type' => 'database',
+    $service = Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'mysql',
+        'type' => 'database',
+    ]);
+
+    SSH::fake('config file content');
+
+    $response = $this->get(route('services.config', [
+        'server' => $this->server,
+        'service' => $service->id,
+        'config_name' => 'my.cnf',
+    ]));
+
+    $response->assertSuccessful()
+        ->assertJson([
+            'content' => 'config file content',
         ]);
+});
 
-        SSH::fake('config file content');
+test('get config file not found', function () {
+    $this->actingAs($this->user);
 
-        $response = $this->get(route('services.config', [
-            'server' => $this->server,
-            'service' => $service->id,
-            'config_name' => 'my.cnf',
-        ]));
+    $service = Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'mysql',
+        'type' => 'database',
+    ]);
 
-        $response->assertSuccessful()
-            ->assertJson([
-                'content' => 'config file content',
-            ]);
-    }
+    $response = $this->get(route('services.config', [
+        'server' => $this->server,
+        'service' => $service->id,
+        'config_name' => 'nonexistent.conf',
+    ]));
 
-    public function test_get_config_file_not_found(): void
-    {
-        $this->actingAs($this->user);
+    $response->assertSessionHasErrors(['config_name']);
+});
 
-        $service = Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'mysql',
-            'type' => 'database',
-        ]);
+test('update config file', function () {
+    $this->actingAs($this->user);
 
-        $response = $this->get(route('services.config', [
-            'server' => $this->server,
-            'service' => $service->id,
-            'config_name' => 'nonexistent.conf',
-        ]));
+    $service = Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'mysql',
+        'type' => 'database',
+    ]);
 
-        $response->assertSessionHasErrors(['config_name']);
-    }
+    SSH::fake('Active: active');
 
-    public function test_update_config_file(): void
-    {
-        $this->actingAs($this->user);
+    $response = $this->patch(route('services.config.update', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]), [
+        'config_name' => 'my.cnf',
+        'content' => 'new config content',
+    ]);
 
-        $service = Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'mysql',
-            'type' => 'database',
-        ]);
+    $response->assertSessionDoesntHaveErrors()
+        ->assertRedirect();
+});
 
-        SSH::fake('Active: active');
+test('update config file validates input', function () {
+    $this->actingAs($this->user);
 
-        $response = $this->patch(route('services.config.update', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]), [
-            'config_name' => 'my.cnf',
-            'content' => 'new config content',
-        ]);
+    $service = Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'mysql',
+        'type' => 'database',
+    ]);
 
-        $response->assertSessionDoesntHaveErrors()
-            ->assertRedirect();
-    }
+    $response = $this->patch(route('services.config.update', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]), [
+        'config_name' => 'my.cnf',
+    ]);
 
-    public function test_update_config_file_validates_input(): void
-    {
-        $this->actingAs($this->user);
+    $response->assertSessionHasErrors(['content']);
+});
 
-        $service = Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'mysql',
-            'type' => 'database',
-        ]);
+test('service without config paths returns error', function () {
+    $this->actingAs($this->user);
 
-        $response = $this->patch(route('services.config.update', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]), [
-            'config_name' => 'my.cnf',
-        ]);
+    $service = Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'vito-agent',
+        'type' => 'monitoring',
+    ]);
 
-        $response->assertSessionHasErrors(['content']);
-    }
+    $response = $this->get(route('services.config', [
+        'server' => $this->server,
+        'service' => $service->id,
+        'config_name' => 'test.conf',
+    ]));
 
-    public function test_service_without_config_paths_returns_error(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'vito-agent',
-            'type' => 'monitoring',
-        ]);
-
-        $response = $this->get(route('services.config', [
-            'server' => $this->server,
-            'service' => $service->id,
-            'config_name' => 'test.conf',
-        ]));
-
-        $response->assertSessionHasErrors(['config_paths']);
-    }
-}
+    $response->assertSessionHasErrors(['config_paths']);
+});

--- a/tests/Feature/ServiceLogsTest.php
+++ b/tests/Feature/ServiceLogsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Facades\SSH;
 use App\Models\Service;
 use App\Models\Site;
@@ -14,329 +12,303 @@ use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class ServiceLogsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_renders_catalogue_for_installed_services(): void
-    {
-        $this->actingAs($this->user);
+test('renders catalogue for installed services', function () {
+    $this->actingAs($this->user);
 
-        $response = $this->get(route('logs.services', $this->server));
+    $response = $this->get(route('logs.services', $this->server));
 
-        $response->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('server-logs/services')
-                ->where('title', 'Service logs')
-                ->has('catalogue')
-            );
+    $response->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('server-logs/services')
+            ->where('title', 'Service logs')
+            ->has('catalogue')
+        );
 
-        $catalogue = $response->viewData('page')['props']['catalogue'];
-        $keys = array_column($catalogue, 'key');
+    $catalogue = $response->viewData('page')['props']['catalogue'];
+    $keys = array_column($catalogue, 'key');
 
-        $this->assertContains('nginx:error', $keys);
-        $this->assertContains('nginx:access', $keys);
-        $this->assertContains('mysql:journal', $keys);
-        $this->assertContains('php:8.2:fpm-journal', $keys);
-        $this->assertContains('ufw:general', $keys);
-        $this->assertContains('supervisor:general', $keys);
-        $this->assertContains('redis:journal', $keys);
-        $this->assertContains('system:sshd', $keys);
-        $this->assertContains('php:8.2:user:vito', $keys);
-    }
+    expect($keys)->toContain('nginx:error');
+    expect($keys)->toContain('nginx:access');
+    expect($keys)->toContain('mysql:journal');
+    expect($keys)->toContain('php:8.2:fpm-journal');
+    expect($keys)->toContain('ufw:general');
+    expect($keys)->toContain('supervisor:general');
+    expect($keys)->toContain('redis:journal');
+    expect($keys)->toContain('system:sshd');
+    expect($keys)->toContain('php:8.2:user:vito');
+});
 
-    public function test_skips_services_without_a_registered_handler(): void
-    {
-        $this->actingAs($this->user);
+test('skips services without a registered handler', function () {
+    $this->actingAs($this->user);
 
-        Service::factory()->create([
-            'server_id' => $this->server->id,
-            'type' => 'vpn',
-            'name' => 'wireguard',
+    Service::factory()->create([
+        'server_id' => $this->server->id,
+        'type' => 'vpn',
+        'name' => 'wireguard',
+    ]);
+
+    $response = $this->get(route('logs.services', $this->server));
+
+    $response->assertSuccessful();
+
+    $catalogue = $response->viewData('page')['props']['catalogue'];
+    $keys = array_column($catalogue, 'key');
+
+    expect($keys)->toContain('nginx:error');
+    expect(array_filter($keys, fn (string $key): bool => str_starts_with($key, 'wireguard')))->toBeEmpty();
+});
+
+test('nginx exposes per site error log', function () {
+    $this->actingAs($this->user);
+
+    $response = $this->get(route('logs.services', $this->server));
+
+    $catalogue = $response->viewData('page')['props']['catalogue'];
+    $entries = collect($catalogue)->keyBy('key');
+
+    $key = 'nginx:site:'.$this->site->id.':error';
+    expect($entries->has($key))->toBeTrue();
+    expect($entries[$key]['display_target'])->toBe('/var/log/nginx/'.$this->site->domain.'-error.log');
+});
+
+test('services without has logs are skipped', function () {
+    $this->actingAs($this->user);
+
+    $response = $this->get(route('logs.services', $this->server));
+    $catalogue = $response->viewData('page')['props']['catalogue'];
+    $serviceLabels = array_unique(array_column($catalogue, 'service_label'));
+
+    expect($serviceLabels)->not->toContain('Node.js');
+    expect($serviceLabels)->not->toContain('NodeJS');
+});
+
+test('read with unknown key returns 404', function () {
+    $this->actingAs($this->user);
+    SSH::fake();
+
+    $this->postJson(route('logs.services.read', $this->server), [
+        'key' => 'nope:does-not-exist',
+    ])->assertNotFound();
+});
+
+test('read happy path for file source', function () {
+    $this->actingAs($this->user);
+    SSH::fake('nginx-error-output');
+
+    $this->postJson(route('logs.services.read', $this->server), [
+        'key' => 'nginx:error',
+    ])
+        ->assertSuccessful()
+        ->assertJson([
+            'content' => 'nginx-error-output',
+            'display_target' => '/var/log/nginx/error.log',
+            'source' => 'file',
         ]);
 
-        $response = $this->get(route('logs.services', $this->server));
+    SSH::assertExecutedContains('/var/log/nginx/error.log');
+});
 
-        $response->assertSuccessful();
+test('read returns 404 when file missing', function () {
+    $this->actingAs($this->user);
+    SSH::fake('VITO_NO_FILE');
 
-        $catalogue = $response->viewData('page')['props']['catalogue'];
-        $keys = array_column($catalogue, 'key');
+    $this->postJson(route('logs.services.read', $this->server), [
+        'key' => 'nginx:error',
+    ])
+        ->assertNotFound()
+        ->assertJson(['message' => 'The log file does not exist on the server.']);
+});
 
-        $this->assertContains('nginx:error', $keys);
-        $this->assertEmpty(array_filter($keys, fn (string $key): bool => str_starts_with($key, 'wireguard')));
-    }
+test('read journal source uses journalctl', function () {
+    $this->actingAs($this->user);
+    SSH::fake('mysql-journal-output');
 
-    public function test_nginx_exposes_per_site_error_log(): void
-    {
-        $this->actingAs($this->user);
+    $this->postJson(route('logs.services.read', $this->server), [
+        'key' => 'mysql:journal',
+    ])->assertSuccessful();
 
-        $response = $this->get(route('logs.services', $this->server));
+    SSH::assertExecutedContains("journalctl -u 'mysql.service'");
+});
 
-        $catalogue = $response->viewData('page')['props']['catalogue'];
-        $entries = collect($catalogue)->keyBy('key');
+test('read rejects lines above max', function () {
+    $this->actingAs($this->user);
 
-        $key = 'nginx:site:'.$this->site->id.':error';
-        $this->assertTrue($entries->has($key));
-        $this->assertSame('/var/log/nginx/'.$this->site->domain.'-error.log', $entries[$key]['display_target']);
-    }
+    $this->postJson(route('logs.services.read', $this->server), [
+        'key' => 'nginx:error',
+        'lines' => 3000,
+    ])->assertStatus(422);
+});
 
-    public function test_services_without_has_logs_are_skipped(): void
-    {
-        $this->actingAs($this->user);
+test('read rejects search with newline', function () {
+    $this->actingAs($this->user);
 
-        $response = $this->get(route('logs.services', $this->server));
-        $catalogue = $response->viewData('page')['props']['catalogue'];
-        $serviceLabels = array_unique(array_column($catalogue, 'service_label'));
+    $this->postJson(route('logs.services.read', $this->server), [
+        'key' => 'nginx:error',
+        'search' => "abc\ninjected",
+    ])->assertStatus(422);
+});
 
-        $this->assertNotContains('Node.js', $serviceLabels);
-        $this->assertNotContains('NodeJS', $serviceLabels);
-    }
+test('read with search shellescapes term', function () {
+    $this->actingAs($this->user);
+    SSH::fake('match');
 
-    public function test_read_with_unknown_key_returns_404(): void
-    {
-        $this->actingAs($this->user);
-        SSH::fake();
+    $this->postJson(route('logs.services.read', $this->server), [
+        'key' => 'nginx:error',
+        'search' => "needle's quote",
+    ])->assertSuccessful();
 
-        $this->postJson(route('logs.services.read', $this->server), [
-            'key' => 'nope:does-not-exist',
-        ])->assertNotFound();
-    }
+    SSH::assertExecutedContains("'needle'\\''s quote'");
+});
 
-    public function test_read_happy_path_for_file_source(): void
-    {
-        $this->actingAs($this->user);
-        SSH::fake('nginx-error-output');
+test('clear truncates file source', function () {
+    $this->actingAs($this->user);
+    SSH::fake();
 
-        $this->postJson(route('logs.services.read', $this->server), [
-            'key' => 'nginx:error',
-        ])
-            ->assertSuccessful()
-            ->assertJson([
-                'content' => 'nginx-error-output',
-                'display_target' => '/var/log/nginx/error.log',
-                'source' => 'file',
-            ]);
+    $this->post(route('logs.services.clear', $this->server), [
+        'key' => 'nginx:error',
+    ])
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Log cleared successfully');
 
-        SSH::assertExecutedContains('/var/log/nginx/error.log');
-    }
+    SSH::assertExecutedContains('/var/log/nginx/error.log');
+});
 
-    public function test_read_returns_404_when_file_missing(): void
-    {
-        $this->actingAs($this->user);
-        SSH::fake('VITO_NO_FILE');
+test('clear rejects journal source', function () {
+    $this->actingAs($this->user);
+    SSH::fake();
 
-        $this->postJson(route('logs.services.read', $this->server), [
-            'key' => 'nginx:error',
-        ])
-            ->assertNotFound()
-            ->assertJson(['message' => 'The log file does not exist on the server.']);
-    }
+    $this->postJson(route('logs.services.clear', $this->server), [
+        'key' => 'mysql:journal',
+    ])->assertStatus(422);
+});
 
-    public function test_read_journal_source_uses_journalctl(): void
-    {
-        $this->actingAs($this->user);
-        SSH::fake('mysql-journal-output');
+test('download invokes ssh download', function () {
+    $this->actingAs($this->user);
+    Bus::fake();
+    Queue::fake();
+    Carbon::setTestNow(Carbon::create(2026, 1, 1, 12));
+    Str::createRandomStringsUsing(fn (int $n): string => str_repeat('a', $n));
+    SSH::fake();
 
-        $this->postJson(route('logs.services.read', $this->server), [
-            'key' => 'mysql:journal',
-        ])->assertSuccessful();
+    $tmpName = $this->server->id.'-'.Carbon::now()->timestamp.'-aaaaaaaa-'.Str::slug('nginx:error').'.log';
+    Storage::disk('local')->put($tmpName, 'pretend-downloaded-bytes');
 
-        SSH::assertExecutedContains("journalctl -u 'mysql.service'");
-    }
-
-    public function test_read_rejects_lines_above_max(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->postJson(route('logs.services.read', $this->server), [
-            'key' => 'nginx:error',
-            'lines' => 3000,
-        ])->assertStatus(422);
-    }
-
-    public function test_read_rejects_search_with_newline(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->postJson(route('logs.services.read', $this->server), [
-            'key' => 'nginx:error',
-            'search' => "abc\ninjected",
-        ])->assertStatus(422);
-    }
-
-    public function test_read_with_search_shellescapes_term(): void
-    {
-        $this->actingAs($this->user);
-        SSH::fake('match');
-
-        $this->postJson(route('logs.services.read', $this->server), [
-            'key' => 'nginx:error',
-            'search' => "needle's quote",
-        ])->assertSuccessful();
-
-        SSH::assertExecutedContains("'needle'\\''s quote'");
-    }
-
-    public function test_clear_truncates_file_source(): void
-    {
-        $this->actingAs($this->user);
-        SSH::fake();
-
-        $this->post(route('logs.services.clear', $this->server), [
-            'key' => 'nginx:error',
-        ])
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Log cleared successfully');
-
-        SSH::assertExecutedContains('/var/log/nginx/error.log');
-    }
-
-    public function test_clear_rejects_journal_source(): void
-    {
-        $this->actingAs($this->user);
-        SSH::fake();
-
-        $this->postJson(route('logs.services.clear', $this->server), [
-            'key' => 'mysql:journal',
-        ])->assertStatus(422);
-    }
-
-    public function test_download_invokes_ssh_download(): void
-    {
-        $this->actingAs($this->user);
-        Bus::fake();
-        Queue::fake();
-        Carbon::setTestNow(Carbon::create(2026, 1, 1, 12));
-        Str::createRandomStringsUsing(fn (int $n): string => str_repeat('a', $n));
-        SSH::fake();
-
-        $tmpName = $this->server->id.'-'.Carbon::now()->timestamp.'-aaaaaaaa-'.Str::slug('nginx:error').'.log';
-        Storage::disk('local')->put($tmpName, 'pretend-downloaded-bytes');
-
-        try {
-            $this->get(route('logs.services.download', ['server' => $this->server, 'key' => 'nginx:error']))
-                ->assertSuccessful();
-
-            SSH::assertExecutedContains("sudo cat '/var/log/nginx/error.log'");
-        } finally {
-            Storage::disk('local')->delete($tmpName);
-            Str::createRandomStringsNormally();
-            Carbon::setTestNow();
-        }
-    }
-
-    public function test_download_journal_source(): void
-    {
-        $this->actingAs($this->user);
-        Bus::fake();
-        Queue::fake();
-        Carbon::setTestNow(Carbon::create(2026, 1, 1, 12));
-        Str::createRandomStringsUsing(fn (int $n): string => str_repeat('a', $n));
-        SSH::fake();
-
-        $tmpName = $this->server->id.'-'.Carbon::now()->timestamp.'-aaaaaaaa-'.Str::slug('mysql:journal').'.log';
-        Storage::disk('local')->put($tmpName, 'pretend-downloaded-bytes');
-
-        try {
-            $this->get(route('logs.services.download', ['server' => $this->server, 'key' => 'mysql:journal']))
-                ->assertSuccessful();
-
-            SSH::assertExecutedContains("sudo journalctl -u 'mysql.service'");
-        } finally {
-            Storage::disk('local')->delete($tmpName);
-            Str::createRandomStringsNormally();
-            Carbon::setTestNow();
-        }
-    }
-
-    public function test_download_returns_404_when_file_missing(): void
-    {
-        $this->actingAs($this->user);
-        SSH::fake('VITO_NO_FILE');
-
-        $this->getJson(route('logs.services.download', ['server' => $this->server, 'key' => 'nginx:error']))
-            ->assertNotFound()
-            ->assertJson(['message' => 'The log file does not exist on the server.']);
-    }
-
-    public function test_unknown_key_on_download_returns_404(): void
-    {
-        $this->actingAs($this->user);
-        SSH::fake();
-
-        $this->get(route('logs.services.download', ['server' => $this->server, 'key' => 'nope']))
-            ->assertNotFound();
-    }
-
-    public function test_multiple_sites_per_user_deduped(): void
-    {
-        $this->actingAs($this->user);
-
-        /** @var SourceControl $sc */
-        $sc = SourceControl::factory()->github()->create();
-        Site::factory()->create([
-            'domain' => 'second.test',
-            'server_id' => $this->server->id,
-            'source_control_id' => $sc->id,
-            'repository' => 'organization/repository',
-            'path' => '/home/vito/second.test',
-            'branch' => 'main',
-            'php_version' => '8.2',
-            'user' => 'vito',
-        ]);
-
-        $response = $this->get(route('logs.services', $this->server));
-        $catalogue = $response->viewData('page')['props']['catalogue'];
-        $userEntries = array_values(array_filter($catalogue, fn ($e) => $e['key'] === 'php:8.2:user:vito'));
-
-        $this->assertCount(1, $userEntries);
-        $this->assertStringContainsString('vito.test', $userEntries[0]['label']);
-        $this->assertStringContainsString('second.test', $userEntries[0]['label']);
-    }
-
-    public function test_unauthorized_user_cannot_view(): void
-    {
-        /** @var User $other */
-        $other = User::factory()->create();
-        $this->actingAs($other);
-
-        $this->get(route('logs.services', $this->server))->assertForbidden();
-    }
-
-    public function test_unauthorized_user_cannot_clear(): void
-    {
-        /** @var User $other */
-        $other = User::factory()->create();
-        $this->actingAs($other);
-        SSH::fake();
-
-        $this->post(route('logs.services.clear', $this->server), [
-            'key' => 'nginx:error',
-        ])->assertForbidden();
-    }
-
-    public function test_unauthorized_user_cannot_read(): void
-    {
-        /** @var User $other */
-        $other = User::factory()->create();
-        $this->actingAs($other);
-        SSH::fake();
-
-        $this->postJson(route('logs.services.read', $this->server), [
-            'key' => 'nginx:error',
-        ])->assertForbidden();
-    }
-
-    public function test_unauthorized_user_cannot_download(): void
-    {
-        /** @var User $other */
-        $other = User::factory()->create();
-        $this->actingAs($other);
-        SSH::fake();
-
+    try {
         $this->get(route('logs.services.download', ['server' => $this->server, 'key' => 'nginx:error']))
-            ->assertForbidden();
+            ->assertSuccessful();
+
+        SSH::assertExecutedContains("sudo cat '/var/log/nginx/error.log'");
+    } finally {
+        Storage::disk('local')->delete($tmpName);
+        Str::createRandomStringsNormally();
+        Carbon::setTestNow();
     }
-}
+});
+
+test('download journal source', function () {
+    $this->actingAs($this->user);
+    Bus::fake();
+    Queue::fake();
+    Carbon::setTestNow(Carbon::create(2026, 1, 1, 12));
+    Str::createRandomStringsUsing(fn (int $n): string => str_repeat('a', $n));
+    SSH::fake();
+
+    $tmpName = $this->server->id.'-'.Carbon::now()->timestamp.'-aaaaaaaa-'.Str::slug('mysql:journal').'.log';
+    Storage::disk('local')->put($tmpName, 'pretend-downloaded-bytes');
+
+    try {
+        $this->get(route('logs.services.download', ['server' => $this->server, 'key' => 'mysql:journal']))
+            ->assertSuccessful();
+
+        SSH::assertExecutedContains("sudo journalctl -u 'mysql.service'");
+    } finally {
+        Storage::disk('local')->delete($tmpName);
+        Str::createRandomStringsNormally();
+        Carbon::setTestNow();
+    }
+});
+
+test('download returns 404 when file missing', function () {
+    $this->actingAs($this->user);
+    SSH::fake('VITO_NO_FILE');
+
+    $this->getJson(route('logs.services.download', ['server' => $this->server, 'key' => 'nginx:error']))
+        ->assertNotFound()
+        ->assertJson(['message' => 'The log file does not exist on the server.']);
+});
+
+test('unknown key on download returns 404', function () {
+    $this->actingAs($this->user);
+    SSH::fake();
+
+    $this->get(route('logs.services.download', ['server' => $this->server, 'key' => 'nope']))
+        ->assertNotFound();
+});
+
+test('multiple sites per user deduped', function () {
+    $this->actingAs($this->user);
+
+    /** @var SourceControl $sc */
+    $sc = SourceControl::factory()->github()->create();
+    Site::factory()->create([
+        'domain' => 'second.test',
+        'server_id' => $this->server->id,
+        'source_control_id' => $sc->id,
+        'repository' => 'organization/repository',
+        'path' => '/home/vito/second.test',
+        'branch' => 'main',
+        'php_version' => '8.2',
+        'user' => 'vito',
+    ]);
+
+    $response = $this->get(route('logs.services', $this->server));
+    $catalogue = $response->viewData('page')['props']['catalogue'];
+    $userEntries = array_values(array_filter($catalogue, fn ($e) => $e['key'] === 'php:8.2:user:vito'));
+
+    expect($userEntries)->toHaveCount(1);
+    $this->assertStringContainsString('vito.test', $userEntries[0]['label']);
+    $this->assertStringContainsString('second.test', $userEntries[0]['label']);
+});
+
+test('unauthorized user cannot view', function () {
+    /** @var User $other */
+    $other = User::factory()->create();
+    $this->actingAs($other);
+
+    $this->get(route('logs.services', $this->server))->assertForbidden();
+});
+
+test('unauthorized user cannot clear', function () {
+    /** @var User $other */
+    $other = User::factory()->create();
+    $this->actingAs($other);
+    SSH::fake();
+
+    $this->post(route('logs.services.clear', $this->server), [
+        'key' => 'nginx:error',
+    ])->assertForbidden();
+});
+
+test('unauthorized user cannot read', function () {
+    /** @var User $other */
+    $other = User::factory()->create();
+    $this->actingAs($other);
+    SSH::fake();
+
+    $this->postJson(route('logs.services.read', $this->server), [
+        'key' => 'nginx:error',
+    ])->assertForbidden();
+});
+
+test('unauthorized user cannot download', function () {
+    /** @var User $other */
+    $other = User::factory()->create();
+    $this->actingAs($other);
+    SSH::fake();
+
+    $this->get(route('logs.services.download', ['server' => $this->server, 'key' => 'nginx:error']))
+        ->assertForbidden();
+});

--- a/tests/Feature/ServiceNetworkingDatabaseTest.php
+++ b/tests/Feature/ServiceNetworkingDatabaseTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\ServiceStatus;
 use App\Exceptions\SSHCommandError;
 use App\Facades\SSH;
@@ -10,496 +8,467 @@ use App\Models\Service;
 use App\Support\Testing\SSHFake;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class ServiceNetworkingDatabaseTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_enable_mysql_networking(): void
+test('enable mysql networking', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('mysql', '8.4');
+
+    SSH::fake("Active: active\n0.0.0.0\nmysqlx_bind_address\t0.0.0.0");
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->type_data['networking'])->toBeTrue();
+    expect($service->status)->toEqual(ServiceStatus::READY);
+    expect($service->secret)->toBeNull();
+
+    SSH::assertExecutedContains('sudo mkdir -p /etc/mysql/mysql.conf.d');
+    SSH::assertExecutedContains('sudo cp /etc/mysql/mysql.conf.d/zz-vito-networking.cnf /etc/mysql/mysql.conf.d/zz-vito-networking.cnf.vito.bak');
+    SSH::assertExecutedContains('printf \'[mysqld]\nbind-address = %s\n\' \'0.0.0.0\' | sudo tee /etc/mysql/mysql.conf.d/zz-vito-networking.cnf > /dev/null');
+    SSH::assertExecutedContains('printf \'loose-mysqlx-bind-address = %s\n\' \'0.0.0.0\' | sudo tee -a /etc/mysql/mysql.conf.d/zz-vito-networking.cnf > /dev/null');
+    SSH::assertExecutedContains('sudo systemctl restart mysql');
+    SSH::assertExecutedContains('sudo mysql -N -e "SELECT @@bind_address"');
+    SSH::assertExecutedContains('sudo mysql -N -e "SHOW VARIABLES LIKE \'mysqlx_bind_address\'"');
+    SSH::assertNotExecutedContains('.vito.bak /etc/mysql/mysql.conf.d/zz-vito-networking.cnf', 'The drop-in must not be rolled back.');
+});
+
+test('disable mysql networking', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('mysql', '8.4');
+    $service->type_data = ['networking' => true];
+    $service->save();
+
+    SSH::fake("Active: active\n127.0.0.1\nmysqlx_bind_address\t127.0.0.1");
+
+    $this->postJson(route('services.networking.disable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->type_data['networking'])->toBeFalse();
+    expect($service->status)->toEqual(ServiceStatus::READY);
+
+    SSH::assertExecutedContains('printf \'[mysqld]\nbind-address = %s\n\' \'127.0.0.1\' | sudo tee /etc/mysql/mysql.conf.d/zz-vito-networking.cnf > /dev/null');
+    SSH::assertExecutedContains('printf \'loose-mysqlx-bind-address = %s\n\' \'127.0.0.1\' | sudo tee -a /etc/mysql/mysql.conf.d/zz-vito-networking.cnf > /dev/null');
+    SSH::assertExecutedContains('sudo systemctl restart mysql');
+    SSH::assertNotExecutedContains('0.0.0.0');
+});
+
+test('enable mysql networking tolerates a disabled x plugin', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('mysql', '8.4');
+
+    SSH::fake("Active: active\n0.0.0.0");
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->type_data['networking'])->toBeTrue();
+    expect($service->status)->toEqual(ServiceStatus::READY);
+
+    SSH::assertExecutedContains('sudo mysql -N -e "SHOW VARIABLES LIKE \'mysqlx_bind_address\'"');
+    SSH::assertNotExecutedContains('SELECT @@mysqlx_bind_address');
+});
+
+test('enable mysql networking fails when the x plugin stays local', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('mysql', '8.4');
+
+    SSH::fake("Active: active\n0.0.0.0\nmysqlx_bind_address\t127.0.0.1");
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+    expect($service->type_data['networking'])->toBeFalse();
+    expect($service->type_data['networking_failed'])->toBeTrue();
+
+    SSH::assertExecutedContains('sudo rm -f /etc/mysql/mysql.conf.d/zz-vito-networking.cnf');
+});
+
+test('enable mariadb networking does not manage the x plugin', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('mariadb', '11.4');
+
+    SSH::fake("Active: active\n0.0.0.0");
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->type_data['networking'])->toBeTrue();
+    expect($service->status)->toEqual(ServiceStatus::READY);
+
+    SSH::assertExecutedContains('sudo mkdir -p /etc/mysql/mariadb.conf.d');
+    SSH::assertExecutedContains('printf \'[mysqld]\nbind-address = %s\n\' \'0.0.0.0\' | sudo tee /etc/mysql/mariadb.conf.d/zz-vito-networking.cnf > /dev/null');
+    SSH::assertExecutedContains('sudo systemctl restart mariadb');
+    SSH::assertExecutedContains('sudo mariadb -N -e "SELECT @@bind_address"');
+    SSH::assertNotExecutedContains('loose-mysqlx-bind-address', 'MariaDB has no X plugin.');
+    SSH::assertNotExecutedContains('mysqlx_bind_address', 'MariaDB has no X plugin.');
+    SSH::assertNotExecutedContains('sudo mysql -N', 'MariaDB must use the mariadb client.');
+});
+
+test('disable mariadb networking', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('mariadb', '11.4');
+    $service->type_data = ['networking' => true];
+    $service->save();
+
+    SSH::fake("Active: active\n127.0.0.1");
+
+    $this->postJson(route('services.networking.disable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    expect($service->refresh()->type_data['networking'])->toBeFalse();
+
+    SSH::assertExecutedContains('printf \'[mysqld]\nbind-address = %s\n\' \'127.0.0.1\' | sudo tee /etc/mysql/mariadb.conf.d/zz-vito-networking.cnf > /dev/null');
+    SSH::assertNotExecutedContains('loose-mysqlx-bind-address');
+});
+
+test('enable postgresql networking', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('postgresql', '16');
+
+    SSH::fake("Active: active\n0.0.0.0");
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->type_data['networking'])->toBeTrue();
+    expect($service->status)->toEqual(ServiceStatus::READY);
+
+    SSH::assertExecutedContains('sudo cp /etc/postgresql/16/main/postgresql.conf /etc/postgresql/16/main/postgresql.conf.vito.bak');
+    SSH::assertExecutedContains('sudo cp /etc/postgresql/16/main/pg_hba.conf /etc/postgresql/16/main/pg_hba.conf.vito.bak');
+    SSH::assertExecutedContains('sudo grep -Eq \'^[[:space:]]*include_dir[[:space:]]*=\' /etc/postgresql/16/main/postgresql.conf || printf "\ninclude_dir = \'conf.d\'\n" | sudo tee -a /etc/postgresql/16/main/postgresql.conf > /dev/null');
+    SSH::assertExecutedContains('sudo mkdir -p /etc/postgresql/16/main/conf.d');
+    SSH::assertExecutedContains('printf "listen_addresses = \'%s\'\n" \'0.0.0.0\' | sudo tee /etc/postgresql/16/main/conf.d/zz-vito-networking.conf > /dev/null');
+    SSH::assertExecutedContains('sudo sed -i \'/^# BEGIN VITO NETWORKING$/,/^# END VITO NETWORKING$/d\' /etc/postgresql/16/main/pg_hba.conf');
+    SSH::assertExecutedContains('host all postgres 0.0.0.0/0 reject\nhost all all 0.0.0.0/0 scram-sha-256');
+    SSH::assertExecutedContains('sudo systemctl restart postgresql');
+    SSH::assertExecutedContains('sudo -u postgres psql -tAc "SHOW listen_addresses"');
+    SSH::assertNotExecutedContains('ALTER SYSTEM', 'PostgreSQL networking must be file based.');
+});
+
+test('disable postgresql networking', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('postgresql', '16');
+    $service->type_data = ['networking' => true];
+    $service->save();
+
+    SSH::fake("Active: active\nlocalhost");
+
+    $this->postJson(route('services.networking.disable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->type_data['networking'])->toBeFalse();
+    expect($service->status)->toEqual(ServiceStatus::READY);
+
+    SSH::assertExecutedContains('sudo grep -Eq \'^[[:space:]]*include_dir[[:space:]]*=\' /etc/postgresql/16/main/postgresql.conf || printf "\ninclude_dir = \'conf.d\'\n" | sudo tee -a /etc/postgresql/16/main/postgresql.conf > /dev/null');
+    SSH::assertExecutedContains('printf "listen_addresses = \'%s\'\n" \'localhost\' | sudo tee /etc/postgresql/16/main/conf.d/zz-vito-networking.conf > /dev/null');
+    SSH::assertExecutedContains('sudo sed -i \'/^# BEGIN VITO NETWORKING$/,/^# END VITO NETWORKING$/d\' /etc/postgresql/16/main/pg_hba.conf');
+    SSH::assertExecutedContains('sudo systemctl restart postgresql');
+    SSH::assertNotExecutedContains('scram-sha-256', 'The managed pg_hba block must not be written back on disable.');
+    SSH::assertNotExecutedContains('sudo rm -f /etc/postgresql/16/main/conf.d/zz-vito-networking.conf', 'Disable rewrites the drop-in instead of deleting it.');
+});
+
+test('enable networking skips the restart when the service is not running', function (string $name, string $version) {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService($name, $version);
+    $service->status = ServiceStatus::STOPPED;
+    $service->save();
+
+    SSH::fake();
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->type_data['networking'])->toBeTrue();
+    expect($service->type_data['networking_effective'])->toBeTrue();
+    expect($service->type_data['networking_checked_at'] ?? null)->toBeNull('A toggle that never restarted or verified must not stamp an observation timestamp.');
+    expect($service->status)->toEqual(ServiceStatus::STOPPED);
+
+    SSH::assertNotExecutedContains('systemctl restart');
+    SSH::assertNotExecutedContains('SELECT @@bind_address');
+    SSH::assertNotExecutedContains('SHOW listen_addresses');
+})->with('databases');
+
+test('failed mysql enable rolls back the drop in and marks the service as failed', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('mysql', '8.4');
+
+    SSH::fake("Active: active\n127.0.0.1");
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+    expect($service->type_data['networking'])->toBeFalse();
+    expect($service->type_data['networking_failed'])->toBeTrue();
+
+    SSH::assertExecutedContains('sudo rm -f /etc/mysql/mysql.conf.d/zz-vito-networking.cnf');
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'enable-networking-failed',
+    ]);
+});
+
+test('failed mysql enable restores a previous drop in instead of deleting it', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('mysql', '8.4');
+
+    SSH::fake("Active: active\n127.0.0.1\nmysqlx_bind_address\t127.0.0.1");
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+
+    SSH::assertExecutedContains('sudo cp /etc/mysql/mysql.conf.d/zz-vito-networking.cnf.vito.bak /etc/mysql/mysql.conf.d/zz-vito-networking.cnf');
+});
+
+test('failed mysql disable does not roll back', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('mysql', '8.4');
+    $service->type_data = ['networking' => true];
+    $service->save();
+
+    SSH::fake("Active: active\n0.0.0.0");
+
+    $this->postJson(route('services.networking.disable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+    expect($service->type_data['networking'])->toBeTrue();
+
+    SSH::assertNotExecutedContains('.vito.bak /etc/mysql/mysql.conf.d/zz-vito-networking.cnf', 'The drop-in must not be rolled back.');
+});
+
+test('failed postgresql enable restores both backups', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('postgresql', '16');
+
+    SSH::fake("Active: active\nlocalhost");
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+    expect($service->type_data['networking'])->toBeFalse();
+    expect($service->type_data['networking_failed'])->toBeTrue();
+
+    SSH::assertExecutedContains('sudo cp /etc/postgresql/16/main/postgresql.conf.vito.bak /etc/postgresql/16/main/postgresql.conf');
+    SSH::assertExecutedContains('sudo cp /etc/postgresql/16/main/pg_hba.conf.vito.bak /etc/postgresql/16/main/pg_hba.conf');
+    SSH::assertExecutedContains('sudo rm -f /etc/postgresql/16/main/conf.d/zz-vito-networking.conf');
+});
+
+test('failed postgresql config write rolls back the drop in', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('postgresql', '16');
+
+    SSH::swap(new class extends SSHFake
     {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService('mysql', '8.4');
-
-        SSH::fake("Active: active\n0.0.0.0\nmysqlx_bind_address\t0.0.0.0");
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertTrue($service->type_data['networking']);
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-        $this->assertNull($service->secret);
-
-        SSH::assertExecutedContains('sudo mkdir -p /etc/mysql/mysql.conf.d');
-        SSH::assertExecutedContains('sudo cp /etc/mysql/mysql.conf.d/zz-vito-networking.cnf /etc/mysql/mysql.conf.d/zz-vito-networking.cnf.vito.bak');
-        SSH::assertExecutedContains('printf \'[mysqld]\nbind-address = %s\n\' \'0.0.0.0\' | sudo tee /etc/mysql/mysql.conf.d/zz-vito-networking.cnf > /dev/null');
-        SSH::assertExecutedContains('printf \'loose-mysqlx-bind-address = %s\n\' \'0.0.0.0\' | sudo tee -a /etc/mysql/mysql.conf.d/zz-vito-networking.cnf > /dev/null');
-        SSH::assertExecutedContains('sudo systemctl restart mysql');
-        SSH::assertExecutedContains('sudo mysql -N -e "SELECT @@bind_address"');
-        SSH::assertExecutedContains('sudo mysql -N -e "SHOW VARIABLES LIKE \'mysqlx_bind_address\'"');
-        SSH::assertNotExecutedContains('.vito.bak /etc/mysql/mysql.conf.d/zz-vito-networking.cnf', 'The drop-in must not be rolled back.');
-    }
-
-    public function test_disable_mysql_networking(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService('mysql', '8.4');
-        $service->type_data = ['networking' => true];
-        $service->save();
-
-        SSH::fake("Active: active\n127.0.0.1\nmysqlx_bind_address\t127.0.0.1");
-
-        $this->postJson(route('services.networking.disable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertFalse($service->type_data['networking']);
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-
-        SSH::assertExecutedContains('printf \'[mysqld]\nbind-address = %s\n\' \'127.0.0.1\' | sudo tee /etc/mysql/mysql.conf.d/zz-vito-networking.cnf > /dev/null');
-        SSH::assertExecutedContains('printf \'loose-mysqlx-bind-address = %s\n\' \'127.0.0.1\' | sudo tee -a /etc/mysql/mysql.conf.d/zz-vito-networking.cnf > /dev/null');
-        SSH::assertExecutedContains('sudo systemctl restart mysql');
-        SSH::assertNotExecutedContains('0.0.0.0');
-    }
-
-    public function test_enable_mysql_networking_tolerates_a_disabled_x_plugin(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService('mysql', '8.4');
-
-        SSH::fake("Active: active\n0.0.0.0");
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertTrue($service->type_data['networking']);
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-
-        SSH::assertExecutedContains('sudo mysql -N -e "SHOW VARIABLES LIKE \'mysqlx_bind_address\'"');
-        SSH::assertNotExecutedContains('SELECT @@mysqlx_bind_address');
-    }
-
-    public function test_enable_mysql_networking_fails_when_the_x_plugin_stays_local(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService('mysql', '8.4');
-
-        SSH::fake("Active: active\n0.0.0.0\nmysqlx_bind_address\t127.0.0.1");
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-        $this->assertFalse($service->type_data['networking']);
-        $this->assertTrue($service->type_data['networking_failed']);
-
-        SSH::assertExecutedContains('sudo rm -f /etc/mysql/mysql.conf.d/zz-vito-networking.cnf');
-    }
-
-    public function test_enable_mariadb_networking_does_not_manage_the_x_plugin(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService('mariadb', '11.4');
-
-        SSH::fake("Active: active\n0.0.0.0");
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertTrue($service->type_data['networking']);
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-
-        SSH::assertExecutedContains('sudo mkdir -p /etc/mysql/mariadb.conf.d');
-        SSH::assertExecutedContains('printf \'[mysqld]\nbind-address = %s\n\' \'0.0.0.0\' | sudo tee /etc/mysql/mariadb.conf.d/zz-vito-networking.cnf > /dev/null');
-        SSH::assertExecutedContains('sudo systemctl restart mariadb');
-        SSH::assertExecutedContains('sudo mariadb -N -e "SELECT @@bind_address"');
-        SSH::assertNotExecutedContains('loose-mysqlx-bind-address', 'MariaDB has no X plugin.');
-        SSH::assertNotExecutedContains('mysqlx_bind_address', 'MariaDB has no X plugin.');
-        SSH::assertNotExecutedContains('sudo mysql -N', 'MariaDB must use the mariadb client.');
-    }
-
-    public function test_disable_mariadb_networking(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService('mariadb', '11.4');
-        $service->type_data = ['networking' => true];
-        $service->save();
-
-        SSH::fake("Active: active\n127.0.0.1");
-
-        $this->postJson(route('services.networking.disable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $this->assertFalse($service->refresh()->type_data['networking']);
-
-        SSH::assertExecutedContains('printf \'[mysqld]\nbind-address = %s\n\' \'127.0.0.1\' | sudo tee /etc/mysql/mariadb.conf.d/zz-vito-networking.cnf > /dev/null');
-        SSH::assertNotExecutedContains('loose-mysqlx-bind-address');
-    }
-
-    public function test_enable_postgresql_networking(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService('postgresql', '16');
-
-        SSH::fake("Active: active\n0.0.0.0");
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertTrue($service->type_data['networking']);
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-
-        SSH::assertExecutedContains('sudo cp /etc/postgresql/16/main/postgresql.conf /etc/postgresql/16/main/postgresql.conf.vito.bak');
-        SSH::assertExecutedContains('sudo cp /etc/postgresql/16/main/pg_hba.conf /etc/postgresql/16/main/pg_hba.conf.vito.bak');
-        SSH::assertExecutedContains('sudo grep -Eq \'^[[:space:]]*include_dir[[:space:]]*=\' /etc/postgresql/16/main/postgresql.conf || printf "\ninclude_dir = \'conf.d\'\n" | sudo tee -a /etc/postgresql/16/main/postgresql.conf > /dev/null');
-        SSH::assertExecutedContains('sudo mkdir -p /etc/postgresql/16/main/conf.d');
-        SSH::assertExecutedContains('printf "listen_addresses = \'%s\'\n" \'0.0.0.0\' | sudo tee /etc/postgresql/16/main/conf.d/zz-vito-networking.conf > /dev/null');
-        SSH::assertExecutedContains('sudo sed -i \'/^# BEGIN VITO NETWORKING$/,/^# END VITO NETWORKING$/d\' /etc/postgresql/16/main/pg_hba.conf');
-        SSH::assertExecutedContains('host all postgres 0.0.0.0/0 reject\nhost all all 0.0.0.0/0 scram-sha-256');
-        SSH::assertExecutedContains('sudo systemctl restart postgresql');
-        SSH::assertExecutedContains('sudo -u postgres psql -tAc "SHOW listen_addresses"');
-        SSH::assertNotExecutedContains('ALTER SYSTEM', 'PostgreSQL networking must be file based.');
-    }
-
-    public function test_disable_postgresql_networking(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService('postgresql', '16');
-        $service->type_data = ['networking' => true];
-        $service->save();
-
-        SSH::fake("Active: active\nlocalhost");
-
-        $this->postJson(route('services.networking.disable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertFalse($service->type_data['networking']);
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-
-        SSH::assertExecutedContains('sudo grep -Eq \'^[[:space:]]*include_dir[[:space:]]*=\' /etc/postgresql/16/main/postgresql.conf || printf "\ninclude_dir = \'conf.d\'\n" | sudo tee -a /etc/postgresql/16/main/postgresql.conf > /dev/null');
-        SSH::assertExecutedContains('printf "listen_addresses = \'%s\'\n" \'localhost\' | sudo tee /etc/postgresql/16/main/conf.d/zz-vito-networking.conf > /dev/null');
-        SSH::assertExecutedContains('sudo sed -i \'/^# BEGIN VITO NETWORKING$/,/^# END VITO NETWORKING$/d\' /etc/postgresql/16/main/pg_hba.conf');
-        SSH::assertExecutedContains('sudo systemctl restart postgresql');
-        SSH::assertNotExecutedContains('scram-sha-256', 'The managed pg_hba block must not be written back on disable.');
-        SSH::assertNotExecutedContains('sudo rm -f /etc/postgresql/16/main/conf.d/zz-vito-networking.conf', 'Disable rewrites the drop-in instead of deleting it.');
-    }
-
-    #[DataProvider('databases')]
-    public function test_enable_networking_skips_the_restart_when_the_service_is_not_running(string $name, string $version): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService($name, $version);
-        $service->status = ServiceStatus::STOPPED;
-        $service->save();
-
-        SSH::fake();
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertTrue($service->type_data['networking']);
-        $this->assertTrue($service->type_data['networking_effective']);
-        $this->assertNull(
-            $service->type_data['networking_checked_at'] ?? null,
-            'A toggle that never restarted or verified must not stamp an observation timestamp.'
-        );
-        $this->assertEquals(ServiceStatus::STOPPED, $service->status);
-
-        SSH::assertNotExecutedContains('systemctl restart');
-        SSH::assertNotExecutedContains('SELECT @@bind_address');
-        SSH::assertNotExecutedContains('SHOW listen_addresses');
-    }
-
-    public function test_failed_mysql_enable_rolls_back_the_drop_in_and_marks_the_service_as_failed(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService('mysql', '8.4');
-
-        SSH::fake("Active: active\n127.0.0.1");
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-        $this->assertFalse($service->type_data['networking']);
-        $this->assertTrue($service->type_data['networking_failed']);
-
-        SSH::assertExecutedContains('sudo rm -f /etc/mysql/mysql.conf.d/zz-vito-networking.cnf');
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'enable-networking-failed',
-        ]);
-    }
-
-    public function test_failed_mysql_enable_restores_a_previous_drop_in_instead_of_deleting_it(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService('mysql', '8.4');
-
-        SSH::fake("Active: active\n127.0.0.1\nmysqlx_bind_address\t127.0.0.1");
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-
-        SSH::assertExecutedContains('sudo cp /etc/mysql/mysql.conf.d/zz-vito-networking.cnf.vito.bak /etc/mysql/mysql.conf.d/zz-vito-networking.cnf');
-    }
-
-    public function test_failed_mysql_disable_does_not_roll_back(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService('mysql', '8.4');
-        $service->type_data = ['networking' => true];
-        $service->save();
-
-        SSH::fake("Active: active\n0.0.0.0");
-
-        $this->postJson(route('services.networking.disable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-        $this->assertTrue($service->type_data['networking']);
-
-        SSH::assertNotExecutedContains('.vito.bak /etc/mysql/mysql.conf.d/zz-vito-networking.cnf', 'The drop-in must not be rolled back.');
-    }
-
-    public function test_failed_postgresql_enable_restores_both_backups(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService('postgresql', '16');
-
-        SSH::fake("Active: active\nlocalhost");
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-        $this->assertFalse($service->type_data['networking']);
-        $this->assertTrue($service->type_data['networking_failed']);
-
-        SSH::assertExecutedContains('sudo cp /etc/postgresql/16/main/postgresql.conf.vito.bak /etc/postgresql/16/main/postgresql.conf');
-        SSH::assertExecutedContains('sudo cp /etc/postgresql/16/main/pg_hba.conf.vito.bak /etc/postgresql/16/main/pg_hba.conf');
-        SSH::assertExecutedContains('sudo rm -f /etc/postgresql/16/main/conf.d/zz-vito-networking.conf');
-    }
-
-    public function test_failed_postgresql_config_write_rolls_back_the_drop_in(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService('postgresql', '16');
-
-        SSH::swap(new class extends SSHFake
+        public function exec(string|View $command, string $log = '', ?int $siteId = null, ?bool $stream = false, ?callable $streamCallback = null, int $timeout = 0): string
         {
-            public function exec(string|View $command, string $log = '', ?int $siteId = null, ?bool $stream = false, ?callable $streamCallback = null, int $timeout = 0): string
-            {
-                if (str((string) $command)->contains('sudo tee /etc/postgresql/16/main/conf.d/zz-vito-networking.conf')) {
-                    throw new SSHCommandError('Connection failed');
-                }
-
-                return parent::exec($command, $log, $siteId, $stream, $streamCallback, $timeout);
+            if (str((string) $command)->contains('sudo tee /etc/postgresql/16/main/conf.d/zz-vito-networking.conf')) {
+                throw new SSHCommandError('Connection failed');
             }
-        });
 
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
+            return parent::exec($command, $log, $siteId, $stream, $streamCallback, $timeout);
+        }
+    });
 
-        $service->refresh();
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
 
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-        $this->assertFalse($service->type_data['networking']);
-        $this->assertTrue($service->type_data['networking_failed']);
+    $service->refresh();
 
-        SSH::assertExecutedContains('sudo rm -f /etc/postgresql/16/main/conf.d/zz-vito-networking.conf');
-        SSH::assertExecutedContains('sudo cp /etc/postgresql/16/main/postgresql.conf.vito.bak /etc/postgresql/16/main/postgresql.conf');
-    }
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+    expect($service->type_data['networking'])->toBeFalse();
+    expect($service->type_data['networking_failed'])->toBeTrue();
 
-    public function test_failed_postgresql_disable_never_restores_the_open_state(): void
-    {
-        $this->actingAs($this->user);
+    SSH::assertExecutedContains('sudo rm -f /etc/postgresql/16/main/conf.d/zz-vito-networking.conf');
+    SSH::assertExecutedContains('sudo cp /etc/postgresql/16/main/postgresql.conf.vito.bak /etc/postgresql/16/main/postgresql.conf');
+});
 
-        $service = $this->databaseService('postgresql', '16');
-        $service->type_data = ['networking' => true];
-        $service->save();
+test('failed postgresql disable never restores the open state', function () {
+    $this->actingAs($this->user);
 
-        SSH::fake("Active: active\n0.0.0.0");
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('postgresql', '16');
+    $service->type_data = ['networking' => true];
+    $service->save();
 
-        $this->postJson(route('services.networking.disable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
+    SSH::fake("Active: active\n0.0.0.0");
 
-        $service->refresh();
+    $this->postJson(route('services.networking.disable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
 
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-        $this->assertTrue($service->type_data['networking']);
+    $service->refresh();
 
-        SSH::assertNotExecutedContains('.vito.bak /etc/postgresql/16/main/', 'A failed disable must never restore the open state.');
-    }
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+    expect($service->type_data['networking'])->toBeTrue();
 
-    public function test_mysql_networking_details(): void
-    {
-        $this->actingAs($this->user);
+    SSH::assertNotExecutedContains('.vito.bak /etc/postgresql/16/main/', 'A failed disable must never restore the open state.');
+});
 
-        $service = $this->databaseService('mysql', '8.4');
-        $service->type_data = [
-            'networking_effective' => true,
-            'networking_checked_at' => '2026-07-26T12:00:00+00:00',
-        ];
-        $service->save();
+test('mysql networking details', function () {
+    $this->actingAs($this->user);
 
-        SSH::fake();
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('mysql', '8.4');
+    $service->type_data = [
+        'networking_effective' => true,
+        'networking_checked_at' => '2026-07-26T12:00:00+00:00',
+    ];
+    $service->save();
 
-        $response = $this->getJson(route('services.networking', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertOk()
-            ->assertJson([
-                'supported' => true,
-                'pending' => false,
-                'enabled' => false,
-                'effective' => true,
-                'checked_at' => '2026-07-26T12:00:00+00:00',
-                'port' => 3306,
-                'requires_remote_users' => true,
-            ]);
+    SSH::fake();
 
-        $this->assertArrayNotHasKey('secret', $response->json());
-
-        SSH::assertNotExecutedContains('SELECT @@bind_address');
-    }
-
-    public function test_postgresql_networking_details(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->databaseService('postgresql', '16');
-        $service->type_data = [
-            'networking' => true,
-            'networking_effective' => false,
-            'networking_checked_at' => '2026-07-26T12:00:00+00:00',
-        ];
-        $service->save();
-
-        SSH::fake();
-
-        $this->getJson(route('services.networking', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertOk()
-            ->assertJson([
-                'supported' => true,
-                'pending' => false,
-                'enabled' => true,
-                'effective' => false,
-                'checked_at' => '2026-07-26T12:00:00+00:00',
-                'port' => 5432,
-                'requires_remote_users' => false,
-            ]);
-
-        SSH::assertNotExecutedContains('SHOW listen_addresses');
-    }
-
-    #[DataProvider('databases')]
-    public function test_resource_supports_networking(string $name, string $version): void
-    {
-        $service = $this->databaseService($name, $version);
-
-        $payload = (new ServiceResource($service))->toArray(request());
-
-        $this->assertTrue($payload['supports_networking']);
-        $this->assertFalse($payload['networking_enabled']);
-    }
-
-    private function databaseService(string $name, string $version): Service
-    {
-        $this->server->services()->where('type', 'database')->delete();
-
-        return Service::factory()->create([
-            'server_id' => $this->server->id,
-            'type' => 'database',
-            'name' => $name,
-            'version' => $version,
-            'status' => ServiceStatus::READY,
+    $response = $this->getJson(route('services.networking', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertOk()
+        ->assertJson([
+            'supported' => true,
+            'pending' => false,
+            'enabled' => false,
+            'effective' => true,
+            'checked_at' => '2026-07-26T12:00:00+00:00',
+            'port' => 3306,
+            'requires_remote_users' => true,
         ]);
-    }
 
-    /**
-     * @return array<array<string>>
-     */
-    public static function databases(): array
-    {
-        return [
-            ['mysql', '8.4'],
-            ['mariadb', '11.4'],
-            ['postgresql', '16'],
-        ];
-    }
+    $this->assertArrayNotHasKey('secret', $response->json());
+
+    SSH::assertNotExecutedContains('SELECT @@bind_address');
+});
+
+test('postgresql networking details', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('postgresql', '16');
+    $service->type_data = [
+        'networking' => true,
+        'networking_effective' => false,
+        'networking_checked_at' => '2026-07-26T12:00:00+00:00',
+    ];
+    $service->save();
+
+    SSH::fake();
+
+    $this->getJson(route('services.networking', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertOk()
+        ->assertJson([
+            'supported' => true,
+            'pending' => false,
+            'enabled' => true,
+            'effective' => false,
+            'checked_at' => '2026-07-26T12:00:00+00:00',
+            'port' => 5432,
+            'requires_remote_users' => false,
+        ]);
+
+    SSH::assertNotExecutedContains('SHOW listen_addresses');
+});
+
+test('resource supports networking', function (string $name, string $version) {
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService($name, $version);
+
+    $payload = (new ServiceResource($service))->toArray(request());
+
+    expect($payload['supports_networking'])->toBeTrue();
+    expect($payload['networking_enabled'])->toBeFalse();
+})->with('databases');
+
+function vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService(string $name, string $version): Service
+{
+    test()->server->services()->where('type', 'database')->delete();
+
+    return Service::factory()->create([
+        'server_id' => test()->server->id,
+        'type' => 'database',
+        'name' => $name,
+        'version' => $version,
+        'status' => ServiceStatus::READY,
+    ]);
 }
+
+/**
+ * @return array<array<string>>
+ */
+dataset('databases', function () {
+    return [
+        ['mysql', '8.4'],
+        ['mariadb', '11.4'],
+        ['postgresql', '16'],
+    ];
+});

--- a/tests/Feature/ServiceNetworkingTest.php
+++ b/tests/Feature/ServiceNetworkingTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\ServiceStatus;
 use App\Enums\UserRole;
 use App\Exceptions\SSHCommandError;
@@ -13,753 +11,714 @@ use App\Support\Testing\SSHFake;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class ServiceNetworkingTest extends TestCase
+uses(RefreshDatabase::class);
+
+test('enable networking', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase($name);
+
+    SSH::fake("Active: active\nbind 0.0.0.0");
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->type_data['networking'])->toBeTrue();
+    expect($service->type_data['networking_effective'])->toBeTrue();
+    expect($service->type_data['networking_checked_at'])->not->toBeNull();
+    expect($service->status)->toEqual(ServiceStatus::READY);
+    expect($service->secret)->not->toBeNull();
+
+    SSH::assertExecutedContains("sudo cp /etc/{$name}/{$name}.conf /etc/{$name}/{$name}.conf.vito.bak");
+    SSH::assertNotExecutedContains('.vito.bak || true', 'A failed backup must abort the write, not be suppressed.');
+    SSH::assertNotExecutedContains("[ -f /etc/{$name}/", 'Guards must run under sudo — the conf directory is not readable by the SSH user.');
+    SSH::assertExecutedContains('bind[[:space:]]+)(0\.0\.0\.0|\*).*$/\1127.0.0.1/');
+    SSH::assertExecutedContains("sudo cp /etc/{$name}/vito-networking.conf /etc/{$name}/vito-networking.conf.vito.bak");
+    SSH::assertExecutedContains("sudo install -o {$name} -g {$name} -m 600 /dev/null /etc/{$name}/vito-networking.conf");
+    SSH::assertExecutedContains('printf \'requirepass "%s"\n\' "$VITO_MEMDB_PASSWORD"');
+    SSH::assertExecutedContains('sudo sed -i \'/^# BEGIN VITO NETWORKING$/,/^# END VITO NETWORKING$/d\'');
+    SSH::assertExecutedContains('# BEGIN VITO NETWORKING\nbind 0.0.0.0\ninclude %s\n# END VITO NETWORKING\n');
+    SSH::assertExecutedContains("sudo systemctl restart {$name}-server");
+    SSH::assertNotExecutedContains((string) $service->secret, 'The networking password must never appear in a command.');
+})->with('memoryDatabases');
+
+test('disable networking', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase($name);
+    $service->type_data = ['networking' => true];
+    $service->secret = 'existing-secret';
+    $service->save();
+
+    SSH::fake("Active: active\nbind 127.0.0.1");
+
+    $this->postJson(route('services.networking.disable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->type_data['networking'])->toBeFalse();
+    expect($service->type_data['networking_effective'])->toBeFalse();
+    expect($service->type_data['networking_checked_at'])->not->toBeNull();
+    expect($service->secret)->toEqual('existing-secret');
+    expect($service->status)->toEqual(ServiceStatus::READY);
+
+    SSH::assertExecutedContains('# BEGIN VITO NETWORKING\nbind 127.0.0.1\ninclude %s\n# END VITO NETWORKING\n');
+    SSH::assertExecutedContains("sudo test -f /etc/{$name}/vito-networking.conf || sudo install -o {$name}");
+    SSH::assertExecutedContains("sudo systemctl restart {$name}-server");
+    SSH::assertNotExecutedContains('bind 0.0.0.0');
+    SSH::assertNotExecutedContains("[ -f /etc/{$name}/", 'An unprivileged guard would truncate the include file and drop the password.');
+})->with('memoryDatabases');
+
+test('enable persists the secret before dispatching the job', function () {
+    Queue::fake();
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    Queue::assertPushed(ToggleNetworkingJob::class);
+    expect($service->status)->toEqual(ServiceStatus::RESTARTING);
+    expect(strlen((string) $service->secret))->toEqual(32);
+
+    $this->getJson(route('services.networking', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertOk()
+        ->assertJson([
+            'supported' => true,
+            'pending' => true,
+            'enabled' => false,
+            'port' => 6379,
+            'secret' => $service->secret,
+            'effective' => null,
+        ]);
+
+    SSH::assertNotExecutedContains('grep -E', 'The host must not be read while the toggle is pending.');
+});
+
+test('enable keeps the existing secret', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+    $service->secret = 'existing-secret';
+    $service->save();
+
+    SSH::fake("Active: active\nbind 0.0.0.0");
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    expect($service->refresh()->secret)->toEqual('existing-secret');
+});
+
+test('secret is encrypted at rest and never exposed by the resource', function () {
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+    $service->secret = 'plain-text-secret';
+    $service->type_data = ['networking' => true];
+    $service->save();
+    $service->refresh();
+
+    $this->assertNotEquals('plain-text-secret', $service->getRawOriginal('secret'));
+    expect($service->secret)->toEqual('plain-text-secret');
+
+    $payload = (new ServiceResource($service))->toArray(request());
+
+    $this->assertArrayNotHasKey('secret', $payload);
+    $this->assertStringNotContainsString('plain-text-secret', (string) json_encode($payload));
+    expect($payload['supports_networking'])->toBeTrue();
+    expect($payload['networking_enabled'])->toBeTrue();
+});
+
+test('resource does not support networking for other services', function () {
+    $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
+
+    $payload = (new ServiceResource($service))->toArray(request());
+
+    expect($payload['supports_networking'])->toBeFalse();
+    expect($payload['networking_enabled'])->toBeFalse();
+});
+
+test('enable networking skips the restart when the service is not running', function (string $status) {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+    $service->status = ServiceStatus::from($status);
+    $service->save();
+
+    SSH::fake();
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->type_data['networking'])->toBeTrue();
+    expect($service->type_data['networking_effective'])->toBeTrue();
+    expect($service->type_data['networking_checked_at'] ?? null)->toBeNull('A toggle that never restarted or verified must not stamp an observation timestamp.');
+    expect($service->status)->toEqual(ServiceStatus::from($status));
+
+    SSH::assertExecutedContains('# BEGIN VITO NETWORKING');
+    SSH::assertNotExecutedContains('systemctl restart');
+    SSH::assertNotExecutedContains('grep -E');
+})->with('settledStatuses');
+
+test('cannot toggle networking while the status is not settled', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+    $service->status = ServiceStatus::RESTARTING;
+    $service->save();
+
+    SSH::fake();
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertStatus(422);
+
+    $this->postJson(route('services.networking.disable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertStatus(422);
+
+    expect($service->refresh()->type_data)->toBeNull();
+});
+
+test('unsupported service cannot toggle networking', function () {
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
+
+    SSH::fake();
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertStatus(422);
+
+    $this->postJson(route('services.networking.disable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertStatus(422);
+
+    $this->getJson(route('services.networking', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertOk()
+        ->assertJson(['supported' => false]);
+});
+
+test('service without a handler does not break networking or the index', function () {
+    $this->actingAs($this->user);
+
+    $service = Service::factory()->create([
+        'server_id' => $this->server->id,
+        'type' => 'memory_database',
+        'name' => 'ghost',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+
+    SSH::fake();
+
+    $this->get(route('services', ['server' => $this->server]))->assertSuccessful();
+
+    $this->getJson(route('services.networking', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertOk()
+        ->assertJson(['supported' => false]);
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertStatus(422);
+});
+
+test('user role cannot manage networking', function () {
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::USER,
+    ]);
+
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $this->getJson(route('services.networking', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertForbidden();
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertForbidden();
+
+    $this->postJson(route('services.networking.disable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertForbidden();
+});
+
+test('networking details report the effective host state', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+    $service->type_data = [
+        'networking_effective' => true,
+        'networking_checked_at' => '2026-07-26T12:00:00+00:00',
+    ];
+    $service->save();
+
+    SSH::fake();
+
+    $this->getJson(route('services.networking', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertOk()
+        ->assertJson([
+            'supported' => true,
+            'pending' => false,
+            'enabled' => false,
+            'effective' => true,
+            'checked_at' => '2026-07-26T12:00:00+00:00',
+            'port' => 6379,
+        ]);
+
+    SSH::assertNotExecutedContains("sudo grep -E '^[[:space:]]*bind' /etc/redis/redis.conf | tail -1 || true");
+});
+
+test('networking details report unknown when never probed', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+
+    $response = $this->getJson(route('services.networking', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertOk()
+        ->assertJson([
+            'supported' => true,
+            'pending' => false,
+            'enabled' => false,
+            'effective' => null,
+            'checked_at' => null,
+            'port' => 6379,
+        ]);
+
+    $this->assertArrayNotHasKey('error', $response->json());
+});
+
+test('failed enable rolls back and marks the service as failed', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+
+    SSH::fake("Active: active\nbind 127.0.0.1");
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+    expect($service->type_data['networking'])->toBeFalse();
+    expect($service->type_data['networking_failed'])->toBeTrue();
+    expect($service->type_data['networking_effective'])->toBeNull();
+
+    SSH::assertExecutedContains('sudo cp /etc/redis/redis.conf.vito.bak /etc/redis/redis.conf');
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'enable-networking-failed',
+    ]);
+});
+
+test('failed config write rolls back and marks the service as failed', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+
+    SSH::swap(new class extends SSHFake
+    {
+        public function exec(string|View $command, string $log = '', ?int $siteId = null, ?bool $stream = false, ?callable $streamCallback = null, int $timeout = 0): string
+        {
+            if (str((string) $command)->contains('requirepass')) {
+                throw new SSHCommandError('Connection failed');
+            }
+
+            return parent::exec($command, $log, $siteId, $stream, $streamCallback, $timeout);
+        }
+    });
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+    expect($service->type_data['networking'])->toBeFalse();
+    expect($service->type_data['networking_failed'])->toBeTrue();
+    expect($service->type_data['networking_effective'])->toBeNull();
+
+    SSH::assertExecutedContains('sudo cp /etc/redis/redis.conf.vito.bak /etc/redis/redis.conf');
+    SSH::assertExecutedContains('sudo cp /etc/redis/vito-networking.conf.vito.bak /etc/redis/vito-networking.conf');
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'enable-networking-failed',
+    ]);
+});
+
+test('failed rollback is logged', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+
+    SSH::swap(new class extends SSHFake
+    {
+        public function exec(string|View $command, string $log = '', ?int $siteId = null, ?bool $stream = false, ?callable $streamCallback = null, int $timeout = 0): string
+        {
+            if (str((string) $command)->contains('.vito.bak /etc/redis/redis.conf')) {
+                throw new SSHCommandError('Rollback failed');
+            }
+
+            return parent::exec($command, $log, $siteId, $stream, $streamCallback, $timeout);
+        }
+    });
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'rollback-redis-networking-failed',
+    ]);
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'enable-networking-failed',
+    ]);
+});
+
+test('networking details report management and password capability', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+
+    SSH::fake('bind 127.0.0.1');
+
+    $this->getJson(route('services.networking', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertOk()
+        ->assertJson([
+            'managed' => false,
+            'failed' => false,
+            'uses_password' => true,
+        ]);
+
+    $service->type_data = ['networking' => false];
+    $service->status = ServiceStatus::FAILED;
+    $service->save();
+
+    $this->getJson(route('services.networking', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertOk()
+        ->assertJson([
+            'managed' => true,
+            'failed' => false,
+        ]);
+
+    $service->type_data = ['networking' => false, 'networking_failed' => true];
+    $service->save();
+
+    $this->getJson(route('services.networking', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertOk()
+        ->assertJson(['failed' => true]);
+});
+
+test('a successful toggle clears a previous networking failure', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+    $service->type_data = ['networking' => false, 'networking_failed' => true];
+    $service->save();
+
+    SSH::fake("Active: active\nbind 0.0.0.0");
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->type_data['networking'])->toBeTrue();
+    $this->assertArrayNotHasKey('networking_failed', $service->type_data);
+});
+
+test('failed disable does not roll back', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+    $service->type_data = ['networking' => true];
+    $service->secret = 'existing-secret';
+    $service->save();
+
+    SSH::fake("Active: active\nbind 0.0.0.0");
+
+    $this->postJson(route('services.networking.disable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+    expect($service->type_data['networking'])->toBeTrue();
+    expect($service->type_data['networking_effective'])->toBeNull();
+
+    SSH::assertNotExecutedContains('sudo cp /etc/redis/redis.conf.vito.bak /etc/redis/redis.conf');
+});
+
+test('regenerate the networking password', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase($name);
+    $service->type_data = ['networking' => true, 'networking_effective' => true];
+    $service->secret = 'existing-secret';
+    $service->save();
+
+    SSH::fake('Active: active');
+
+    $this->postJson(route('services.networking.secret.regenerate', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect(strlen((string) $service->secret))->toEqual(32);
+    $this->assertNotEquals('existing-secret', $service->secret);
+    expect($service->type_data['networking'])->toBeTrue();
+    expect($service->status)->toEqual(ServiceStatus::READY);
+
+    SSH::assertExecutedContains("sudo install -o {$name} -g {$name} -m 600 /dev/null /etc/{$name}/vito-networking.conf");
+    SSH::assertExecutedContains('printf \'requirepass "%s"\n\' "$VITO_MEMDB_PASSWORD"');
+    SSH::assertExecutedContains("sudo systemctl restart {$name}-server");
+    SSH::assertNotExecutedContains('# BEGIN VITO NETWORKING', 'Regenerating a password must not rewrite the bind configuration.');
+    SSH::assertNotExecutedContains((string) $service->secret, 'The networking password must never appear in a command.');
+})->with('memoryDatabases');
+
+test('remove the networking password', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+    $service->type_data = ['networking' => false, 'networking_effective' => false];
+    $service->secret = 'existing-secret';
+    $service->save();
+
+    SSH::fake('Active: active');
+
+    $this->deleteJson(route('services.networking.secret.destroy', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->secret)->toBeNull();
+    expect($service->status)->toEqual(ServiceStatus::READY);
+
+    SSH::assertExecutedContains('sudo install -o redis -g redis -m 600 /dev/null /etc/redis/vito-networking.conf');
+    SSH::assertNotExecutedContains('requirepass');
+    SSH::assertExecutedContains('sudo systemctl restart redis-server');
+});
+
+test('cannot remove the password while networking is open', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+    $service->type_data = ['networking' => true];
+    $service->secret = 'existing-secret';
+    $service->save();
+
+    SSH::fake();
+
+    $this->deleteJson(route('services.networking.secret.destroy', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertStatus(422);
+
+    $service->type_data = ['networking' => false, 'networking_effective' => true];
+    $service->save();
+
+    $this->deleteJson(route('services.networking.secret.destroy', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertStatus(422);
+
+    expect($service->refresh()->secret)->toEqual('existing-secret');
+    SSH::assertNotExecutedContains('vito-networking.conf');
+});
+
+test('cannot manage the password without one or on unsupported services', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+
+    SSH::fake();
+
+    $this->postJson(route('services.networking.secret.regenerate', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertStatus(422);
+
+    $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
+
+    $this->postJson(route('services.networking.secret.regenerate', [
+        'server' => $this->server,
+        'service' => $nginx->id,
+    ]))->assertStatus(422);
+
+    $this->deleteJson(route('services.networking.secret.destroy', [
+        'server' => $this->server,
+        'service' => $nginx->id,
+    ]))->assertStatus(422);
+});
+
+test('user role cannot manage the networking password', function () {
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+    $service->secret = 'existing-secret';
+    $service->save();
+
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::USER,
+    ]);
+
+    $this->actingAs($this->user);
+
+    SSH::fake();
+
+    $this->postJson(route('services.networking.secret.regenerate', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertForbidden();
+
+    $this->deleteJson(route('services.networking.secret.destroy', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertForbidden();
+});
+
+test('failed password write restores the previous password', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingTestMemoryDatabase('redis');
+    $service->type_data = ['networking' => true, 'networking_effective' => true];
+    $service->secret = 'existing-secret';
+    $service->save();
+
+    SSH::swap(new class extends SSHFake
+    {
+        public function exec(string|View $command, string $log = '', ?int $siteId = null, ?bool $stream = false, ?callable $streamCallback = null, int $timeout = 0): string
+        {
+            if (str((string) $command)->contains('requirepass')) {
+                throw new SSHCommandError('Connection failed');
+            }
+
+            return parent::exec($command, $log, $siteId, $stream, $streamCallback, $timeout);
+        }
+    });
+
+    $this->postJson(route('services.networking.secret.regenerate', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->secret)->toEqual('existing-secret');
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+
+    SSH::assertExecutedContains('sudo cp /etc/redis/vito-networking.conf.vito.bak /etc/redis/vito-networking.conf');
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'regenerate-networking-secret-failed',
+    ]);
+});
+
+function vitoPestFeatureServiceNetworkingTestMemoryDatabase(string $name): Service
 {
-    use RefreshDatabase;
-
-    #[DataProvider('memoryDatabases')]
-    public function test_enable_networking(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase($name);
-
-        SSH::fake("Active: active\nbind 0.0.0.0");
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertTrue($service->type_data['networking']);
-        $this->assertTrue($service->type_data['networking_effective']);
-        $this->assertNotNull($service->type_data['networking_checked_at']);
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-        $this->assertNotNull($service->secret);
-
-        SSH::assertExecutedContains("sudo cp /etc/{$name}/{$name}.conf /etc/{$name}/{$name}.conf.vito.bak");
-        SSH::assertNotExecutedContains('.vito.bak || true', 'A failed backup must abort the write, not be suppressed.');
-        SSH::assertNotExecutedContains("[ -f /etc/{$name}/", 'Guards must run under sudo — the conf directory is not readable by the SSH user.');
-        SSH::assertExecutedContains('bind[[:space:]]+)(0\.0\.0\.0|\*).*$/\1127.0.0.1/');
-        SSH::assertExecutedContains("sudo cp /etc/{$name}/vito-networking.conf /etc/{$name}/vito-networking.conf.vito.bak");
-        SSH::assertExecutedContains("sudo install -o {$name} -g {$name} -m 600 /dev/null /etc/{$name}/vito-networking.conf");
-        SSH::assertExecutedContains('printf \'requirepass "%s"\n\' "$VITO_MEMDB_PASSWORD"');
-        SSH::assertExecutedContains('sudo sed -i \'/^# BEGIN VITO NETWORKING$/,/^# END VITO NETWORKING$/d\'');
-        SSH::assertExecutedContains('# BEGIN VITO NETWORKING\nbind 0.0.0.0\ninclude %s\n# END VITO NETWORKING\n');
-        SSH::assertExecutedContains("sudo systemctl restart {$name}-server");
-        SSH::assertNotExecutedContains((string) $service->secret, 'The networking password must never appear in a command.');
-    }
-
-    #[DataProvider('memoryDatabases')]
-    public function test_disable_networking(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase($name);
-        $service->type_data = ['networking' => true];
-        $service->secret = 'existing-secret';
-        $service->save();
-
-        SSH::fake("Active: active\nbind 127.0.0.1");
-
-        $this->postJson(route('services.networking.disable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertFalse($service->type_data['networking']);
-        $this->assertFalse($service->type_data['networking_effective']);
-        $this->assertNotNull($service->type_data['networking_checked_at']);
-        $this->assertEquals('existing-secret', $service->secret);
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-
-        SSH::assertExecutedContains('# BEGIN VITO NETWORKING\nbind 127.0.0.1\ninclude %s\n# END VITO NETWORKING\n');
-        SSH::assertExecutedContains("sudo test -f /etc/{$name}/vito-networking.conf || sudo install -o {$name}");
-        SSH::assertExecutedContains("sudo systemctl restart {$name}-server");
-        SSH::assertNotExecutedContains('bind 0.0.0.0');
-        SSH::assertNotExecutedContains("[ -f /etc/{$name}/", 'An unprivileged guard would truncate the include file and drop the password.');
-    }
-
-    public function test_enable_persists_the_secret_before_dispatching_the_job(): void
-    {
-        Queue::fake();
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        Queue::assertPushed(ToggleNetworkingJob::class);
-        $this->assertEquals(ServiceStatus::RESTARTING, $service->status);
-        $this->assertEquals(32, strlen((string) $service->secret));
-
-        $this->getJson(route('services.networking', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertOk()
-            ->assertJson([
-                'supported' => true,
-                'pending' => true,
-                'enabled' => false,
-                'port' => 6379,
-                'secret' => $service->secret,
-                'effective' => null,
-            ]);
-
-        SSH::assertNotExecutedContains('grep -E', 'The host must not be read while the toggle is pending.');
-    }
-
-    public function test_enable_keeps_the_existing_secret(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-        $service->secret = 'existing-secret';
-        $service->save();
-
-        SSH::fake("Active: active\nbind 0.0.0.0");
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $this->assertEquals('existing-secret', $service->refresh()->secret);
-    }
-
-    public function test_secret_is_encrypted_at_rest_and_never_exposed_by_the_resource(): void
-    {
-        $service = $this->memoryDatabase('redis');
-        $service->secret = 'plain-text-secret';
-        $service->type_data = ['networking' => true];
-        $service->save();
-        $service->refresh();
-
-        $this->assertNotEquals('plain-text-secret', $service->getRawOriginal('secret'));
-        $this->assertEquals('plain-text-secret', $service->secret);
-
-        $payload = (new ServiceResource($service))->toArray(request());
-
-        $this->assertArrayNotHasKey('secret', $payload);
-        $this->assertStringNotContainsString('plain-text-secret', (string) json_encode($payload));
-        $this->assertTrue($payload['supports_networking']);
-        $this->assertTrue($payload['networking_enabled']);
-    }
-
-    public function test_resource_does_not_support_networking_for_other_services(): void
-    {
-        $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
-
-        $payload = (new ServiceResource($service))->toArray(request());
-
-        $this->assertFalse($payload['supports_networking']);
-        $this->assertFalse($payload['networking_enabled']);
-    }
-
-    #[DataProvider('settledStatuses')]
-    public function test_enable_networking_skips_the_restart_when_the_service_is_not_running(string $status): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-        $service->status = ServiceStatus::from($status);
-        $service->save();
-
-        SSH::fake();
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertTrue($service->type_data['networking']);
-        $this->assertTrue($service->type_data['networking_effective']);
-        $this->assertNull(
-            $service->type_data['networking_checked_at'] ?? null,
-            'A toggle that never restarted or verified must not stamp an observation timestamp.'
-        );
-        $this->assertEquals(ServiceStatus::from($status), $service->status);
-
-        SSH::assertExecutedContains('# BEGIN VITO NETWORKING');
-        SSH::assertNotExecutedContains('systemctl restart');
-        SSH::assertNotExecutedContains('grep -E');
-    }
-
-    public function test_cannot_toggle_networking_while_the_status_is_not_settled(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-        $service->status = ServiceStatus::RESTARTING;
-        $service->save();
-
-        SSH::fake();
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertStatus(422);
-
-        $this->postJson(route('services.networking.disable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertStatus(422);
-
-        $this->assertNull($service->refresh()->type_data);
-    }
-
-    public function test_unsupported_service_cannot_toggle_networking(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->where('name', 'nginx')->firstOrFail();
-
-        SSH::fake();
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertStatus(422);
-
-        $this->postJson(route('services.networking.disable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertStatus(422);
-
-        $this->getJson(route('services.networking', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertOk()
-            ->assertJson(['supported' => false]);
-    }
-
-    public function test_service_without_a_handler_does_not_break_networking_or_the_index(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = Service::factory()->create([
-            'server_id' => $this->server->id,
-            'type' => 'memory_database',
-            'name' => 'ghost',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-
-        SSH::fake();
-
-        $this->get(route('services', ['server' => $this->server]))->assertSuccessful();
-
-        $this->getJson(route('services.networking', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertOk()
-            ->assertJson(['supported' => false]);
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertStatus(422);
-    }
-
-    public function test_user_role_cannot_manage_networking(): void
-    {
-        $service = $this->memoryDatabase('redis');
-
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::USER,
-        ]);
-
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $this->getJson(route('services.networking', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertForbidden();
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertForbidden();
-
-        $this->postJson(route('services.networking.disable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertForbidden();
-    }
-
-    public function test_networking_details_report_the_effective_host_state(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-        $service->type_data = [
-            'networking_effective' => true,
-            'networking_checked_at' => '2026-07-26T12:00:00+00:00',
-        ];
-        $service->save();
-
-        SSH::fake();
-
-        $this->getJson(route('services.networking', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertOk()
-            ->assertJson([
-                'supported' => true,
-                'pending' => false,
-                'enabled' => false,
-                'effective' => true,
-                'checked_at' => '2026-07-26T12:00:00+00:00',
-                'port' => 6379,
-            ]);
-
-        SSH::assertNotExecutedContains("sudo grep -E '^[[:space:]]*bind' /etc/redis/redis.conf | tail -1 || true");
-    }
-
-    public function test_networking_details_report_unknown_when_never_probed(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-
-        $response = $this->getJson(route('services.networking', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertOk()
-            ->assertJson([
-                'supported' => true,
-                'pending' => false,
-                'enabled' => false,
-                'effective' => null,
-                'checked_at' => null,
-                'port' => 6379,
-            ]);
-
-        $this->assertArrayNotHasKey('error', $response->json());
-    }
-
-    public function test_failed_enable_rolls_back_and_marks_the_service_as_failed(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-
-        SSH::fake("Active: active\nbind 127.0.0.1");
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-        $this->assertFalse($service->type_data['networking']);
-        $this->assertTrue($service->type_data['networking_failed']);
-        $this->assertNull($service->type_data['networking_effective']);
-
-        SSH::assertExecutedContains('sudo cp /etc/redis/redis.conf.vito.bak /etc/redis/redis.conf');
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'enable-networking-failed',
-        ]);
-    }
-
-    public function test_failed_config_write_rolls_back_and_marks_the_service_as_failed(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-
-        SSH::swap(new class extends SSHFake
-        {
-            public function exec(string|View $command, string $log = '', ?int $siteId = null, ?bool $stream = false, ?callable $streamCallback = null, int $timeout = 0): string
-            {
-                if (str((string) $command)->contains('requirepass')) {
-                    throw new SSHCommandError('Connection failed');
-                }
-
-                return parent::exec($command, $log, $siteId, $stream, $streamCallback, $timeout);
-            }
-        });
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-        $this->assertFalse($service->type_data['networking']);
-        $this->assertTrue($service->type_data['networking_failed']);
-        $this->assertNull($service->type_data['networking_effective']);
-
-        SSH::assertExecutedContains('sudo cp /etc/redis/redis.conf.vito.bak /etc/redis/redis.conf');
-        SSH::assertExecutedContains('sudo cp /etc/redis/vito-networking.conf.vito.bak /etc/redis/vito-networking.conf');
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'enable-networking-failed',
-        ]);
-    }
-
-    public function test_failed_rollback_is_logged(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-
-        SSH::swap(new class extends SSHFake
-        {
-            public function exec(string|View $command, string $log = '', ?int $siteId = null, ?bool $stream = false, ?callable $streamCallback = null, int $timeout = 0): string
-            {
-                if (str((string) $command)->contains('.vito.bak /etc/redis/redis.conf')) {
-                    throw new SSHCommandError('Rollback failed');
-                }
-
-                return parent::exec($command, $log, $siteId, $stream, $streamCallback, $timeout);
-            }
-        });
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'rollback-redis-networking-failed',
-        ]);
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'enable-networking-failed',
-        ]);
-    }
-
-    public function test_networking_details_report_management_and_password_capability(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-
-        SSH::fake('bind 127.0.0.1');
-
-        $this->getJson(route('services.networking', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertOk()
-            ->assertJson([
-                'managed' => false,
-                'failed' => false,
-                'uses_password' => true,
-            ]);
-
-        $service->type_data = ['networking' => false];
-        $service->status = ServiceStatus::FAILED;
-        $service->save();
-
-        $this->getJson(route('services.networking', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertOk()
-            ->assertJson([
-                'managed' => true,
-                'failed' => false,
-            ]);
-
-        $service->type_data = ['networking' => false, 'networking_failed' => true];
-        $service->save();
-
-        $this->getJson(route('services.networking', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertOk()
-            ->assertJson(['failed' => true]);
-    }
-
-    public function test_a_successful_toggle_clears_a_previous_networking_failure(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-        $service->type_data = ['networking' => false, 'networking_failed' => true];
-        $service->save();
-
-        SSH::fake("Active: active\nbind 0.0.0.0");
-
-        $this->postJson(route('services.networking.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertTrue($service->type_data['networking']);
-        $this->assertArrayNotHasKey('networking_failed', $service->type_data);
-    }
-
-    public function test_failed_disable_does_not_roll_back(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-        $service->type_data = ['networking' => true];
-        $service->secret = 'existing-secret';
-        $service->save();
-
-        SSH::fake("Active: active\nbind 0.0.0.0");
-
-        $this->postJson(route('services.networking.disable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-        $this->assertTrue($service->type_data['networking']);
-        $this->assertNull($service->type_data['networking_effective']);
-
-        SSH::assertNotExecutedContains('sudo cp /etc/redis/redis.conf.vito.bak /etc/redis/redis.conf');
-    }
-
-    #[DataProvider('memoryDatabases')]
-    public function test_regenerate_the_networking_password(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase($name);
-        $service->type_data = ['networking' => true, 'networking_effective' => true];
-        $service->secret = 'existing-secret';
-        $service->save();
-
-        SSH::fake('Active: active');
-
-        $this->postJson(route('services.networking.secret.regenerate', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertEquals(32, strlen((string) $service->secret));
-        $this->assertNotEquals('existing-secret', $service->secret);
-        $this->assertTrue($service->type_data['networking']);
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-
-        SSH::assertExecutedContains("sudo install -o {$name} -g {$name} -m 600 /dev/null /etc/{$name}/vito-networking.conf");
-        SSH::assertExecutedContains('printf \'requirepass "%s"\n\' "$VITO_MEMDB_PASSWORD"');
-        SSH::assertExecutedContains("sudo systemctl restart {$name}-server");
-        SSH::assertNotExecutedContains('# BEGIN VITO NETWORKING', 'Regenerating a password must not rewrite the bind configuration.');
-        SSH::assertNotExecutedContains((string) $service->secret, 'The networking password must never appear in a command.');
-    }
-
-    public function test_remove_the_networking_password(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-        $service->type_data = ['networking' => false, 'networking_effective' => false];
-        $service->secret = 'existing-secret';
-        $service->save();
-
-        SSH::fake('Active: active');
-
-        $this->deleteJson(route('services.networking.secret.destroy', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertNull($service->secret);
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-
-        SSH::assertExecutedContains('sudo install -o redis -g redis -m 600 /dev/null /etc/redis/vito-networking.conf');
-        SSH::assertNotExecutedContains('requirepass');
-        SSH::assertExecutedContains('sudo systemctl restart redis-server');
-    }
-
-    public function test_cannot_remove_the_password_while_networking_is_open(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-        $service->type_data = ['networking' => true];
-        $service->secret = 'existing-secret';
-        $service->save();
-
-        SSH::fake();
-
-        $this->deleteJson(route('services.networking.secret.destroy', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertStatus(422);
-
-        $service->type_data = ['networking' => false, 'networking_effective' => true];
-        $service->save();
-
-        $this->deleteJson(route('services.networking.secret.destroy', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertStatus(422);
-
-        $this->assertEquals('existing-secret', $service->refresh()->secret);
-        SSH::assertNotExecutedContains('vito-networking.conf');
-    }
-
-    public function test_cannot_manage_the_password_without_one_or_on_unsupported_services(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-
-        SSH::fake();
-
-        $this->postJson(route('services.networking.secret.regenerate', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertStatus(422);
-
-        $nginx = $this->server->services()->where('name', 'nginx')->firstOrFail();
-
-        $this->postJson(route('services.networking.secret.regenerate', [
-            'server' => $this->server,
-            'service' => $nginx->id,
-        ]))->assertStatus(422);
-
-        $this->deleteJson(route('services.networking.secret.destroy', [
-            'server' => $this->server,
-            'service' => $nginx->id,
-        ]))->assertStatus(422);
-    }
-
-    public function test_user_role_cannot_manage_the_networking_password(): void
-    {
-        $service = $this->memoryDatabase('redis');
-        $service->secret = 'existing-secret';
-        $service->save();
-
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::USER,
-        ]);
-
-        $this->actingAs($this->user);
-
-        SSH::fake();
-
-        $this->postJson(route('services.networking.secret.regenerate', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertForbidden();
-
-        $this->deleteJson(route('services.networking.secret.destroy', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertForbidden();
-    }
-
-    public function test_failed_password_write_restores_the_previous_password(): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->memoryDatabase('redis');
-        $service->type_data = ['networking' => true, 'networking_effective' => true];
-        $service->secret = 'existing-secret';
-        $service->save();
-
-        SSH::swap(new class extends SSHFake
-        {
-            public function exec(string|View $command, string $log = '', ?int $siteId = null, ?bool $stream = false, ?callable $streamCallback = null, int $timeout = 0): string
-            {
-                if (str((string) $command)->contains('requirepass')) {
-                    throw new SSHCommandError('Connection failed');
-                }
-
-                return parent::exec($command, $log, $siteId, $stream, $streamCallback, $timeout);
-            }
-        });
-
-        $this->postJson(route('services.networking.secret.regenerate', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))->assertNoContent();
-
-        $service->refresh();
-
-        $this->assertEquals('existing-secret', $service->secret);
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-
-        SSH::assertExecutedContains('sudo cp /etc/redis/vito-networking.conf.vito.bak /etc/redis/vito-networking.conf');
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'regenerate-networking-secret-failed',
-        ]);
-    }
-
-    private function memoryDatabase(string $name): Service
-    {
-        $this->server->services()->where('type', 'memory_database')->delete();
-
-        return Service::factory()->create([
-            'server_id' => $this->server->id,
-            'type' => 'memory_database',
-            'name' => $name,
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-    }
-
-    /**
-     * @return array<array<string>>
-     */
-    public static function memoryDatabases(): array
-    {
-        return [
-            ['redis'],
-            ['valkey'],
-        ];
-    }
-
-    /**
-     * @return array<array<string>>
-     */
-    public static function settledStatuses(): array
-    {
-        return [
-            [ServiceStatus::STOPPED->value],
-            [ServiceStatus::DISABLED->value],
-            [ServiceStatus::FAILED->value],
-        ];
-    }
+    test()->server->services()->where('type', 'memory_database')->delete();
+
+    return Service::factory()->create([
+        'server_id' => test()->server->id,
+        'type' => 'memory_database',
+        'name' => $name,
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
 }
+
+/**
+ * @return array<array<string>>
+ */
+dataset('memoryDatabases', function () {
+    return [
+        ['redis'],
+        ['valkey'],
+    ];
+});
+
+/**
+ * @return array<array<string>>
+ */
+dataset('settledStatuses', function () {
+    return [
+        [ServiceStatus::STOPPED->value],
+        [ServiceStatus::DISABLED->value],
+        [ServiceStatus::FAILED->value],
+    ];
+});

--- a/tests/Feature/ServiceRefreshTest.php
+++ b/tests/Feature/ServiceRefreshTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\Service\ProbeServices;
 use App\Actions\Service\RefreshServices;
 use App\Enums\ServiceStatus;
@@ -14,406 +12,364 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Queue;
-use Tests\TestCase;
 
-class ServiceRefreshTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    protected function setUp(): void
+beforeEach(function () {
+    $this->server->services()->update(['status' => ServiceStatus::READY]);
+});
+
+test('refresh dispatches the job and flags the server', function () {
+    Queue::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('services.refresh', ['server' => $this->server]))
+        ->assertRedirect()
+        ->assertSessionHas('info', 'Refreshing services…');
+
+    Queue::assertPushed(RefreshServicesJob::class);
+    expect(RefreshServices::refreshing($this->server))->toBeTrue();
+});
+
+test('refresh is a no op while already flagged', function () {
+    Queue::fake();
+
+    $this->actingAs($this->user);
+
+    Cache::put("services-refreshing:{$this->server->id}", true, 900);
+
+    $this->post(route('services.refresh', ['server' => $this->server]))
+        ->assertRedirect()
+        ->assertSessionHas('info', 'A services refresh is already running.');
+
+    Queue::assertNothingPushed();
+});
+
+test('user role cannot refresh services', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::USER,
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('services.refresh', ['server' => $this->server]))->assertForbidden();
+});
+
+test('refresh persists status version and networking in one ssh call', function () {
+    $mysql = vitoPestFeatureServiceRefreshTestService('mysql');
+    $redis = vitoPestFeatureServiceRefreshTestService('redis');
+
+    SSH::fake(vitoPestFeatureServiceRefreshTestMarkers([
+        [$mysql->id, 'status', 'active'],
+        [$mysql->id, 'version', '8.4.5'],
+        [$mysql->id, 'networking', '0.0.0.0'],
+        [$redis->id, 'status', 'inactive'],
+        [$redis->id, 'version', '7.2.4'],
+        [$redis->id, 'networking', 'bind 127.0.0.1 -::1'],
+    ]));
+
+    app(ProbeServices::class)->probe($this->server);
+
+    $mysql->refresh();
+    $redis->refresh();
+
+    expect($mysql->installed_version)->toEqual('8.4.5');
+    expect($mysql->type_data['networking_effective'])->toBeTrue();
+    expect($mysql->type_data['networking_checked_at'])->not->toBeNull();
+    expect($mysql->status)->toEqual(ServiceStatus::READY);
+
+    expect($redis->installed_version)->toEqual('7.2.4');
+    expect($redis->type_data['networking_effective'])->toBeFalse();
+    expect($redis->status)->toEqual(ServiceStatus::STOPPED);
+
+    $script = vitoPestFeatureServiceRefreshTestExecutedScript();
+
+    expect(substr_count($script, 'systemctl is-active'))->toEqual(1);
+    $this->assertStringContainsString('###VITO:', $script);
+});
+
+test('refresh reads memory database config while stopped', function () {
+    $redis = vitoPestFeatureServiceRefreshTestService('redis');
+
+    SSH::fake(vitoPestFeatureServiceRefreshTestMarkers([
+        [$redis->id, 'status', 'inactive'],
+        [$redis->id, 'networking', 'bind 0.0.0.0'],
+    ]));
+
+    app(ProbeServices::class)->probe($this->server);
+
+    expect($redis->refresh()->type_data['networking_effective'])->toBeTrue();
+});
+
+test('refresh survives a fragment with no trailing newline', function () {
+    $php = vitoPestFeatureServiceRefreshTestService('php');
+    $mysql = vitoPestFeatureServiceRefreshTestService('mysql');
+
+    $output = "###VITO:{$php->id}:version###\n8.2.19"
+        ."###VITO:{$mysql->id}:version###\n8.4.5\n";
+
+    SSH::fake($output);
+
+    app(ProbeServices::class)->probe($this->server);
+
+    expect($mysql->refresh()->installed_version)->toBeNull('A glued marker must not be attributed to the following service.');
+
+    SSH::fake(vitoPestFeatureServiceRefreshTestMarkers([
+        [$php->id, 'version', '8.2.19'],
+        [$mysql->id, 'version', '8.4.5'],
+    ]));
+
+    app(ProbeServices::class)->probe($this->server);
+
+    expect($php->refresh()->installed_version)->toEqual('8.2.19');
+    expect($mysql->refresh()->installed_version)->toEqual('8.4.5');
+
+    $this->assertStringContainsString('printf \'%s\n\' "$OUT"', vitoPestFeatureServiceRefreshTestExecutedScript());
+});
+
+test('refresh script render is not html escaped', function () {
+    $php = vitoPestFeatureServiceRefreshTestService('php');
+    $php->version = "8.3'; rm -rf /tmp; echo '";
+    $php->save();
+
+    SSH::fake();
+
+    app(ProbeServices::class)->probe($this->server);
+
+    $script = vitoPestFeatureServiceRefreshTestExecutedScript();
+
+    $this->assertStringContainsString('grep -oE', $script);
+    $this->assertStringNotContainsString('&#039;', $script);
+    $this->assertStringNotContainsString('&quot;', $script);
+    $this->assertStringNotContainsString(
+        "php8.3'; rm -rf /tmp",
+        $script,
+        'The hostile version must never reach the script with its quote unescaped.'
+    );
+    $this->assertStringContainsString(escapeshellarg((string) $php->handler()->versionCommand()), $script);
+    $this->assertStringContainsString('timeout 15 bash -c', $script);
+});
+
+test('refresh marks networking unknown when a running probe returns nothing', function () {
+    $mysql = vitoPestFeatureServiceRefreshTestService('mysql');
+
+    SSH::fake(vitoPestFeatureServiceRefreshTestMarkers([
+        [$mysql->id, 'status', 'active'],
+        [$mysql->id, 'networking', ''],
+    ]));
+
+    app(ProbeServices::class)->probe($this->server);
+
+    $mysql->refresh();
+
+    expect($mysql->type_data['networking_effective'])->toBeNull();
+    expect($mysql->type_data['networking_checked_at'])->not->toBeNull('A probe that ran and could not read is still an observation.');
+});
+
+test('refresh leaves networking untouched for a stopped sql engine', function () {
+    $mysql = vitoPestFeatureServiceRefreshTestService('mysql');
+    $mysql->type_data = [
+        'networking' => false,
+        'networking_effective' => true,
+        'networking_checked_at' => '2026-07-01T00:00:00+00:00',
+    ];
+    $mysql->save();
+
+    SSH::fake(vitoPestFeatureServiceRefreshTestMarkers([[$mysql->id, 'status', 'inactive']]));
+
+    app(ProbeServices::class)->probe($this->server);
+
+    $mysql->refresh();
+
+    expect($mysql->status)->toEqual(ServiceStatus::STOPPED);
+    expect($mysql->type_data['networking_effective'])->toBeTrue('A skipped probe must not erase the last observation.');
+    expect($mysql->type_data['networking_checked_at'])->toEqual('2026-07-01T00:00:00+00:00');
+
+    $script = vitoPestFeatureServiceRefreshTestExecutedScript();
+
+    $this->assertStringContainsString("if [ \"\$STATE_{$mysql->id}\" = \"active\" ]; then", $script);
+});
+
+test('refresh omits status section for unitless services', function () {
+    $nodejs = vitoPestFeatureServiceRefreshTestService('nodejs');
+
+    SSH::fake(vitoPestFeatureServiceRefreshTestMarkers([[$nodejs->id, 'version', '22.1.0']]));
+
+    app(ProbeServices::class)->probe($this->server);
+
+    $script = vitoPestFeatureServiceRefreshTestExecutedScript();
+
+    $this->assertStringNotContainsString("###VITO:{$nodejs->id}:status###", $script);
+    $this->assertStringContainsString("###VITO:{$nodejs->id}:version###", $script);
+    expect($nodejs->refresh()->installed_version)->toEqual('22.1.0');
+});
+
+test('refresh skips version for handlers without a version command', function () {
+    $agent = $this->server->services()->create([
+        'type' => 'monitoring',
+        'name' => 'vito-agent',
+        'version' => '0.1.0',
+        'status' => ServiceStatus::READY,
+    ]);
+
+    SSH::fake(vitoPestFeatureServiceRefreshTestMarkers([[$agent->id, 'status', 'active']]));
+
+    app(ProbeServices::class)->probe($this->server);
+
+    $this->assertStringNotContainsString("###VITO:{$agent->id}:version###", vitoPestFeatureServiceRefreshTestExecutedScript());
+    expect($agent->refresh()->installed_version)->toBeNull();
+});
+
+test('refresh skips a service deleted mid batch and persists the rest', function () {
+    $mysql = vitoPestFeatureServiceRefreshTestService('mysql');
+    $redis = vitoPestFeatureServiceRefreshTestService('redis');
+    $nginx = vitoPestFeatureServiceRefreshTestService('nginx');
+
+    $output = vitoPestFeatureServiceRefreshTestMarkers([
+        [$mysql->id, 'version', '8.4.5'],
+        [$redis->id, 'version', '7.2.4'],
+        [$nginx->id, 'version', '1.24.0'],
+    ]);
+
+    SSH::swap(new class($output, $redis->id) extends SSHFake
     {
-        parent::setUp();
-
-        $this->server->services()->update(['status' => ServiceStatus::READY]);
-    }
-
-    public function test_refresh_dispatches_the_job_and_flags_the_server(): void
-    {
-        Queue::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('services.refresh', ['server' => $this->server]))
-            ->assertRedirect()
-            ->assertSessionHas('info', 'Refreshing services…');
-
-        Queue::assertPushed(RefreshServicesJob::class);
-        $this->assertTrue(RefreshServices::refreshing($this->server));
-    }
-
-    public function test_refresh_is_a_no_op_while_already_flagged(): void
-    {
-        Queue::fake();
-
-        $this->actingAs($this->user);
-
-        Cache::put("services-refreshing:{$this->server->id}", true, 900);
-
-        $this->post(route('services.refresh', ['server' => $this->server]))
-            ->assertRedirect()
-            ->assertSessionHas('info', 'A services refresh is already running.');
-
-        Queue::assertNothingPushed();
-    }
-
-    public function test_user_role_cannot_refresh_services(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::USER,
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('services.refresh', ['server' => $this->server]))->assertForbidden();
-    }
-
-    public function test_refresh_persists_status_version_and_networking_in_one_ssh_call(): void
-    {
-        $mysql = $this->service('mysql');
-        $redis = $this->service('redis');
-
-        SSH::fake($this->markers([
-            [$mysql->id, 'status', 'active'],
-            [$mysql->id, 'version', '8.4.5'],
-            [$mysql->id, 'networking', '0.0.0.0'],
-            [$redis->id, 'status', 'inactive'],
-            [$redis->id, 'version', '7.2.4'],
-            [$redis->id, 'networking', 'bind 127.0.0.1 -::1'],
-        ]));
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $mysql->refresh();
-        $redis->refresh();
-
-        $this->assertEquals('8.4.5', $mysql->installed_version);
-        $this->assertTrue($mysql->type_data['networking_effective']);
-        $this->assertNotNull($mysql->type_data['networking_checked_at']);
-        $this->assertEquals(ServiceStatus::READY, $mysql->status);
-
-        $this->assertEquals('7.2.4', $redis->installed_version);
-        $this->assertFalse($redis->type_data['networking_effective']);
-        $this->assertEquals(ServiceStatus::STOPPED, $redis->status);
-
-        $script = $this->executedScript();
-
-        $this->assertEquals(1, substr_count($script, 'systemctl is-active'));
-        $this->assertStringContainsString('###VITO:', $script);
-    }
-
-    public function test_refresh_reads_memory_database_config_while_stopped(): void
-    {
-        $redis = $this->service('redis');
-
-        SSH::fake($this->markers([
-            [$redis->id, 'status', 'inactive'],
-            [$redis->id, 'networking', 'bind 0.0.0.0'],
-        ]));
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $this->assertTrue($redis->refresh()->type_data['networking_effective']);
-    }
-
-    public function test_refresh_survives_a_fragment_with_no_trailing_newline(): void
-    {
-        $php = $this->service('php');
-        $mysql = $this->service('mysql');
-
-        $output = "###VITO:{$php->id}:version###\n8.2.19"
-            ."###VITO:{$mysql->id}:version###\n8.4.5\n";
-
-        SSH::fake($output);
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $this->assertNull(
-            $mysql->refresh()->installed_version,
-            'A glued marker must not be attributed to the following service.'
-        );
-
-        SSH::fake($this->markers([
-            [$php->id, 'version', '8.2.19'],
-            [$mysql->id, 'version', '8.4.5'],
-        ]));
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $this->assertEquals('8.2.19', $php->refresh()->installed_version);
-        $this->assertEquals('8.4.5', $mysql->refresh()->installed_version);
-
-        $this->assertStringContainsString('printf \'%s\n\' "$OUT"', $this->executedScript());
-    }
-
-    public function test_refresh_script_render_is_not_html_escaped(): void
-    {
-        $php = $this->service('php');
-        $php->version = "8.3'; rm -rf /tmp; echo '";
-        $php->save();
-
-        SSH::fake();
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $script = $this->executedScript();
-
-        $this->assertStringContainsString('grep -oE', $script);
-        $this->assertStringNotContainsString('&#039;', $script);
-        $this->assertStringNotContainsString('&quot;', $script);
-        $this->assertStringNotContainsString(
-            "php8.3'; rm -rf /tmp",
-            $script,
-            'The hostile version must never reach the script with its quote unescaped.'
-        );
-        $this->assertStringContainsString(escapeshellarg((string) $php->handler()->versionCommand()), $script);
-        $this->assertStringContainsString('timeout 15 bash -c', $script);
-    }
-
-    public function test_refresh_marks_networking_unknown_when_a_running_probe_returns_nothing(): void
-    {
-        $mysql = $this->service('mysql');
-
-        SSH::fake($this->markers([
-            [$mysql->id, 'status', 'active'],
-            [$mysql->id, 'networking', ''],
-        ]));
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $mysql->refresh();
-
-        $this->assertNull($mysql->type_data['networking_effective']);
-        $this->assertNotNull(
-            $mysql->type_data['networking_checked_at'],
-            'A probe that ran and could not read is still an observation.'
-        );
-    }
-
-    public function test_refresh_leaves_networking_untouched_for_a_stopped_sql_engine(): void
-    {
-        $mysql = $this->service('mysql');
-        $mysql->type_data = [
-            'networking' => false,
-            'networking_effective' => true,
-            'networking_checked_at' => '2026-07-01T00:00:00+00:00',
-        ];
-        $mysql->save();
-
-        SSH::fake($this->markers([[$mysql->id, 'status', 'inactive']]));
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $mysql->refresh();
-
-        $this->assertEquals(ServiceStatus::STOPPED, $mysql->status);
-        $this->assertTrue(
-            $mysql->type_data['networking_effective'],
-            'A skipped probe must not erase the last observation.'
-        );
-        $this->assertEquals('2026-07-01T00:00:00+00:00', $mysql->type_data['networking_checked_at']);
-
-        $script = $this->executedScript();
-
-        $this->assertStringContainsString("if [ \"\$STATE_{$mysql->id}\" = \"active\" ]; then", $script);
-    }
-
-    public function test_refresh_omits_status_section_for_unitless_services(): void
-    {
-        $nodejs = $this->service('nodejs');
-
-        SSH::fake($this->markers([[$nodejs->id, 'version', '22.1.0']]));
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $script = $this->executedScript();
-
-        $this->assertStringNotContainsString("###VITO:{$nodejs->id}:status###", $script);
-        $this->assertStringContainsString("###VITO:{$nodejs->id}:version###", $script);
-        $this->assertEquals('22.1.0', $nodejs->refresh()->installed_version);
-    }
-
-    public function test_refresh_skips_version_for_handlers_without_a_version_command(): void
-    {
-        $agent = $this->server->services()->create([
-            'type' => 'monitoring',
-            'name' => 'vito-agent',
-            'version' => '0.1.0',
-            'status' => ServiceStatus::READY,
-        ]);
-
-        SSH::fake($this->markers([[$agent->id, 'status', 'active']]));
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $this->assertStringNotContainsString("###VITO:{$agent->id}:version###", $this->executedScript());
-        $this->assertNull($agent->refresh()->installed_version);
-    }
-
-    public function test_refresh_skips_a_service_deleted_mid_batch_and_persists_the_rest(): void
-    {
-        $mysql = $this->service('mysql');
-        $redis = $this->service('redis');
-        $nginx = $this->service('nginx');
-
-        $output = $this->markers([
-            [$mysql->id, 'version', '8.4.5'],
-            [$redis->id, 'version', '7.2.4'],
-            [$nginx->id, 'version', '1.24.0'],
-        ]);
-
-        SSH::swap(new class($output, $redis->id) extends SSHFake
+        public function __construct(private readonly string $markerOutput, private readonly int $deleteServiceId)
         {
-            public function __construct(private readonly string $markerOutput, private readonly int $deleteServiceId)
-            {
-                parent::__construct($markerOutput);
-            }
-
-            public function exec(string|View $command, string $log = '', ?int $siteId = null, ?bool $stream = false, ?callable $streamCallback = null, int $timeout = 0): string
-            {
-                Service::query()->whereKey($this->deleteServiceId)->delete();
-
-                return $this->markerOutput;
-            }
-        });
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $this->assertEquals('8.4.5', $mysql->refresh()->installed_version);
-        $this->assertEquals(
-            '1.24.0',
-            $nginx->refresh()->installed_version,
-            'A service deleted mid-batch must not discard the services probed after it.'
-        );
-    }
-
-    public function test_refresh_ignores_a_service_whose_sections_are_missing(): void
-    {
-        $mysql = $this->service('mysql');
-        $mysql->installed_version = '8.4.0';
-        $mysql->save();
-
-        SSH::fake('');
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $this->assertEquals('8.4.0', $mysql->refresh()->installed_version);
-    }
-
-    public function test_refresh_parses_sections_out_of_order_and_keeps_the_first_duplicate(): void
-    {
-        $mysql = $this->service('mysql');
-
-        SSH::fake($this->markers([
-            [$mysql->id, 'version', '8.4.5'],
-            [$mysql->id, 'status', 'active'],
-            [$mysql->id, 'version', '9.9.9'],
-            [99999, 'version', '1.2.3'],
-        ]));
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $this->assertEquals('8.4.5', $mysql->refresh()->installed_version);
-    }
-
-    public function test_refresh_parses_crlf_output_and_trims_section_values(): void
-    {
-        $mysql = $this->service('mysql');
-
-        SSH::fake("###VITO:{$mysql->id}:version###\r\n  8.4.5  \r\n");
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $this->assertEquals('8.4.5', $mysql->refresh()->installed_version);
-    }
-
-    public function test_refresh_never_creates_the_networking_intent_key(): void
-    {
-        $mysql = $this->service('mysql');
-
-        SSH::fake($this->markers([
-            [$mysql->id, 'status', 'active'],
-            [$mysql->id, 'networking', '0.0.0.0'],
-        ]));
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $mysql->refresh();
-
-        $this->assertArrayNotHasKey('networking', $mysql->type_data);
-        $this->assertFalse($mysql->handler()->networkingManaged());
-    }
-
-    public function test_refresh_forces_the_status_sync_without_double_confirmation(): void
-    {
-        $mysql = $this->service('mysql');
-
-        SSH::fake($this->markers([[$mysql->id, 'status', 'failed']]));
-
-        app(ProbeServices::class)->probe($this->server);
-
-        $this->assertEquals(ServiceStatus::FAILED, $mysql->refresh()->status);
-    }
-
-    public function test_refresh_keeps_the_flag_when_the_server_lock_is_contended(): void
-    {
-        Cache::put("services-refreshing:{$this->server->id}", true, 900);
-
-        $lock = Cache::lock("unique-queue:server-{$this->server->id}", 60);
-        $lock->get();
-
-        (new RefreshServicesJob($this->server))->handle();
-
-        $this->assertTrue(
-            RefreshServices::refreshing($this->server),
-            'A job released because the server lock was held must not clear the flag.'
-        );
-
-        $lock->release();
-    }
-
-    public function test_refresh_clears_the_flag_and_broadcasts_on_failure(): void
-    {
-        Cache::put("services-refreshing:{$this->server->id}", true, 900);
-
-        (new RefreshServicesJob($this->server))->failed(new \Exception('boom'));
-
-        $this->assertFalse(RefreshServices::refreshing($this->server));
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'refresh-services-failed',
-        ]);
-    }
-
-    private function service(string $name): Service
-    {
-        /** @var Service $service */
-        $service = $this->server->services()->where('name', $name)->firstOrFail();
-
-        return $service;
-    }
-
-    /**
-     * @param  array<int, array{0: int, 1: string, 2: string}>  $sections
-     */
-    private function markers(array $sections): string
-    {
-        $output = '';
-
-        foreach ($sections as [$id, $section, $body]) {
-            $output .= "###VITO:{$id}:{$section}###\n{$body}\n";
+            parent::__construct($markerOutput);
         }
 
-        return $output;
-    }
+        public function exec(string|View $command, string $log = '', ?int $siteId = null, ?bool $stream = false, ?callable $streamCallback = null, int $timeout = 0): string
+        {
+            Service::query()->whereKey($this->deleteServiceId)->delete();
 
-    private function executedScript(): string
-    {
-        foreach (SSH::getExecutedCommands() as $command) {
-            if (str_contains($command, '###VITO:')) {
-                return $command;
-            }
+            return $this->markerOutput;
         }
+    });
 
-        $this->fail('The refresh script was never executed.');
+    app(ProbeServices::class)->probe($this->server);
+
+    expect($mysql->refresh()->installed_version)->toEqual('8.4.5');
+    expect($nginx->refresh()->installed_version)->toEqual('1.24.0', 'A service deleted mid-batch must not discard the services probed after it.');
+});
+
+test('refresh ignores a service whose sections are missing', function () {
+    $mysql = vitoPestFeatureServiceRefreshTestService('mysql');
+    $mysql->installed_version = '8.4.0';
+    $mysql->save();
+
+    SSH::fake('');
+
+    app(ProbeServices::class)->probe($this->server);
+
+    expect($mysql->refresh()->installed_version)->toEqual('8.4.0');
+});
+
+test('refresh parses sections out of order and keeps the first duplicate', function () {
+    $mysql = vitoPestFeatureServiceRefreshTestService('mysql');
+
+    SSH::fake(vitoPestFeatureServiceRefreshTestMarkers([
+        [$mysql->id, 'version', '8.4.5'],
+        [$mysql->id, 'status', 'active'],
+        [$mysql->id, 'version', '9.9.9'],
+        [99999, 'version', '1.2.3'],
+    ]));
+
+    app(ProbeServices::class)->probe($this->server);
+
+    expect($mysql->refresh()->installed_version)->toEqual('8.4.5');
+});
+
+test('refresh parses crlf output and trims section values', function () {
+    $mysql = vitoPestFeatureServiceRefreshTestService('mysql');
+
+    SSH::fake("###VITO:{$mysql->id}:version###\r\n  8.4.5  \r\n");
+
+    app(ProbeServices::class)->probe($this->server);
+
+    expect($mysql->refresh()->installed_version)->toEqual('8.4.5');
+});
+
+test('refresh never creates the networking intent key', function () {
+    $mysql = vitoPestFeatureServiceRefreshTestService('mysql');
+
+    SSH::fake(vitoPestFeatureServiceRefreshTestMarkers([
+        [$mysql->id, 'status', 'active'],
+        [$mysql->id, 'networking', '0.0.0.0'],
+    ]));
+
+    app(ProbeServices::class)->probe($this->server);
+
+    $mysql->refresh();
+
+    $this->assertArrayNotHasKey('networking', $mysql->type_data);
+    expect($mysql->handler()->networkingManaged())->toBeFalse();
+});
+
+test('refresh forces the status sync without double confirmation', function () {
+    $mysql = vitoPestFeatureServiceRefreshTestService('mysql');
+
+    SSH::fake(vitoPestFeatureServiceRefreshTestMarkers([[$mysql->id, 'status', 'failed']]));
+
+    app(ProbeServices::class)->probe($this->server);
+
+    expect($mysql->refresh()->status)->toEqual(ServiceStatus::FAILED);
+});
+
+test('refresh keeps the flag when the server lock is contended', function () {
+    Cache::put("services-refreshing:{$this->server->id}", true, 900);
+
+    $lock = Cache::lock("unique-queue:server-{$this->server->id}", 60);
+    $lock->get();
+
+    (new RefreshServicesJob($this->server))->handle();
+
+    expect(RefreshServices::refreshing($this->server))->toBeTrue('A job released because the server lock was held must not clear the flag.');
+
+    $lock->release();
+});
+
+test('refresh clears the flag and broadcasts on failure', function () {
+    Cache::put("services-refreshing:{$this->server->id}", true, 900);
+
+    (new RefreshServicesJob($this->server))->failed(new Exception('boom'));
+
+    expect(RefreshServices::refreshing($this->server))->toBeFalse();
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'refresh-services-failed',
+    ]);
+});
+
+function vitoPestFeatureServiceRefreshTestService(string $name): Service
+{
+    /** @var Service $service */
+    $service = test()->server->services()->where('name', $name)->firstOrFail();
+
+    return $service;
+}
+
+/**
+ * @param  array<int, array{0: int, 1: string, 2: string}>  $sections
+ */
+function vitoPestFeatureServiceRefreshTestMarkers(array $sections): string
+{
+    $output = '';
+
+    foreach ($sections as [$id, $section, $body]) {
+        $output .= "###VITO:{$id}:{$section}###\n{$body}\n";
     }
+
+    return $output;
+}
+
+function vitoPestFeatureServiceRefreshTestExecutedScript(): string
+{
+    foreach (SSH::getExecutedCommands() as $command) {
+        if (str_contains($command, '###VITO:')) {
+            return $command;
+        }
+    }
+
+    test()->fail('The refresh script was never executed.');
 }

--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\ServiceStatus;
 use App\Facades\SSH;
 use App\Models\Server;
@@ -11,492 +9,444 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Route;
 use Inertia\Testing\AssertableInertia;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class ServicesTest extends TestCase
-{
-    use RefreshDatabase;
-
-    public function test_see_services_list(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->get(route('services', [
-            'server' => $this->server,
-        ]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('services/index'));
-    }
-
-    public function test_services_index_returns_the_inertia_table(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->get(route('services', ['server' => $this->server]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('services/index')
-                ->where('refreshing', false)
-                ->has('services.columns')
-                ->has('services.data.0.resource')
-                ->has('services.data.0.networked')
-            );
-    }
-
-    #[DataProvider('data')]
-    public function test_restart_service(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->where('name', $name)->firstOrFail();
-        $service->status = ServiceStatus::STOPPED;
-        $service->save();
-
-        SSH::fake('Active: active');
-
-        $this->post(route('services.restart', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-    }
-
-    #[DataProvider('data')]
-    public function test_reload_service(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->where('name', $name)->firstOrFail();
-        $service->status = ServiceStatus::READY;
-        $service->save();
-
-        SSH::fake('Active: active');
-
-        $this->post(route('services.reload', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-    }
-
-    #[DataProvider('data')]
-    public function test_failed_to_reload_service(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->where('name', $name)->firstOrFail();
-
-        SSH::fake('Active: inactive');
-
-        $this->post(route('services.reload', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-    }
-
-    #[DataProvider('data')]
-    public function test_failed_to_restart_service(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->where('name', $name)->firstOrFail();
-
-        SSH::fake('Active: inactive');
-
-        $this->post(route('services.restart', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-    }
-
-    #[DataProvider('data')]
-    public function test_stop_service(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->where('name', $name)->firstOrFail();
-
-        SSH::fake('Active: inactive');
-
-        $this->post(route('services.stop', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::STOPPED, $service->status);
-    }
-
-    #[DataProvider('data')]
-    public function test_failed_to_stop_service(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->where('name', $name)->firstOrFail();
-
-        SSH::fake('Active: active');
-
-        $this->post(route('services.stop', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-    }
-
-    #[DataProvider('data')]
-    public function test_start_service(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->where('name', $name)->firstOrFail();
-        $service->status = ServiceStatus::STOPPED;
-        $service->save();
-
-        SSH::fake('Active: active');
-
-        $this->post(route('services.start', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-    }
-
-    #[DataProvider('data')]
-    public function test_failed_to_start_service(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->where('name', $name)->firstOrFail();
-
-        SSH::fake('Active: inactive');
-
-        $this->post(route('services.start', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-    }
-
-    #[DataProvider('data')]
-    public function test_enable_service(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->where('name', $name)->firstOrFail();
-        $service->status = ServiceStatus::DISABLED;
-        $service->save();
-
-        SSH::fake('Active: active');
-
-        $this->post(route('services.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::READY, $service->status);
-    }
-
-    #[DataProvider('data')]
-    public function test_failed_to_enable_service(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->where('name', $name)->firstOrFail();
-
-        SSH::fake('Active: inactive');
-
-        $this->post(route('services.enable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-    }
-
-    #[DataProvider('data')]
-    public function test_disable_service(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->where('name', $name)->firstOrFail();
-
-        SSH::fake('Active: inactive');
-
-        $this->post(route('services.disable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::DISABLED, $service->status);
-    }
-
-    #[DataProvider('data')]
-    public function test_failed_to_disable_service(string $name): void
-    {
-        $this->actingAs($this->user);
-
-        $service = $this->server->services()->where('name', $name)->firstOrFail();
-
-        SSH::fake('Active: active');
-
-        $this->post(route('services.disable', [
-            'server' => $this->server,
-            'service' => $service->id,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $service->refresh();
-
-        $this->assertEquals(ServiceStatus::FAILED, $service->status);
-    }
-
-    #[DataProvider('installData')]
-    public function test_install_service(string $name, string $type, string $version): void
-    {
-        Http::fake([
-            'https://api.github.com/repos/vito/vito-agent/releases/latest' => Http::response([
-                'tag_name' => '0.1.0',
-            ]),
-        ]);
-        SSH::fake('Active: active');
-
-        $this->actingAs($this->user);
-
-        $server = Server::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $keys = $server->sshKey();
-        if (! File::exists($keys['public_key_path']) || ! File::exists($keys['private_key_path'])) {
-            $server->provider()->generateKeyPair();
-        }
-
-        $this->post(route('services.store', [
-            'server' => $server,
-        ]), [
-            'name' => $name,
-            'version' => $version,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('services', [
-            'server_id' => $server->id,
-            'name' => $name,
-            'type' => $type,
-            'status' => ServiceStatus::READY,
-        ]);
-    }
-
-    public function test_install_service_creates_installation_log(): void
-    {
-        Http::fake([
-            'https://api.github.com/repos/vito/vito-agent/releases/latest' => Http::response([
-                'tag_name' => '0.1.0',
-            ]),
-        ]);
-        SSH::fake('Active: active');
-
-        $this->actingAs($this->user);
-
-        $server = Server::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
-
-        $keys = $server->sshKey();
-        if (! File::exists($keys['public_key_path']) || ! File::exists($keys['private_key_path'])) {
-            $server->provider()->generateKeyPair();
-        }
-
-        $this->post(route('services.store', [
-            'server' => $server,
-        ]), [
-            'name' => 'redis',
-            'version' => 'latest',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $service = $server->services()->where('name', 'redis')->firstOrFail();
-
-        // Verify that the installation log is linked to the service
-        $this->assertNotNull($service->log_id);
-        $this->assertNotNull($service->log);
-        $this->assertStringStartsWith('install-redis', $service->log->type);
-
-        $this->assertNull(
-            $service->type_data['networking_effective'] ?? null,
-            'Install never observes the live bind state, so it must not claim one.'
+uses(RefreshDatabase::class);
+
+test('see services list', function () {
+    $this->actingAs($this->user);
+
+    $this->get(route('services', [
+        'server' => $this->server,
+    ]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('services/index'));
+});
+
+test('services index returns the inertia table', function () {
+    $this->actingAs($this->user);
+
+    $this->get(route('services', ['server' => $this->server]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('services/index')
+            ->where('refreshing', false)
+            ->has('services.columns')
+            ->has('services.data.0.resource')
+            ->has('services.data.0.networked')
         );
-        $this->assertNull($service->type_data['networking_checked_at'] ?? null);
-        $this->assertArrayNotHasKey('networking', $service->type_data);
+});
+
+test('restart service', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->where('name', $name)->firstOrFail();
+    $service->status = ServiceStatus::STOPPED;
+    $service->save();
+
+    SSH::fake('Active: active');
+
+    $this->post(route('services.restart', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::READY);
+})->with('data');
+
+test('reload service', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->where('name', $name)->firstOrFail();
+    $service->status = ServiceStatus::READY;
+    $service->save();
+
+    SSH::fake('Active: active');
+
+    $this->post(route('services.reload', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::READY);
+})->with('data');
+
+test('failed to reload service', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->where('name', $name)->firstOrFail();
+
+    SSH::fake('Active: inactive');
+
+    $this->post(route('services.reload', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+})->with('data');
+
+test('failed to restart service', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->where('name', $name)->firstOrFail();
+
+    SSH::fake('Active: inactive');
+
+    $this->post(route('services.restart', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+})->with('data');
+
+test('stop service', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->where('name', $name)->firstOrFail();
+
+    SSH::fake('Active: inactive');
+
+    $this->post(route('services.stop', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::STOPPED);
+})->with('data');
+
+test('failed to stop service', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->where('name', $name)->firstOrFail();
+
+    SSH::fake('Active: active');
+
+    $this->post(route('services.stop', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+})->with('data');
+
+test('start service', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->where('name', $name)->firstOrFail();
+    $service->status = ServiceStatus::STOPPED;
+    $service->save();
+
+    SSH::fake('Active: active');
+
+    $this->post(route('services.start', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::READY);
+})->with('data');
+
+test('failed to start service', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->where('name', $name)->firstOrFail();
+
+    SSH::fake('Active: inactive');
+
+    $this->post(route('services.start', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+})->with('data');
+
+test('enable service', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->where('name', $name)->firstOrFail();
+    $service->status = ServiceStatus::DISABLED;
+    $service->save();
+
+    SSH::fake('Active: active');
+
+    $this->post(route('services.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::READY);
+})->with('data');
+
+test('failed to enable service', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->where('name', $name)->firstOrFail();
+
+    SSH::fake('Active: inactive');
+
+    $this->post(route('services.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+})->with('data');
+
+test('disable service', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->where('name', $name)->firstOrFail();
+
+    SSH::fake('Active: inactive');
+
+    $this->post(route('services.disable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::DISABLED);
+})->with('data');
+
+test('failed to disable service', function (string $name) {
+    $this->actingAs($this->user);
+
+    $service = $this->server->services()->where('name', $name)->firstOrFail();
+
+    SSH::fake('Active: active');
+
+    $this->post(route('services.disable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $service->refresh();
+
+    expect($service->status)->toEqual(ServiceStatus::FAILED);
+})->with('data');
+
+test('install service', function (string $name, string $type, string $version) {
+    Http::fake([
+        'https://api.github.com/repos/vito/vito-agent/releases/latest' => Http::response([
+            'tag_name' => '0.1.0',
+        ]),
+    ]);
+    SSH::fake('Active: active');
+
+    $this->actingAs($this->user);
+
+    $server = Server::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $keys = $server->sshKey();
+    if (! File::exists($keys['public_key_path']) || ! File::exists($keys['private_key_path'])) {
+        $server->provider()->generateKeyPair();
     }
 
-    #[DataProvider('phpVersionOutputData')]
-    public function test_parse_php_installed_version(string $sshOutput, string $expectedVersion): void
-    {
-        /** @var Service $service */
-        $service = $this->server->services()->where('name', 'php')->firstOrFail();
+    $this->post(route('services.store', [
+        'server' => $server,
+    ]), [
+        'name' => $name,
+        'version' => $version,
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertEquals($expectedVersion, $service->handler()->parseVersionOutput($sshOutput));
+    $this->assertDatabaseHas('services', [
+        'server_id' => $server->id,
+        'name' => $name,
+        'type' => $type,
+        'status' => ServiceStatus::READY,
+    ]);
+})->with('installData');
+
+test('install service creates installation log', function () {
+    Http::fake([
+        'https://api.github.com/repos/vito/vito-agent/releases/latest' => Http::response([
+            'tag_name' => '0.1.0',
+        ]),
+    ]);
+    SSH::fake('Active: active');
+
+    $this->actingAs($this->user);
+
+    $server = Server::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
+
+    $keys = $server->sshKey();
+    if (! File::exists($keys['public_key_path']) || ! File::exists($keys['private_key_path'])) {
+        $server->provider()->generateKeyPair();
     }
 
-    public function test_version_falls_back_to_the_raw_output_when_it_cannot_be_parsed(): void
-    {
-        SSH::fake('no version here');
+    $this->post(route('services.store', [
+        'server' => $server,
+    ]), [
+        'name' => 'redis',
+        'version' => 'latest',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        /** @var Service $service */
-        $service = $this->server->services()->where('name', 'php')->firstOrFail();
+    $service = $server->services()->where('name', 'redis')->firstOrFail();
 
-        $this->assertEquals('no version here', $service->handler()->version());
-    }
+    // Verify that the installation log is linked to the service
+    expect($service->log_id)->not->toBeNull();
+    expect($service->log)->not->toBeNull();
+    expect($service->log->type)->toStartWith('install-redis');
 
-    public function test_php_version_command_escapes_the_configured_version(): void
-    {
-        /** @var Service $service */
-        $service = $this->server->services()->where('name', 'php')->firstOrFail();
-        $service->version = "8.3'; rm -rf /tmp; echo '";
+    expect($service->type_data['networking_effective'] ?? null)->toBeNull('Install never observes the live bind state, so it must not claim one.');
+    expect($service->type_data['networking_checked_at'] ?? null)->toBeNull();
+    $this->assertArrayNotHasKey('networking', $service->type_data);
+});
 
-        $this->assertEquals(
-            '/usr/bin/php\'8.3\'\\\'\'; rm -rf /tmp; echo \'\\\'\'\' -r \'echo PHP_VERSION;\' 2>/dev/null',
-            $service->handler()->versionCommand()
-        );
-    }
+test('parse php installed version', function (string $sshOutput, string $expectedVersion) {
+    /** @var Service $service */
+    $service = $this->server->services()->where('name', 'php')->firstOrFail();
 
-    public function test_services_version_route_is_removed(): void
-    {
-        $this->assertFalse(Route::has('services.version'));
-    }
+    expect($service->handler()->parseVersionOutput($sshOutput))->toEqual($expectedVersion);
+})->with('phpVersionOutputData');
 
-    /**
-     * @return array<array<string>>
-     */
-    public static function phpVersionOutputData(): array
-    {
-        return [
-            'clean version' => ['8.4.10', '8.4.10'],
-            'version with noise' => ["Deprecated: some deprecation notice in php\n8.5.2", '8.5.2'],
-            'version with whitespace' => ["  8.5.1\n", '8.5.1'],
-        ];
-    }
+test('version falls back to the raw output when it cannot be parsed', function () {
+    SSH::fake('no version here');
 
-    /**
-     * @return array<array<string>>
-     */
-    public static function data(): array
-    {
-        return [
-            ['nginx'],
-            ['php'],
-            ['supervisor'],
-            ['redis'],
-            ['mysql'],
-        ];
-    }
+    /** @var Service $service */
+    $service = $this->server->services()->where('name', 'php')->firstOrFail();
 
-    /**
-     * @return array<array<string>>
-     */
-    public static function installData(): array
-    {
-        return [
-            [
-                'nginx',
-                'webserver',
-                'latest',
-            ],
-            [
-                'caddy',
-                'webserver',
-                'latest',
-            ],
-            [
-                'php',
-                'php',
-                '7.4',
-            ],
-            [
-                'nodejs',
-                'nodejs',
-                '16',
-            ],
-            [
-                'supervisor',
-                'process_manager',
-                'latest',
-            ],
-            [
-                'goaccess',
-                'log_analysis',
-                'latest',
-            ],
-            [
-                'redis',
-                'memory_database',
-                'latest',
-            ],
-            [
-                'valkey',
-                'memory_database',
-                'latest',
-            ],
-            [
-                'mysql',
-                'database',
-                '8.4',
-            ],
-            [
-                'mariadb',
-                'database',
-                '10.11',
-            ],
-            [
-                'postgresql',
-                'database',
-                '16',
-            ],
-        ];
-    }
-}
+    expect($service->handler()->version())->toEqual('no version here');
+});
+
+test('php version command escapes the configured version', function () {
+    /** @var Service $service */
+    $service = $this->server->services()->where('name', 'php')->firstOrFail();
+    $service->version = "8.3'; rm -rf /tmp; echo '";
+
+    expect($service->handler()->versionCommand())->toEqual('/usr/bin/php\'8.3\'\\\'\'; rm -rf /tmp; echo \'\\\'\'\' -r \'echo PHP_VERSION;\' 2>/dev/null');
+});
+
+test('services version route is removed', function () {
+    expect(Route::has('services.version'))->toBeFalse();
+});
+
+/**
+ * @return array<array<string>>
+ */
+dataset('phpVersionOutputData', function () {
+    return [
+        'clean version' => ['8.4.10', '8.4.10'],
+        'version with noise' => ["Deprecated: some deprecation notice in php\n8.5.2", '8.5.2'],
+        'version with whitespace' => ["  8.5.1\n", '8.5.1'],
+    ];
+});
+
+/**
+ * @return array<array<string>>
+ */
+dataset('data', function () {
+    return [
+        ['nginx'],
+        ['php'],
+        ['supervisor'],
+        ['redis'],
+        ['mysql'],
+    ];
+});
+
+/**
+ * @return array<array<string>>
+ */
+dataset('installData', function () {
+    return [
+        [
+            'nginx',
+            'webserver',
+            'latest',
+        ],
+        [
+            'caddy',
+            'webserver',
+            'latest',
+        ],
+        [
+            'php',
+            'php',
+            '7.4',
+        ],
+        [
+            'nodejs',
+            'nodejs',
+            '16',
+        ],
+        [
+            'supervisor',
+            'process_manager',
+            'latest',
+        ],
+        [
+            'goaccess',
+            'log_analysis',
+            'latest',
+        ],
+        [
+            'redis',
+            'memory_database',
+            'latest',
+        ],
+        [
+            'valkey',
+            'memory_database',
+            'latest',
+        ],
+        [
+            'mysql',
+            'database',
+            '8.4',
+        ],
+        [
+            'mariadb',
+            'database',
+            '10.11',
+        ],
+        [
+            'postgresql',
+            'database',
+            '16',
+        ],
+    ];
+});

--- a/tests/Feature/SiteAccessorBackcompatTest.php
+++ b/tests/Feature/SiteAccessorBackcompatTest.php
@@ -1,130 +1,119 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\IsolatedUser;
 use App\Models\Site;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
-use Tests\TestCase;
 
-class SiteAccessorBackcompatTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_user_accessor_prefers_legacy_column_over_isolated_user(): void
-    {
-        $iuser = IsolatedUser::factory()->create([
-            'server_id' => $this->server->id,
-            'username' => 'iuser-name',
-        ]);
+test('user accessor prefers legacy column over isolated user', function () {
+    $iuser = IsolatedUser::factory()->create([
+        'server_id' => $this->server->id,
+        'username' => 'iuser-name',
+    ]);
 
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'legacy-name',
-        ]);
-        DB::table('sites')->where('id', $site->id)->update(['isolated_user_id' => $iuser->id]);
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'legacy-name',
+    ]);
+    DB::table('sites')->where('id', $site->id)->update(['isolated_user_id' => $iuser->id]);
 
-        $this->assertSame('legacy-name', $site->fresh()->user);
-    }
+    expect($site->fresh()->user)->toBe('legacy-name');
+});
 
-    public function test_user_accessor_falls_back_to_isolated_user_when_column_empty(): void
-    {
-        $iuser = IsolatedUser::factory()->create([
-            'server_id' => $this->server->id,
-            'username' => 'iuser-name',
-        ]);
+test('user accessor falls back to isolated user when column empty', function () {
+    $iuser = IsolatedUser::factory()->create([
+        'server_id' => $this->server->id,
+        'username' => 'iuser-name',
+    ]);
 
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'iuser-name',
-        ]);
-        DB::table('sites')->where('id', $site->id)->update([
-            'isolated_user_id' => $iuser->id,
-            'user' => null,
-        ]);
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'iuser-name',
+    ]);
+    DB::table('sites')->where('id', $site->id)->update([
+        'isolated_user_id' => $iuser->id,
+        'user' => null,
+    ]);
 
-        $this->assertSame('iuser-name', $site->fresh()->user);
-    }
+    expect($site->fresh()->user)->toBe('iuser-name');
+});
 
-    public function test_ssh_key_name_returns_site_when_legacy_column_populated(): void
-    {
-        $iuser = IsolatedUser::factory()->create([
-            'server_id' => $this->server->id,
-            'username' => 'iuser-name',
-            'ssh_key' => 'IUSER-PUBLIC-KEY',
-        ]);
+test('ssh key name returns site when legacy column populated', function () {
+    $iuser = IsolatedUser::factory()->create([
+        'server_id' => $this->server->id,
+        'username' => 'iuser-name',
+        'ssh_key' => 'IUSER-PUBLIC-KEY',
+    ]);
 
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'iuser-name',
-            'ssh_key' => 'LEGACY-PUBLIC-KEY',
-        ]);
-        DB::table('sites')->where('id', $site->id)->update(['isolated_user_id' => $iuser->id]);
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'iuser-name',
+        'ssh_key' => 'LEGACY-PUBLIC-KEY',
+    ]);
+    DB::table('sites')->where('id', $site->id)->update(['isolated_user_id' => $iuser->id]);
 
-        $site = $site->fresh();
+    $site = $site->fresh();
 
-        $this->assertSame('site_'.$site->id, $site->getSshKeyName());
-        $this->assertSame('LEGACY-PUBLIC-KEY', $site->ssh_key);
-    }
+    expect($site->getSshKeyName())->toBe('site_'.$site->id);
+    expect($site->ssh_key)->toBe('LEGACY-PUBLIC-KEY');
+});
 
-    public function test_ssh_key_name_returns_iuser_when_no_legacy_column_and_iuser_key_set(): void
-    {
-        $iuser = IsolatedUser::factory()->create([
-            'server_id' => $this->server->id,
-            'username' => 'iuser-name',
-            'ssh_key' => 'IUSER-PUBLIC-KEY',
-        ]);
+test('ssh key name returns iuser when no legacy column and iuser key set', function () {
+    $iuser = IsolatedUser::factory()->create([
+        'server_id' => $this->server->id,
+        'username' => 'iuser-name',
+        'ssh_key' => 'IUSER-PUBLIC-KEY',
+    ]);
 
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'iuser-name',
-        ]);
-        DB::table('sites')->where('id', $site->id)->update([
-            'isolated_user_id' => $iuser->id,
-            'ssh_key' => null,
-        ]);
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'iuser-name',
+    ]);
+    DB::table('sites')->where('id', $site->id)->update([
+        'isolated_user_id' => $iuser->id,
+        'ssh_key' => null,
+    ]);
 
-        $site = $site->fresh();
+    $site = $site->fresh();
 
-        $this->assertSame('iuser_'.$iuser->id, $site->getSshKeyName());
-        $this->assertSame('IUSER-PUBLIC-KEY', $site->ssh_key);
-    }
+    expect($site->getSshKeyName())->toBe('iuser_'.$iuser->id);
+    expect($site->ssh_key)->toBe('IUSER-PUBLIC-KEY');
+});
 
-    public function test_new_site_joining_legacy_iuser_lazy_resolves_to_iuser_key(): void
-    {
-        // Legacy iuser: backfilled from a 3.x server, ssh_key still NULL,
-        // existing sibling carrying its own per-site key on disk.
-        $iuser = IsolatedUser::factory()->create([
-            'server_id' => $this->server->id,
-            'username' => 'shared',
-            'ssh_key' => null,
-        ]);
+test('new site joining legacy iuser lazy resolves to iuser key', function () {
+    // Legacy iuser: backfilled from a 3.x server, ssh_key still NULL,
+    // existing sibling carrying its own per-site key on disk.
+    $iuser = IsolatedUser::factory()->create([
+        'server_id' => $this->server->id,
+        'username' => 'shared',
+        'ssh_key' => null,
+    ]);
 
-        $siblingWithLegacy = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'shared',
-            'ssh_key' => 'SIBLING-LEGACY-KEY',
-            'domain' => 'sibling.test',
-            'path' => '/home/shared/sibling.test',
-        ]);
-        DB::table('sites')->where('id', $siblingWithLegacy->id)->update(['isolated_user_id' => $iuser->id]);
+    $siblingWithLegacy = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'shared',
+        'ssh_key' => 'SIBLING-LEGACY-KEY',
+        'domain' => 'sibling.test',
+        'path' => '/home/shared/sibling.test',
+    ]);
+    DB::table('sites')->where('id', $siblingWithLegacy->id)->update(['isolated_user_id' => $iuser->id]);
 
-        $newSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'shared',
-            'domain' => 'new.test',
-            'path' => '/home/shared/new.test',
-        ]);
-        DB::table('sites')->where('id', $newSite->id)->update([
-            'isolated_user_id' => $iuser->id,
-            'ssh_key' => null,
-        ]);
+    $newSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'shared',
+        'domain' => 'new.test',
+        'path' => '/home/shared/new.test',
+    ]);
+    DB::table('sites')->where('id', $newSite->id)->update([
+        'isolated_user_id' => $iuser->id,
+        'ssh_key' => null,
+    ]);
 
-        $newSite = $newSite->fresh();
-        $siblingWithLegacy = $siblingWithLegacy->fresh();
+    $newSite = $newSite->fresh();
+    $siblingWithLegacy = $siblingWithLegacy->fresh();
 
-        $this->assertSame('iuser_'.$iuser->id, $newSite->getSshKeyName(), 'new site lazy-resolves to iuser key');
-        $this->assertSame('site_'.$siblingWithLegacy->id, $siblingWithLegacy->getSshKeyName(), 'legacy sibling keeps per-site key (its public key may be bound to a Git provider deploy key)');
-    }
-}
+    expect($newSite->getSshKeyName())->toBe('iuser_'.$iuser->id, 'new site lazy-resolves to iuser key');
+    expect($siblingWithLegacy->getSshKeyName())->toBe('site_'.$siblingWithLegacy->id, 'legacy sibling keeps per-site key (its public key may be bound to a Git provider deploy key)');
+});

--- a/tests/Feature/SiteCronjobTest.php
+++ b/tests/Feature/SiteCronjobTest.php
@@ -1,266 +1,251 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\CronjobStatus;
 use App\Facades\SSH;
 use App\Models\CronJob;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class SiteCronjobTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_see_site_cronjobs_list(): void
-    {
-        $this->actingAs($this->user);
+test('see site cronjobs list', function () {
+    $this->actingAs($this->user);
 
-        CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-        ]);
+    CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+    ]);
 
-        $this->get(route('cronjobs.site', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('cronjobs/index'));
-    }
+    $this->get(route('cronjobs.site', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('cronjobs/index'));
+});
 
-    public function test_delete_site_cronjob(): void
-    {
-        SSH::fake();
+test('delete site cronjob', function () {
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'user' => 'vito',
-        ]);
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'user' => 'vito',
+    ]);
 
-        $this->delete(route('cronjobs.site.destroy', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'cronJob' => $cronjob,
-        ]));
+    $this->delete(route('cronjobs.site.destroy', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'cronJob' => $cronjob,
+    ]));
 
-        $this->assertDatabaseMissing('cron_jobs', [
-            'id' => $cronjob->id,
-        ]);
+    $this->assertDatabaseMissing('cron_jobs', [
+        'id' => $cronjob->id,
+    ]);
 
-        SSH::assertExecutedContains("echo '' | sudo -u vito crontab -");
-        SSH::assertExecutedContains('sudo -u vito crontab -l');
-    }
+    SSH::assertExecutedContains("echo '' | sudo -u vito crontab -");
+    SSH::assertExecutedContains('sudo -u vito crontab -l');
+});
 
-    public function test_create_site_cronjob(): void
-    {
-        SSH::fake();
+test('create site cronjob', function () {
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->post(route('cronjobs.site.store', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'command' => 'ls -la',
-            'user' => 'vito',
-            'frequency' => '* * * * *',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('cronjobs.site.store', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('cron_jobs', [
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'command' => 'ls -la',
-            'user' => 'vito',
-            'frequency' => '* * * * *',
-            'status' => CronjobStatus::READY,
-        ]);
+    $this->assertDatabaseHas('cron_jobs', [
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => '* * * * *',
+        'status' => CronjobStatus::READY,
+    ]);
 
-        SSH::assertExecutedContains("echo '* * * * * bash -lc '\\''ls -la'\\''' | sudo -u vito crontab -");
-        SSH::assertExecutedContains('sudo -u vito crontab -l');
-    }
+    SSH::assertExecutedContains("echo '* * * * * bash -lc '\\''ls -la'\\''' | sudo -u vito crontab -");
+    SSH::assertExecutedContains('sudo -u vito crontab -l');
+});
 
-    public function test_create_site_cronjob_for_isolated_user(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
+test('create site cronjob for isolated user', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->site->user = 'example';
-        $this->site->save();
+    $this->site->user = 'example';
+    $this->site->save();
 
-        $this->post(route('cronjobs.site.store', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'command' => 'ls -la',
-            'user' => 'example',
-            'frequency' => '* * * * *',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('cronjobs.site.store', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'command' => 'ls -la',
+        'user' => 'example',
+        'frequency' => '* * * * *',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('cron_jobs', [
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'user' => 'example',
-        ]);
+    $this->assertDatabaseHas('cron_jobs', [
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'user' => 'example',
+    ]);
 
-        SSH::assertExecutedContains("echo '* * * * * bash -lc '\\''ls -la'\\''' | sudo -u example crontab -");
-        SSH::assertExecutedContains('sudo -u example crontab -l');
-    }
+    SSH::assertExecutedContains("echo '* * * * * bash -lc '\\''ls -la'\\''' | sudo -u example crontab -");
+    SSH::assertExecutedContains('sudo -u example crontab -l');
+});
 
-    public function test_cannot_create_site_cronjob_for_non_existing_user(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
+test('cannot create site cronjob for non existing user', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->post(route('cronjobs.site.store', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'command' => 'ls -la',
-            'user' => 'nonexistent',
-            'frequency' => '* * * * *',
-        ])
-            ->assertSessionHasErrors();
+    $this->post(route('cronjobs.site.store', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'command' => 'ls -la',
+        'user' => 'nonexistent',
+        'frequency' => '* * * * *',
+    ])
+        ->assertSessionHasErrors();
 
-        $this->assertDatabaseMissing('cron_jobs', [
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'user' => 'nonexistent',
-        ]);
-    }
+    $this->assertDatabaseMissing('cron_jobs', [
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'user' => 'nonexistent',
+    ]);
+});
 
-    public function test_create_custom_site_cronjob(): void
-    {
-        SSH::fake();
+test('create custom site cronjob', function () {
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->post(route('cronjobs.site.store', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'command' => 'ls -la',
-            'user' => 'vito',
-            'frequency' => 'custom',
-            'custom' => '* * * 1 1',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('cronjobs.site.store', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => 'custom',
+        'custom' => '* * * 1 1',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('cron_jobs', [
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'command' => 'ls -la',
-            'user' => 'vito',
-            'frequency' => '* * * 1 1',
-            'status' => CronjobStatus::READY,
-        ]);
+    $this->assertDatabaseHas('cron_jobs', [
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'command' => 'ls -la',
+        'user' => 'vito',
+        'frequency' => '* * * 1 1',
+        'status' => CronjobStatus::READY,
+    ]);
 
-        SSH::assertExecutedContains("echo '* * * 1 1 bash -lc '\\''ls -la'\\''' | sudo -u vito crontab -");
-        SSH::assertExecutedContains('sudo -u vito crontab -l');
-    }
+    SSH::assertExecutedContains("echo '* * * 1 1 bash -lc '\\''ls -la'\\''' | sudo -u vito crontab -");
+    SSH::assertExecutedContains('sudo -u vito crontab -l');
+});
 
-    public function test_enable_site_cronjob(): void
-    {
-        SSH::fake();
+test('enable site cronjob', function () {
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'user' => 'vito',
-            'command' => 'ls -la',
-            'frequency' => '* * * 1 1',
-            'status' => CronjobStatus::DISABLED,
-        ]);
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'user' => 'vito',
+        'command' => 'ls -la',
+        'frequency' => '* * * 1 1',
+        'status' => CronjobStatus::DISABLED,
+    ]);
 
-        $this->post(route('cronjobs.site.enable', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'cronJob' => $cronjob,
-        ]))
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('cronjobs.site.enable', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'cronJob' => $cronjob,
+    ]))
+        ->assertSessionDoesntHaveErrors();
 
-        $cronjob->refresh();
+    $cronjob->refresh();
 
-        $this->assertEquals(CronjobStatus::READY, $cronjob->status);
+    expect($cronjob->status)->toEqual(CronjobStatus::READY);
 
-        SSH::assertExecutedContains("echo '* * * 1 1 bash -lc '\\''ls -la'\\''' | sudo -u vito crontab -");
-        SSH::assertExecutedContains('sudo -u vito crontab -l');
-    }
+    SSH::assertExecutedContains("echo '* * * 1 1 bash -lc '\\''ls -la'\\''' | sudo -u vito crontab -");
+    SSH::assertExecutedContains('sudo -u vito crontab -l');
+});
 
-    public function test_disable_site_cronjob(): void
-    {
-        SSH::fake();
+test('disable site cronjob', function () {
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'user' => 'vito',
-            'command' => 'ls -la',
-            'frequency' => '* * * 1 1',
-            'status' => CronjobStatus::READY,
-        ]);
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'user' => 'vito',
+        'command' => 'ls -la',
+        'frequency' => '* * * 1 1',
+        'status' => CronjobStatus::READY,
+    ]);
 
-        $this->post(route('cronjobs.site.disable', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'cronJob' => $cronjob,
-        ]))
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('cronjobs.site.disable', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'cronJob' => $cronjob,
+    ]))
+        ->assertSessionDoesntHaveErrors();
 
-        $cronjob->refresh();
+    $cronjob->refresh();
 
-        $this->assertEquals(CronjobStatus::DISABLED, $cronjob->status);
+    expect($cronjob->status)->toEqual(CronjobStatus::DISABLED);
 
-        SSH::assertExecutedContains("echo '' | sudo -u vito crontab -");
-        SSH::assertExecutedContains('sudo -u vito crontab -l');
-    }
+    SSH::assertExecutedContains("echo '' | sudo -u vito crontab -");
+    SSH::assertExecutedContains('sudo -u vito crontab -l');
+});
 
-    public function test_update_site_cronjob(): void
-    {
-        SSH::fake();
+test('update site cronjob', function () {
+    SSH::fake();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        /** @var CronJob $cronjob */
-        $cronjob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'user' => 'vito',
-            'command' => 'ls -la',
-            'frequency' => '* * * * *',
-            'status' => CronjobStatus::READY,
-        ]);
+    /** @var CronJob $cronjob */
+    $cronjob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'user' => 'vito',
+        'command' => 'ls -la',
+        'frequency' => '* * * * *',
+        'status' => CronjobStatus::READY,
+    ]);
 
-        $this->put(route('cronjobs.site.update', [
-            'server' => $this->server,
-            'site' => $this->site,
-            'cronJob' => $cronjob,
-        ]), [
-            'command' => 'php artisan schedule:run',
-            'user' => 'vito',
-            'frequency' => '0 * * * *',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->put(route('cronjobs.site.update', [
+        'server' => $this->server,
+        'site' => $this->site,
+        'cronJob' => $cronjob,
+    ]), [
+        'command' => 'php artisan schedule:run',
+        'user' => 'vito',
+        'frequency' => '0 * * * *',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $cronjob->refresh();
+    $cronjob->refresh();
 
-        $this->assertEquals('php artisan schedule:run', $cronjob->command);
-        $this->assertEquals('0 * * * *', $cronjob->frequency);
+    expect($cronjob->command)->toEqual('php artisan schedule:run');
+    expect($cronjob->frequency)->toEqual('0 * * * *');
 
-        SSH::assertExecutedContains("echo '0 * * * * bash -lc '\\''php artisan schedule:run'\\''' | sudo -u vito crontab -");
-        SSH::assertExecutedContains('sudo -u vito crontab -l');
-    }
-}
+    SSH::assertExecutedContains("echo '0 * * * * bash -lc '\\''php artisan schedule:run'\\''' | sudo -u vito crontab -");
+    SSH::assertExecutedContains('sudo -u vito crontab -l');
+});

--- a/tests/Feature/SiteSettings/BasicAuthTest.php
+++ b/tests/Feature/SiteSettings/BasicAuthTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\SiteSettings;
-
 use App\Actions\Site\UpdateBasicAuth;
 use App\Facades\SSH;
 use App\Http\Resources\SiteResource;
@@ -11,312 +9,296 @@ use App\Models\User;
 use App\Services\Webserver\Caddy;
 use App\Services\Webserver\Nginx;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class BasicAuthTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_endpoint_enables_basic_auth_with_users(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
+test('endpoint enables basic auth with users', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->patch(route('site-settings.update-basic-auth', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
+    $this->patch(route('site-settings.update-basic-auth', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'enabled' => true,
+        'users' => [
+            ['username' => 'alice', 'password' => 'secret123'],
+            ['username' => 'bob', 'password' => 'hunter2'],
+        ],
+    ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+    $auth = $this->site->type_data['basic_auth'];
+
+    expect($auth['enabled'])->toBeTrue();
+    expect($auth['users'])->toHaveCount(2);
+    expect($auth['users'][0]['username'])->toBe('alice');
+    expect($auth['users'][0]['apr1'])->toStartWith('$apr1$');
+    expect(password_verify('secret123', $auth['users'][0]['bcrypt']))->toBeTrue();
+
+    SSH::assertExecutedContains('/etc/nginx/auth/site-'.$this->site->id.'.htpasswd');
+});
+
+test('empty users forces disabled', function () {
+    $this->site->type_data = [
+        'basic_auth' => [
             'enabled' => true,
             'users' => [
-                ['username' => 'alice', 'password' => 'secret123'],
-                ['username' => 'bob', 'password' => 'hunter2'],
+                ['username' => 'alice', 'apr1' => '$apr1$existing', 'bcrypt' => '$2y$10$existing'],
             ],
-        ])
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
+        ],
+    ];
+    $this->site->save();
 
-        $this->site->refresh();
-        $auth = $this->site->type_data['basic_auth'];
+    /** @var Site $site */
+    $site = Mockery::mock($this->site)->makePartial();
+    $site->shouldReceive('webserver->updateVHost')->andReturn();
+    $site->shouldReceive('webserver->id')->andReturn(Nginx::id());
 
-        $this->assertTrue($auth['enabled']);
-        $this->assertCount(2, $auth['users']);
-        $this->assertSame('alice', $auth['users'][0]['username']);
-        $this->assertStringStartsWith('$apr1$', $auth['users'][0]['apr1']);
-        $this->assertTrue(password_verify('secret123', $auth['users'][0]['bcrypt']));
+    SSH::fake();
 
-        SSH::assertExecutedContains('/etc/nginx/auth/site-'.$this->site->id.'.htpasswd');
-    }
+    app(UpdateBasicAuth::class)->update($site, [
+        'enabled' => true,
+        'users' => [],
+    ]);
 
-    public function test_empty_users_forces_disabled(): void
-    {
-        $this->site->type_data = [
-            'basic_auth' => [
-                'enabled' => true,
-                'users' => [
-                    ['username' => 'alice', 'apr1' => '$apr1$existing', 'bcrypt' => '$2y$10$existing'],
-                ],
-            ],
-        ];
-        $this->site->save();
+    $site->refresh();
+    expect($site->type_data['basic_auth']['enabled'])->toBeFalse();
+    expect($site->type_data['basic_auth']['users'])->toBe([]);
 
-        /** @var Site $site */
-        $site = \Mockery::mock($this->site)->makePartial();
-        $site->shouldReceive('webserver->updateVHost')->andReturn();
-        $site->shouldReceive('webserver->id')->andReturn(Nginx::id());
+    SSH::assertExecutedContains('rm -f');
+});
 
-        SSH::fake();
+test('blank password preserves existing hashes', function () {
+    $apr1 = '$apr1$abcdefgh$existinghash1234567890';
+    $bcrypt = password_hash('original', PASSWORD_BCRYPT);
 
-        app(UpdateBasicAuth::class)->update($site, [
-            'enabled' => true,
-            'users' => [],
-        ]);
-
-        $site->refresh();
-        $this->assertFalse($site->type_data['basic_auth']['enabled']);
-        $this->assertSame([], $site->type_data['basic_auth']['users']);
-
-        SSH::assertExecutedContains('rm -f');
-    }
-
-    public function test_blank_password_preserves_existing_hashes(): void
-    {
-        $apr1 = '$apr1$abcdefgh$existinghash1234567890';
-        $bcrypt = password_hash('original', PASSWORD_BCRYPT);
-
-        $this->site->type_data = [
-            'basic_auth' => [
-                'enabled' => true,
-                'users' => [
-                    ['username' => 'alice', 'apr1' => $apr1, 'bcrypt' => $bcrypt],
-                ],
-            ],
-        ];
-        $this->site->save();
-
-        /** @var Site $site */
-        $site = \Mockery::mock($this->site)->makePartial();
-        $site->shouldReceive('webserver->updateVHost')->andReturn();
-        $site->shouldReceive('webserver->id')->andReturn(Nginx::id());
-
-        SSH::fake();
-
-        app(UpdateBasicAuth::class)->update($site, [
+    $this->site->type_data = [
+        'basic_auth' => [
             'enabled' => true,
             'users' => [
-                ['username' => 'alice', 'password' => ''],
+                ['username' => 'alice', 'apr1' => $apr1, 'bcrypt' => $bcrypt],
             ],
-        ]);
+        ],
+    ];
+    $this->site->save();
 
-        $site->refresh();
-        $this->assertSame($apr1, $site->type_data['basic_auth']['users'][0]['apr1']);
-        $this->assertSame($bcrypt, $site->type_data['basic_auth']['users'][0]['bcrypt']);
-    }
+    /** @var Site $site */
+    $site = Mockery::mock($this->site)->makePartial();
+    $site->shouldReceive('webserver->updateVHost')->andReturn();
+    $site->shouldReceive('webserver->id')->andReturn(Nginx::id());
 
-    public function test_validation_rejects_duplicate_usernames(): void
-    {
-        $this->actingAs($this->user);
+    SSH::fake();
 
-        $this->patch(route('site-settings.update-basic-auth', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
+    app(UpdateBasicAuth::class)->update($site, [
+        'enabled' => true,
+        'users' => [
+            ['username' => 'alice', 'password' => ''],
+        ],
+    ]);
+
+    $site->refresh();
+    expect($site->type_data['basic_auth']['users'][0]['apr1'])->toBe($apr1);
+    expect($site->type_data['basic_auth']['users'][0]['bcrypt'])->toBe($bcrypt);
+});
+
+test('validation rejects duplicate usernames', function () {
+    $this->actingAs($this->user);
+
+    $this->patch(route('site-settings.update-basic-auth', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'enabled' => true,
+        'users' => [
+            ['username' => 'alice', 'password' => 'p1'],
+            ['username' => 'alice', 'password' => 'p2'],
+        ],
+    ])->assertSessionHasErrors();
+});
+
+test('validation rejects new user without password', function () {
+    $this->actingAs($this->user);
+
+    $this->patch(route('site-settings.update-basic-auth', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'enabled' => true,
+        'users' => [
+            ['username' => 'newbie', 'password' => ''],
+        ],
+    ])->assertSessionHasErrors();
+});
+
+test('caddy server does not write htpasswd file', function () {
+    $this->server->webserver()?->update([
+        'name' => Caddy::id(),
+    ]);
+
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->patch(route('site-settings.update-basic-auth', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'enabled' => true,
+        'users' => [
+            ['username' => 'alice', 'password' => 'secret123'],
+        ],
+    ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    SSH::assertNotExecutedContains('/etc/nginx/auth/');
+});
+
+test('vhost generation includes auth basic when enabled', function () {
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
+
+    $this->site->type_data = [
+        'basic_auth' => [
             'enabled' => true,
             'users' => [
-                ['username' => 'alice', 'password' => 'p1'],
-                ['username' => 'alice', 'password' => 'p2'],
+                ['username' => 'alice', 'apr1' => '$apr1$saltxxxx$hashhashhashhashhashhh', 'bcrypt' => '$2y$10$bcrypthashhere'],
             ],
-        ])->assertSessionHasErrors();
-    }
+        ],
+    ];
+    $this->site->save();
 
-    public function test_validation_rejects_new_user_without_password(): void
-    {
-        $this->actingAs($this->user);
+    $vhost = $this->site->webserver()->generateVhost($this->site);
 
-        $this->patch(route('site-settings.update-basic-auth', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
+    $this->assertStringContainsString('auth_basic "'.$this->site->domain.'"', $vhost);
+    $this->assertStringContainsString('auth_basic_user_file /etc/nginx/auth/site-'.$this->site->id.'.htpasswd', $vhost);
+});
+
+test('vhost exempts acme challenge path when basic auth enabled', function () {
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
+
+    $this->site->type_data = [
+        'basic_auth' => [
             'enabled' => true,
             'users' => [
-                ['username' => 'newbie', 'password' => ''],
+                ['username' => 'alice', 'apr1' => '$apr1$saltxxxx$hashhashhashhashhashhh', 'bcrypt' => '$2y$10$bcrypthashhere'],
             ],
-        ])->assertSessionHasErrors();
-    }
+        ],
+    ];
+    $this->site->save();
 
-    public function test_caddy_server_does_not_write_htpasswd_file(): void
-    {
-        $this->server->webserver()?->update([
-            'name' => Caddy::id(),
-        ]);
+    $vhost = $this->site->webserver()->generateVhost($this->site);
 
-        SSH::fake();
-        $this->actingAs($this->user);
+    $this->assertStringContainsString('location ^~ /.well-known/acme-challenge/', $vhost);
+    $this->assertStringContainsString('auth_basic off', $vhost);
+});
 
-        $this->patch(route('site-settings.update-basic-auth', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'enabled' => true,
-            'users' => [
-                ['username' => 'alice', 'password' => 'secret123'],
-            ],
-        ])
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
+test('vhost generation omits auth basic when disabled', function () {
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
 
-        SSH::assertNotExecutedContains('/etc/nginx/auth/');
-    }
-
-    public function test_vhost_generation_includes_auth_basic_when_enabled(): void
-    {
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
-
-        $this->site->type_data = [
-            'basic_auth' => [
-                'enabled' => true,
-                'users' => [
-                    ['username' => 'alice', 'apr1' => '$apr1$saltxxxx$hashhashhashhashhashhh', 'bcrypt' => '$2y$10$bcrypthashhere'],
-                ],
-            ],
-        ];
-        $this->site->save();
-
-        $vhost = $this->site->webserver()->generateVhost($this->site);
-
-        $this->assertStringContainsString('auth_basic "'.$this->site->domain.'"', $vhost);
-        $this->assertStringContainsString('auth_basic_user_file /etc/nginx/auth/site-'.$this->site->id.'.htpasswd', $vhost);
-    }
-
-    public function test_vhost_exempts_acme_challenge_path_when_basic_auth_enabled(): void
-    {
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
-
-        $this->site->type_data = [
-            'basic_auth' => [
-                'enabled' => true,
-                'users' => [
-                    ['username' => 'alice', 'apr1' => '$apr1$saltxxxx$hashhashhashhashhashhh', 'bcrypt' => '$2y$10$bcrypthashhere'],
-                ],
-            ],
-        ];
-        $this->site->save();
-
-        $vhost = $this->site->webserver()->generateVhost($this->site);
-
-        $this->assertStringContainsString('location ^~ /.well-known/acme-challenge/', $vhost);
-        $this->assertStringContainsString('auth_basic off', $vhost);
-    }
-
-    public function test_vhost_generation_omits_auth_basic_when_disabled(): void
-    {
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
-
-        $this->site->type_data = [
-            'basic_auth' => [
-                'enabled' => false,
-                'users' => [],
-            ],
-        ];
-        $this->site->save();
-
-        $vhost = $this->site->webserver()->generateVhost($this->site);
-
-        $this->assertStringNotContainsString('auth_basic', $vhost);
-    }
-
-    public function test_site_resource_does_not_leak_hashes(): void
-    {
-        $this->site->type_data = [
-            'basic_auth' => [
-                'enabled' => true,
-                'users' => [
-                    ['username' => 'alice', 'apr1' => '$apr1$leakedapr1', 'bcrypt' => '$2y$10$leakedbcrypt'],
-                ],
-            ],
-        ];
-        $this->site->save();
-        $this->site->load('server');
-
-        $json = json_encode(SiteResource::make($this->site)->toArray(request()));
-
-        $this->assertIsString($json);
-        $this->assertStringNotContainsString('apr1', $json);
-        $this->assertStringNotContainsString('bcrypt', $json);
-        $this->assertStringNotContainsString('leakedapr1', $json);
-        $this->assertStringNotContainsString('leakedbcrypt', $json);
-        $this->assertStringContainsString('alice', $json);
-    }
-
-    public function test_disable_keeps_users_but_removes_htpasswd_and_strips_auth_basic(): void
-    {
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
-
-        $apr1 = '$apr1$abcdefgh$existinghash1234567890';
-        $bcrypt = password_hash('original', PASSWORD_BCRYPT);
-        $this->site->type_data = [
-            'basic_auth' => [
-                'enabled' => true,
-                'users' => [
-                    ['username' => 'alice', 'apr1' => $apr1, 'bcrypt' => $bcrypt],
-                ],
-            ],
-        ];
-        $this->site->save();
-
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->patch(route('site-settings.update-basic-auth', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
+    $this->site->type_data = [
+        'basic_auth' => [
             'enabled' => false,
-            'users' => [
-                ['username' => 'alice', 'password' => ''],
-            ],
-        ])
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
+            'users' => [],
+        ],
+    ];
+    $this->site->save();
 
-        $this->site->refresh();
-        $this->assertFalse($this->site->type_data['basic_auth']['enabled']);
-        $this->assertCount(1, $this->site->type_data['basic_auth']['users']);
-        $this->assertSame($apr1, $this->site->type_data['basic_auth']['users'][0]['apr1']);
-        $this->assertSame($bcrypt, $this->site->type_data['basic_auth']['users'][0]['bcrypt']);
+    $vhost = $this->site->webserver()->generateVhost($this->site);
 
-        SSH::assertExecutedContains('rm -f');
+    $this->assertStringNotContainsString('auth_basic', $vhost);
+});
 
-        $vhost = $this->site->webserver()->generateVhost($this->site);
-        $this->assertStringNotContainsString('auth_basic', $vhost);
-    }
-
-    public function test_authorization_requires_project_access(): void
-    {
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-
-        $this->actingAs($otherUser);
-
-        $this->patch(route('site-settings.update-basic-auth', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
+test('site resource does not leak hashes', function () {
+    $this->site->type_data = [
+        'basic_auth' => [
             'enabled' => true,
             'users' => [
-                ['username' => 'alice', 'password' => 'secret123'],
+                ['username' => 'alice', 'apr1' => '$apr1$leakedapr1', 'bcrypt' => '$2y$10$leakedbcrypt'],
             ],
-        ])->assertForbidden();
-    }
-}
+        ],
+    ];
+    $this->site->save();
+    $this->site->load('server');
+
+    $json = json_encode(SiteResource::make($this->site)->toArray(request()));
+
+    expect($json)->toBeString();
+    $this->assertStringNotContainsString('apr1', $json);
+    $this->assertStringNotContainsString('bcrypt', $json);
+    $this->assertStringNotContainsString('leakedapr1', $json);
+    $this->assertStringNotContainsString('leakedbcrypt', $json);
+    $this->assertStringContainsString('alice', $json);
+});
+
+test('disable keeps users but removes htpasswd and strips auth basic', function () {
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
+
+    $apr1 = '$apr1$abcdefgh$existinghash1234567890';
+    $bcrypt = password_hash('original', PASSWORD_BCRYPT);
+    $this->site->type_data = [
+        'basic_auth' => [
+            'enabled' => true,
+            'users' => [
+                ['username' => 'alice', 'apr1' => $apr1, 'bcrypt' => $bcrypt],
+            ],
+        ],
+    ];
+    $this->site->save();
+
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->patch(route('site-settings.update-basic-auth', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'enabled' => false,
+        'users' => [
+            ['username' => 'alice', 'password' => ''],
+        ],
+    ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+    expect($this->site->type_data['basic_auth']['enabled'])->toBeFalse();
+    expect($this->site->type_data['basic_auth']['users'])->toHaveCount(1);
+    expect($this->site->type_data['basic_auth']['users'][0]['apr1'])->toBe($apr1);
+    expect($this->site->type_data['basic_auth']['users'][0]['bcrypt'])->toBe($bcrypt);
+
+    SSH::assertExecutedContains('rm -f');
+
+    $vhost = $this->site->webserver()->generateVhost($this->site);
+    $this->assertStringNotContainsString('auth_basic', $vhost);
+});
+
+test('authorization requires project access', function () {
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+
+    $this->actingAs($otherUser);
+
+    $this->patch(route('site-settings.update-basic-auth', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'enabled' => true,
+        'users' => [
+            ['username' => 'alice', 'password' => 'secret123'],
+        ],
+    ])->assertForbidden();
+});

--- a/tests/Feature/SiteSettings/PhpSettingsTest.php
+++ b/tests/Feature/SiteSettings/PhpSettingsTest.php
@@ -1,265 +1,245 @@
 <?php
 
-namespace Tests\Feature\SiteSettings;
-
 use App\Facades\SSH;
 use App\Http\Resources\SiteResource;
 use App\Models\HostedDomain;
 use App\Models\User;
 use App\Services\Webserver\Caddy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class PhpSettingsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_endpoint_persists_php_settings(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
+test('endpoint persists php settings', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->patch(route('site-settings.update-php-settings', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
+    $this->patch(route('site-settings.update-php-settings', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'max_upload_size' => 64,
+        'max_execution_time' => 120,
+        'memory_limit' => 256,
+        'max_input_vars' => 5000,
+    ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+
+    expect($this->site->type_data['php'])->toBe([
+        'max_upload_size' => 64,
+        'max_execution_time' => 120,
+        'memory_limit' => 256,
+        'max_input_vars' => 5000,
+    ]);
+});
+
+test('blank values persist as null', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->patch(route('site-settings.update-php-settings', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'max_upload_size' => '',
+        'max_execution_time' => null,
+    ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+
+    expect($this->site->type_data['php']['max_upload_size'])->toBeNull();
+    expect($this->site->type_data['php']['memory_limit'])->toBeNull();
+});
+
+test('nginx vhost includes php directives intact', function () {
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
+
+    $this->site->type_data = [
+        'php' => [
             'max_upload_size' => 64,
             'max_execution_time' => 120,
             'memory_limit' => 256,
             'max_input_vars' => 5000,
-        ])
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
+        ],
+    ];
+    $this->site->save();
 
-        $this->site->refresh();
+    $vhost = $this->site->webserver()->generateVhost($this->site);
 
-        $this->assertSame([
+    $this->assertStringContainsString('fastcgi_param PHP_VALUE "upload_max_filesize=64M', $vhost);
+    $this->assertStringContainsString("\npost_max_size=64M", $vhost);
+    $this->assertStringContainsString("\nmemory_limit=256M", $vhost);
+    $this->assertStringContainsString('max_input_vars=5000";', $vhost);
+
+    $this->assertStringContainsString('client_max_body_size 64M;', $vhost);
+    $this->assertStringContainsString('fastcgi_read_timeout 120s;', $vhost);
+});
+
+test('nginx vhost omits directives when unset', function () {
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
+
+    $vhost = $this->site->webserver()->generateVhost($this->site);
+
+    $this->assertStringNotContainsString('PHP_VALUE', $vhost);
+    $this->assertStringNotContainsString('client_max_body_size', $vhost);
+    $this->assertStringNotContainsString('fastcgi_read_timeout', $vhost);
+});
+
+test('nginx vhost emits only set directives', function () {
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
+
+    $this->site->type_data = ['php' => ['max_input_vars' => 5000]];
+    $this->site->save();
+
+    $vhost = $this->site->webserver()->generateVhost($this->site);
+
+    $this->assertStringContainsString('fastcgi_param PHP_VALUE "max_input_vars=5000";', $vhost);
+    $this->assertStringNotContainsString('client_max_body_size', $vhost);
+    $this->assertStringNotContainsString('fastcgi_read_timeout', $vhost);
+});
+
+test('caddy vhost includes php directives', function () {
+    $this->server->webserver()?->update(['name' => Caddy::id()]);
+
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
+
+    $this->site->type_data = [
+        'php' => [
             'max_upload_size' => 64,
             'max_execution_time' => 120,
             'memory_limit' => 256,
             'max_input_vars' => 5000,
-        ], $this->site->type_data['php']);
-    }
+        ],
+    ];
+    $this->site->save();
 
-    public function test_blank_values_persist_as_null(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
+    $vhost = $this->site->webserver()->generateVhost($this->site);
 
-        $this->patch(route('site-settings.update-php-settings', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'max_upload_size' => '',
-            'max_execution_time' => null,
-        ])
-            ->assertRedirect()
-            ->assertSessionDoesntHaveErrors();
+    $this->assertStringContainsString('env PHP_VALUE "upload_max_filesize=64M', $vhost);
+    $this->assertStringContainsString('max_size 64MB', $vhost);
+});
 
-        $this->site->refresh();
+test('custom template sentinel is stripped', function () {
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
 
-        $this->assertNull($this->site->type_data['php']['max_upload_size']);
-        $this->assertNull($this->site->type_data['php']['memory_limit']);
-    }
+    $this->site->type_data = ['php' => ['max_upload_size' => 64]];
+    $this->site->vhost_template = "server {\n    fastcgi_param PHP_VALUE \"@@VITO_PHP_VALUE@@\";\n}";
+    $this->site->save();
 
-    public function test_nginx_vhost_includes_php_directives_intact(): void
-    {
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
+    $vhost = $this->site->webserver()->generateVhost($this->site);
 
-        $this->site->type_data = [
-            'php' => [
-                'max_upload_size' => 64,
-                'max_execution_time' => 120,
-                'memory_limit' => 256,
-                'max_input_vars' => 5000,
-            ],
-        ];
-        $this->site->save();
+    $this->assertStringNotContainsString('@@VITO_PHP_VALUE@@', $vhost);
+});
 
-        $vhost = $this->site->webserver()->generateVhost($this->site);
+test('validation requires memory limit at least upload size', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->assertStringContainsString('fastcgi_param PHP_VALUE "upload_max_filesize=64M', $vhost);
-        $this->assertStringContainsString("\npost_max_size=64M", $vhost);
-        $this->assertStringContainsString("\nmemory_limit=256M", $vhost);
-        $this->assertStringContainsString('max_input_vars=5000";', $vhost);
+    $this->patch(route('site-settings.update-php-settings', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'max_upload_size' => 512,
+        'memory_limit' => 256,
+    ])->assertSessionHasErrors('memory_limit');
+});
 
-        $this->assertStringContainsString('client_max_body_size 64M;', $vhost);
-        $this->assertStringContainsString('fastcgi_read_timeout 120s;', $vhost);
-    }
+test('validation rejects out of range values', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
 
-    public function test_nginx_vhost_omits_directives_when_unset(): void
-    {
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
+    $this->patch(route('site-settings.update-php-settings', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'max_input_vars' => 5,
+    ])->assertSessionHasErrors('max_input_vars');
+});
 
-        $vhost = $this->site->webserver()->generateVhost($this->site);
+test('route 404s for custom vhost template', function () {
+    $this->site->vhost_template = 'server { }';
+    $this->site->save();
 
-        $this->assertStringNotContainsString('PHP_VALUE', $vhost);
-        $this->assertStringNotContainsString('client_max_body_size', $vhost);
-        $this->assertStringNotContainsString('fastcgi_read_timeout', $vhost);
-    }
+    $this->actingAs($this->user);
 
-    public function test_nginx_vhost_emits_only_set_directives(): void
-    {
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
+    $this->patch(route('site-settings.update-php-settings', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'max_upload_size' => 64,
+    ])->assertNotFound();
+});
 
-        $this->site->type_data = ['php' => ['max_input_vars' => 5000]];
-        $this->site->save();
+test('route 404s for octane site', function () {
+    $this->site->type_data = ['octane' => true];
+    $this->site->save();
 
-        $vhost = $this->site->webserver()->generateVhost($this->site);
+    $this->actingAs($this->user);
 
-        $this->assertStringContainsString('fastcgi_param PHP_VALUE "max_input_vars=5000";', $vhost);
-        $this->assertStringNotContainsString('client_max_body_size', $vhost);
-        $this->assertStringNotContainsString('fastcgi_read_timeout', $vhost);
-    }
+    $this->patch(route('site-settings.update-php-settings', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'max_upload_size' => 64,
+    ])->assertNotFound();
+});
 
-    public function test_caddy_vhost_includes_php_directives(): void
-    {
-        $this->server->webserver()?->update(['name' => Caddy::id()]);
+test('route 404s when vhost generation disabled', function () {
+    $this->site->vhost_generation_enabled = false;
+    $this->site->save();
 
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
+    $this->actingAs($this->user);
 
-        $this->site->type_data = [
-            'php' => [
-                'max_upload_size' => 64,
-                'max_execution_time' => 120,
-                'memory_limit' => 256,
-                'max_input_vars' => 5000,
-            ],
-        ];
-        $this->site->save();
+    $this->patch(route('site-settings.update-php-settings', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'max_upload_size' => 64,
+    ])->assertNotFound();
+});
 
-        $vhost = $this->site->webserver()->generateVhost($this->site);
+test('resource exposes php settings', function () {
+    $this->site->type_data = ['php' => ['max_upload_size' => 64, 'max_execution_time' => null, 'memory_limit' => null, 'max_input_vars' => null]];
+    $this->site->save();
+    $this->site->load('server');
 
-        $this->assertStringContainsString('env PHP_VALUE "upload_max_filesize=64M', $vhost);
-        $this->assertStringContainsString('max_size 64MB', $vhost);
-    }
+    $resource = SiteResource::make($this->site)->toArray(request());
 
-    public function test_custom_template_sentinel_is_stripped(): void
-    {
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
+    expect($resource['supports_php_settings'])->toBeTrue();
+    expect($resource['php_settings']['max_upload_size'])->toBe(64);
+    expect($resource['php_settings']['memory_limit'])->toBeNull();
+    $this->assertArrayNotHasKey('php', $resource['type_data']);
+});
 
-        $this->site->type_data = ['php' => ['max_upload_size' => 64]];
-        $this->site->vhost_template = "server {\n    fastcgi_param PHP_VALUE \"@@VITO_PHP_VALUE@@\";\n}";
-        $this->site->save();
+test('authorization requires project access', function () {
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
 
-        $vhost = $this->site->webserver()->generateVhost($this->site);
+    $this->actingAs($otherUser);
 
-        $this->assertStringNotContainsString('@@VITO_PHP_VALUE@@', $vhost);
-    }
-
-    public function test_validation_requires_memory_limit_at_least_upload_size(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->patch(route('site-settings.update-php-settings', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'max_upload_size' => 512,
-            'memory_limit' => 256,
-        ])->assertSessionHasErrors('memory_limit');
-    }
-
-    public function test_validation_rejects_out_of_range_values(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->patch(route('site-settings.update-php-settings', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'max_input_vars' => 5,
-        ])->assertSessionHasErrors('max_input_vars');
-    }
-
-    public function test_route_404s_for_custom_vhost_template(): void
-    {
-        $this->site->vhost_template = 'server { }';
-        $this->site->save();
-
-        $this->actingAs($this->user);
-
-        $this->patch(route('site-settings.update-php-settings', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'max_upload_size' => 64,
-        ])->assertNotFound();
-    }
-
-    public function test_route_404s_for_octane_site(): void
-    {
-        $this->site->type_data = ['octane' => true];
-        $this->site->save();
-
-        $this->actingAs($this->user);
-
-        $this->patch(route('site-settings.update-php-settings', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'max_upload_size' => 64,
-        ])->assertNotFound();
-    }
-
-    public function test_route_404s_when_vhost_generation_disabled(): void
-    {
-        $this->site->vhost_generation_enabled = false;
-        $this->site->save();
-
-        $this->actingAs($this->user);
-
-        $this->patch(route('site-settings.update-php-settings', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'max_upload_size' => 64,
-        ])->assertNotFound();
-    }
-
-    public function test_resource_exposes_php_settings(): void
-    {
-        $this->site->type_data = ['php' => ['max_upload_size' => 64, 'max_execution_time' => null, 'memory_limit' => null, 'max_input_vars' => null]];
-        $this->site->save();
-        $this->site->load('server');
-
-        $resource = SiteResource::make($this->site)->toArray(request());
-
-        $this->assertTrue($resource['supports_php_settings']);
-        $this->assertSame(64, $resource['php_settings']['max_upload_size']);
-        $this->assertNull($resource['php_settings']['memory_limit']);
-        $this->assertArrayNotHasKey('php', $resource['type_data']);
-    }
-
-    public function test_authorization_requires_project_access(): void
-    {
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-
-        $this->actingAs($otherUser);
-
-        $this->patch(route('site-settings.update-php-settings', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'max_upload_size' => 64,
-        ])->assertForbidden();
-    }
-}
+    $this->patch(route('site-settings.update-php-settings', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'max_upload_size' => 64,
+    ])->assertForbidden();
+});

--- a/tests/Feature/SiteSettingsProxiedSiteTest.php
+++ b/tests/Feature/SiteSettingsProxiedSiteTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\DeploymentStatus;
 use App\Enums\WorkerStatus;
 use App\Events\SocketEvent;
@@ -14,249 +12,228 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class SiteSettingsProxiedSiteTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    private Site $proxiedSite;
+beforeEach(function () {
+    $this->proxiedSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'isolated-foo',
+        'path' => '/home/isolated-foo/app.test',
+        'type' => NodeSite::id(),
+        'port' => 3000,
+        'type_data' => [
+            'node_version' => '22',
+            'package_manager' => 'npm',
+            'start_command' => 'npm start',
+        ],
+    ]);
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+    $this->actingAs($this->user);
+});
 
-        $this->proxiedSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'isolated-foo',
-            'path' => '/home/isolated-foo/app.test',
-            'type' => NodeSite::id(),
-            'port' => 3000,
-            'type_data' => [
-                'node_version' => '22',
-                'package_manager' => 'npm',
-                'start_command' => 'npm start',
-            ],
-        ]);
+test('settings page exposes proxied site flags', function () {
+    $this->get(route('site-settings', ['server' => $this->server, 'site' => $this->proxiedSite]))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $a) => $a
+            ->component('site-settings/index')
+            ->where('site.is_proxied_site_type', true)
+            ->where('site.start_command', 'npm start')
+            ->where('site.port', 3000)
+        );
+});
 
-        $this->actingAs($this->user);
-    }
+test('update port updates site and regenerates vhost', function () {
+    SSH::fake();
+    Event::fake([SocketEvent::class]);
 
-    public function test_settings_page_exposes_proxied_site_flags(): void
-    {
-        $this->get(route('site-settings', ['server' => $this->server, 'site' => $this->proxiedSite]))
-            ->assertOk()
-            ->assertInertia(fn (AssertableInertia $a) => $a
-                ->component('site-settings/index')
-                ->where('site.is_proxied_site_type', true)
-                ->where('site.start_command', 'npm start')
-                ->where('site.port', 3000)
-            );
-    }
+    $this->patch(route('site-settings.update-port', ['server' => $this->server, 'site' => $this->proxiedSite]), [
+        'port' => 4000,
+    ])->assertRedirect();
 
-    public function test_update_port_updates_site_and_regenerates_vhost(): void
-    {
-        SSH::fake();
-        Event::fake([SocketEvent::class]);
+    $this->proxiedSite->refresh();
+    expect($this->proxiedSite->port)->toBe(4000);
 
-        $this->patch(route('site-settings.update-port', ['server' => $this->server, 'site' => $this->proxiedSite]), [
-            'port' => 4000,
-        ])->assertRedirect();
+    Event::assertDispatched(SocketEvent::class, fn (SocketEvent $event) => $event->data->type === 'site.updated');
+});
 
-        $this->proxiedSite->refresh();
-        $this->assertSame(4000, $this->proxiedSite->port);
+test('update port validates', function () {
+    SSH::fake();
 
-        Event::assertDispatched(SocketEvent::class, fn (SocketEvent $event) => $event->data->type === 'site.updated');
-    }
+    $this->patch(route('site-settings.update-port', ['server' => $this->server, 'site' => $this->proxiedSite]), [
+        'port' => 99999,
+    ])->assertSessionHasErrors('port');
+});
 
-    public function test_update_port_validates(): void
-    {
-        SSH::fake();
+test('update start command rejects newline injection', function () {
+    SSH::fake();
 
-        $this->patch(route('site-settings.update-port', ['server' => $this->server, 'site' => $this->proxiedSite]), [
-            'port' => 99999,
-        ])->assertSessionHasErrors('port');
-    }
+    $this->patch(route('site-settings.update-start-command', ['server' => $this->server, 'site' => $this->proxiedSite]), [
+        'start_command' => "npm start\nuser=root",
+    ])->assertSessionHasErrors('start_command');
 
-    public function test_update_start_command_rejects_newline_injection(): void
-    {
-        SSH::fake();
+    $this->patch(route('site-settings.update-start-command', ['server' => $this->server, 'site' => $this->proxiedSite]), [
+        'start_command' => "npm start\rcommand=/bin/sh",
+    ])->assertSessionHasErrors('start_command');
 
-        $this->patch(route('site-settings.update-start-command', ['server' => $this->server, 'site' => $this->proxiedSite]), [
-            'start_command' => "npm start\nuser=root",
-        ])->assertSessionHasErrors('start_command');
+    $this->proxiedSite->refresh();
+    expect($this->proxiedSite->type_data['start_command'])->toBe('npm start');
+});
 
-        $this->patch(route('site-settings.update-start-command', ['server' => $this->server, 'site' => $this->proxiedSite]), [
-            'start_command' => "npm start\rcommand=/bin/sh",
-        ])->assertSessionHasErrors('start_command');
+test('update start command pre first deploy stores only', function () {
+    SSH::fake();
 
-        $this->proxiedSite->refresh();
-        $this->assertSame('npm start', $this->proxiedSite->type_data['start_command']);
-    }
+    $this->patch(route('site-settings.update-start-command', ['server' => $this->server, 'site' => $this->proxiedSite]), [
+        'start_command' => 'pnpm start',
+    ])->assertRedirect()
+        ->assertSessionHas('info');
 
-    public function test_update_start_command_pre_first_deploy_stores_only(): void
-    {
-        SSH::fake();
+    $this->proxiedSite->refresh();
+    expect($this->proxiedSite->type_data['start_command'])->toBe('pnpm start');
+    expect($this->proxiedSite->workers()->where('name', 'app')->first())->toBeNull();
+});
 
-        $this->patch(route('site-settings.update-start-command', ['server' => $this->server, 'site' => $this->proxiedSite]), [
-            'start_command' => 'pnpm start',
-        ])->assertRedirect()
-            ->assertSessionHas('info');
+test('update start command with existing worker updates conf no restart', function () {
+    $fake = SSH::fake();
 
-        $this->proxiedSite->refresh();
-        $this->assertSame('pnpm start', $this->proxiedSite->type_data['start_command']);
-        $this->assertNull($this->proxiedSite->workers()->where('name', 'app')->first());
-    }
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->proxiedSite->id,
+        'user' => 'isolated-foo',
+        'name' => 'app',
+        'command' => 'npm start',
+        'status' => WorkerStatus::RUNNING,
+    ]);
+    $this->proxiedSite->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
 
-    public function test_update_start_command_with_existing_worker_updates_conf_no_restart(): void
-    {
-        $fake = SSH::fake();
+    $this->patch(route('site-settings.update-start-command', ['server' => $this->server, 'site' => $this->proxiedSite]), [
+        'start_command' => 'pnpm start',
+    ])->assertRedirect()
+        ->assertSessionHas('warning');
 
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->proxiedSite->id,
-            'user' => 'isolated-foo',
-            'name' => 'app',
-            'command' => 'npm start',
-            'status' => WorkerStatus::RUNNING,
-        ]);
-        $this->proxiedSite->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
+    $worker->refresh();
+    expect($worker->command)->toBe('pnpm start');
 
-        $this->patch(route('site-settings.update-start-command', ['server' => $this->server, 'site' => $this->proxiedSite]), [
-            'start_command' => 'pnpm start',
-        ])->assertRedirect()
-            ->assertSessionHas('warning');
+    $fake->assertNotExecutedContains('supervisorctl restart');
+});
 
-        $worker->refresh();
-        $this->assertSame('pnpm start', $worker->command);
+test('update start command with restart rewrites config and restarts', function () {
+    $fake = SSH::fake();
 
-        $fake->assertNotExecutedContains('supervisorctl restart');
-    }
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->proxiedSite->id,
+        'user' => 'isolated-foo',
+        'name' => 'app',
+        'command' => 'npm start',
+        'status' => WorkerStatus::RUNNING,
+    ]);
+    $this->proxiedSite->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
 
-    public function test_update_start_command_with_restart_rewrites_config_and_restarts(): void
-    {
-        $fake = SSH::fake();
+    $this->patch(route('site-settings.update-start-command', ['server' => $this->server, 'site' => $this->proxiedSite]), [
+        'start_command' => 'pnpm start',
+        'restart' => true,
+    ])->assertRedirect()
+        ->assertSessionHas('info');
 
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->proxiedSite->id,
-            'user' => 'isolated-foo',
-            'name' => 'app',
-            'command' => 'npm start',
-            'status' => WorkerStatus::RUNNING,
-        ]);
-        $this->proxiedSite->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
+    $worker->refresh();
+    expect($worker->command)->toBe('pnpm start');
 
-        $this->patch(route('site-settings.update-start-command', ['server' => $this->server, 'site' => $this->proxiedSite]), [
-            'start_command' => 'pnpm start',
-            'restart' => true,
-        ])->assertRedirect()
-            ->assertSessionHas('info');
+    $fake->assertExecutedContains("/etc/supervisor/conf.d/{$worker->id}.conf");
+    $fake->assertExecutedContains("supervisorctl restart {$worker->id}:*");
+});
 
-        $worker->refresh();
-        $this->assertSame('pnpm start', $worker->command);
+test('worker env pre deploy returns masked site variables', function () {
+    $this->proxiedSite->worker_environment = [
+        ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+        ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
+    ];
+    $this->proxiedSite->save();
 
-        $fake->assertExecutedContains("/etc/supervisor/conf.d/{$worker->id}.conf");
-        $fake->assertExecutedContains("supervisorctl restart {$worker->id}:*");
-    }
-
-    public function test_worker_env_pre_deploy_returns_masked_site_variables(): void
-    {
-        $this->proxiedSite->worker_environment = [
-            ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-            ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
-        ];
-        $this->proxiedSite->save();
-
-        $this->get(route('site-settings.worker-env', ['server' => $this->server, 'site' => $this->proxiedSite]))
-            ->assertOk()
-            ->assertJson([
-                'variables' => [
-                    ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-                    ['key' => 'API_KEY', 'value' => '', 'is_secret' => true],
-                ],
-            ]);
-    }
-
-    public function test_update_worker_env_pre_deploy_stores_encrypted_on_site(): void
-    {
-        $fake = SSH::fake();
-
-        $this->patch(route('site-settings.update-worker-env', ['server' => $this->server, 'site' => $this->proxiedSite]), [
+    $this->get(route('site-settings.worker-env', ['server' => $this->server, 'site' => $this->proxiedSite]))
+        ->assertOk()
+        ->assertJson([
             'variables' => [
                 ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+                ['key' => 'API_KEY', 'value' => '', 'is_secret' => true],
             ],
-        ])->assertRedirect()
-            ->assertSessionHas('info');
-
-        $this->proxiedSite->refresh();
-        $this->assertEquals([
-            ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-        ], $this->proxiedSite->worker_environment);
-
-        $raw = (string) DB::table('sites')->where('id', $this->proxiedSite->id)->value('worker_environment');
-        $this->assertStringNotContainsString('production', $raw);
-
-        $fake->assertNotExecutedContains('supervisor');
-    }
-
-    public function test_update_worker_env_with_existing_worker_delegates_to_worker(): void
-    {
-        $fake = SSH::fake();
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->proxiedSite->id,
-            'user' => 'isolated-foo',
-            'name' => 'app',
-            'command' => 'npm start',
-            'status' => WorkerStatus::RUNNING,
         ]);
-        $this->proxiedSite->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
+});
 
-        $this->patch(route('site-settings.update-worker-env', ['server' => $this->server, 'site' => $this->proxiedSite]), [
-            'variables' => [
-                ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-            ],
-            'restart' => true,
-        ])->assertRedirect()
-            ->assertSessionHas('info');
+test('update worker env pre deploy stores encrypted on site', function () {
+    $fake = SSH::fake();
 
-        $worker->refresh();
-        $this->assertEquals([
+    $this->patch(route('site-settings.update-worker-env', ['server' => $this->server, 'site' => $this->proxiedSite]), [
+        'variables' => [
             ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-        ], $worker->environment);
-        $this->assertNull($this->proxiedSite->refresh()->worker_environment);
+        ],
+    ])->assertRedirect()
+        ->assertSessionHas('info');
 
-        $fake->assertExecutedContains("/etc/supervisor/conf.d/{$worker->id}.conf");
-        $fake->assertExecutedContains("supervisorctl restart {$worker->id}:*");
-    }
+    $this->proxiedSite->refresh();
+    expect($this->proxiedSite->worker_environment)->toEqual([
+        ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+    ]);
 
-    public function test_worker_env_endpoints_404_for_non_proxied_site(): void
-    {
-        $this->get(route('site-settings.worker-env', ['server' => $this->server, 'site' => $this->site]))
-            ->assertNotFound();
+    $raw = (string) DB::table('sites')->where('id', $this->proxiedSite->id)->value('worker_environment');
+    $this->assertStringNotContainsString('production', $raw);
 
-        $this->patch(route('site-settings.update-worker-env', ['server' => $this->server, 'site' => $this->site]), [
-            'variables' => [],
-        ])->assertNotFound();
-    }
+    $fake->assertNotExecutedContains('supervisor');
+});
 
-    public function test_needs_first_deploy_warning_present_until_finished_deployment(): void
-    {
-        $beforeDeploy = $this->get(route('site-settings', ['server' => $this->server, 'site' => $this->proxiedSite]));
-        $beforeDeploy->assertInertia(fn (AssertableInertia $a) => $a
-            ->where('site.warnings', fn ($warnings) => collect($warnings)->contains(fn ($w) => $w['key'] === 'needs_first_deploy'))
-        );
+test('update worker env with existing worker delegates to worker', function () {
+    $fake = SSH::fake();
 
-        Deployment::factory()->create([
-            'site_id' => $this->proxiedSite->id,
-            'status' => DeploymentStatus::FINISHED,
-        ]);
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->proxiedSite->id,
+        'user' => 'isolated-foo',
+        'name' => 'app',
+        'command' => 'npm start',
+        'status' => WorkerStatus::RUNNING,
+    ]);
+    $this->proxiedSite->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
 
-        $afterDeploy = $this->get(route('site-settings', ['server' => $this->server, 'site' => $this->proxiedSite]));
-        $afterDeploy->assertInertia(fn (AssertableInertia $a) => $a
-            ->where('site.warnings', fn ($warnings) => ! collect($warnings)->contains(fn ($w) => $w['key'] === 'needs_first_deploy'))
-        );
-    }
-}
+    $this->patch(route('site-settings.update-worker-env', ['server' => $this->server, 'site' => $this->proxiedSite]), [
+        'variables' => [
+            ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+        ],
+        'restart' => true,
+    ])->assertRedirect()
+        ->assertSessionHas('info');
+
+    $worker->refresh();
+    expect($worker->environment)->toEqual([
+        ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+    ]);
+    expect($this->proxiedSite->refresh()->worker_environment)->toBeNull();
+
+    $fake->assertExecutedContains("/etc/supervisor/conf.d/{$worker->id}.conf");
+    $fake->assertExecutedContains("supervisorctl restart {$worker->id}:*");
+});
+
+test('worker env endpoints 404 for non proxied site', function () {
+    $this->get(route('site-settings.worker-env', ['server' => $this->server, 'site' => $this->site]))
+        ->assertNotFound();
+
+    $this->patch(route('site-settings.update-worker-env', ['server' => $this->server, 'site' => $this->site]), [
+        'variables' => [],
+    ])->assertNotFound();
+});
+
+test('needs first deploy warning present until finished deployment', function () {
+    $beforeDeploy = $this->get(route('site-settings', ['server' => $this->server, 'site' => $this->proxiedSite]));
+    $beforeDeploy->assertInertia(fn (AssertableInertia $a) => $a
+        ->where('site.warnings', fn ($warnings) => collect($warnings)->contains(fn ($w) => $w['key'] === 'needs_first_deploy'))
+    );
+
+    Deployment::factory()->create([
+        'site_id' => $this->proxiedSite->id,
+        'status' => DeploymentStatus::FINISHED,
+    ]);
+
+    $afterDeploy = $this->get(route('site-settings', ['server' => $this->server, 'site' => $this->proxiedSite]));
+    $afterDeploy->assertInertia(fn (AssertableInertia $a) => $a
+        ->where('site.warnings', fn ($warnings) => ! collect($warnings)->contains(fn ($w) => $w['key'] === 'needs_first_deploy'))
+    );
+});

--- a/tests/Feature/SiteStatsTest.php
+++ b/tests/Feature/SiteStatsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\CronJob\SyncCronJobs;
 use App\Actions\Site\UpdateSiteStats;
 use App\Actions\SiteStats\GetSiteStats;
@@ -25,349 +23,320 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Queue;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class SiteStatsTest extends TestCase
+uses(RefreshDatabase::class);
+
+function vitoPestFeatureSiteStatsTestInstallGoAccess(): Service
 {
-    use RefreshDatabase;
-
-    private function installGoAccess(): Service
-    {
-        return Service::factory()->create([
-            'server_id' => $this->server->id,
-            'type' => 'log_analysis',
-            'name' => 'goaccess',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-            'is_default' => true,
-            'type_data' => ['data_retention' => 12],
-        ]);
-    }
-
-    private function sampleReport(): string
-    {
-        return json_encode([
-            'general' => ['total_requests' => 1000, 'unique_visitors' => 200, 'bandwidth' => 50000],
-            'visitors' => ['data' => [
-                ['data' => '20260501', 'hits' => ['count' => 100], 'visitors' => ['count' => 20], 'bytes' => ['count' => 5000]],
-            ]],
-            'requests' => ['data' => [
-                ['data' => '/home', 'hits' => ['count' => 50], 'visitors' => ['count' => 10], 'bytes' => ['count' => 2500]],
-            ]],
-            'referrers' => ['data' => [
-                ['data' => 'google.com', 'hits' => ['count' => 30], 'visitors' => ['count' => 8], 'bytes' => ['count' => 0]],
-            ]],
-            'status_codes' => ['data' => [
-                ['data' => '2xx Success', 'items' => [['data' => '200', 'hits' => ['count' => 900]]]],
-            ]],
-            'not_found' => ['data' => [
-                ['data' => '/missing', 'hits' => ['count' => 7], 'visitors' => ['count' => 5], 'bytes' => ['count' => 0]],
-            ]],
-        ]);
-    }
-
-    public function test_stats_page_renders_without_service(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->get(route('site-stats', ['server' => $this->server, 'site' => $this->site]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/stats')->where('hasStatsService', false));
-    }
-
-    public function test_stats_page_reports_service_installed(): void
-    {
-        $this->actingAs($this->user);
-        $this->installGoAccess();
-
-        $this->get(route('site-stats', ['server' => $this->server, 'site' => $this->site]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->where('hasStatsService', true));
-    }
-
-    public function test_conf_renderer_emits_expected_vars(): void
-    {
-        $conf = app(RenderSiteStatsConf::class)->render($this->site);
-
-        $this->assertStringContainsString("SITE_ID='{$this->site->id}'", $conf);
-        $this->assertStringContainsString("DOMAIN='{$this->site->domain}'", $conf);
-        $this->assertStringContainsString("LOG_FORMAT='COMBINED'", $conf);
-        $this->assertStringContainsString('RETENTION_MONTHS=', $conf);
-        $this->assertStringContainsString("SSH_USER='{$this->server->getSshUser()}'", $conf);
-    }
-
-    public function test_conf_renderer_rejects_unsafe_domain(): void
-    {
-        $this->site->domain = 'bad domain; rm -rf /';
-        $this->site->save();
-
-        $this->expectException(\Exception::class);
-        app(RenderSiteStatsConf::class)->render($this->site->refresh());
-    }
-
-    public function test_get_site_stats_parses_report_over_ssh(): void
-    {
-        SSH::fake($this->sampleReport());
-
-        $stats = app(GetSiteStats::class)->get($this->site, '2026-05');
-
-        $this->assertSame(200, $stats['detail']['totals']['visitors']);
-        $this->assertSame(1000, $stats['detail']['totals']['hits']);
-        $this->assertSame('/home', $stats['detail']['top_pages'][0]['name']);
-        $this->assertSame('200', $stats['detail']['status_codes'][0]['name']);
-        $this->assertSame(900, $stats['detail']['status_codes'][0]['hits']);
-        $this->assertSame('/missing', $stats['detail']['not_found'][0]['name']);
-        $this->assertSame(7, $stats['detail']['not_found'][0]['hits']);
-    }
-
-    public function test_json_endpoint_returns_detail(): void
-    {
-        SSH::fake($this->sampleReport());
-        $this->actingAs($this->user);
-        $this->installGoAccess();
-
-        $this->get(route('site-stats.json', ['server' => $this->server, 'site' => $this->site, 'month' => '2026-05']))
-            ->assertSuccessful()
-            ->assertJsonPath('detail.totals.visitors', 200)
-            ->assertJsonPath('detail.top_pages.0.name', '/home');
-    }
-
-    public function test_get_site_stats_tolerates_invalid_utf8_in_report(): void
-    {
-        Cache::flush();
-        $report = str_replace('/home', "/home\x80\x81", $this->sampleReport());
-        $this->assertFalse(mb_check_encoding($report, 'UTF-8'));
-        SSH::fake($report);
-
-        $stats = app(GetSiteStats::class)->get($this->site, '2026-05');
-
-        $this->assertNotNull($stats['detail']);
-        $this->assertSame(1000, $stats['detail']['totals']['hits']);
-        $this->assertStringStartsWith('/home', $stats['detail']['top_pages'][0]['name']);
-    }
-
-    public function test_refresh_requires_service(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->post(route('site-stats.refresh', ['server' => $this->server, 'site' => $this->site]))
-            ->assertNotFound();
-    }
-
-    public function test_refresh_dispatches_job_when_installed(): void
-    {
-        Queue::fake();
-        $this->actingAs($this->user);
-        $this->installGoAccess();
-
-        $this->post(route('site-stats.refresh', ['server' => $this->server, 'site' => $this->site]))
-            ->assertSessionDoesntHaveErrors();
-
-        Queue::assertPushed(RefreshSiteStatsJob::class);
-    }
-
-    public function test_resync_requires_service_and_dispatches_job(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->post(route('log-analysis.resync', ['server' => $this->server]))->assertNotFound();
-
-        Queue::fake();
-        $this->installGoAccess();
-
-        $this->post(route('log-analysis.resync', ['server' => $this->server]))->assertSessionDoesntHaveErrors();
-        Queue::assertPushed(ResyncGoAccessJob::class);
-    }
-
-    public function test_site_created_listener_writes_conf_when_installed(): void
-    {
-        Queue::fake();
-        $this->installGoAccess();
-
-        (new HandleSiteCreatedStats)->handle(new SiteCreatedEvent($this->site));
-
-        Queue::assertPushed(WriteSiteStatsConfJob::class);
-    }
-
-    public function test_site_created_listener_noop_without_service(): void
-    {
-        Queue::fake();
-
-        (new HandleSiteCreatedStats)->handle(new SiteCreatedEvent($this->site));
-
-        Queue::assertNotPushed(WriteSiteStatsConfJob::class);
-    }
-
-    public function test_site_deleted_listener_dispatches_cleanup_when_installed(): void
-    {
-        Queue::fake();
-        $this->installGoAccess();
-
-        (new HandleSiteDeletedStats)->handle(new SiteDeletedEvent($this->server, $this->site->id, $this->site->domain));
-
-        Queue::assertPushed(CleanupSiteStatsJob::class);
-    }
-
-    public function test_sync_creates_named_root_cron(): void
-    {
-        SSH::fake('');
-        $this->installGoAccess();
-
-        app(SyncGoAccessServer::class)->sync($this->server);
-
-        $this->assertDatabaseHas('cron_jobs', [
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'hidden' => false,
-            'name' => GoAccess::CRON_NAME,
-            'command' => GoAccess::CRON_COMMAND,
-            'status' => CronjobStatus::READY->value,
-        ]);
-    }
-
-    public function test_resync_preserves_disabled_cron(): void
-    {
-        SSH::fake('');
-        $this->installGoAccess();
-
-        $cron = $this->server->cronJobs()->create([
-            'site_id' => null,
-            'name' => GoAccess::CRON_NAME,
-            'user' => 'root',
-            'command' => GoAccess::CRON_COMMAND,
-            'frequency' => GoAccess::CRON_FREQUENCY,
-            'status' => CronjobStatus::DISABLED,
-        ]);
-
-        app(SyncGoAccessServer::class)->sync($this->server);
-
-        $this->assertSame(CronjobStatus::DISABLED, $cron->refresh()->status);
-    }
-
-    public function test_goaccess_can_be_managed(): void
-    {
-        $service = $this->installGoAccess();
-
-        $this->assertTrue($service->handler()->canBeManaged());
-    }
-
-    public function test_stop_disables_cron_and_start_reenables(): void
-    {
-        SSH::fake('');
-        $service = $this->installGoAccess();
-        app(SyncGoAccessServer::class)->sync($this->server);
-
-        $cron = $this->server->cronJobs()->where('command', GoAccess::CRON_COMMAND)->firstOrFail();
-
-        $service->handler()->manage('stop');
-        $this->assertSame(CronjobStatus::DISABLED, $cron->refresh()->status);
-
-        $service->handler()->manage('start');
-        $this->assertSame(CronjobStatus::READY, $cron->refresh()->status);
-    }
-
-    public function test_service_stop_route_works_for_goaccess(): void
-    {
-        Queue::fake();
-        $this->actingAs($this->user);
-        $service = $this->installGoAccess();
-
-        $this->post(route('services.stop', ['server' => $this->server, 'service' => $service->id]))
-            ->assertSessionDoesntHaveErrors();
-
-        Queue::assertPushed(ManageJob::class);
-    }
-
-    public function test_stats_enabled_defaults_true(): void
-    {
-        $this->assertTrue($this->site->statsEnabled());
-    }
-
-    public function test_disable_sets_flag_and_dispatches_cleanup_when_installed(): void
-    {
-        Queue::fake();
-        $this->installGoAccess();
-
-        app(UpdateSiteStats::class)->disable($this->site);
-
-        $this->assertFalse($this->site->refresh()->statsEnabled());
-        $this->assertTrue($this->site->type_data['stats_disabled']);
-        Queue::assertPushed(CleanupSiteStatsJob::class);
-    }
-
-    public function test_disable_without_service_does_not_dispatch(): void
-    {
-        Queue::fake();
-
-        app(UpdateSiteStats::class)->disable($this->site);
-
-        $this->assertFalse($this->site->refresh()->statsEnabled());
-        Queue::assertNotPushed(CleanupSiteStatsJob::class);
-    }
-
-    public function test_enable_unsets_flag_and_dispatches_write_when_installed(): void
-    {
-        Queue::fake();
-        $this->installGoAccess();
-        $this->site->jsonUpdate('type_data', 'stats_disabled', true);
-
-        app(UpdateSiteStats::class)->enable($this->site);
-
-        $this->site->refresh();
-        $this->assertTrue($this->site->statsEnabled());
-        $this->assertArrayNotHasKey('stats_disabled', $this->site->type_data ?? []);
-        Queue::assertPushed(WriteSiteStatsConfJob::class);
-    }
-
-    public function test_disable_route_disables_stats(): void
-    {
-        Queue::fake();
-        $this->actingAs($this->user);
-        $this->installGoAccess();
-
-        $this->post(route('site-settings.disable-stats', ['server' => $this->server, 'site' => $this->site]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertFalse($this->site->refresh()->statsEnabled());
-    }
-
-    public function test_json_returns_404_when_stats_disabled(): void
-    {
-        SSH::fake($this->sampleReport());
-        $this->actingAs($this->user);
-        $this->installGoAccess();
-        $this->site->jsonUpdate('type_data', 'stats_disabled', true);
-
-        $this->get(route('site-stats.json', ['server' => $this->server, 'site' => $this->site, 'month' => '2026-05']))
-            ->assertNotFound();
-    }
-
-    public function test_write_conf_job_noop_when_disabled(): void
-    {
-        SSH::fake('');
-        $this->site->jsonUpdate('type_data', 'stats_disabled', true);
-
-        (new WriteSiteStatsConfJob($this->site->refresh()))->handle();
-
-        SSH::assertNotExecutedContains('sites/'.$this->site->id.'.conf');
-        $this->assertFalse($this->site->statsEnabled());
-    }
-
-    public function test_stats_cron_is_subject_to_crontab_sync(): void
-    {
-        SSH::fake(''); // getUserCrontab returns empty for every user
-
-        $cron = $this->server->cronJobs()->create([
-            'site_id' => null,
-            'name' => GoAccess::CRON_NAME,
-            'user' => 'root',
-            'command' => GoAccess::CRON_COMMAND,
-            'frequency' => GoAccess::CRON_FREQUENCY,
-            'status' => CronjobStatus::READY,
-        ]);
-
-        app(SyncCronJobs::class)->sync($this->server);
-
-        $this->assertSame(CronjobStatus::DISABLED, $cron->refresh()->status);
-    }
+    return Service::factory()->create([
+        'server_id' => test()->server->id,
+        'type' => 'log_analysis',
+        'name' => 'goaccess',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+        'is_default' => true,
+        'type_data' => ['data_retention' => 12],
+    ]);
 }
+
+function vitoPestFeatureSiteStatsTestSampleReport(): string
+{
+    return json_encode([
+        'general' => ['total_requests' => 1000, 'unique_visitors' => 200, 'bandwidth' => 50000],
+        'visitors' => ['data' => [
+            ['data' => '20260501', 'hits' => ['count' => 100], 'visitors' => ['count' => 20], 'bytes' => ['count' => 5000]],
+        ]],
+        'requests' => ['data' => [
+            ['data' => '/home', 'hits' => ['count' => 50], 'visitors' => ['count' => 10], 'bytes' => ['count' => 2500]],
+        ]],
+        'referrers' => ['data' => [
+            ['data' => 'google.com', 'hits' => ['count' => 30], 'visitors' => ['count' => 8], 'bytes' => ['count' => 0]],
+        ]],
+        'status_codes' => ['data' => [
+            ['data' => '2xx Success', 'items' => [['data' => '200', 'hits' => ['count' => 900]]]],
+        ]],
+        'not_found' => ['data' => [
+            ['data' => '/missing', 'hits' => ['count' => 7], 'visitors' => ['count' => 5], 'bytes' => ['count' => 0]],
+        ]],
+    ]);
+}
+
+test('stats page renders without service', function () {
+    $this->actingAs($this->user);
+
+    $this->get(route('site-stats', ['server' => $this->server, 'site' => $this->site]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/stats')->where('hasStatsService', false));
+});
+
+test('stats page reports service installed', function () {
+    $this->actingAs($this->user);
+    vitoPestFeatureSiteStatsTestInstallGoAccess();
+
+    $this->get(route('site-stats', ['server' => $this->server, 'site' => $this->site]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->where('hasStatsService', true));
+});
+
+test('conf renderer emits expected vars', function () {
+    $conf = app(RenderSiteStatsConf::class)->render($this->site);
+
+    $this->assertStringContainsString("SITE_ID='{$this->site->id}'", $conf);
+    $this->assertStringContainsString("DOMAIN='{$this->site->domain}'", $conf);
+    $this->assertStringContainsString("LOG_FORMAT='COMBINED'", $conf);
+    $this->assertStringContainsString('RETENTION_MONTHS=', $conf);
+    $this->assertStringContainsString("SSH_USER='{$this->server->getSshUser()}'", $conf);
+});
+
+test('conf renderer rejects unsafe domain', function () {
+    $this->site->domain = 'bad domain; rm -rf /';
+    $this->site->save();
+
+    $this->expectException(Exception::class);
+    app(RenderSiteStatsConf::class)->render($this->site->refresh());
+});
+
+test('get site stats parses report over ssh', function () {
+    SSH::fake(vitoPestFeatureSiteStatsTestSampleReport());
+
+    $stats = app(GetSiteStats::class)->get($this->site, '2026-05');
+
+    expect($stats['detail']['totals']['visitors'])->toBe(200);
+    expect($stats['detail']['totals']['hits'])->toBe(1000);
+    expect($stats['detail']['top_pages'][0]['name'])->toBe('/home');
+    expect($stats['detail']['status_codes'][0]['name'])->toBe('200');
+    expect($stats['detail']['status_codes'][0]['hits'])->toBe(900);
+    expect($stats['detail']['not_found'][0]['name'])->toBe('/missing');
+    expect($stats['detail']['not_found'][0]['hits'])->toBe(7);
+});
+
+test('json endpoint returns detail', function () {
+    SSH::fake(vitoPestFeatureSiteStatsTestSampleReport());
+    $this->actingAs($this->user);
+    vitoPestFeatureSiteStatsTestInstallGoAccess();
+
+    $this->get(route('site-stats.json', ['server' => $this->server, 'site' => $this->site, 'month' => '2026-05']))
+        ->assertSuccessful()
+        ->assertJsonPath('detail.totals.visitors', 200)
+        ->assertJsonPath('detail.top_pages.0.name', '/home');
+});
+
+test('get site stats tolerates invalid utf8 in report', function () {
+    Cache::flush();
+    $report = str_replace('/home', "/home\x80\x81", vitoPestFeatureSiteStatsTestSampleReport());
+    expect(mb_check_encoding($report, 'UTF-8'))->toBeFalse();
+    SSH::fake($report);
+
+    $stats = app(GetSiteStats::class)->get($this->site, '2026-05');
+
+    expect($stats['detail'])->not->toBeNull();
+    expect($stats['detail']['totals']['hits'])->toBe(1000);
+    expect($stats['detail']['top_pages'][0]['name'])->toStartWith('/home');
+});
+
+test('refresh requires service', function () {
+    $this->actingAs($this->user);
+
+    $this->post(route('site-stats.refresh', ['server' => $this->server, 'site' => $this->site]))
+        ->assertNotFound();
+});
+
+test('refresh dispatches job when installed', function () {
+    Queue::fake();
+    $this->actingAs($this->user);
+    vitoPestFeatureSiteStatsTestInstallGoAccess();
+
+    $this->post(route('site-stats.refresh', ['server' => $this->server, 'site' => $this->site]))
+        ->assertSessionDoesntHaveErrors();
+
+    Queue::assertPushed(RefreshSiteStatsJob::class);
+});
+
+test('resync requires service and dispatches job', function () {
+    $this->actingAs($this->user);
+
+    $this->post(route('log-analysis.resync', ['server' => $this->server]))->assertNotFound();
+
+    Queue::fake();
+    vitoPestFeatureSiteStatsTestInstallGoAccess();
+
+    $this->post(route('log-analysis.resync', ['server' => $this->server]))->assertSessionDoesntHaveErrors();
+    Queue::assertPushed(ResyncGoAccessJob::class);
+});
+
+test('site created listener writes conf when installed', function () {
+    Queue::fake();
+    vitoPestFeatureSiteStatsTestInstallGoAccess();
+
+    (new HandleSiteCreatedStats)->handle(new SiteCreatedEvent($this->site));
+
+    Queue::assertPushed(WriteSiteStatsConfJob::class);
+});
+
+test('site created listener noop without service', function () {
+    Queue::fake();
+
+    (new HandleSiteCreatedStats)->handle(new SiteCreatedEvent($this->site));
+
+    Queue::assertNotPushed(WriteSiteStatsConfJob::class);
+});
+
+test('site deleted listener dispatches cleanup when installed', function () {
+    Queue::fake();
+    vitoPestFeatureSiteStatsTestInstallGoAccess();
+
+    (new HandleSiteDeletedStats)->handle(new SiteDeletedEvent($this->server, $this->site->id, $this->site->domain));
+
+    Queue::assertPushed(CleanupSiteStatsJob::class);
+});
+
+test('sync creates named root cron', function () {
+    SSH::fake('');
+    vitoPestFeatureSiteStatsTestInstallGoAccess();
+
+    app(SyncGoAccessServer::class)->sync($this->server);
+
+    $this->assertDatabaseHas('cron_jobs', [
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'hidden' => false,
+        'name' => GoAccess::CRON_NAME,
+        'command' => GoAccess::CRON_COMMAND,
+        'status' => CronjobStatus::READY->value,
+    ]);
+});
+
+test('resync preserves disabled cron', function () {
+    SSH::fake('');
+    vitoPestFeatureSiteStatsTestInstallGoAccess();
+
+    $cron = $this->server->cronJobs()->create([
+        'site_id' => null,
+        'name' => GoAccess::CRON_NAME,
+        'user' => 'root',
+        'command' => GoAccess::CRON_COMMAND,
+        'frequency' => GoAccess::CRON_FREQUENCY,
+        'status' => CronjobStatus::DISABLED,
+    ]);
+
+    app(SyncGoAccessServer::class)->sync($this->server);
+
+    expect($cron->refresh()->status)->toBe(CronjobStatus::DISABLED);
+});
+
+test('goaccess can be managed', function () {
+    $service = vitoPestFeatureSiteStatsTestInstallGoAccess();
+
+    expect($service->handler()->canBeManaged())->toBeTrue();
+});
+
+test('stop disables cron and start reenables', function () {
+    SSH::fake('');
+    $service = vitoPestFeatureSiteStatsTestInstallGoAccess();
+    app(SyncGoAccessServer::class)->sync($this->server);
+
+    $cron = $this->server->cronJobs()->where('command', GoAccess::CRON_COMMAND)->firstOrFail();
+
+    $service->handler()->manage('stop');
+    expect($cron->refresh()->status)->toBe(CronjobStatus::DISABLED);
+
+    $service->handler()->manage('start');
+    expect($cron->refresh()->status)->toBe(CronjobStatus::READY);
+});
+
+test('service stop route works for goaccess', function () {
+    Queue::fake();
+    $this->actingAs($this->user);
+    $service = vitoPestFeatureSiteStatsTestInstallGoAccess();
+
+    $this->post(route('services.stop', ['server' => $this->server, 'service' => $service->id]))
+        ->assertSessionDoesntHaveErrors();
+
+    Queue::assertPushed(ManageJob::class);
+});
+
+test('stats enabled defaults true', function () {
+    expect($this->site->statsEnabled())->toBeTrue();
+});
+
+test('disable sets flag and dispatches cleanup when installed', function () {
+    Queue::fake();
+    vitoPestFeatureSiteStatsTestInstallGoAccess();
+
+    app(UpdateSiteStats::class)->disable($this->site);
+
+    expect($this->site->refresh()->statsEnabled())->toBeFalse();
+    expect($this->site->type_data['stats_disabled'])->toBeTrue();
+    Queue::assertPushed(CleanupSiteStatsJob::class);
+});
+
+test('disable without service does not dispatch', function () {
+    Queue::fake();
+
+    app(UpdateSiteStats::class)->disable($this->site);
+
+    expect($this->site->refresh()->statsEnabled())->toBeFalse();
+    Queue::assertNotPushed(CleanupSiteStatsJob::class);
+});
+
+test('enable unsets flag and dispatches write when installed', function () {
+    Queue::fake();
+    vitoPestFeatureSiteStatsTestInstallGoAccess();
+    $this->site->jsonUpdate('type_data', 'stats_disabled', true);
+
+    app(UpdateSiteStats::class)->enable($this->site);
+
+    $this->site->refresh();
+    expect($this->site->statsEnabled())->toBeTrue();
+    $this->assertArrayNotHasKey('stats_disabled', $this->site->type_data ?? []);
+    Queue::assertPushed(WriteSiteStatsConfJob::class);
+});
+
+test('disable route disables stats', function () {
+    Queue::fake();
+    $this->actingAs($this->user);
+    vitoPestFeatureSiteStatsTestInstallGoAccess();
+
+    $this->post(route('site-settings.disable-stats', ['server' => $this->server, 'site' => $this->site]))
+        ->assertSessionDoesntHaveErrors();
+
+    expect($this->site->refresh()->statsEnabled())->toBeFalse();
+});
+
+test('json returns 404 when stats disabled', function () {
+    SSH::fake(vitoPestFeatureSiteStatsTestSampleReport());
+    $this->actingAs($this->user);
+    vitoPestFeatureSiteStatsTestInstallGoAccess();
+    $this->site->jsonUpdate('type_data', 'stats_disabled', true);
+
+    $this->get(route('site-stats.json', ['server' => $this->server, 'site' => $this->site, 'month' => '2026-05']))
+        ->assertNotFound();
+});
+
+test('write conf job noop when disabled', function () {
+    SSH::fake('');
+    $this->site->jsonUpdate('type_data', 'stats_disabled', true);
+
+    (new WriteSiteStatsConfJob($this->site->refresh()))->handle();
+
+    SSH::assertNotExecutedContains('sites/'.$this->site->id.'.conf');
+    expect($this->site->statsEnabled())->toBeFalse();
+});
+
+test('stats cron is subject to crontab sync', function () {
+    SSH::fake('');
+
+    // getUserCrontab returns empty for every user
+    $cron = $this->server->cronJobs()->create([
+        'site_id' => null,
+        'name' => GoAccess::CRON_NAME,
+        'user' => 'root',
+        'command' => GoAccess::CRON_COMMAND,
+        'frequency' => GoAccess::CRON_FREQUENCY,
+        'status' => CronjobStatus::READY,
+    ]);
+
+    app(SyncCronJobs::class)->sync($this->server);
+
+    expect($cron->refresh()->status)->toBe(CronjobStatus::DISABLED);
+});

--- a/tests/Feature/SiteToolingTest.php
+++ b/tests/Feature/SiteToolingTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\DTOs\DynamicField;
 use App\Enums\SiteStatus;
 use App\Events\SocketEvent;
@@ -30,648 +28,602 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class SiteToolingTest extends TestCase
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->isolatedSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'domain' => 'iso-one.test',
+        'user' => 'isolated-foo',
+        'path' => '/home/isolated-foo/iso-one.test',
+        'source_control_id' => $sourceControl->id,
+        'type' => Laravel::id(),
+        'status' => SiteStatus::READY,
+        'type_data' => [],
+    ]);
+
+    $this->sibling = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'domain' => 'iso-two.test',
+        'user' => 'isolated-foo',
+        'path' => '/home/isolated-foo/iso-two.test',
+        'source_control_id' => $sourceControl->id,
+        'type' => Laravel::id(),
+        'status' => SiteStatus::READY,
+        'type_data' => [],
+    ]);
+});
+
+function vitoPestFeatureSiteToolingTestIuser(): IsolatedUser
 {
-    use RefreshDatabase;
-
-    private Site $isolatedSite;
-
-    private Site $sibling;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Github::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->isolatedSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'domain' => 'iso-one.test',
-            'user' => 'isolated-foo',
-            'path' => '/home/isolated-foo/iso-one.test',
-            'source_control_id' => $sourceControl->id,
-            'type' => Laravel::id(),
-            'status' => SiteStatus::READY,
-            'type_data' => [],
-        ]);
-
-        $this->sibling = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'domain' => 'iso-two.test',
-            'user' => 'isolated-foo',
-            'path' => '/home/isolated-foo/iso-two.test',
-            'source_control_id' => $sourceControl->id,
-            'type' => Laravel::id(),
-            'status' => SiteStatus::READY,
-            'type_data' => [],
-        ]);
-    }
-
-    private function iuser(): IsolatedUser
-    {
-        return $this->isolatedSite->isolatedUser()->firstOrFail();
-    }
-
-    public function test_failed_site_is_forbidden(): void
-    {
-        $this->isolatedSite->update(['status' => SiteStatus::INSTALLATION_FAILED]);
-
-        $this->actingAs($this->user);
-
-        $this->get(route('site-tooling', ['server' => $this->server, 'site' => $this->isolatedSite]))
-            ->assertForbidden();
-
-        $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']), [
-            'version' => '22',
-        ])->assertForbidden();
-    }
-
-    public function test_index_renders_for_isolated_site(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->get(route('site-tooling', ['server' => $this->server, 'site' => $this->isolatedSite]))
-            ->assertOk()
-            ->assertInertia(fn (AssertableInertia $assert) => $assert
-                ->component('site-tooling/index')
-                ->where('isolated_user', 'isolated-foo')
-                ->has('sibling_sites', 1)
-                ->where('sibling_sites.0.domain', 'iso-two.test')
-                ->where('installed_versions.node', null)
-                ->where('installed_versions.bun', null)
-                ->where('installed_versions.pnpm', null)
-                ->where('installed_versions.yarn', null)
-            );
-    }
-
-    public function test_non_isolated_site_is_forbidden(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->get(route('site-tooling', ['server' => $this->server, 'site' => $this->site]))
-            ->assertForbidden();
-
-        $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->site, 'tool' => 'node']), [
-            'version' => '22',
-        ])->assertForbidden();
-
-        $this->delete(route('site-tooling.uninstall', ['server' => $this->server, 'site' => $this->site, 'tool' => 'node']))
-            ->assertForbidden();
-    }
-
-    public function test_install_dispatches_and_propagates_to_siblings(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']), [
-            'version' => '24',
-        ])->assertRedirect();
-
-        SSH::assertExecutedContains('mise use -g node@24');
-
-        $iuser = $this->iuser();
-        $this->assertSame('24', $iuser->toolingVersion('node'));
-        $this->assertSame('24', $this->sibling->refresh()->isolatedUser?->toolingVersion('node'));
-    }
-
-    public function test_install_pnpm_works_for_new_tool(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'pnpm']), [
-            'version' => '9',
-        ])->assertRedirect();
-
-        SSH::assertExecutedContains('mise use -g pnpm@9');
-
-        $iuser = $this->iuser();
-        $this->assertSame('9', $iuser->toolingVersion('pnpm'));
-    }
-
-    public function test_uninstall_removes_tool_entry_from_iuser(): void
-    {
-        SSH::fake();
-
-        $this->iuser()->setToolingVersion('node', '22');
-
-        $this->actingAs($this->user);
-
-        $this->delete(route('site-tooling.uninstall', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']))
-            ->assertRedirect();
-
-        SSH::assertExecutedContains('mise unuse -g node');
-        SSH::assertExecutedContains('mise uninstall node --all');
-
-        $iuser = $this->iuser();
-        $this->assertNull($iuser->toolingVersion('node'));
-        $this->assertNull($iuser->toolingStatus('node'));
-        $this->assertArrayNotHasKey('node', $iuser->installed_tooling ?? []);
-    }
-
-    public function test_install_validation_rejects_unsupported_version(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']), [
-            'version' => '99',
-        ])->assertSessionHasErrors('version');
-
-        $this->assertNull($this->iuser()->toolingVersion('node'));
-    }
-
-    public function test_unknown_tool_returns_404(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'rustup']), [
-            'version' => '1',
-        ])->assertNotFound();
-    }
-
-    public function test_unauthenticated_request_is_redirected(): void
-    {
-        $this->get(route('site-tooling', ['server' => $this->server, 'site' => $this->isolatedSite]))
-            ->assertRedirect();
-    }
-
-    public function test_user_from_another_project_is_forbidden(): void
-    {
-        $otherUser = User::factory()->create();
-        $otherUser->ensureHasDefaultProject();
-
-        $this->actingAs($otherUser);
-
-        $this->get(route('site-tooling', ['server' => $this->server, 'site' => $this->isolatedSite]))
-            ->assertForbidden();
-    }
-
-    public function test_lock_runtime_versions_now_covers_pnpm_and_yarn(): void
-    {
-        SSH::fake();
-
-        $this->iuser()->setToolingVersion('node', '22');
-
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Github::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->actingAs($this->user);
-
-        Http::fake([
-            'https://api.github.com/repos/*' => Http::response([], 200),
-        ]);
-
-        $this->post(route('sites.store', ['server' => $this->server]), [
-            'type' => Laravel::id(),
-            'domain' => 'iso-three.test',
-            'user' => 'isolated-foo',
-            'php_version' => '8.2',
-            'web_directory' => 'public',
-            'repository' => 'organization/repository',
-            'branch' => 'main',
-            'source_control' => $sourceControl->id,
-            'node_version' => '24',
-            'bun_version' => 'none',
-        ])->assertSessionHasErrors('node_version');
-    }
-
-    public function test_only_sibling_sites_with_mise_trait_are_updated(): void
-    {
-        SSH::fake();
-
-        Site::factory()->create([
-            'server_id' => $this->server->id,
-            'domain' => 'lb.test',
-            'user' => 'isolated-foo',
-            'path' => '/home/isolated-foo/lb.test',
-            'type' => LoadBalancer::id(),
-            'type_data' => [],
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']), [
-            'version' => '22',
-        ])->assertRedirect();
-
-        $this->assertSame('22', $this->iuser()->toolingVersion('node'));
-    }
-
-    public function test_installing_status_blocks_concurrent_install(): void
-    {
-        SSH::fake();
-
-        $this->iuser()->setToolingStatus('node', SiteToolingState::STATUS_INSTALLING);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']), [
-            'version' => '24',
-        ])->assertSessionHasErrors('tool');
-    }
-
-    public function test_failed_install_records_failed_status(): void
-    {
-        $job = new InstallSiteToolingJob($this->isolatedSite, 'node', '24');
-
-        $job->failed(new \RuntimeException('boom'));
-
-        $iuser = $this->iuser();
-        $this->assertSame('install_failed', $iuser->toolingStatus('node'));
-    }
-
-    public function test_failed_uninstall_records_failed_status(): void
-    {
-        $this->iuser()->setToolingVersion('node', '22');
-
-        $job = new UninstallSiteToolingJob($this->isolatedSite, 'node');
-
-        $job->failed(new \RuntimeException('boom'));
-
-        $iuser = $this->iuser();
-        $this->assertSame('uninstall_failed', $iuser->toolingStatus('node'));
-    }
-
-    public function test_install_marks_failed_when_tool_missing_from_registry(): void
-    {
-        Event::fake([SocketEvent::class]);
-
-        $this->iuser()->setToolingStatus('ghost-tool', SiteToolingState::STATUS_INSTALLING);
-
-        dispatch_sync(new InstallSiteToolingJob($this->isolatedSite, 'ghost-tool', '1.0'));
-
-        $this->assertSame('install_failed', $this->iuser()->toolingStatus('ghost-tool'));
-
-        Event::assertDispatched(
-            SocketEvent::class,
-            fn (SocketEvent $event) => $event->data->type === 'isolated-user.tooling-updated',
-        );
-    }
-
-    public function test_uninstall_marks_failed_when_tool_missing_from_registry(): void
-    {
-        Event::fake([SocketEvent::class]);
-
-        $this->iuser()->setToolingStatus('ghost-tool', SiteToolingState::STATUS_UNINSTALLING);
-
-        dispatch_sync(new UninstallSiteToolingJob($this->isolatedSite, 'ghost-tool'));
-
-        $this->assertSame('uninstall_failed', $this->iuser()->toolingStatus('ghost-tool'));
-
-        Event::assertDispatched(
-            SocketEvent::class,
-            fn (SocketEvent $event) => $event->data->type === 'isolated-user.tooling-updated',
-        );
-    }
-
-    public function test_complete_install_broadcasts_tooling_updated(): void
-    {
-        Event::fake([SocketEvent::class]);
-
-        SiteToolingState::completeInstall($this->isolatedSite, 'node', '22');
-
-        Event::assertDispatched(
-            SocketEvent::class,
-            fn (SocketEvent $event) => $event->data->type === 'isolated-user.tooling-updated'
-                && $event->data->data['id'] === $this->iuser()->id,
-        );
-    }
-
-    public function test_complete_uninstall_broadcasts_tooling_updated(): void
-    {
-        $this->iuser()->setToolingVersion('node', '22');
-
-        Event::fake([SocketEvent::class]);
-
-        SiteToolingState::completeUninstall($this->isolatedSite, 'node');
-
-        Event::assertDispatched(
-            SocketEvent::class,
-            fn (SocketEvent $event) => $event->data->type === 'isolated-user.tooling-updated'
-                && $event->data->data['id'] === $this->iuser()->id,
-        );
-    }
-
-    public function test_successful_install_clears_status(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']), [
-            'version' => '22',
-        ])->assertRedirect();
-
-        $iuser = $this->iuser();
-        $this->assertNull($iuser->toolingStatus('node'));
-        $this->assertSame('22', $iuser->toolingVersion('node'));
-    }
-
-    public function test_setup_requested_tooling_installs_each_requested_tool_and_strips_type_data(): void
-    {
-        SSH::fake();
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'domain' => 'iso-three.test',
-            'user' => 'isolated-foo',
-            'path' => '/home/isolated-foo/iso-three.test',
-            'type' => Laravel::id(),
-            'status' => SiteStatus::READY,
-            'type_data' => [
-                'node_version' => '22',
-                'pnpm_version' => '9',
-                'yarn_version' => 'none',
-            ],
-        ]);
-
-        $siteType = new class($site) extends AbstractSiteType
-        {
-            public static function id(): string
-            {
-                return 'test-setup-requested-tooling';
-            }
-
-            public function language(): string
-            {
-                return 'php';
-            }
-
-            public function requiredServices(): array
-            {
-                return [];
-            }
-
-            public function install(): void {}
-
-            public static function make(): self
-            {
-                return new self(new Site);
-            }
-
-            public static function createTimeTools(): array
-            {
-                return ['node', 'pnpm', 'yarn'];
-            }
-
-            public function runSetup(): void
-            {
-                $this->setupRequestedTooling();
-            }
-        };
-
-        $siteType->runSetup();
-
-        $iuser = $site->isolatedUser()->firstOrFail();
-
-        $this->assertSame('22', $iuser->toolingVersion('node'));
-        $this->assertSame('9', $iuser->toolingVersion('pnpm'));
-        $this->assertNull($iuser->toolingVersion('yarn'));
-
-        $site->refresh();
-        $this->assertArrayNotHasKey('node_version', $site->type_data);
-        $this->assertArrayNotHasKey('pnpm_version', $site->type_data);
-    }
-
-    public function test_index_exposes_required_tooling_from_sibling_site_types(): void
-    {
-        Site::factory()->create([
-            'server_id' => $this->server->id,
-            'domain' => 'iso-node.test',
-            'user' => 'isolated-foo',
-            'path' => '/home/isolated-foo/iso-node.test',
-            'type' => NodeSite::id(),
-            'status' => SiteStatus::READY,
-            'type_data' => [],
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->get(route('site-tooling', ['server' => $this->server, 'site' => $this->isolatedSite]))
-            ->assertOk()
-            ->assertInertia(fn (AssertableInertia $assert) => $assert
-                ->where('required_tooling.node', 'Node.js')
-                ->missing('required_tooling.bun')
-            );
-    }
-
-    public function test_uninstall_rejected_for_required_tooling(): void
-    {
-        SSH::fake();
-
-        Site::factory()->create([
-            'server_id' => $this->server->id,
-            'domain' => 'iso-node.test',
-            'user' => 'isolated-foo',
-            'path' => '/home/isolated-foo/iso-node.test',
-            'type' => NodeSite::id(),
-            'status' => SiteStatus::READY,
-            'type_data' => [],
-        ]);
-
-        $this->iuser()->setToolingVersion('node', '22');
-
-        $this->actingAs($this->user);
-
-        $this->delete(route('site-tooling.uninstall', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']))
-            ->assertSessionHasErrors('tool');
-
-        SSH::assertNotExecutedContains('mise unuse -g node');
-        $this->assertSame('22', $this->iuser()->toolingVersion('node'));
-    }
-
-    public function test_composer_tool_is_registered(): void
-    {
-        $composer = ToolingRegistry::find('composer');
-
-        $this->assertNotNull($composer);
-        $this->assertSame(['composer'], $composer::commands());
-        $this->assertSame(['2'], $composer::supportedVersions());
-    }
-
-    public function test_bootstrap_exposes_composer_descriptor(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->getJson(route('bootstrap.show'))
-            ->assertOk()
-            ->assertJsonPath('configs.tooling', fn (array $tooling): bool => in_array('composer', array_column($tooling, 'id'), true));
-    }
-
-    public function test_composer_required_for_php_types_but_not_wordpress_or_phpmyadmin(): void
-    {
-        foreach ([PHPSite::class, Laravel::class, PHPBlank::class] as $type) {
-            $this->assertContains('composer', $type::createTimeTools(), "{$type} createTimeTools");
-            $this->assertContains('composer', $type::requiredTooling(), "{$type} requiredTooling");
-        }
-
-        foreach ([Wordpress::class, PHPMyAdmin::class] as $type) {
-            $this->assertSame([], $type::createTimeTools(), "{$type} createTimeTools");
-            $this->assertSame([], $type::requiredTooling(), "{$type} requiredTooling");
-        }
-    }
-
-    public function test_composer_installs_at_latest_without_a_create_form_picker(): void
-    {
-        $data = (new Laravel(new Site(['type' => Laravel::id()])))->data([]);
-        $this->assertSame('2', $data['composer_version']);
-
-        $selector = collect(config('site.types.php.form'))->firstWhere('name', 'package_manager');
-        $this->assertNotContains('composer', $selector['options']);
-    }
-
-    public function test_php_and_php_blank_package_manager_defaults_to_none(): void
-    {
-        foreach (['php', 'php-blank'] as $typeId) {
-            $selector = collect(config('site.types.'.$typeId.'.form'))->firstWhere('name', 'package_manager');
-            $this->assertSame('none', $selector['default'], $typeId);
-            $this->assertContains('none', $selector['options'], $typeId);
-        }
-
-        $laravel = collect(config('site.types.laravel.form'))->firstWhere('name', 'package_manager');
-        $this->assertSame('node', $laravel['default']);
-        $this->assertNotContains('none', $laravel['options']);
-    }
-
-    public function test_php_with_no_package_manager_installs_only_composer(): void
-    {
-        $data = (new PHPSite(new Site(['type' => 'php'])))->data([]);
-
-        $this->assertSame('none', $data['node_version']);
-        $this->assertSame('none', $data['pnpm_version']);
-        $this->assertSame('none', $data['yarn_version']);
-        $this->assertSame('2', $data['composer_version']);
-    }
-
-    public function test_tooling_selector_supports_explicit_default(): void
-    {
-        $explicit = DynamicField::make('package_manager')->toolingSelector(
-            [NodeTooling::class, PnpmTooling::class, YarnTooling::class],
-            [NodeTooling::class => 'npm'],
-            PnpmTooling::class,
-        )->toArray();
-
-        $this->assertSame('tooling-selector', $explicit['type']);
-        $this->assertSame('pnpm', $explicit['default']);
-        $this->assertSame('npm', $explicit['optionLabels']['node']);
-
-        $implicit = DynamicField::make('package_manager')->toolingSelector(
-            [YarnTooling::class, PnpmTooling::class],
-        )->toArray();
-
-        $this->assertSame('yarn', $implicit['default']);
-    }
-
-    public function test_laravel_package_manager_drives_tooling_versions(): void
-    {
-        $type = new Laravel(new Site(['type' => Laravel::id()]));
-
-        $npm = $type->data(['package_manager' => 'node', 'node_version' => '22']);
-        $this->assertSame('22', $npm['node_version']);
-        $this->assertSame('none', $npm['pnpm_version']);
-        $this->assertSame('none', $npm['yarn_version']);
-        $this->assertSame('2', $npm['composer_version']);
-
-        $pnpm = $type->data(['package_manager' => 'pnpm', 'pnpm_version' => '9']);
-        $this->assertSame('9', $pnpm['pnpm_version']);
-        $this->assertSame('none', $pnpm['yarn_version']);
-        $this->assertSame('none', $pnpm['node_version']);
-
-        $none = $type->data(['package_manager' => 'none']);
-        $this->assertSame('none', $none['node_version']);
-        $this->assertSame('none', $none['pnpm_version']);
-        $this->assertSame('none', $none['yarn_version']);
-
-        $this->assertSame(['node', 'pnpm', 'yarn', 'composer'], Laravel::createTimeTools());
-    }
-
-    public function test_install_composer_installs_locally(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'composer']), [
-            'version' => '2',
-        ])->assertRedirect();
-
-        SSH::assertExecutedContains('composer-setup.php');
-        SSH::assertExecutedContains('.local/vito/bin');
-        SSH::assertExecutedContains('$HOME/.bashrc');
-
-        $this->assertSame('2', $this->iuser()->toolingVersion('composer'));
-    }
-
-    public function test_uninstall_composer_removes_binary_and_path_activation(): void
-    {
-        SSH::fake();
-
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'domain' => 'node-only.test',
-            'user' => 'isolated-node',
-            'path' => '/home/isolated-node/node-only.test',
-            'type' => NodeSite::id(),
-            'status' => SiteStatus::READY,
-            'type_data' => [],
-        ]);
-
-        $site->isolatedUser()->firstOrFail()->setToolingVersion('composer', '2');
-
-        $this->actingAs($this->user);
-
-        $this->delete(route('site-tooling.uninstall', ['server' => $this->server, 'site' => $site, 'tool' => 'composer']))
-            ->assertRedirect();
-
-        SSH::assertExecutedContains('rm -f "$HOME/.local/vito/bin/composer"');
-        SSH::assertExecutedContains('.bashrc');
-
-        $this->assertNull($site->isolatedUser()->firstOrFail()->toolingVersion('composer'));
-    }
-
-    public function test_uninstall_composer_rejected_on_laravel_site(): void
-    {
-        SSH::fake();
-
-        $this->iuser()->setToolingVersion('composer', '2');
-
-        $this->actingAs($this->user);
-
-        $this->delete(route('site-tooling.uninstall', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'composer']))
-            ->assertSessionHasErrors('tool');
-
-        SSH::assertNotExecutedContains('.local/vito/bin/composer');
-        $this->assertSame('2', $this->iuser()->toolingVersion('composer'));
-    }
-
-    public function test_other_user_sites_are_not_touched(): void
-    {
-        SSH::fake();
-
-        $otherUserSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'domain' => 'other-user.test',
-            'user' => 'isolated-bar',
-            'path' => '/home/isolated-bar/other-user.test',
-            'type' => Laravel::id(),
-            'type_data' => [],
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']), [
-            'version' => '22',
-        ])->assertRedirect();
-
-        $otherUserSite->refresh();
-        $this->assertNull($otherUserSite->isolatedUser?->toolingVersion('node'));
-    }
+    return test()->isolatedSite->isolatedUser()->firstOrFail();
 }
+
+test('failed site is forbidden', function () {
+    $this->isolatedSite->update(['status' => SiteStatus::INSTALLATION_FAILED]);
+
+    $this->actingAs($this->user);
+
+    $this->get(route('site-tooling', ['server' => $this->server, 'site' => $this->isolatedSite]))
+        ->assertForbidden();
+
+    $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']), [
+        'version' => '22',
+    ])->assertForbidden();
+});
+
+test('index renders for isolated site', function () {
+    $this->actingAs($this->user);
+
+    $this->get(route('site-tooling', ['server' => $this->server, 'site' => $this->isolatedSite]))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $assert) => $assert
+            ->component('site-tooling/index')
+            ->where('isolated_user', 'isolated-foo')
+            ->has('sibling_sites', 1)
+            ->where('sibling_sites.0.domain', 'iso-two.test')
+            ->where('installed_versions.node', null)
+            ->where('installed_versions.bun', null)
+            ->where('installed_versions.pnpm', null)
+            ->where('installed_versions.yarn', null)
+        );
+});
+
+test('non isolated site is forbidden', function () {
+    $this->actingAs($this->user);
+
+    $this->get(route('site-tooling', ['server' => $this->server, 'site' => $this->site]))
+        ->assertForbidden();
+
+    $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->site, 'tool' => 'node']), [
+        'version' => '22',
+    ])->assertForbidden();
+
+    $this->delete(route('site-tooling.uninstall', ['server' => $this->server, 'site' => $this->site, 'tool' => 'node']))
+        ->assertForbidden();
+});
+
+test('install dispatches and propagates to siblings', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']), [
+        'version' => '24',
+    ])->assertRedirect();
+
+    SSH::assertExecutedContains('mise use -g node@24');
+
+    $iuser = vitoPestFeatureSiteToolingTestIuser();
+    expect($iuser->toolingVersion('node'))->toBe('24');
+    expect($this->sibling->refresh()->isolatedUser?->toolingVersion('node'))->toBe('24');
+});
+
+test('install pnpm works for new tool', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'pnpm']), [
+        'version' => '9',
+    ])->assertRedirect();
+
+    SSH::assertExecutedContains('mise use -g pnpm@9');
+
+    $iuser = vitoPestFeatureSiteToolingTestIuser();
+    expect($iuser->toolingVersion('pnpm'))->toBe('9');
+});
+
+test('uninstall removes tool entry from iuser', function () {
+    SSH::fake();
+
+    vitoPestFeatureSiteToolingTestIuser()->setToolingVersion('node', '22');
+
+    $this->actingAs($this->user);
+
+    $this->delete(route('site-tooling.uninstall', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']))
+        ->assertRedirect();
+
+    SSH::assertExecutedContains('mise unuse -g node');
+    SSH::assertExecutedContains('mise uninstall node --all');
+
+    $iuser = vitoPestFeatureSiteToolingTestIuser();
+    expect($iuser->toolingVersion('node'))->toBeNull();
+    expect($iuser->toolingStatus('node'))->toBeNull();
+    $this->assertArrayNotHasKey('node', $iuser->installed_tooling ?? []);
+});
+
+test('install validation rejects unsupported version', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']), [
+        'version' => '99',
+    ])->assertSessionHasErrors('version');
+
+    expect(vitoPestFeatureSiteToolingTestIuser()->toolingVersion('node'))->toBeNull();
+});
+
+test('unknown tool returns 404', function () {
+    $this->actingAs($this->user);
+
+    $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'rustup']), [
+        'version' => '1',
+    ])->assertNotFound();
+});
+
+test('unauthenticated request is redirected', function () {
+    $this->get(route('site-tooling', ['server' => $this->server, 'site' => $this->isolatedSite]))
+        ->assertRedirect();
+});
+
+test('user from another project is forbidden', function () {
+    $otherUser = User::factory()->create();
+    $otherUser->ensureHasDefaultProject();
+
+    $this->actingAs($otherUser);
+
+    $this->get(route('site-tooling', ['server' => $this->server, 'site' => $this->isolatedSite]))
+        ->assertForbidden();
+});
+
+test('lock runtime versions now covers pnpm and yarn', function () {
+    SSH::fake();
+
+    vitoPestFeatureSiteToolingTestIuser()->setToolingVersion('node', '22');
+
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->actingAs($this->user);
+
+    Http::fake([
+        'https://api.github.com/repos/*' => Http::response([], 200),
+    ]);
+
+    $this->post(route('sites.store', ['server' => $this->server]), [
+        'type' => Laravel::id(),
+        'domain' => 'iso-three.test',
+        'user' => 'isolated-foo',
+        'php_version' => '8.2',
+        'web_directory' => 'public',
+        'repository' => 'organization/repository',
+        'branch' => 'main',
+        'source_control' => $sourceControl->id,
+        'node_version' => '24',
+        'bun_version' => 'none',
+    ])->assertSessionHasErrors('node_version');
+});
+
+test('only sibling sites with mise trait are updated', function () {
+    SSH::fake();
+
+    Site::factory()->create([
+        'server_id' => $this->server->id,
+        'domain' => 'lb.test',
+        'user' => 'isolated-foo',
+        'path' => '/home/isolated-foo/lb.test',
+        'type' => LoadBalancer::id(),
+        'type_data' => [],
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']), [
+        'version' => '22',
+    ])->assertRedirect();
+
+    expect(vitoPestFeatureSiteToolingTestIuser()->toolingVersion('node'))->toBe('22');
+});
+
+test('installing status blocks concurrent install', function () {
+    SSH::fake();
+
+    vitoPestFeatureSiteToolingTestIuser()->setToolingStatus('node', SiteToolingState::STATUS_INSTALLING);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']), [
+        'version' => '24',
+    ])->assertSessionHasErrors('tool');
+});
+
+test('failed install records failed status', function () {
+    $job = new InstallSiteToolingJob($this->isolatedSite, 'node', '24');
+
+    $job->failed(new RuntimeException('boom'));
+
+    $iuser = vitoPestFeatureSiteToolingTestIuser();
+    expect($iuser->toolingStatus('node'))->toBe('install_failed');
+});
+
+test('failed uninstall records failed status', function () {
+    vitoPestFeatureSiteToolingTestIuser()->setToolingVersion('node', '22');
+
+    $job = new UninstallSiteToolingJob($this->isolatedSite, 'node');
+
+    $job->failed(new RuntimeException('boom'));
+
+    $iuser = vitoPestFeatureSiteToolingTestIuser();
+    expect($iuser->toolingStatus('node'))->toBe('uninstall_failed');
+});
+
+test('install marks failed when tool missing from registry', function () {
+    Event::fake([SocketEvent::class]);
+
+    vitoPestFeatureSiteToolingTestIuser()->setToolingStatus('ghost-tool', SiteToolingState::STATUS_INSTALLING);
+
+    dispatch_sync(new InstallSiteToolingJob($this->isolatedSite, 'ghost-tool', '1.0'));
+
+    expect(vitoPestFeatureSiteToolingTestIuser()->toolingStatus('ghost-tool'))->toBe('install_failed');
+
+    Event::assertDispatched(
+        SocketEvent::class,
+        fn (SocketEvent $event) => $event->data->type === 'isolated-user.tooling-updated',
+    );
+});
+
+test('uninstall marks failed when tool missing from registry', function () {
+    Event::fake([SocketEvent::class]);
+
+    vitoPestFeatureSiteToolingTestIuser()->setToolingStatus('ghost-tool', SiteToolingState::STATUS_UNINSTALLING);
+
+    dispatch_sync(new UninstallSiteToolingJob($this->isolatedSite, 'ghost-tool'));
+
+    expect(vitoPestFeatureSiteToolingTestIuser()->toolingStatus('ghost-tool'))->toBe('uninstall_failed');
+
+    Event::assertDispatched(
+        SocketEvent::class,
+        fn (SocketEvent $event) => $event->data->type === 'isolated-user.tooling-updated',
+    );
+});
+
+test('complete install broadcasts tooling updated', function () {
+    Event::fake([SocketEvent::class]);
+
+    SiteToolingState::completeInstall($this->isolatedSite, 'node', '22');
+
+    Event::assertDispatched(
+        SocketEvent::class,
+        fn (SocketEvent $event) => $event->data->type === 'isolated-user.tooling-updated'
+            && $event->data->data['id'] === vitoPestFeatureSiteToolingTestIuser()->id,
+    );
+});
+
+test('complete uninstall broadcasts tooling updated', function () {
+    vitoPestFeatureSiteToolingTestIuser()->setToolingVersion('node', '22');
+
+    Event::fake([SocketEvent::class]);
+
+    SiteToolingState::completeUninstall($this->isolatedSite, 'node');
+
+    Event::assertDispatched(
+        SocketEvent::class,
+        fn (SocketEvent $event) => $event->data->type === 'isolated-user.tooling-updated'
+            && $event->data->data['id'] === vitoPestFeatureSiteToolingTestIuser()->id,
+    );
+});
+
+test('successful install clears status', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']), [
+        'version' => '22',
+    ])->assertRedirect();
+
+    $iuser = vitoPestFeatureSiteToolingTestIuser();
+    expect($iuser->toolingStatus('node'))->toBeNull();
+    expect($iuser->toolingVersion('node'))->toBe('22');
+});
+
+test('setup requested tooling installs each requested tool and strips type data', function () {
+    SSH::fake();
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'domain' => 'iso-three.test',
+        'user' => 'isolated-foo',
+        'path' => '/home/isolated-foo/iso-three.test',
+        'type' => Laravel::id(),
+        'status' => SiteStatus::READY,
+        'type_data' => [
+            'node_version' => '22',
+            'pnpm_version' => '9',
+            'yarn_version' => 'none',
+        ],
+    ]);
+
+    $siteType = new class($site) extends AbstractSiteType
+    {
+        public static function id(): string
+        {
+            return 'test-setup-requested-tooling';
+        }
+
+        public function language(): string
+        {
+            return 'php';
+        }
+
+        public function requiredServices(): array
+        {
+            return [];
+        }
+
+        public function install(): void {}
+
+        public static function make(): self
+        {
+            return new self(new Site);
+        }
+
+        public static function createTimeTools(): array
+        {
+            return ['node', 'pnpm', 'yarn'];
+        }
+
+        public function runSetup(): void
+        {
+            $this->setupRequestedTooling();
+        }
+    };
+
+    $siteType->runSetup();
+
+    $iuser = $site->isolatedUser()->firstOrFail();
+
+    expect($iuser->toolingVersion('node'))->toBe('22');
+    expect($iuser->toolingVersion('pnpm'))->toBe('9');
+    expect($iuser->toolingVersion('yarn'))->toBeNull();
+
+    $site->refresh();
+    $this->assertArrayNotHasKey('node_version', $site->type_data);
+    $this->assertArrayNotHasKey('pnpm_version', $site->type_data);
+});
+
+test('index exposes required tooling from sibling site types', function () {
+    Site::factory()->create([
+        'server_id' => $this->server->id,
+        'domain' => 'iso-node.test',
+        'user' => 'isolated-foo',
+        'path' => '/home/isolated-foo/iso-node.test',
+        'type' => NodeSite::id(),
+        'status' => SiteStatus::READY,
+        'type_data' => [],
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->get(route('site-tooling', ['server' => $this->server, 'site' => $this->isolatedSite]))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $assert) => $assert
+            ->where('required_tooling.node', 'Node.js')
+            ->missing('required_tooling.bun')
+        );
+});
+
+test('uninstall rejected for required tooling', function () {
+    SSH::fake();
+
+    Site::factory()->create([
+        'server_id' => $this->server->id,
+        'domain' => 'iso-node.test',
+        'user' => 'isolated-foo',
+        'path' => '/home/isolated-foo/iso-node.test',
+        'type' => NodeSite::id(),
+        'status' => SiteStatus::READY,
+        'type_data' => [],
+    ]);
+
+    vitoPestFeatureSiteToolingTestIuser()->setToolingVersion('node', '22');
+
+    $this->actingAs($this->user);
+
+    $this->delete(route('site-tooling.uninstall', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']))
+        ->assertSessionHasErrors('tool');
+
+    SSH::assertNotExecutedContains('mise unuse -g node');
+    expect(vitoPestFeatureSiteToolingTestIuser()->toolingVersion('node'))->toBe('22');
+});
+
+test('composer tool is registered', function () {
+    $composer = ToolingRegistry::find('composer');
+
+    expect($composer)->not->toBeNull();
+    expect($composer::commands())->toBe(['composer']);
+    expect($composer::supportedVersions())->toBe(['2']);
+});
+
+test('bootstrap exposes composer descriptor', function () {
+    $this->actingAs($this->user);
+
+    $this->getJson(route('bootstrap.show'))
+        ->assertOk()
+        ->assertJsonPath('configs.tooling', fn (array $tooling): bool => in_array('composer', array_column($tooling, 'id'), true));
+});
+
+test('composer required for php types but not wordpress or phpmyadmin', function () {
+    foreach ([PHPSite::class, Laravel::class, PHPBlank::class] as $type) {
+        expect($type::createTimeTools())->toContain('composer');
+        expect($type::requiredTooling())->toContain('composer');
+    }
+
+    foreach ([Wordpress::class, PHPMyAdmin::class] as $type) {
+        expect($type::createTimeTools())->toBe([]);
+        expect($type::requiredTooling())->toBe([]);
+    }
+});
+
+test('composer installs at latest without a create form picker', function () {
+    $data = (new Laravel(new Site(['type' => Laravel::id()])))->data([]);
+    expect($data['composer_version'])->toBe('2');
+
+    $selector = collect(config('site.types.php.form'))->firstWhere('name', 'package_manager');
+    expect($selector['options'])->not->toContain('composer');
+});
+
+test('php and php blank package manager defaults to none', function () {
+    foreach (['php', 'php-blank'] as $typeId) {
+        $selector = collect(config('site.types.'.$typeId.'.form'))->firstWhere('name', 'package_manager');
+        expect($selector['default'])->toBe('none');
+        expect($selector['options'])->toContain('none');
+    }
+
+    $laravel = collect(config('site.types.laravel.form'))->firstWhere('name', 'package_manager');
+    expect($laravel['default'])->toBe('node');
+    expect($laravel['options'])->not->toContain('none');
+});
+
+test('php with no package manager installs only composer', function () {
+    $data = (new PHPSite(new Site(['type' => 'php'])))->data([]);
+
+    expect($data['node_version'])->toBe('none');
+    expect($data['pnpm_version'])->toBe('none');
+    expect($data['yarn_version'])->toBe('none');
+    expect($data['composer_version'])->toBe('2');
+});
+
+test('tooling selector supports explicit default', function () {
+    $explicit = DynamicField::make('package_manager')->toolingSelector(
+        [NodeTooling::class, PnpmTooling::class, YarnTooling::class],
+        [NodeTooling::class => 'npm'],
+        PnpmTooling::class,
+    )->toArray();
+
+    expect($explicit['type'])->toBe('tooling-selector');
+    expect($explicit['default'])->toBe('pnpm');
+    expect($explicit['optionLabels']['node'])->toBe('npm');
+
+    $implicit = DynamicField::make('package_manager')->toolingSelector(
+        [YarnTooling::class, PnpmTooling::class],
+    )->toArray();
+
+    expect($implicit['default'])->toBe('yarn');
+});
+
+test('laravel package manager drives tooling versions', function () {
+    $type = new Laravel(new Site(['type' => Laravel::id()]));
+
+    $npm = $type->data(['package_manager' => 'node', 'node_version' => '22']);
+    expect($npm['node_version'])->toBe('22');
+    expect($npm['pnpm_version'])->toBe('none');
+    expect($npm['yarn_version'])->toBe('none');
+    expect($npm['composer_version'])->toBe('2');
+
+    $pnpm = $type->data(['package_manager' => 'pnpm', 'pnpm_version' => '9']);
+    expect($pnpm['pnpm_version'])->toBe('9');
+    expect($pnpm['yarn_version'])->toBe('none');
+    expect($pnpm['node_version'])->toBe('none');
+
+    $none = $type->data(['package_manager' => 'none']);
+    expect($none['node_version'])->toBe('none');
+    expect($none['pnpm_version'])->toBe('none');
+    expect($none['yarn_version'])->toBe('none');
+
+    expect(Laravel::createTimeTools())->toBe(['node', 'pnpm', 'yarn', 'composer']);
+});
+
+test('install composer installs locally', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'composer']), [
+        'version' => '2',
+    ])->assertRedirect();
+
+    SSH::assertExecutedContains('composer-setup.php');
+    SSH::assertExecutedContains('.local/vito/bin');
+    SSH::assertExecutedContains('$HOME/.bashrc');
+
+    expect(vitoPestFeatureSiteToolingTestIuser()->toolingVersion('composer'))->toBe('2');
+});
+
+test('uninstall composer removes binary and path activation', function () {
+    SSH::fake();
+
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'domain' => 'node-only.test',
+        'user' => 'isolated-node',
+        'path' => '/home/isolated-node/node-only.test',
+        'type' => NodeSite::id(),
+        'status' => SiteStatus::READY,
+        'type_data' => [],
+    ]);
+
+    $site->isolatedUser()->firstOrFail()->setToolingVersion('composer', '2');
+
+    $this->actingAs($this->user);
+
+    $this->delete(route('site-tooling.uninstall', ['server' => $this->server, 'site' => $site, 'tool' => 'composer']))
+        ->assertRedirect();
+
+    SSH::assertExecutedContains('rm -f "$HOME/.local/vito/bin/composer"');
+    SSH::assertExecutedContains('.bashrc');
+
+    expect($site->isolatedUser()->firstOrFail()->toolingVersion('composer'))->toBeNull();
+});
+
+test('uninstall composer rejected on laravel site', function () {
+    SSH::fake();
+
+    vitoPestFeatureSiteToolingTestIuser()->setToolingVersion('composer', '2');
+
+    $this->actingAs($this->user);
+
+    $this->delete(route('site-tooling.uninstall', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'composer']))
+        ->assertSessionHasErrors('tool');
+
+    SSH::assertNotExecutedContains('.local/vito/bin/composer');
+    expect(vitoPestFeatureSiteToolingTestIuser()->toolingVersion('composer'))->toBe('2');
+});
+
+test('other user sites are not touched', function () {
+    SSH::fake();
+
+    $otherUserSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'domain' => 'other-user.test',
+        'user' => 'isolated-bar',
+        'path' => '/home/isolated-bar/other-user.test',
+        'type' => Laravel::id(),
+        'type_data' => [],
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('site-tooling.install', ['server' => $this->server, 'site' => $this->isolatedSite, 'tool' => 'node']), [
+        'version' => '22',
+    ])->assertRedirect();
+
+    $otherUserSite->refresh();
+    expect($otherUserSite->isolatedUser?->toolingVersion('node'))->toBeNull();
+});

--- a/tests/Feature/SitesTest.php
+++ b/tests/Feature/SitesTest.php
@@ -441,9 +441,10 @@ test('change php version', function () {
 
     $site = Site::factory()->create([
         'server_id' => $this->server->id,
+        'php_version' => '8.3',
     ]);
 
-    $this->delete(route('site-settings.update-php-version', [
+    $this->patch(route('site-settings.update-php-version', [
         'server' => $this->server->id,
         'site' => $site->id,
     ]), [
@@ -772,10 +773,7 @@ test('create site rejects directory traversal', function () {
     ]);
 });
 
-/**
- * @return array<array<int, mixed>>
- */
-dataset('failure_create_data', function () {
+dataset('failure_create_data', /** @return array<int, array{0: array<string, mixed>}> */ function (): array {
     return [
         [
             [
@@ -852,17 +850,11 @@ dataset('failure_create_data', function () {
     ];
 });
 
-/**
- * @return array<array<array<string, mixed>>>
- */
-dataset('create_data', function () {
+dataset('create_data', /** @return array<int, array{0: array<string, mixed>}> */ function (): array {
     return vitoPestSiteCreateData();
 });
 
-/**
- * @return array<array<int>>
- */
-dataset('create_failure_data', function () {
+dataset('create_failure_data', /** @return array<int, array{0: int}> */ function (): array {
     return [
         [401],
         [403],

--- a/tests/Feature/SitesTest.php
+++ b/tests/Feature/SitesTest.php
@@ -1,8 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
-use App\Enums\LoadBalancerMethod;
 use App\Enums\ServiceStatus;
 use App\Enums\SiteStatus;
 use App\Facades\SSH;
@@ -12,1028 +9,863 @@ use App\Models\Service;
 use App\Models\Site;
 use App\Models\SourceControl;
 use App\SiteTypes\Blank;
-use App\SiteTypes\BunSite;
 use App\SiteTypes\Laravel;
-use App\SiteTypes\LoadBalancer;
-use App\SiteTypes\NodeSite;
 use App\SiteTypes\PHPBlank;
-use App\SiteTypes\PHPMyAdmin;
-use App\SiteTypes\Wordpress;
 use App\SourceControlProviders\Github;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Inertia\Testing\AssertableInertia;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class SitesTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    /**
-     * @param  array<string, mixed>  $inputs
-     */
-    #[DataProvider('create_data')]
-    public function test_create_site(array $inputs): void
-    {
-        SSH::fake();
+test('create site', function (array $inputs) {
+    SSH::fake();
 
-        Http::fake([
-            'https://api.github.com/repos/*' => Http::response([
-            ], 201),
-        ]);
+    Http::fake([
+        'https://api.github.com/repos/*' => Http::response([
+        ], 201),
+    ]);
 
-        if (isset($inputs['database']) && isset($inputs['database_user'])) {
-            /** @var Database $database */
-            $database = Database::factory()->create([
-                'server_id' => $this->server->id,
-            ]);
-            /** @var DatabaseUser $databaseUser */
-            $databaseUser = DatabaseUser::factory()->create([
-                'server_id' => $this->server->id,
-            ]);
-            $inputs['database'] = $database->id;
-            $inputs['database_user'] = $databaseUser->id;
-        }
-
-        $this->actingAs($this->user);
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Github::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $inputs['source_control'] = $sourceControl->id;
-
-        $this->post(route('sites.store', ['server' => $this->server]), $inputs)
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('sites', [
-            'domain' => $inputs['domain'],
-            'status' => SiteStatus::READY->value,
-            'user' => $inputs['user'],
-            'path' => '/home/'.$inputs['user'].'/'.$inputs['domain'],
-        ]);
-    }
-
-    /**
-     * @param  array<string, mixed>  $inputs
-     */
-    #[DataProvider('failure_create_data')]
-    public function test_isolated_user_failure(array $inputs): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->post(route('sites.store', ['server' => $this->server]), $inputs)
-            ->assertSessionHasErrors();
-    }
-
-    public function test_create_site_reusing_existing_isolated_user(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'shared',
-            'domain' => 'first.example.com',
-            'path' => '/home/shared/first.example.com',
-            'php_version' => '8.2',
-        ]);
-
-        $this->post(route('sites.store', ['server' => $this->server]), [
-            'type' => PHPBlank::id(),
-            'domain' => 'second.example.com',
-            'aliases' => [],
-            'php_version' => '8.2',
-            'web_directory' => 'public',
-            'user' => 'shared',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('sites', [
-            'domain' => 'first.example.com',
-            'user' => 'shared',
-        ]);
-        $this->assertDatabaseHas('sites', [
-            'domain' => 'second.example.com',
-            'user' => 'shared',
-            'path' => '/home/shared/second.example.com',
-        ]);
-
-        SSH::assertExecutedContains('User shared already exists');
-    }
-
-    public function test_isolated_users_endpoint_lists_users_with_counts(): void
-    {
-        $this->actingAs($this->user);
-
-        Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'shop',
-            'domain' => 'shop1.test',
-            'path' => '/home/shop/shop1.test',
-        ]);
-        Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'shop',
-            'domain' => 'shop2.test',
-            'path' => '/home/shop/shop2.test',
-        ]);
-        Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'blog',
-            'domain' => 'blog.test',
-            'path' => '/home/blog/blog.test',
-        ]);
-
-        $response = $this->getJson(route('sites.isolated-users', ['server' => $this->server]));
-
-        $response->assertSuccessful();
-        $data = collect($response->json())->keyBy('user');
-
-        $this->assertSame(2, $data['shop']['sites_count']);
-        $this->assertSame(1, $data['blog']['sites_count']);
-        $this->assertArrayNotHasKey('vito', $data->all());
-    }
-
-    public function test_delete_site_keeps_isolated_user_when_others_share_it(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $siteA = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'shared',
-            'domain' => 'a.test',
-            'path' => '/home/shared/a.test',
-            'php_version' => '8.2',
-        ]);
-        Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'shared',
-            'domain' => 'b.test',
-            'path' => '/home/shared/b.test',
-            'php_version' => '8.2',
-        ]);
-
-        $this->delete(route('site-settings.destroy', [
-            'server' => $this->server->id,
-            'site' => $siteA->id,
-        ]), [
-            'domain' => $siteA->domain,
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('sites', ['id' => $siteA->id]);
-        $this->assertDatabaseHas('sites', ['domain' => 'b.test', 'user' => 'shared']);
-
-        SSH::assertNotExecutedContains('userdel');
-    }
-
-    public function test_delete_last_isolated_site_removes_user(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'lonely',
-            'domain' => 'lonely.test',
-            'path' => '/home/lonely/lonely.test',
-            'php_version' => '8.2',
-        ]);
-
-        $this->delete(route('site-settings.destroy', [
-            'server' => $this->server->id,
-            'site' => $site->id,
-        ]), [
-            'domain' => $site->domain,
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('sites', ['id' => $site->id]);
-
-        SSH::assertExecutedContains('userdel');
-    }
-
-    public function test_php_version_switch_removes_old_pool_when_not_shared(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        Service::query()->create([
-            'server_id' => $this->server->id,
-            'type' => 'php',
-            'name' => 'php',
-            'version' => '8.4',
-            'status' => ServiceStatus::READY,
-        ]);
-
-        Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'shared',
-            'domain' => 'a.test',
-            'path' => '/home/shared/a.test',
-            'php_version' => '8.2',
-        ]);
-        $siteB = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'shared',
-            'domain' => 'b.test',
-            'path' => '/home/shared/b.test',
-            'php_version' => '8.4',
-        ]);
-
-        $this->patch(route('site-settings.update-php-version', [
-            'server' => $this->server->id,
-            'site' => $siteB->id,
-        ]), [
-            'version' => '8.2',
-        ])->assertSessionDoesntHaveErrors();
-
-        $siteB->refresh();
-        $this->assertSame('8.2', $siteB->php_version);
-
-        SSH::assertExecutedContains('rm -f /etc/php/8.4/fpm/pool.d/shared.conf');
-    }
-
-    public function test_php_version_switch_preserves_shared_old_pool(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        Service::query()->create([
-            'server_id' => $this->server->id,
-            'type' => 'php',
-            'name' => 'php',
-            'version' => '8.4',
-            'status' => ServiceStatus::READY,
-        ]);
-
-        Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'shared',
-            'domain' => 'a.test',
-            'path' => '/home/shared/a.test',
-            'php_version' => '8.2',
-        ]);
-        $siteB = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'shared',
-            'domain' => 'b.test',
-            'path' => '/home/shared/b.test',
-            'php_version' => '8.2',
-        ]);
-
-        $this->patch(route('site-settings.update-php-version', [
-            'server' => $this->server->id,
-            'site' => $siteB->id,
-        ]), [
-            'version' => '8.4',
-        ])->assertSessionDoesntHaveErrors();
-
-        $siteB->refresh();
-        $this->assertSame('8.4', $siteB->php_version);
-
-        SSH::assertNotExecutedContains('rm -f /etc/php/8.2/fpm/pool.d/shared.conf');
-    }
-
-    #[DataProvider('create_failure_data')]
-    public function test_create_site_failed_due_to_source_control(int $status): void
-    {
-        $inputs = [
-            'type' => Laravel::id(),
-            'domain' => 'example.com',
-            'php_version' => '8.2',
-            'web_directory' => 'public',
-            'repository' => 'test/test',
-            'branch' => 'main',
-            'composer' => true,
-            'user' => 'example',
-        ];
-
-        SSH::fake();
-
-        Http::fake([
-            'https://api.github.com/repos/*' => Http::response([
-            ], $status),
-        ]);
-
-        $this->actingAs($this->user);
-
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Github::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $inputs['source_control'] = $sourceControl->id;
-
-        $this->post(route('sites.store', ['server' => $this->server]), $inputs)
-            ->assertSessionHasErrors();
-
-        $this->assertDatabaseMissing('sites', [
-            'domain' => 'example.com',
-            'status' => SiteStatus::READY,
-        ]);
-    }
-
-    public function test_create_blank_site_without_source_control(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('sites.store', ['server' => $this->server]), [
-            'type' => Blank::id(),
-            'domain' => 'blank-example.com',
-            'port' => '3000',
-            'user' => 'blanktest',
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('sites', [
-            'domain' => 'blank-example.com',
-            'status' => SiteStatus::READY->value,
-            'user' => 'blanktest',
-            'source_control_id' => null,
-        ]);
-    }
-
-    public function test_create_blank_site_with_source_control_requires_repository(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Github::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->post(route('sites.store', ['server' => $this->server]), [
-            'type' => Blank::id(),
-            'domain' => 'blank-sc.com',
-            'port' => '3000',
-            'user' => 'blanksc',
-            'use_source_control' => true,
-            'source_control' => $sourceControl->id,
-        ])->assertSessionHasErrors(['repository', 'branch']);
-    }
-
-    public function test_create_laravel_site_dispatches_ensure_env_script(): void
-    {
-        SSH::fake();
-        Http::fake([
-            'https://api.github.com/repos/*' => Http::response([], 201),
-        ]);
-
-        $this->actingAs($this->user);
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Github::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->post(route('sites.store', ['server' => $this->server]), [
-            'type' => Laravel::id(),
-            'domain' => 'env-example.com',
-            'php_version' => '8.2',
-            'web_directory' => 'public',
-            'repository' => 'test/test',
-            'branch' => 'main',
-            'composer' => false,
-            'node_version' => 'none',
-            'user' => 'envtest',
-            'source_control' => $sourceControl->id,
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('sites', [
-            'domain' => 'env-example.com',
-            'status' => SiteStatus::READY->value,
-            'user' => 'envtest',
-            'path' => '/home/envtest/env-example.com',
-        ]);
-
-        $envPath = '/home/envtest/env-example.com/.env';
-        $examplePath = '/home/envtest/env-example.com/.env.example';
-
-        SSH::assertExecutedContains("[ -f '{$envPath}' ]");
-        SSH::assertExecutedContains("cp -- '{$examplePath}' '{$envPath}'");
-        SSH::assertExecutedContains("touch -- '{$envPath}'");
-        SSH::assertExecutedContains("chmod 640 -- '{$envPath}'");
-    }
-
-    public function test_see_sites_list(): void
-    {
-        $this->actingAs($this->user);
-
-        Site::factory()->create([
+    if (isset($inputs['database']) && isset($inputs['database_user'])) {
+        /** @var Database $database */
+        $database = Database::factory()->create([
             'server_id' => $this->server->id,
         ]);
-
-        $this->get(route('sites', [
-            'server' => $this->server,
-        ]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/index'));
-    }
-
-    public function test_delete_site(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $site = Site::factory()->create([
+        /** @var DatabaseUser $databaseUser */
+        $databaseUser = DatabaseUser::factory()->create([
             'server_id' => $this->server->id,
         ]);
-
-        $this->delete(route('site-settings.destroy', [
-            'server' => $this->server->id,
-            'site' => $site->id,
-        ]), [
-            'domain' => $site->domain,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('sites', [
-            'id' => $site->id,
-        ]);
+        $inputs['database'] = $database->id;
+        $inputs['database_user'] = $databaseUser->id;
     }
 
-    public function test_change_php_version(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->delete(route('site-settings.update-php-version', [
-            'server' => $this->server->id,
-            'site' => $site->id,
-        ]), [
-            'version' => '8.2',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $site->refresh();
-
-        $this->assertEquals('8.2', $site->php_version);
-    }
-
-    public function test_update_source_control(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        Http::fake([
-            'https://api.github.com/repos/*' => Http::response([
-            ], 201),
-        ]);
-
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Github::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->patch(route('site-settings.update-source-control', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'source_control' => $sourceControl->id,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->site->refresh();
-
-        $this->assertEquals($sourceControl->id, $this->site->source_control_id);
-    }
-
-    public function test_failed_to_update_source_control(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        Http::fake([
-            'https://api.github.com/repos/*' => Http::response([
-            ], 404),
-        ]);
-
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Github::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->patch(route('site-settings.update-source-control', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'source_control' => $sourceControl->id,
-        ])
-            ->assertSessionHasErrors();
-    }
-
-    public function test_update_v_host(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->patch(route('site-settings.update-vhost', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'vhost' => 'test',
-        ])
-            ->assertSessionDoesntHaveErrors();
-    }
-
-    public function test_see_logs(): void
-    {
-        $this->actingAs($this->user);
-
-        $this->get(route('sites.logs', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/logs'));
-    }
-
-    public function test_change_branch(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->patch(route('site-settings.update-branch', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'branch' => 'master',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->site->refresh();
-        $this->assertEquals('master', $this->site->branch);
-
-        SSH::assertExecutedContains("git checkout -f 'master'");
-    }
-
-    public function test_update_web_directory(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->patch(route('site-settings.update-web-directory', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'web_directory' => 'public',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->site->refresh();
-        $this->assertEquals('public', $this->site->web_directory);
-    }
-
-    public function test_update_web_directory_empty(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->patch(route('site-settings.update-web-directory', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'web_directory' => '',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->site->refresh();
-        $this->assertNull($this->site->web_directory);
-    }
-
-    public function test_update_web_directory_normalizes_slashes(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->patch(route('site-settings.update-web-directory', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'web_directory' => '/public/dist/',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->site->refresh();
-        $this->assertEquals('public/dist', $this->site->web_directory);
-    }
-
-    public function test_update_web_directory_normalizes_root(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->patch(route('site-settings.update-web-directory', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'web_directory' => '/',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->site->refresh();
-        $this->assertNull($this->site->web_directory);
-    }
-
-    public function test_update_web_directory_rejects_invalid_characters(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->patch(route('site-settings.update-web-directory', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'web_directory' => 'public@invalid!',
-        ])
-            ->assertSessionHasErrors(['web_directory']);
-    }
-
-    public function test_update_web_directory_rejects_directory_traversal(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->patch(route('site-settings.update-web-directory', [
-            'server' => $this->server->id,
-            'site' => $this->site,
-        ]), [
-            'web_directory' => '../etc/passwd',
-        ])
-            ->assertSessionHasErrors(['web_directory']);
-    }
-
-    public function test_create_site_with_valid_web_directory(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('sites.store', ['server' => $this->server]), [
-            'type' => PHPBlank::id(),
-            'domain' => 'example.com',
-            'php_version' => '8.2',
-            'web_directory' => 'public/dist',
-            'user' => 'example',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('sites', [
-            'domain' => 'example.com',
-            'web_directory' => 'public/dist',
-        ]);
-    }
-
-    public function test_create_site_with_special_characters_web_directory(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('sites.store', ['server' => $this->server]), [
-            'type' => PHPBlank::id(),
-            'domain' => 'example.com',
-            'php_version' => '8.2',
-            'web_directory' => 'public-dist_v1.0',
-            'user' => 'example',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('sites', [
-            'domain' => 'example.com',
-            'web_directory' => 'public-dist_v1.0',
-        ]);
-    }
-
-    public function test_create_site_normalizes_web_directory_slashes(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('sites.store', ['server' => $this->server]), [
-            'type' => PHPBlank::id(),
-            'domain' => 'example.com',
-            'php_version' => '8.2',
-            'web_directory' => '/public/',
-            'user' => 'example',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('sites', [
-            'domain' => 'example.com',
-            'web_directory' => 'public',
-        ]);
-    }
-
-    public function test_create_site_normalizes_root_web_directory(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('sites.store', ['server' => $this->server]), [
-            'type' => PHPBlank::id(),
-            'domain' => 'example.com',
-            'php_version' => '8.2',
-            'web_directory' => '/',
-            'user' => 'example',
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('sites', [
-            'domain' => 'example.com',
-            'web_directory' => null,
-        ]);
-    }
-
-    public function test_create_site_rejects_invalid_web_directory_characters(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('sites.store', ['server' => $this->server]), [
-            'type' => PHPBlank::id(),
-            'domain' => 'example.com',
-            'php_version' => '8.2',
-            'web_directory' => 'public@invalid!',
-            'user' => 'example',
-        ])
-            ->assertSessionHasErrors(['web_directory']);
-
-        $this->assertDatabaseMissing('sites', [
-            'domain' => 'example.com',
-        ]);
-    }
-
-    public function test_create_site_rejects_directory_traversal(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('sites.store', ['server' => $this->server]), [
-            'type' => PHPBlank::id(),
-            'domain' => 'example.com',
-            'php_version' => '8.2',
-            'web_directory' => '../etc/passwd',
-            'user' => 'example',
-        ])
-            ->assertSessionHasErrors(['web_directory']);
-
-        $this->assertDatabaseMissing('sites', [
-            'domain' => 'example.com',
-        ]);
-    }
-
-    /**
-     * @return array<array<int, mixed>>
-     */
-    public static function failure_create_data(): array
-    {
-        return [
+    $this->actingAs($this->user);
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    $inputs['source_control'] = $sourceControl->id;
+
+    $this->post(route('sites.store', ['server' => $this->server]), $inputs)
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('sites', [
+        'domain' => $inputs['domain'],
+        'status' => SiteStatus::READY->value,
+        'user' => $inputs['user'],
+        'path' => '/home/'.$inputs['user'].'/'.$inputs['domain'],
+    ]);
+})->with('create_data');
+
+test('isolated user failure', function (array $inputs) {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->post(route('sites.store', ['server' => $this->server]), $inputs)
+        ->assertSessionHasErrors();
+})->with('failure_create_data');
+
+test('create site reusing existing isolated user', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'shared',
+        'domain' => 'first.example.com',
+        'path' => '/home/shared/first.example.com',
+        'php_version' => '8.2',
+    ]);
+
+    $this->post(route('sites.store', ['server' => $this->server]), [
+        'type' => PHPBlank::id(),
+        'domain' => 'second.example.com',
+        'aliases' => [],
+        'php_version' => '8.2',
+        'web_directory' => 'public',
+        'user' => 'shared',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('sites', [
+        'domain' => 'first.example.com',
+        'user' => 'shared',
+    ]);
+    $this->assertDatabaseHas('sites', [
+        'domain' => 'second.example.com',
+        'user' => 'shared',
+        'path' => '/home/shared/second.example.com',
+    ]);
+
+    SSH::assertExecutedContains('User shared already exists');
+});
+
+test('isolated users endpoint lists users with counts', function () {
+    $this->actingAs($this->user);
+
+    Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'shop',
+        'domain' => 'shop1.test',
+        'path' => '/home/shop/shop1.test',
+    ]);
+    Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'shop',
+        'domain' => 'shop2.test',
+        'path' => '/home/shop/shop2.test',
+    ]);
+    Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'blog',
+        'domain' => 'blog.test',
+        'path' => '/home/blog/blog.test',
+    ]);
+
+    $response = $this->getJson(route('sites.isolated-users', ['server' => $this->server]));
+
+    $response->assertSuccessful();
+    $data = collect($response->json())->keyBy('user');
+
+    expect($data['shop']['sites_count'])->toBe(2);
+    expect($data['blog']['sites_count'])->toBe(1);
+    $this->assertArrayNotHasKey('vito', $data->all());
+});
+
+test('delete site keeps isolated user when others share it', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $siteA = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'shared',
+        'domain' => 'a.test',
+        'path' => '/home/shared/a.test',
+        'php_version' => '8.2',
+    ]);
+    Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'shared',
+        'domain' => 'b.test',
+        'path' => '/home/shared/b.test',
+        'php_version' => '8.2',
+    ]);
+
+    $this->delete(route('site-settings.destroy', [
+        'server' => $this->server->id,
+        'site' => $siteA->id,
+    ]), [
+        'domain' => $siteA->domain,
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseMissing('sites', ['id' => $siteA->id]);
+    $this->assertDatabaseHas('sites', ['domain' => 'b.test', 'user' => 'shared']);
+
+    SSH::assertNotExecutedContains('userdel');
+});
+
+test('delete last isolated site removes user', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'lonely',
+        'domain' => 'lonely.test',
+        'path' => '/home/lonely/lonely.test',
+        'php_version' => '8.2',
+    ]);
+
+    $this->delete(route('site-settings.destroy', [
+        'server' => $this->server->id,
+        'site' => $site->id,
+    ]), [
+        'domain' => $site->domain,
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseMissing('sites', ['id' => $site->id]);
+
+    SSH::assertExecutedContains('userdel');
+});
+
+test('php version switch removes old pool when not shared', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    Service::query()->create([
+        'server_id' => $this->server->id,
+        'type' => 'php',
+        'name' => 'php',
+        'version' => '8.4',
+        'status' => ServiceStatus::READY,
+    ]);
+
+    Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'shared',
+        'domain' => 'a.test',
+        'path' => '/home/shared/a.test',
+        'php_version' => '8.2',
+    ]);
+    $siteB = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'shared',
+        'domain' => 'b.test',
+        'path' => '/home/shared/b.test',
+        'php_version' => '8.4',
+    ]);
+
+    $this->patch(route('site-settings.update-php-version', [
+        'server' => $this->server->id,
+        'site' => $siteB->id,
+    ]), [
+        'version' => '8.2',
+    ])->assertSessionDoesntHaveErrors();
+
+    $siteB->refresh();
+    expect($siteB->php_version)->toBe('8.2');
+
+    SSH::assertExecutedContains('rm -f /etc/php/8.4/fpm/pool.d/shared.conf');
+});
+
+test('php version switch preserves shared old pool', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    Service::query()->create([
+        'server_id' => $this->server->id,
+        'type' => 'php',
+        'name' => 'php',
+        'version' => '8.4',
+        'status' => ServiceStatus::READY,
+    ]);
+
+    Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'shared',
+        'domain' => 'a.test',
+        'path' => '/home/shared/a.test',
+        'php_version' => '8.2',
+    ]);
+    $siteB = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'shared',
+        'domain' => 'b.test',
+        'path' => '/home/shared/b.test',
+        'php_version' => '8.2',
+    ]);
+
+    $this->patch(route('site-settings.update-php-version', [
+        'server' => $this->server->id,
+        'site' => $siteB->id,
+    ]), [
+        'version' => '8.4',
+    ])->assertSessionDoesntHaveErrors();
+
+    $siteB->refresh();
+    expect($siteB->php_version)->toBe('8.4');
+
+    SSH::assertNotExecutedContains('rm -f /etc/php/8.2/fpm/pool.d/shared.conf');
+});
+
+test('create site failed due to source control', function (int $status) {
+    $inputs = [
+        'type' => Laravel::id(),
+        'domain' => 'example.com',
+        'php_version' => '8.2',
+        'web_directory' => 'public',
+        'repository' => 'test/test',
+        'branch' => 'main',
+        'composer' => true,
+        'user' => 'example',
+    ];
+
+    SSH::fake();
+
+    Http::fake([
+        'https://api.github.com/repos/*' => Http::response([
+        ], $status),
+    ]);
+
+    $this->actingAs($this->user);
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    $inputs['source_control'] = $sourceControl->id;
+
+    $this->post(route('sites.store', ['server' => $this->server]), $inputs)
+        ->assertSessionHasErrors();
+
+    $this->assertDatabaseMissing('sites', [
+        'domain' => 'example.com',
+        'status' => SiteStatus::READY,
+    ]);
+})->with('create_failure_data');
+
+test('create blank site without source control', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('sites.store', ['server' => $this->server]), [
+        'type' => Blank::id(),
+        'domain' => 'blank-example.com',
+        'port' => '3000',
+        'user' => 'blanktest',
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('sites', [
+        'domain' => 'blank-example.com',
+        'status' => SiteStatus::READY->value,
+        'user' => 'blanktest',
+        'source_control_id' => null,
+    ]);
+});
+
+test('create blank site with source control requires repository', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->post(route('sites.store', ['server' => $this->server]), [
+        'type' => Blank::id(),
+        'domain' => 'blank-sc.com',
+        'port' => '3000',
+        'user' => 'blanksc',
+        'use_source_control' => true,
+        'source_control' => $sourceControl->id,
+    ])->assertSessionHasErrors(['repository', 'branch']);
+});
+
+test('create laravel site dispatches ensure env script', function () {
+    SSH::fake();
+    Http::fake([
+        'https://api.github.com/repos/*' => Http::response([], 201),
+    ]);
+
+    $this->actingAs($this->user);
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->post(route('sites.store', ['server' => $this->server]), [
+        'type' => Laravel::id(),
+        'domain' => 'env-example.com',
+        'php_version' => '8.2',
+        'web_directory' => 'public',
+        'repository' => 'test/test',
+        'branch' => 'main',
+        'composer' => false,
+        'node_version' => 'none',
+        'user' => 'envtest',
+        'source_control' => $sourceControl->id,
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('sites', [
+        'domain' => 'env-example.com',
+        'status' => SiteStatus::READY->value,
+        'user' => 'envtest',
+        'path' => '/home/envtest/env-example.com',
+    ]);
+
+    $envPath = '/home/envtest/env-example.com/.env';
+    $examplePath = '/home/envtest/env-example.com/.env.example';
+
+    SSH::assertExecutedContains("[ -f '{$envPath}' ]");
+    SSH::assertExecutedContains("cp -- '{$examplePath}' '{$envPath}'");
+    SSH::assertExecutedContains("touch -- '{$envPath}'");
+    SSH::assertExecutedContains("chmod 640 -- '{$envPath}'");
+});
+
+test('see sites list', function () {
+    $this->actingAs($this->user);
+
+    Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->get(route('sites', [
+        'server' => $this->server,
+    ]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/index'));
+});
+
+test('delete site', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->delete(route('site-settings.destroy', [
+        'server' => $this->server->id,
+        'site' => $site->id,
+    ]), [
+        'domain' => $site->domain,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseMissing('sites', [
+        'id' => $site->id,
+    ]);
+});
+
+test('change php version', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->delete(route('site-settings.update-php-version', [
+        'server' => $this->server->id,
+        'site' => $site->id,
+    ]), [
+        'version' => '8.2',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $site->refresh();
+
+    expect($site->php_version)->toEqual('8.2');
+});
+
+test('update source control', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    Http::fake([
+        'https://api.github.com/repos/*' => Http::response([
+        ], 201),
+    ]);
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->patch(route('site-settings.update-source-control', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'source_control' => $sourceControl->id,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+
+    expect($this->site->source_control_id)->toEqual($sourceControl->id);
+});
+
+test('failed to update source control', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    Http::fake([
+        'https://api.github.com/repos/*' => Http::response([
+        ], 404),
+    ]);
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->patch(route('site-settings.update-source-control', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'source_control' => $sourceControl->id,
+    ])
+        ->assertSessionHasErrors();
+});
+
+test('update v host', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->patch(route('site-settings.update-vhost', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'vhost' => 'test',
+    ])
+        ->assertSessionDoesntHaveErrors();
+});
+
+test('see logs', function () {
+    $this->actingAs($this->user);
+
+    $this->get(route('sites.logs', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/logs'));
+});
+
+test('change branch', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->patch(route('site-settings.update-branch', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'branch' => 'master',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+    expect($this->site->branch)->toEqual('master');
+
+    SSH::assertExecutedContains("git checkout -f 'master'");
+});
+
+test('update web directory', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->patch(route('site-settings.update-web-directory', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'web_directory' => 'public',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+    expect($this->site->web_directory)->toEqual('public');
+});
+
+test('update web directory empty', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->patch(route('site-settings.update-web-directory', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'web_directory' => '',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+    expect($this->site->web_directory)->toBeNull();
+});
+
+test('update web directory normalizes slashes', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->patch(route('site-settings.update-web-directory', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'web_directory' => '/public/dist/',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+    expect($this->site->web_directory)->toEqual('public/dist');
+});
+
+test('update web directory normalizes root', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->patch(route('site-settings.update-web-directory', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'web_directory' => '/',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+    expect($this->site->web_directory)->toBeNull();
+});
+
+test('update web directory rejects invalid characters', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->patch(route('site-settings.update-web-directory', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'web_directory' => 'public@invalid!',
+    ])
+        ->assertSessionHasErrors(['web_directory']);
+});
+
+test('update web directory rejects directory traversal', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->patch(route('site-settings.update-web-directory', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'web_directory' => '../etc/passwd',
+    ])
+        ->assertSessionHasErrors(['web_directory']);
+});
+
+test('create site with valid web directory', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('sites.store', ['server' => $this->server]), [
+        'type' => PHPBlank::id(),
+        'domain' => 'example.com',
+        'php_version' => '8.2',
+        'web_directory' => 'public/dist',
+        'user' => 'example',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('sites', [
+        'domain' => 'example.com',
+        'web_directory' => 'public/dist',
+    ]);
+});
+
+test('create site with special characters web directory', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('sites.store', ['server' => $this->server]), [
+        'type' => PHPBlank::id(),
+        'domain' => 'example.com',
+        'php_version' => '8.2',
+        'web_directory' => 'public-dist_v1.0',
+        'user' => 'example',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('sites', [
+        'domain' => 'example.com',
+        'web_directory' => 'public-dist_v1.0',
+    ]);
+});
+
+test('create site normalizes web directory slashes', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('sites.store', ['server' => $this->server]), [
+        'type' => PHPBlank::id(),
+        'domain' => 'example.com',
+        'php_version' => '8.2',
+        'web_directory' => '/public/',
+        'user' => 'example',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('sites', [
+        'domain' => 'example.com',
+        'web_directory' => 'public',
+    ]);
+});
+
+test('create site normalizes root web directory', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('sites.store', ['server' => $this->server]), [
+        'type' => PHPBlank::id(),
+        'domain' => 'example.com',
+        'php_version' => '8.2',
+        'web_directory' => '/',
+        'user' => 'example',
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('sites', [
+        'domain' => 'example.com',
+        'web_directory' => null,
+    ]);
+});
+
+test('create site rejects invalid web directory characters', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('sites.store', ['server' => $this->server]), [
+        'type' => PHPBlank::id(),
+        'domain' => 'example.com',
+        'php_version' => '8.2',
+        'web_directory' => 'public@invalid!',
+        'user' => 'example',
+    ])
+        ->assertSessionHasErrors(['web_directory']);
+
+    $this->assertDatabaseMissing('sites', [
+        'domain' => 'example.com',
+    ]);
+});
+
+test('create site rejects directory traversal', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('sites.store', ['server' => $this->server]), [
+        'type' => PHPBlank::id(),
+        'domain' => 'example.com',
+        'php_version' => '8.2',
+        'web_directory' => '../etc/passwd',
+        'user' => 'example',
+    ])
+        ->assertSessionHasErrors(['web_directory']);
+
+    $this->assertDatabaseMissing('sites', [
+        'domain' => 'example.com',
+    ]);
+});
+
+/**
+ * @return array<array<int, mixed>>
+ */
+dataset('failure_create_data', function () {
+    return [
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'a',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'a',
             ],
+        ],
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'root',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'root',
             ],
+        ],
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'vito',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'vito',
             ],
+        ],
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => '123',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => '123',
             ],
+        ],
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'qwertyuiopasdfghjklzxcvbnmqwertyu',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'qwertyuiopasdfghjklzxcvbnmqwertyu',
             ],
+        ],
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'www-data',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'www-data',
             ],
+        ],
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'mysql',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'mysql',
             ],
+        ],
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'ubuntu',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'ubuntu',
             ],
-        ];
-    }
+        ],
+    ];
+});
 
-    /**
-     * @return array<array<array<string, mixed>>>
-     */
-    public static function create_data(): array
-    {
-        return [
-            [
-                [
-                    'type' => Laravel::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'repository' => 'test/test',
-                    'branch' => 'main',
-                    'composer' => true,
-                    'node_version' => 'none',
-                    'user' => 'example',
-                ],
-            ],
-            [
-                [
-                    'type' => Wordpress::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'title' => 'Example',
-                    'username' => 'example',
-                    'email' => 'email@example.com',
-                    'password' => 'password',
-                    'database' => '1',
-                    'database_user' => '1',
-                    'user' => 'example',
-                ],
-            ],
-            [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'example',
-                ],
-            ],
-            [
-                [
-                    'type' => PHPMyAdmin::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'version' => '5.1.2',
-                    'user' => 'example',
-                ],
-            ],
-            [
-                [
-                    'type' => LoadBalancer::id(),
-                    'domain' => 'example.com',
-                    'user' => 'example',
-                    'method' => LoadBalancerMethod::ROUND_ROBIN->value,
-                ],
-            ],
-            [
-                [
-                    'type' => NodeSite::id(),
-                    'domain' => 'example.com',
-                    'node_version' => '23',
-                    'package_manager' => 'node',
-                    'port' => '3000',
-                    'repository' => 'test/test',
-                    'branch' => 'main',
-                    'user' => 'example',
-                ],
-            ],
-            [
-                [
-                    'type' => NodeSite::id(),
-                    'domain' => 'example.com',
-                    'node_version' => '22',
-                    'package_manager' => 'yarn',
-                    'yarn_version' => '4',
-                    'port' => '3000',
-                    'repository' => 'test/test',
-                    'branch' => 'main',
-                    'user' => 'example',
-                ],
-            ],
-            [
-                [
-                    'type' => NodeSite::id(),
-                    'domain' => 'example.com',
-                    'node_version' => '22',
-                    'package_manager' => 'pnpm',
-                    'pnpm_version' => '9',
-                    'port' => '3000',
-                    'repository' => 'test/test',
-                    'branch' => 'main',
-                    'user' => 'example',
-                ],
-            ],
-            [
-                [
-                    'type' => BunSite::id(),
-                    'domain' => 'example.com',
-                    'bun_version' => '1.2',
-                    'port' => '3000',
-                    'repository' => 'test/test',
-                    'branch' => 'main',
-                    'user' => 'example',
-                ],
-            ],
-            [
-                [
-                    'type' => BunSite::id(),
-                    'domain' => 'example.com',
-                    'bun_version' => '1.1',
-                    'port' => '3000',
-                    'repository' => 'test/test',
-                    'branch' => 'main',
-                    'user' => 'example',
-                ],
-            ],
-        ];
-    }
+/**
+ * @return array<array<array<string, mixed>>>
+ */
+dataset('create_data', function () {
+    return vitoPestSiteCreateData();
+});
 
-    /**
-     * @return array<array<int>>
-     */
-    public static function create_failure_data(): array
-    {
-        return [
-            [401],
-            [403],
-            [404],
-        ];
-    }
-}
+/**
+ * @return array<array<int>>
+ */
+dataset('create_failure_data', function () {
+    return [
+        [401],
+        [403],
+        [404],
+    ];
+});

--- a/tests/Feature/SourceControlsTest.php
+++ b/tests/Feature/SourceControlsTest.php
@@ -16,7 +16,6 @@ uses(RefreshDatabase::class);
 test('connect provider', function (string $provider, ?string $customUrl, array $input) {
     $this->actingAs($this->user);
 
-    // Configure HTTP fake responses for BitbucketV2 OAuth flow
     if ($provider === BitbucketV2::id()) {
         Http::fake([
             'bitbucket.org/site/oauth2/access_token' => Http::response([
@@ -40,7 +39,8 @@ test('connect provider', function (string $provider, ?string $customUrl, array $
         $input['url'] = $customUrl;
     }
 
-    $this->post(route('source-controls.store'), $input);
+    $this->post(route('source-controls.store'), $input)
+        ->assertSessionDoesntHaveErrors();
 
     $this->assertDatabaseHas('source_controls', [
         'provider' => $provider,
@@ -194,7 +194,8 @@ test('cannot manipulate user id on creation', function () {
         'user_id' => $otherUser->id,
     ];
 
-    $this->post(route('source-controls.store'), $data);
+    $this->post(route('source-controls.store'), $data)
+        ->assertSessionDoesntHaveErrors();
 
     $this->assertDatabaseHas('source_controls', [
         'profile' => 'test',
@@ -432,10 +433,7 @@ test('clone script renders default port 22', function () {
     $this->assertStringContainsString('ssh-keyscan -T 5 -p 22 -H gitea.example.com', $rendered);
 });
 
-/**
- * @return array<int, mixed>
- */
-dataset('data', function () {
+dataset('data', /** @return array<int, array{0: string, 1: ?string, 2: array<string, mixed>}> */ function (): array {
     return [
         [Github::id(), null, ['token' => 'test']],
         [Github::id(), null, ['token' => 'test', 'global' => true]],

--- a/tests/Feature/SourceControlsTest.php
+++ b/tests/Feature/SourceControlsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\SourceControl;
 use App\Models\User;
 use App\SourceControlProviders\Bitbucket;
@@ -12,476 +10,441 @@ use App\SourceControlProviders\Gitlab;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Inertia\Testing\AssertableInertia;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class SourceControlsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    /**
-     * @param  array<string, mixed>  $input
-     */
-    #[DataProvider('data')]
-    public function test_connect_provider(string $provider, ?string $customUrl, array $input): void
-    {
-        $this->actingAs($this->user);
+test('connect provider', function (string $provider, ?string $customUrl, array $input) {
+    $this->actingAs($this->user);
 
-        // Configure HTTP fake responses for BitbucketV2 OAuth flow
-        if ($provider === BitbucketV2::id()) {
-            Http::fake([
-                'bitbucket.org/site/oauth2/access_token' => Http::response([
-                    'access_token' => 'fake-access-token',
-                    'token_type' => 'Bearer',
-                ], 200),
-                'api.bitbucket.org/2.0/user' => Http::response([
-                    'username' => 'test-user',
-                ], 200),
-            ]);
-        } else {
-            Http::fake();
-        }
+    // Configure HTTP fake responses for BitbucketV2 OAuth flow
+    if ($provider === BitbucketV2::id()) {
+        Http::fake([
+            'bitbucket.org/site/oauth2/access_token' => Http::response([
+                'access_token' => 'fake-access-token',
+                'token_type' => 'Bearer',
+            ], 200),
+            'api.bitbucket.org/2.0/user' => Http::response([
+                'username' => 'test-user',
+            ], 200),
+        ]);
+    } else {
+        Http::fake();
+    }
 
-        $input = array_merge([
-            'name' => 'test',
-            'provider' => $provider,
-        ], $input);
+    $input = array_merge([
+        'name' => 'test',
+        'provider' => $provider,
+    ], $input);
 
-        if ($customUrl !== null) {
-            $input['url'] = $customUrl;
-        }
+    if ($customUrl !== null) {
+        $input['url'] = $customUrl;
+    }
 
-        $this->post(route('source-controls.store'), $input);
+    $this->post(route('source-controls.store'), $input);
 
+    $this->assertDatabaseHas('source_controls', [
+        'provider' => $provider,
+        'url' => $customUrl,
+    ]);
+
+    if (isset($input['global']) && $input['global']) {
         $this->assertDatabaseHas('source_controls', [
             'provider' => $provider,
             'url' => $customUrl,
+            'project_id' => null,
         ]);
-
-        if (isset($input['global']) && $input['global']) {
-            $this->assertDatabaseHas('source_controls', [
-                'provider' => $provider,
-                'url' => $customUrl,
-                'project_id' => null,
-            ]);
-        } else {
-            $this->assertDatabaseHas('source_controls', [
-                'provider' => $provider,
-                'url' => $customUrl,
-                'project_id' => $this->user->current_project_id,
-            ]);
-        }
-    }
-
-    #[DataProvider('data')]
-    public function test_delete_provider(string $provider, ?string $url, array $input): void
-    {
-        unset($url, $input);
-
-        $this->actingAs($this->user);
-
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => $provider,
-            'profile' => 'test',
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->delete(route('source-controls.destroy', $sourceControl))
-            ->assertSessionDoesntHaveErrors()
-            ->assertRedirect(route('source-controls'));
-
-        $this->assertSoftDeleted('source_controls', [
-            'id' => $sourceControl->id,
-        ]);
-    }
-
-    #[DataProvider('data')]
-    public function test_cannot_delete_provider(string $provider, ?string $url, array $input): void
-    {
-        unset($url, $input);
-
-        $this->actingAs($this->user);
-
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => $provider,
-            'profile' => 'test',
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->site->update([
-            'source_control_id' => $sourceControl->id,
-        ]);
-
-        $this->delete(route('source-controls.destroy', $sourceControl))
-            ->assertSessionHasErrors([
-                'source_control' => 'This source control is being used by a site.',
-            ]);
-
-        $this->assertNotSoftDeleted('source_controls', [
-            'id' => $sourceControl->id,
-        ]);
-    }
-
-    /**
-     * @param  array<string, mixed>  $input
-     */
-    #[DataProvider('data')]
-    public function test_edit_source_control(string $provider, ?string $url, array $input): void
-    {
-        Http::fake();
-
-        $this->actingAs($this->user);
-
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => $provider,
-            'profile' => 'old-name',
-            'url' => $url,
-            'user_id' => $this->user->id,
-        ]);
-
-        $input['name'] = 'new-name';
-
-        $this->patch(route('source-controls.update', $sourceControl), $input)
-            ->assertSessionDoesntHaveErrors();
-
-        $sourceControl->refresh();
-
-        $this->assertEquals('new-name', $sourceControl->profile);
-        $this->assertEquals($url, $sourceControl->url);
-    }
-
-    public function test_user_cannot_update_other_users_source_control(): void
-    {
-        $this->actingAs($this->user);
-
-        $otherUser = User::factory()->create();
-        $sourceControl = SourceControl::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
-
-        Http::fake();
-
-        $this->patch(route('source-controls.update', $sourceControl), [
-            'name' => 'hacked',
-            'token' => 'hacked-token',
-        ])
-            ->assertForbidden();
-    }
-
-    public function test_user_cannot_delete_other_users_source_control(): void
-    {
-        $this->actingAs($this->user);
-
-        $otherUser = User::factory()->create();
-        $sourceControl = SourceControl::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
-
-        $this->delete(route('source-controls.destroy', $sourceControl))
-            ->assertForbidden();
-    }
-
-    public function test_guest_cannot_access_source_controls(): void
-    {
-        $sourceControl = SourceControl::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->get(route('source-controls'))
-            ->assertRedirect('/');
-
-        $this->post(route('source-controls.store'), [])
-            ->assertRedirect('/');
-
-        $this->patch(route('source-controls.update', $sourceControl), [])
-            ->assertRedirect('/');
-
-        $this->delete(route('source-controls.destroy', $sourceControl))
-            ->assertRedirect('/');
-    }
-
-    public function test_cannot_manipulate_user_id_on_creation(): void
-    {
-        $this->actingAs($this->user);
-
-        $otherUser = User::factory()->create();
-
-        Http::fake();
-
-        $data = [
-            'provider' => Github::id(),
-            'name' => 'test',
-            'token' => 'fake-token',
-            'user_id' => $otherUser->id,
-        ];
-
-        $this->post(route('source-controls.store'), $data);
-
+    } else {
         $this->assertDatabaseHas('source_controls', [
-            'profile' => 'test',
-            'provider' => Github::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->assertDatabaseMissing('source_controls', [
-            'profile' => 'test',
-            'provider' => Github::id(),
-            'user_id' => $otherUser->id,
+            'provider' => $provider,
+            'url' => $customUrl,
+            'project_id' => $this->user->current_project_id,
         ]);
     }
+})->with('data');
 
-    public function test_cannot_transfer_ownership_via_update(): void
-    {
-        Http::fake();
+test('delete provider', function (string $provider, ?string $url, array $input) {
+    unset($url, $input);
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $otherUser = User::factory()->create();
-        $sourceControl = SourceControl::factory()->create([
-            'user_id' => $this->user->id,
-            'profile' => 'original',
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => $provider,
+        'profile' => 'test',
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->delete(route('source-controls.destroy', $sourceControl))
+        ->assertSessionDoesntHaveErrors()
+        ->assertRedirect(route('source-controls'));
+
+    $this->assertSoftDeleted('source_controls', [
+        'id' => $sourceControl->id,
+    ]);
+})->with('data');
+
+test('cannot delete provider', function (string $provider, ?string $url, array $input) {
+    unset($url, $input);
+
+    $this->actingAs($this->user);
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => $provider,
+        'profile' => 'test',
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->site->update([
+        'source_control_id' => $sourceControl->id,
+    ]);
+
+    $this->delete(route('source-controls.destroy', $sourceControl))
+        ->assertSessionHasErrors([
+            'source_control' => 'This source control is being used by a site.',
         ]);
 
-        $this->patch(route('source-controls.update', $sourceControl), [
-            'name' => 'updated',
-            'token' => 'new-token',
-            'user_id' => $otherUser->id,
-        ]);
+    $this->assertNotSoftDeleted('source_controls', [
+        'id' => $sourceControl->id,
+    ]);
+})->with('data');
 
-        $sourceControl->refresh();
+test('edit source control', function (string $provider, ?string $url, array $input) {
+    Http::fake();
 
-        $this->assertEquals($this->user->id, $sourceControl->user_id);
-        $this->assertNotEquals($otherUser->id, $sourceControl->user_id);
-    }
+    $this->actingAs($this->user);
 
-    public function test_user_can_only_see_own_source_controls_in_list(): void
-    {
-        $this->actingAs($this->user);
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => $provider,
+        'profile' => 'old-name',
+        'url' => $url,
+        'user_id' => $this->user->id,
+    ]);
 
-        $otherUser = User::factory()->create();
+    $input['name'] = 'new-name';
 
-        $ownSourceControl = SourceControl::factory()->create([
-            'user_id' => $this->user->id,
-            'profile' => 'own-source-control',
-        ]);
+    $this->patch(route('source-controls.update', $sourceControl), $input)
+        ->assertSessionDoesntHaveErrors();
 
-        $otherSourceControl = SourceControl::factory()->create([
-            'user_id' => $otherUser->id,
-            'profile' => 'other-source-control',
-        ]);
+    $sourceControl->refresh();
 
-        $response = $this->get(route('source-controls'))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('source-controls/index'));
+    expect($sourceControl->profile)->toEqual('new-name');
+    expect($sourceControl->url)->toEqual($url);
+})->with('data');
 
-        $response->assertInertia(fn (AssertableInertia $page) => $page->has('sourceControls.data')
-            ->where('sourceControls.data.0.id', $ownSourceControl->id)
-            ->whereNot('sourceControls.data.0.id', $otherSourceControl->id)
-        );
-    }
+test('user cannot update other users source control', function () {
+    $this->actingAs($this->user);
 
-    public function test_connect_gitea_persists_ssh_port_in_provider_data(): void
-    {
-        Http::fake();
-        $this->actingAs($this->user);
+    $otherUser = User::factory()->create();
+    $sourceControl = SourceControl::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
 
-        $this->post(route('source-controls.store'), [
-            'name' => 'gitea-custom-port',
-            'provider' => Gitea::id(),
-            'token' => 'test-token',
-            'url' => 'https://gitea.example.com/',
-            'ssh_port' => 2222,
-        ])->assertSessionDoesntHaveErrors();
+    Http::fake();
 
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::query()
-            ->where('provider', Gitea::id())
-            ->where('profile', 'gitea-custom-port')
-            ->firstOrFail();
+    $this->patch(route('source-controls.update', $sourceControl), [
+        'name' => 'hacked',
+        'token' => 'hacked-token',
+    ])
+        ->assertForbidden();
+});
 
-        $this->assertSame(2222, $sourceControl->provider_data['ssh_port']);
-        $this->assertSame('test-token', $sourceControl->provider_data['token']);
-        $this->assertSame(2222, $sourceControl->provider()->getSshPort());
-    }
+test('user cannot delete other users source control', function () {
+    $this->actingAs($this->user);
 
-    public function test_connect_gitea_without_ssh_port_defaults_to_22(): void
-    {
-        Http::fake();
-        $this->actingAs($this->user);
+    $otherUser = User::factory()->create();
+    $sourceControl = SourceControl::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
 
-        $this->post(route('source-controls.store'), [
-            'name' => 'gitea-default',
-            'provider' => Gitea::id(),
-            'token' => 'test-token',
-        ])->assertSessionDoesntHaveErrors();
+    $this->delete(route('source-controls.destroy', $sourceControl))
+        ->assertForbidden();
+});
 
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::query()
-            ->where('provider', Gitea::id())
-            ->where('profile', 'gitea-default')
-            ->firstOrFail();
+test('guest cannot access source controls', function () {
+    $sourceControl = SourceControl::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-        $this->assertSame(22, $sourceControl->provider_data['ssh_port']);
-        $this->assertSame(22, $sourceControl->provider()->getSshPort());
-    }
+    $this->get(route('source-controls'))
+        ->assertRedirect('/');
 
-    public function test_edit_gitea_updates_ssh_port(): void
-    {
-        Http::fake();
-        $this->actingAs($this->user);
+    $this->post(route('source-controls.store'), [])
+        ->assertRedirect('/');
 
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Gitea::id(),
-            'user_id' => $this->user->id,
-            'profile' => 'gitea',
-            'provider_data' => ['token' => 'original-token', 'ssh_port' => 22],
-        ]);
+    $this->patch(route('source-controls.update', $sourceControl), [])
+        ->assertRedirect('/');
 
-        $this->patch(route('source-controls.update', $sourceControl), [
-            'name' => 'gitea',
-            'ssh_port' => 2222,
-        ])->assertSessionDoesntHaveErrors();
+    $this->delete(route('source-controls.destroy', $sourceControl))
+        ->assertRedirect('/');
+});
 
-        $sourceControl->refresh();
+test('cannot manipulate user id on creation', function () {
+    $this->actingAs($this->user);
 
-        $this->assertSame(2222, $sourceControl->provider_data['ssh_port']);
-        $this->assertSame('original-token', $sourceControl->provider_data['token']);
-    }
+    $otherUser = User::factory()->create();
 
-    public function test_edit_cannot_clobber_token_via_extra_input(): void
-    {
-        Http::fake();
-        $this->actingAs($this->user);
+    Http::fake();
 
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Gitea::id(),
-            'user_id' => $this->user->id,
-            'profile' => 'gitea',
-            'provider_data' => ['token' => 'original-token', 'ssh_port' => 22],
-        ]);
+    $data = [
+        'provider' => Github::id(),
+        'name' => 'test',
+        'token' => 'fake-token',
+        'user_id' => $otherUser->id,
+    ];
 
-        $this->patch(route('source-controls.update', $sourceControl), [
-            'name' => 'gitea',
-            'ssh_port' => 2222,
-            'token' => 'stolen-token',
-        ])->assertSessionDoesntHaveErrors();
+    $this->post(route('source-controls.store'), $data);
 
-        $sourceControl->refresh();
+    $this->assertDatabaseHas('source_controls', [
+        'profile' => 'test',
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
 
-        $this->assertSame('original-token', $sourceControl->provider_data['token']);
-        $this->assertSame(2222, $sourceControl->provider_data['ssh_port']);
-    }
+    $this->assertDatabaseMissing('source_controls', [
+        'profile' => 'test',
+        'provider' => Github::id(),
+        'user_id' => $otherUser->id,
+    ]);
+});
 
-    public function test_edit_gitlab_cannot_clobber_token_via_extra_input(): void
-    {
-        Http::fake();
-        $this->actingAs($this->user);
+test('cannot transfer ownership via update', function () {
+    Http::fake();
 
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Gitlab::id(),
-            'user_id' => $this->user->id,
-            'profile' => 'gitlab',
-            'provider_data' => ['token' => 'original-token', 'ssh_port' => 22],
-        ]);
+    $this->actingAs($this->user);
 
-        $this->patch(route('source-controls.update', $sourceControl), [
-            'name' => 'gitlab',
-            'ssh_port' => 2222,
-            'token' => 'stolen-token',
-        ])->assertSessionDoesntHaveErrors();
+    $otherUser = User::factory()->create();
+    $sourceControl = SourceControl::factory()->create([
+        'user_id' => $this->user->id,
+        'profile' => 'original',
+    ]);
 
-        $sourceControl->refresh();
+    $this->patch(route('source-controls.update', $sourceControl), [
+        'name' => 'updated',
+        'token' => 'new-token',
+        'user_id' => $otherUser->id,
+    ]);
 
-        $this->assertSame('original-token', $sourceControl->provider_data['token']);
-        $this->assertSame(2222, $sourceControl->provider_data['ssh_port']);
-    }
+    $sourceControl->refresh();
 
-    public function test_edit_gitea_rejects_out_of_range_ssh_port(): void
-    {
-        Http::fake();
-        $this->actingAs($this->user);
+    expect($sourceControl->user_id)->toEqual($this->user->id);
+    $this->assertNotEquals($otherUser->id, $sourceControl->user_id);
+});
 
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Gitea::id(),
-            'user_id' => $this->user->id,
-            'provider_data' => ['token' => 'original-token', 'ssh_port' => 22],
-        ]);
+test('user can only see own source controls in list', function () {
+    $this->actingAs($this->user);
 
-        $this->patch(route('source-controls.update', $sourceControl), [
-            'name' => 'gitea',
-            'ssh_port' => 70000,
-        ])->assertSessionHasErrors(['ssh_port']);
+    $otherUser = User::factory()->create();
 
-        $sourceControl->refresh();
-        $this->assertSame(22, $sourceControl->provider_data['ssh_port']);
-    }
+    $ownSourceControl = SourceControl::factory()->create([
+        'user_id' => $this->user->id,
+        'profile' => 'own-source-control',
+    ]);
 
-    public function test_legacy_row_without_ssh_port_falls_back_to_22(): void
-    {
-        /** @var SourceControl $sourceControl */
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Gitea::id(),
-            'user_id' => $this->user->id,
-            'provider_data' => ['token' => 'legacy-token'],
-        ]);
+    $otherSourceControl = SourceControl::factory()->create([
+        'user_id' => $otherUser->id,
+        'profile' => 'other-source-control',
+    ]);
 
-        $this->assertSame(22, $sourceControl->provider()->getSshPort());
-        $this->assertSame(22, $sourceControl->provider()->data()['ssh_port']);
-    }
+    $response = $this->get(route('source-controls'))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('source-controls/index'));
 
-    public function test_clone_script_renders_custom_port(): void
-    {
-        $rendered = view('ssh.git.clone', [
-            'host' => 'gitea.example.com',
-            'repo' => 'git@gitea.example.com-site_1:owner/repo.git',
-            'path' => '/home/vito/test',
-            'branch' => 'main',
-            'key' => 'site_1',
-            'port' => 2222,
-        ])->render();
+    $response->assertInertia(fn (AssertableInertia $page) => $page->has('sourceControls.data')
+        ->where('sourceControls.data.0.id', $ownSourceControl->id)
+        ->whereNot('sourceControls.data.0.id', $otherSourceControl->id)
+    );
+});
 
-        $this->assertStringContainsString('Port 2222', $rendered);
-        $this->assertStringContainsString('ssh-keyscan -T 5 -p 2222 -H gitea.example.com', $rendered);
-        $this->assertStringContainsString("alias_name='gitea.example.com-site_1'", $rendered);
-    }
+test('connect gitea persists ssh port in provider data', function () {
+    Http::fake();
+    $this->actingAs($this->user);
 
-    public function test_clone_script_renders_default_port_22(): void
-    {
-        $rendered = view('ssh.git.clone', [
-            'host' => 'gitea.example.com',
-            'repo' => 'git@gitea.example.com-site_1:owner/repo.git',
-            'path' => '/home/vito/test',
-            'branch' => 'main',
-            'key' => 'site_1',
-            'port' => 22,
-        ])->render();
+    $this->post(route('source-controls.store'), [
+        'name' => 'gitea-custom-port',
+        'provider' => Gitea::id(),
+        'token' => 'test-token',
+        'url' => 'https://gitea.example.com/',
+        'ssh_port' => 2222,
+    ])->assertSessionDoesntHaveErrors();
 
-        $this->assertStringContainsString('Port 22', $rendered);
-        $this->assertStringContainsString('ssh-keyscan -T 5 -p 22 -H gitea.example.com', $rendered);
-    }
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::query()
+        ->where('provider', Gitea::id())
+        ->where('profile', 'gitea-custom-port')
+        ->firstOrFail();
 
-    /**
-     * @return array<int, mixed>
-     */
-    public static function data(): array
-    {
-        return [
-            [Github::id(), null, ['token' => 'test']],
-            [Github::id(), null, ['token' => 'test', 'global' => true]],
-            [Gitlab::id(), null, ['token' => 'test']],
-            [Gitlab::id(), 'https://git.example.com/', ['token' => 'test']],
-            [Gitlab::id(), 'https://git.example.com/', ['token' => 'test', 'ssh_port' => 2222]],
-            [Gitea::id(), null, ['token' => 'test']],
-            [Gitea::id(), 'https://gitea.example.com/', ['token' => 'test', 'ssh_port' => 222]],
-            [Bitbucket::id(), null, ['username' => 'test', 'password' => 'test']],
-            [BitbucketV2::id(), null, ['key' => 'test', 'secret' => 'test']],
-        ];
-    }
-}
+    expect($sourceControl->provider_data['ssh_port'])->toBe(2222);
+    expect($sourceControl->provider_data['token'])->toBe('test-token');
+    expect($sourceControl->provider()->getSshPort())->toBe(2222);
+});
+
+test('connect gitea without ssh port defaults to 22', function () {
+    Http::fake();
+    $this->actingAs($this->user);
+
+    $this->post(route('source-controls.store'), [
+        'name' => 'gitea-default',
+        'provider' => Gitea::id(),
+        'token' => 'test-token',
+    ])->assertSessionDoesntHaveErrors();
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::query()
+        ->where('provider', Gitea::id())
+        ->where('profile', 'gitea-default')
+        ->firstOrFail();
+
+    expect($sourceControl->provider_data['ssh_port'])->toBe(22);
+    expect($sourceControl->provider()->getSshPort())->toBe(22);
+});
+
+test('edit gitea updates ssh port', function () {
+    Http::fake();
+    $this->actingAs($this->user);
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Gitea::id(),
+        'user_id' => $this->user->id,
+        'profile' => 'gitea',
+        'provider_data' => ['token' => 'original-token', 'ssh_port' => 22],
+    ]);
+
+    $this->patch(route('source-controls.update', $sourceControl), [
+        'name' => 'gitea',
+        'ssh_port' => 2222,
+    ])->assertSessionDoesntHaveErrors();
+
+    $sourceControl->refresh();
+
+    expect($sourceControl->provider_data['ssh_port'])->toBe(2222);
+    expect($sourceControl->provider_data['token'])->toBe('original-token');
+});
+
+test('edit cannot clobber token via extra input', function () {
+    Http::fake();
+    $this->actingAs($this->user);
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Gitea::id(),
+        'user_id' => $this->user->id,
+        'profile' => 'gitea',
+        'provider_data' => ['token' => 'original-token', 'ssh_port' => 22],
+    ]);
+
+    $this->patch(route('source-controls.update', $sourceControl), [
+        'name' => 'gitea',
+        'ssh_port' => 2222,
+        'token' => 'stolen-token',
+    ])->assertSessionDoesntHaveErrors();
+
+    $sourceControl->refresh();
+
+    expect($sourceControl->provider_data['token'])->toBe('original-token');
+    expect($sourceControl->provider_data['ssh_port'])->toBe(2222);
+});
+
+test('edit gitlab cannot clobber token via extra input', function () {
+    Http::fake();
+    $this->actingAs($this->user);
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Gitlab::id(),
+        'user_id' => $this->user->id,
+        'profile' => 'gitlab',
+        'provider_data' => ['token' => 'original-token', 'ssh_port' => 22],
+    ]);
+
+    $this->patch(route('source-controls.update', $sourceControl), [
+        'name' => 'gitlab',
+        'ssh_port' => 2222,
+        'token' => 'stolen-token',
+    ])->assertSessionDoesntHaveErrors();
+
+    $sourceControl->refresh();
+
+    expect($sourceControl->provider_data['token'])->toBe('original-token');
+    expect($sourceControl->provider_data['ssh_port'])->toBe(2222);
+});
+
+test('edit gitea rejects out of range ssh port', function () {
+    Http::fake();
+    $this->actingAs($this->user);
+
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Gitea::id(),
+        'user_id' => $this->user->id,
+        'provider_data' => ['token' => 'original-token', 'ssh_port' => 22],
+    ]);
+
+    $this->patch(route('source-controls.update', $sourceControl), [
+        'name' => 'gitea',
+        'ssh_port' => 70000,
+    ])->assertSessionHasErrors(['ssh_port']);
+
+    $sourceControl->refresh();
+    expect($sourceControl->provider_data['ssh_port'])->toBe(22);
+});
+
+test('legacy row without ssh port falls back to 22', function () {
+    /** @var SourceControl $sourceControl */
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Gitea::id(),
+        'user_id' => $this->user->id,
+        'provider_data' => ['token' => 'legacy-token'],
+    ]);
+
+    expect($sourceControl->provider()->getSshPort())->toBe(22);
+    expect($sourceControl->provider()->data()['ssh_port'])->toBe(22);
+});
+
+test('clone script renders custom port', function () {
+    $rendered = view('ssh.git.clone', [
+        'host' => 'gitea.example.com',
+        'repo' => 'git@gitea.example.com-site_1:owner/repo.git',
+        'path' => '/home/vito/test',
+        'branch' => 'main',
+        'key' => 'site_1',
+        'port' => 2222,
+    ])->render();
+
+    $this->assertStringContainsString('Port 2222', $rendered);
+    $this->assertStringContainsString('ssh-keyscan -T 5 -p 2222 -H gitea.example.com', $rendered);
+    $this->assertStringContainsString("alias_name='gitea.example.com-site_1'", $rendered);
+});
+
+test('clone script renders default port 22', function () {
+    $rendered = view('ssh.git.clone', [
+        'host' => 'gitea.example.com',
+        'repo' => 'git@gitea.example.com-site_1:owner/repo.git',
+        'path' => '/home/vito/test',
+        'branch' => 'main',
+        'key' => 'site_1',
+        'port' => 22,
+    ])->render();
+
+    $this->assertStringContainsString('Port 22', $rendered);
+    $this->assertStringContainsString('ssh-keyscan -T 5 -p 22 -H gitea.example.com', $rendered);
+});
+
+/**
+ * @return array<int, mixed>
+ */
+dataset('data', function () {
+    return [
+        [Github::id(), null, ['token' => 'test']],
+        [Github::id(), null, ['token' => 'test', 'global' => true]],
+        [Gitlab::id(), null, ['token' => 'test']],
+        [Gitlab::id(), 'https://git.example.com/', ['token' => 'test']],
+        [Gitlab::id(), 'https://git.example.com/', ['token' => 'test', 'ssh_port' => 2222]],
+        [Gitea::id(), null, ['token' => 'test']],
+        [Gitea::id(), 'https://gitea.example.com/', ['token' => 'test', 'ssh_port' => 222]],
+        [Bitbucket::id(), null, ['username' => 'test', 'password' => 'test']],
+        [BitbucketV2::id(), null, ['key' => 'test', 'secret' => 'test']],
+    ];
+});

--- a/tests/Feature/SshKeysTest.php
+++ b/tests/Feature/SshKeysTest.php
@@ -1,154 +1,139 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\SshKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
-class SshKeysTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_ssh_key(): void
-    {
-        $this->actingAs($this->user);
+test('create ssh key', function () {
+    $this->actingAs($this->user);
 
-        $this->post(route('ssh-keys.store'), [
-            'name' => 'test',
-            'public_key' => 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q== test@test.local',
-        ])
-            ->assertSessionDoesntHaveErrors();
+    $this->post(route('ssh-keys.store'), [
+        'name' => 'test',
+        'public_key' => 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q== test@test.local',
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-        $this->assertDatabaseHas('ssh_keys', [
-            'name' => 'test',
-        ]);
+    $this->assertDatabaseHas('ssh_keys', [
+        'name' => 'test',
+    ]);
+});
+
+test('get public keys list', function () {
+    $this->actingAs($this->user);
+
+    SshKey::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->get(route('ssh-keys'))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('ssh-keys/index'));
+});
+
+test('delete key', function () {
+    $this->actingAs($this->user);
+
+    $key = SshKey::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->delete(route('ssh-keys.destroy', ['sshKey' => $key->id]));
+
+    $this->assertSoftDeleted('ssh_keys', [
+        'id' => $key->id,
+    ]);
+});
+
+test('create ssh key handles invalid or partial keys', function (array $postBody, bool $expectedToSucceed) {
+    $this->actingAs($this->user);
+
+    // Some existing amount of seed data to make the test more realistic
+    SshKey::factory()->create([
+        'user_id' => $this->user->id,
+        'name' => 'My first key',
+        'public_key' => 'public-key-content',
+    ]);
+
+    $response = $this->post(route('ssh-keys.store'), $postBody);
+
+    if ($expectedToSucceed) {
+        $response->assertSessionDoesntHaveErrors();
+    } else {
+        $response->assertSessionHasErrors();
     }
+})->with('ssh_key_data_provider');
 
-    public function test_get_public_keys_list(): void
-    {
-        $this->actingAs($this->user);
-
-        SshKey::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->get(route('ssh-keys'))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('ssh-keys/index'));
-    }
-
-    public function test_delete_key(): void
-    {
-        $this->actingAs($this->user);
-
-        $key = SshKey::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->delete(route('ssh-keys.destroy', ['sshKey' => $key->id]));
-
-        $this->assertSoftDeleted('ssh_keys', [
-            'id' => $key->id,
-        ]);
-    }
-
-    /**
-     * @param  array<string, string>  $postBody
-     */
-    #[DataProvider('ssh_key_data_provider')]
-    public function test_create_ssh_key_handles_invalid_or_partial_keys(array $postBody, bool $expectedToSucceed): void
-    {
-        $this->actingAs($this->user);
-
-        // Some existing amount of seed data to make the test more realistic
-        SshKey::factory()->create([
-            'user_id' => $this->user->id,
-            'name' => 'My first key',
-            'public_key' => 'public-key-content',
-        ]);
-
-        $response = $this->post(route('ssh-keys.store'), $postBody);
-
-        if ($expectedToSucceed) {
-            $response->assertSessionDoesntHaveErrors();
-        } else {
-            $response->assertSessionHasErrors();
-        }
-    }
-
-    /**
-     * @return array<array{0: array<string, string>, 1: bool}>
-     */
-    public static function ssh_key_data_provider(): array
-    {
-        return [
+/**
+ * @return array<array{0: array<string, string>, 1: bool}>
+ */
+dataset('ssh_key_data_provider', function () {
+    return [
+        [
             [
-                [
-                    'name' => 'My first key',
-                    // Key Already exists
-                    'public_key' => 'public-key-content',
-                ],
-                self::EXPECT_FAILURE,
+                'name' => 'My first key',
+                // Key Already exists
+                'public_key' => 'public-key-content',
             ],
+            TestCase::EXPECT_FAILURE,
+        ],
+        [
             [
-                [
-                    'name' => 'My first key',
-                    // RSA type
-                    'public_key' => 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q== test@test.local',
-                ],
-                self::EXPECT_SUCCESS,
+                'name' => 'My first key',
+                // RSA type
+                'public_key' => 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q== test@test.local',
             ],
+            TestCase::EXPECT_SUCCESS,
+        ],
+        [
             [
-                [
-                    'name' => 'My first key',
-                    //  DSS
-                    'public_key' => 'ssh-dss AAAAB3NzaC1kc3MAAACBAPLQ1v111G0vuWwurCJdg0rt2C8OwWW88sR3sCS+CPjvqPyRtFOiJLqnO0/J/tIlCZVHN0VWgKN19jOiMy2Kx2mMZoAJ0z6AGxQMoTB0eqBeYYfAfxL9KwVw6EV7QWXTu5/EDbl+6k60EQ9EXOIsnhTQsok2Ki52Td0TUxfA3Vy7AAAAFQDx8Fi0pWPoJDn7jUqog7L748iBowAAAIADrgFxfpQuujYgxS2RXX8euxgrfa1KMQNT2kXQ3781L7ihS5EjyFy03K2pV0DSQo2NeFSJv9rtJNXfCDoAofUhgugZkMWUAv8ebZsy6SxWAocjw6A5ED1YkvA03eNUEaSm9vb8ts8m1wJme6Urx41Yh9c2YVXB6yJ7T1jaeZrhbQAAAIEA3hp8vZeImWol/tTm4LE1FXkqU7cMo863MAs5gdqRhJ5Xnwvsbx1WSVajJY78e8s/Yd4GhBAJpNjAVfep0CqbfJeNKV/D6oCKCfVikKefRw4GIREtAfkijlh/WOkwmWE0VcZRQk1sIizYtqIwtghvMvzDRSGFMC3l6hF5AHYyrSg= test@test.local',
-                ],
-                self::EXPECT_SUCCESS,
+                'name' => 'My first key',
+                //  DSS
+                'public_key' => 'ssh-dss AAAAB3NzaC1kc3MAAACBAPLQ1v111G0vuWwurCJdg0rt2C8OwWW88sR3sCS+CPjvqPyRtFOiJLqnO0/J/tIlCZVHN0VWgKN19jOiMy2Kx2mMZoAJ0z6AGxQMoTB0eqBeYYfAfxL9KwVw6EV7QWXTu5/EDbl+6k60EQ9EXOIsnhTQsok2Ki52Td0TUxfA3Vy7AAAAFQDx8Fi0pWPoJDn7jUqog7L748iBowAAAIADrgFxfpQuujYgxS2RXX8euxgrfa1KMQNT2kXQ3781L7ihS5EjyFy03K2pV0DSQo2NeFSJv9rtJNXfCDoAofUhgugZkMWUAv8ebZsy6SxWAocjw6A5ED1YkvA03eNUEaSm9vb8ts8m1wJme6Urx41Yh9c2YVXB6yJ7T1jaeZrhbQAAAIEA3hp8vZeImWol/tTm4LE1FXkqU7cMo863MAs5gdqRhJ5Xnwvsbx1WSVajJY78e8s/Yd4GhBAJpNjAVfep0CqbfJeNKV/D6oCKCfVikKefRw4GIREtAfkijlh/WOkwmWE0VcZRQk1sIizYtqIwtghvMvzDRSGFMC3l6hF5AHYyrSg= test@test.local',
             ],
+            TestCase::EXPECT_SUCCESS,
+        ],
+        [
             [
-                [
-                    'name' => 'My first key',
-                    // ECDSA type
-                    'public_key' => 'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBY0xeD9/iTVZZO/qVFRjAwtNmC0zHVWqY4Q7nmB4nGvfpHhlze+rEpxXwNWW5olIcAjAXJO+gQCa4iNV6UYDp8= test@test.local',
-                ],
-                self::EXPECT_SUCCESS,
+                'name' => 'My first key',
+                // ECDSA type
+                'public_key' => 'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBY0xeD9/iTVZZO/qVFRjAwtNmC0zHVWqY4Q7nmB4nGvfpHhlze+rEpxXwNWW5olIcAjAXJO+gQCa4iNV6UYDp8= test@test.local',
             ],
+            TestCase::EXPECT_SUCCESS,
+        ],
+        [
             [
-                [
-                    'name' => 'My first key',
-                    // ED25519 type
-                    'public_key' => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIxUhYjgZEXKYnlerxHYyL/e0HZ4C9t3WCpQ/LCPQZMp test@test.local',
-                ],
-                self::EXPECT_SUCCESS,
+                'name' => 'My first key',
+                // ED25519 type
+                'public_key' => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIxUhYjgZEXKYnlerxHYyL/e0HZ4C9t3WCpQ/LCPQZMp test@test.local',
             ],
+            TestCase::EXPECT_SUCCESS,
+        ],
+        [
             [
-                [
-                    'name' => 'My first key',
-                    // Partial ED25519 type
-                    'public_key' => 'ssh-afeef AAAAC3NzaC1lZDI1NTE5AAAAIIxUhYjgZEXKYnlerxHYyL/e0HZ4C9t3WCpQ/LCPQZMp test@test.local',
-                ],
-                self::EXPECT_FAILURE,
+                'name' => 'My first key',
+                // Partial ED25519 type
+                'public_key' => 'ssh-afeef AAAAC3NzaC1lZDI1NTE5AAAAIIxUhYjgZEXKYnlerxHYyL/e0HZ4C9t3WCpQ/LCPQZMp test@test.local',
             ],
+            TestCase::EXPECT_FAILURE,
+        ],
+        [
             [
-                [
-                    'name' => 'My first key',
-                    // Partial ED25519 type
-                    'public_key' => 'ssh-ed25519 AAAAC3NzAffefIIIAAAAAAAIIxUhYjgZEXKYnlerxHYyL/e0HZ4C9t3WCpQ/LCPQZMp test@test.local',
-                ],
-                self::EXPECT_FAILURE,
+                'name' => 'My first key',
+                // Partial ED25519 type
+                'public_key' => 'ssh-ed25519 AAAAC3NzAffefIIIAAAAAAAIIxUhYjgZEXKYnlerxHYyL/e0HZ4C9t3WCpQ/LCPQZMp test@test.local',
             ],
+            TestCase::EXPECT_FAILURE,
+        ],
+        [
             [
-                [
-                    'name' => 'My first key',
-                    // Partial DSS type, close but not quite
-                    'public_key' => 'ssh-dss AAAAB3NzaC1kc3MAAACBAPLQ1v111G0vuWwurCJdga830asW88sR3sCS+CPjvqPyRtFOiJLqnO0/J/tIlCZVHN0VWgKN19jOiMy2Kx2mMZoAJ0z6AGxQMoTB0eqBeYYfAfxL9KwVw6EV7QWXTu5/EDbl+6k60EQ9EXOIsnhTQsok2Ki52Td0TUxfA3Vy7AAAAFQDx8Fi0pWPoJDn7jUqog7L748iBowAAAIADrgFxfpQuujYgxS2RXX8euxgrfa1KMQNT2kXQ3781L7ihS5EjyFy03K2pV0DSQo2NeFSJv9rtJNXfCDoAofUhgugZkMWUAv8ebZsy6SxWAocjw6A5ED1YkvA03eNUEaSm9vb8ts8m1wJme6Urx41Yh9c2YVXB6yJ7T1jaeZrhbQAAAIEA3hp8vZeImWol/tTm4LE1FXkqU7cMo863MAs5gdqRhJ5Xnwvsbx1WSVajJYa103s/Yd4GhBAJpNjAVfep0CqbfJeNKV/D6oCKCfVikKefRw4GIREtAfkijlh/WOkwmWE0VcZRQk1sIizYtqIwtghvMvzDRSGFMC3l6hF5AHYyrSg= test@test.local',
-                ],
-                self::EXPECT_FAILURE,
+                'name' => 'My first key',
+                // Partial DSS type, close but not quite
+                'public_key' => 'ssh-dss AAAAB3NzaC1kc3MAAACBAPLQ1v111G0vuWwurCJdga830asW88sR3sCS+CPjvqPyRtFOiJLqnO0/J/tIlCZVHN0VWgKN19jOiMy2Kx2mMZoAJ0z6AGxQMoTB0eqBeYYfAfxL9KwVw6EV7QWXTu5/EDbl+6k60EQ9EXOIsnhTQsok2Ki52Td0TUxfA3Vy7AAAAFQDx8Fi0pWPoJDn7jUqog7L748iBowAAAIADrgFxfpQuujYgxS2RXX8euxgrfa1KMQNT2kXQ3781L7ihS5EjyFy03K2pV0DSQo2NeFSJv9rtJNXfCDoAofUhgugZkMWUAv8ebZsy6SxWAocjw6A5ED1YkvA03eNUEaSm9vb8ts8m1wJme6Urx41Yh9c2YVXB6yJ7T1jaeZrhbQAAAIEA3hp8vZeImWol/tTm4LE1FXkqU7cMo863MAs5gdqRhJ5Xnwvsbx1WSVajJYa103s/Yd4GhBAJpNjAVfep0CqbfJeNKV/D6oCKCfVikKefRw4GIREtAfkijlh/WOkwmWE0VcZRQk1sIizYtqIwtghvMvzDRSGFMC3l6hF5AHYyrSg= test@test.local',
             ],
-        ];
-    }
-}
+            TestCase::EXPECT_FAILURE,
+        ],
+    ];
+});

--- a/tests/Feature/StorageProvidersTest.php
+++ b/tests/Feature/StorageProvidersTest.php
@@ -25,7 +25,8 @@ test('create', function (array $input) {
         SFTP::fake();
     }
 
-    $this->post(route('storage-providers.store'), $input);
+    $this->post(route('storage-providers.store'), $input)
+        ->assertSessionDoesntHaveErrors();
 
     if ($input['provider'] === App\StorageProviders\FTP::id()) {
         FTP::assertConnected($input['host']);
@@ -163,7 +164,7 @@ test('cannot delete provider', function () {
     $this->actingAs($this->user);
 
     $database = Database::factory()->create([
-        'server_id' => $this->server,
+        'server_id' => $this->server->id,
     ]);
 
     $provider = StorageProviderModel::factory()->create([
@@ -300,10 +301,7 @@ test('user can only see own storage providers in list', function () {
     );
 });
 
-/**
- * @return array<int, mixed>
- */
-dataset('createData', function () {
+dataset('createData', /** @return array<int, array{0: array<string, mixed>}> */ function (): array {
     return [
         [
             [

--- a/tests/Feature/StorageProvidersTest.php
+++ b/tests/Feature/StorageProvidersTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Facades\FTP;
 use App\Facades\SFTP;
 use App\Models\Backup;
@@ -13,388 +11,364 @@ use App\StorageProviders\Local;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Inertia\Testing\AssertableInertia;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class StorageProvidersTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    /**
-     * @param  array<string, mixed>  $input
-     */
-    #[DataProvider('createData')]
-    public function test_create(array $input): void
-    {
-        $this->actingAs($this->user);
+test('create', function (array $input) {
+    $this->actingAs($this->user);
 
-        if ($input['provider'] === \App\StorageProviders\FTP::id()) {
-            FTP::fake();
-        }
-
-        if ($input['provider'] === \App\StorageProviders\SFTP::id()) {
-            SFTP::fake();
-        }
-
-        $this->post(route('storage-providers.store'), $input);
-
-        if ($input['provider'] === \App\StorageProviders\FTP::id()) {
-            FTP::assertConnected($input['host']);
-        }
-
-        if ($input['provider'] === \App\StorageProviders\SFTP::id()) {
-            SFTP::assertConnected($input['host']);
-        }
-
-        $this->assertDatabaseHas('storage_providers', [
-            'provider' => $input['provider'],
-            'profile' => $input['name'],
-            'project_id' => isset($input['global']) ? null : $this->user->current_project_id,
-        ]);
+    if ($input['provider'] === App\StorageProviders\FTP::id()) {
+        FTP::fake();
     }
 
-    public function test_dropbox_oauth_redirect(): void
-    {
-        $this->actingAs($this->user);
+    if ($input['provider'] === App\StorageProviders\SFTP::id()) {
+        SFTP::fake();
+    }
 
-        $response = $this->post(route('storage-providers.dropbox.redirect'), [
-            'provider' => Dropbox::id(),
+    $this->post(route('storage-providers.store'), $input);
+
+    if ($input['provider'] === App\StorageProviders\FTP::id()) {
+        FTP::assertConnected($input['host']);
+    }
+
+    if ($input['provider'] === App\StorageProviders\SFTP::id()) {
+        SFTP::assertConnected($input['host']);
+    }
+
+    $this->assertDatabaseHas('storage_providers', [
+        'provider' => $input['provider'],
+        'profile' => $input['name'],
+        'project_id' => isset($input['global']) ? null : $this->user->current_project_id,
+    ]);
+})->with('createData');
+
+test('dropbox oauth redirect', function () {
+    $this->actingAs($this->user);
+
+    $response = $this->post(route('storage-providers.dropbox.redirect'), [
+        'provider' => Dropbox::id(),
+        'name' => 'dropbox-test',
+        'app_key' => 'my-app-key',
+        'app_secret' => 'my-app-secret',
+    ]);
+
+    $response->assertRedirect();
+
+    $location = (string) $response->headers->get('Location');
+    $this->assertStringContainsString('dropbox.com/oauth2/authorize', $location);
+    $this->assertStringContainsString('token_access_type=offline', $location);
+    $this->assertStringContainsString('my-app-key', $location);
+    expect(session('dropbox_oauth.state'))->not->toBeEmpty();
+});
+
+test('dropbox callback creates provider', function () {
+    $this->actingAs($this->user);
+
+    Http::fake([
+        '*oauth2/token' => Http::response([
+            'access_token' => 'fresh-access',
+            'expires_in' => 14400,
+            'refresh_token' => 'the-refresh-token',
+        ]),
+        '*' => Http::response([], 200),
+    ]);
+
+    $response = $this->withSession([
+        'dropbox_oauth' => [
+            'state' => 'state-123',
             'name' => 'dropbox-test',
             'app_key' => 'my-app-key',
             'app_secret' => 'my-app-secret',
+            'global' => false,
+        ],
+    ])->get(route('storage-providers.dropbox.callback', ['code' => 'auth-code', 'state' => 'state-123']));
+
+    $response->assertRedirect(route('storage-providers'));
+    $response->assertSessionHas('success');
+
+    $this->assertDatabaseHas('storage_providers', [
+        'provider' => Dropbox::id(),
+        'profile' => 'dropbox-test',
+        'user_id' => $this->user->id,
+    ]);
+
+    $provider = StorageProviderModel::query()->where('profile', 'dropbox-test')->firstOrFail();
+    expect($provider->credentials['refresh_token'])->toBe('the-refresh-token');
+    expect($provider->credentials['app_key'])->toBe('my-app-key');
+});
+
+test('dropbox callback rejects bad state', function () {
+    $this->actingAs($this->user);
+
+    $response = $this->withSession([
+        'dropbox_oauth' => [
+            'state' => 'correct-state',
+            'name' => 'dropbox-test',
+            'app_key' => 'my-app-key',
+            'app_secret' => 'my-app-secret',
+            'global' => false,
+        ],
+    ])->get(route('storage-providers.dropbox.callback', ['code' => 'auth-code', 'state' => 'wrong-state']));
+
+    $response->assertRedirect(route('storage-providers'));
+    $response->assertSessionHas('error');
+    $this->assertDatabaseMissing('storage_providers', ['profile' => 'dropbox-test']);
+});
+
+test('dropbox callback rejects missing code', function () {
+    $this->actingAs($this->user);
+
+    $response = $this->withSession([
+        'dropbox_oauth' => [
+            'state' => 'state-123',
+            'name' => 'dropbox-test',
+            'app_key' => 'my-app-key',
+            'app_secret' => 'my-app-secret',
+            'global' => false,
+        ],
+    ])->get(route('storage-providers.dropbox.callback', ['state' => 'state-123']));
+
+    $response->assertRedirect(route('storage-providers'));
+    $response->assertSessionHas('error');
+    $this->assertDatabaseMissing('storage_providers', ['profile' => 'dropbox-test']);
+});
+
+test('see providers list', function () {
+    $this->actingAs($this->user);
+
+    StorageProviderModel::factory()->dropbox()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->get(route('storage-providers'))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('storage-providers/index'));
+});
+
+test('delete provider', function () {
+    $this->actingAs($this->user);
+
+    $provider = StorageProviderModel::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->delete(route('storage-providers.destroy', ['storageProvider' => $provider->id]));
+
+    $this->assertDatabaseMissing('storage_providers', [
+        'id' => $provider->id,
+    ]);
+});
+
+test('cannot delete provider', function () {
+    $this->actingAs($this->user);
+
+    $database = Database::factory()->create([
+        'server_id' => $this->server,
+    ]);
+
+    $provider = StorageProviderModel::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Backup::factory()->create([
+        'server_id' => $this->server->id,
+        'database_id' => $database->id,
+        'storage_id' => $provider->id,
+    ]);
+
+    $this->delete(route('storage-providers.destroy', ['storageProvider' => $provider->id]))
+        ->assertSessionHasErrors([
+            'provider' => 'This storage provider is being used by a backup.',
         ]);
 
-        $response->assertRedirect();
+    $this->assertDatabaseHas('storage_providers', [
+        'id' => $provider->id,
+    ]);
+});
 
-        $location = (string) $response->headers->get('Location');
-        $this->assertStringContainsString('dropbox.com/oauth2/authorize', $location);
-        $this->assertStringContainsString('token_access_type=offline', $location);
-        $this->assertStringContainsString('my-app-key', $location);
-        $this->assertNotEmpty(session('dropbox_oauth.state'));
-    }
+test('user cannot update other users storage provider', function () {
+    $this->actingAs($this->user);
 
-    public function test_dropbox_callback_creates_provider(): void
-    {
-        $this->actingAs($this->user);
+    $otherUser = User::factory()->create();
+    $storageProvider = StorageProviderModel::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
 
-        Http::fake([
-            '*oauth2/token' => Http::response([
-                'access_token' => 'fresh-access',
-                'expires_in' => 14400,
-                'refresh_token' => 'the-refresh-token',
-            ]),
-            '*' => Http::response([], 200),
-        ]);
+    $this->patch(route('storage-providers.update', $storageProvider), [
+        'name' => 'hacked',
+    ])
+        ->assertForbidden();
+});
 
-        $response = $this->withSession([
-            'dropbox_oauth' => [
-                'state' => 'state-123',
-                'name' => 'dropbox-test',
-                'app_key' => 'my-app-key',
-                'app_secret' => 'my-app-secret',
-                'global' => false,
-            ],
-        ])->get(route('storage-providers.dropbox.callback', ['code' => 'auth-code', 'state' => 'state-123']));
+test('user cannot delete other users storage provider', function () {
+    $this->actingAs($this->user);
 
-        $response->assertRedirect(route('storage-providers'));
-        $response->assertSessionHas('success');
+    $otherUser = User::factory()->create();
+    $storageProvider = StorageProviderModel::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
 
-        $this->assertDatabaseHas('storage_providers', [
-            'provider' => Dropbox::id(),
-            'profile' => 'dropbox-test',
-            'user_id' => $this->user->id,
-        ]);
+    $this->delete(route('storage-providers.destroy', $storageProvider))
+        ->assertForbidden();
+});
 
-        $provider = StorageProviderModel::query()->where('profile', 'dropbox-test')->firstOrFail();
-        $this->assertSame('the-refresh-token', $provider->credentials['refresh_token']);
-        $this->assertSame('my-app-key', $provider->credentials['app_key']);
-    }
+test('guest cannot access storage providers', function () {
+    $storageProvider = StorageProviderModel::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
 
-    public function test_dropbox_callback_rejects_bad_state(): void
-    {
-        $this->actingAs($this->user);
+    $this->get(route('storage-providers'))
+        ->assertRedirect('/');
 
-        $response = $this->withSession([
-            'dropbox_oauth' => [
-                'state' => 'correct-state',
-                'name' => 'dropbox-test',
-                'app_key' => 'my-app-key',
-                'app_secret' => 'my-app-secret',
-                'global' => false,
-            ],
-        ])->get(route('storage-providers.dropbox.callback', ['code' => 'auth-code', 'state' => 'wrong-state']));
+    $this->post(route('storage-providers.store'), [])
+        ->assertRedirect('/');
 
-        $response->assertRedirect(route('storage-providers'));
-        $response->assertSessionHas('error');
-        $this->assertDatabaseMissing('storage_providers', ['profile' => 'dropbox-test']);
-    }
+    $this->patch(route('storage-providers.update', $storageProvider), [])
+        ->assertRedirect('/');
 
-    public function test_dropbox_callback_rejects_missing_code(): void
-    {
-        $this->actingAs($this->user);
+    $this->delete(route('storage-providers.destroy', $storageProvider))
+        ->assertRedirect('/');
+});
 
-        $response = $this->withSession([
-            'dropbox_oauth' => [
-                'state' => 'state-123',
-                'name' => 'dropbox-test',
-                'app_key' => 'my-app-key',
-                'app_secret' => 'my-app-secret',
-                'global' => false,
-            ],
-        ])->get(route('storage-providers.dropbox.callback', ['state' => 'state-123']));
+test('cannot manipulate user id on creation', function () {
+    $this->actingAs($this->user);
 
-        $response->assertRedirect(route('storage-providers'));
-        $response->assertSessionHas('error');
-        $this->assertDatabaseMissing('storage_providers', ['profile' => 'dropbox-test']);
-    }
+    $otherUser = User::factory()->create();
 
-    public function test_see_providers_list(): void
-    {
-        $this->actingAs($this->user);
+    $this->post(route('storage-providers.store'), [
+        'provider' => Local::id(),
+        'name' => 'test',
+        'path' => '/home/test',
+        'user_id' => $otherUser->id,
+    ]);
 
-        StorageProviderModel::factory()->dropbox()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $this->assertDatabaseHas('storage_providers', [
+        'profile' => 'test',
+        'provider' => Local::id(),
+        'user_id' => $this->user->id,
+    ]);
 
-        $this->get(route('storage-providers'))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('storage-providers/index'));
-    }
+    $this->assertDatabaseMissing('storage_providers', [
+        'profile' => 'test',
+        'provider' => Local::id(),
+        'user_id' => $otherUser->id,
+    ]);
+});
 
-    public function test_delete_provider(): void
-    {
-        $this->actingAs($this->user);
+test('cannot transfer ownership via update', function () {
+    $this->actingAs($this->user);
 
-        $provider = StorageProviderModel::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $otherUser = User::factory()->create();
+    $storageProvider = StorageProviderModel::factory()->create([
+        'user_id' => $this->user->id,
+        'profile' => 'original',
+    ]);
 
-        $this->delete(route('storage-providers.destroy', ['storageProvider' => $provider->id]));
+    $this->patch(route('storage-providers.update', $storageProvider), [
+        'name' => 'updated',
+        'user_id' => $otherUser->id,
+    ]);
 
-        $this->assertDatabaseMissing('storage_providers', [
-            'id' => $provider->id,
-        ]);
-    }
+    $storageProvider->refresh();
 
-    public function test_cannot_delete_provider(): void
-    {
-        $this->actingAs($this->user);
+    expect($storageProvider->user_id)->toEqual($this->user->id);
+    $this->assertNotEquals($otherUser->id, $storageProvider->user_id);
+});
 
-        $database = Database::factory()->create([
-            'server_id' => $this->server,
-        ]);
+test('user can only see own storage providers in list', function () {
+    $this->actingAs($this->user);
 
-        $provider = StorageProviderModel::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
+    $otherUser = User::factory()->create();
 
-        Backup::factory()->create([
-            'server_id' => $this->server->id,
-            'database_id' => $database->id,
-            'storage_id' => $provider->id,
-        ]);
+    $ownProvider = StorageProviderModel::factory()->create([
+        'user_id' => $this->user->id,
+        'profile' => 'own-provider',
+    ]);
 
-        $this->delete(route('storage-providers.destroy', ['storageProvider' => $provider->id]))
-            ->assertSessionHasErrors([
-                'provider' => 'This storage provider is being used by a backup.',
-            ]);
+    $otherProvider = StorageProviderModel::factory()->create([
+        'user_id' => $otherUser->id,
+        'profile' => 'other-provider',
+    ]);
 
-        $this->assertDatabaseHas('storage_providers', [
-            'id' => $provider->id,
-        ]);
-    }
+    $response = $this->get(route('storage-providers'))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('storage-providers/index'));
 
-    public function test_user_cannot_update_other_users_storage_provider(): void
-    {
-        $this->actingAs($this->user);
+    $response->assertInertia(fn (AssertableInertia $page) => $page->has('storageProviders.data')
+        ->where('storageProviders.data.0.id', $ownProvider->id)
+        ->whereNot('storageProviders.data.0.id', $otherProvider->id)
+    );
+});
 
-        $otherUser = User::factory()->create();
-        $storageProvider = StorageProviderModel::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
-
-        $this->patch(route('storage-providers.update', $storageProvider), [
-            'name' => 'hacked',
-        ])
-            ->assertForbidden();
-    }
-
-    public function test_user_cannot_delete_other_users_storage_provider(): void
-    {
-        $this->actingAs($this->user);
-
-        $otherUser = User::factory()->create();
-        $storageProvider = StorageProviderModel::factory()->create([
-            'user_id' => $otherUser->id,
-        ]);
-
-        $this->delete(route('storage-providers.destroy', $storageProvider))
-            ->assertForbidden();
-    }
-
-    public function test_guest_cannot_access_storage_providers(): void
-    {
-        $storageProvider = StorageProviderModel::factory()->create([
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->get(route('storage-providers'))
-            ->assertRedirect('/');
-
-        $this->post(route('storage-providers.store'), [])
-            ->assertRedirect('/');
-
-        $this->patch(route('storage-providers.update', $storageProvider), [])
-            ->assertRedirect('/');
-
-        $this->delete(route('storage-providers.destroy', $storageProvider))
-            ->assertRedirect('/');
-    }
-
-    public function test_cannot_manipulate_user_id_on_creation(): void
-    {
-        $this->actingAs($this->user);
-
-        $otherUser = User::factory()->create();
-
-        $this->post(route('storage-providers.store'), [
-            'provider' => Local::id(),
-            'name' => 'test',
-            'path' => '/home/test',
-            'user_id' => $otherUser->id,
-        ]);
-
-        $this->assertDatabaseHas('storage_providers', [
-            'profile' => 'test',
-            'provider' => Local::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->assertDatabaseMissing('storage_providers', [
-            'profile' => 'test',
-            'provider' => Local::id(),
-            'user_id' => $otherUser->id,
-        ]);
-    }
-
-    public function test_cannot_transfer_ownership_via_update(): void
-    {
-        $this->actingAs($this->user);
-
-        $otherUser = User::factory()->create();
-        $storageProvider = StorageProviderModel::factory()->create([
-            'user_id' => $this->user->id,
-            'profile' => 'original',
-        ]);
-
-        $this->patch(route('storage-providers.update', $storageProvider), [
-            'name' => 'updated',
-            'user_id' => $otherUser->id,
-        ]);
-
-        $storageProvider->refresh();
-
-        $this->assertEquals($this->user->id, $storageProvider->user_id);
-        $this->assertNotEquals($otherUser->id, $storageProvider->user_id);
-    }
-
-    public function test_user_can_only_see_own_storage_providers_in_list(): void
-    {
-        $this->actingAs($this->user);
-
-        $otherUser = User::factory()->create();
-
-        $ownProvider = StorageProviderModel::factory()->create([
-            'user_id' => $this->user->id,
-            'profile' => 'own-provider',
-        ]);
-
-        $otherProvider = StorageProviderModel::factory()->create([
-            'user_id' => $otherUser->id,
-            'profile' => 'other-provider',
-        ]);
-
-        $response = $this->get(route('storage-providers'))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('storage-providers/index'));
-
-        $response->assertInertia(fn (AssertableInertia $page) => $page->has('storageProviders.data')
-            ->where('storageProviders.data.0.id', $ownProvider->id)
-            ->whereNot('storageProviders.data.0.id', $otherProvider->id)
-        );
-    }
-
-    /**
-     * @return array<int, mixed>
-     */
-    public static function createData(): array
-    {
-        return [
+/**
+ * @return array<int, mixed>
+ */
+dataset('createData', function () {
+    return [
+        [
             [
-                [
-                    'provider' => Local::id(),
-                    'name' => 'local-test',
-                    'path' => '/home/vito/backups',
-                ],
+                'provider' => Local::id(),
+                'name' => 'local-test',
+                'path' => '/home/vito/backups',
             ],
+        ],
+        [
             [
-                [
-                    'provider' => Local::id(),
-                    'name' => 'local-test',
-                    'path' => '/home/vito/backups',
-                    'global' => 1,
-                ],
+                'provider' => Local::id(),
+                'name' => 'local-test',
+                'path' => '/home/vito/backups',
+                'global' => 1,
             ],
+        ],
+        [
             [
-                [
-                    'provider' => \App\StorageProviders\FTP::id(),
-                    'name' => 'ftp-test',
-                    'host' => '1.2.3.4',
-                    'port' => '22',
-                    'path' => '/home/vito',
-                    'username' => 'username',
-                    'password' => 'password',
-                    'ssl' => 1,
-                    'passive' => 1,
-                ],
+                'provider' => App\StorageProviders\FTP::id(),
+                'name' => 'ftp-test',
+                'host' => '1.2.3.4',
+                'port' => '22',
+                'path' => '/home/vito',
+                'username' => 'username',
+                'password' => 'password',
+                'ssl' => 1,
+                'passive' => 1,
             ],
+        ],
+        [
             [
-                [
-                    'provider' => \App\StorageProviders\FTP::id(),
-                    'name' => 'ftp-test',
-                    'host' => '1.2.3.4',
-                    'port' => '22',
-                    'path' => '/home/vito',
-                    'username' => 'username',
-                    'password' => 'password',
-                    'ssl' => 1,
-                    'passive' => 1,
-                    'global' => 1,
-                ],
+                'provider' => App\StorageProviders\FTP::id(),
+                'name' => 'ftp-test',
+                'host' => '1.2.3.4',
+                'port' => '22',
+                'path' => '/home/vito',
+                'username' => 'username',
+                'password' => 'password',
+                'ssl' => 1,
+                'passive' => 1,
+                'global' => 1,
             ],
+        ],
+        [
             [
-                [
-                    'provider' => \App\StorageProviders\SFTP::id(),
-                    'name' => 'sftp-test',
-                    'host' => '1.2.3.4',
-                    'port' => '22',
-                    'path' => '/home/vito',
-                    'username' => 'username',
-                    'password' => 'password',
-                ],
+                'provider' => App\StorageProviders\SFTP::id(),
+                'name' => 'sftp-test',
+                'host' => '1.2.3.4',
+                'port' => '22',
+                'path' => '/home/vito',
+                'username' => 'username',
+                'password' => 'password',
             ],
+        ],
+        [
             [
-                [
-                    'provider' => \App\StorageProviders\SFTP::id(),
-                    'name' => 'sftp-test',
-                    'host' => '1.2.3.4',
-                    'port' => '22',
-                    'path' => '/home/vito',
-                    'username' => 'username',
-                    'password' => 'password',
-                    'global' => 1,
-                ],
+                'provider' => App\StorageProviders\SFTP::id(),
+                'name' => 'sftp-test',
+                'host' => '1.2.3.4',
+                'port' => '22',
+                'path' => '/home/vito',
+                'username' => 'username',
+                'password' => 'password',
+                'global' => 1,
             ],
-        ];
-    }
-}
+        ],
+    ];
+});

--- a/tests/Feature/SyncCronjobTest.php
+++ b/tests/Feature/SyncCronjobTest.php
@@ -10,7 +10,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class);
 
 test('sync cronjobs from server', function () {
-    // Mock SSH to return some existing cronjobs
     SSH::fake("0 2 * * * /usr/bin/backup.sh\n0 4 * * * /usr/bin/cleanup.sh");
 
     $this->actingAs($this->user)
@@ -18,19 +17,15 @@ test('sync cronjobs from server', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // Check that cronjobs were created
     $serverCronJobs = CronJob::where('server_id', $this->server->id)->get();
 
-    // Should have 4 cronjobs (2 for root user, 2 for vito user)
     expect($serverCronJobs)->toHaveCount(4);
 
-    // Check that we have the expected commands
     expect($serverCronJobs->contains('command', '/usr/bin/backup.sh'))->toBeTrue();
     expect($serverCronJobs->contains('command', '/usr/bin/cleanup.sh'))->toBeTrue();
     expect($serverCronJobs->contains('frequency', '0 2 * * *'))->toBeTrue();
     expect($serverCronJobs->contains('frequency', '0 4 * * *'))->toBeTrue();
 
-    // Check that we have cronjobs for both users
     $rootCronJobs = $serverCronJobs->where('user', 'root');
     $vitoCronJobs = $serverCronJobs->where('user', 'vito');
     expect($rootCronJobs)->toHaveCount(2);
@@ -38,7 +33,6 @@ test('sync cronjobs from server', function () {
 });
 
 test('sync skips existing cronjobs', function () {
-    // Create an existing cronjob
     CronJob::factory()->create([
         'server_id' => $this->server->id,
         'user' => 'root',
@@ -47,7 +41,6 @@ test('sync skips existing cronjobs', function () {
         'status' => CronjobStatus::READY,
     ]);
 
-    // Mock SSH to return the same cronjob plus a new one
     SSH::fake("0 2 * * * /usr/bin/backup.sh\n0 4 * * * /usr/bin/cleanup.sh");
 
     $this->actingAs($this->user)
@@ -55,17 +48,14 @@ test('sync skips existing cronjobs', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // Should have 4 cronjobs (1 existing + 3 new ones from sync)
     $cronJobs = CronJob::where('server_id', $this->server->id)->get();
     expect($cronJobs)->toHaveCount(4);
 
-    // Should have both the existing and new cronjob
     expect($cronJobs->contains('command', '/usr/bin/backup.sh'))->toBeTrue();
     expect($cronJobs->contains('command', '/usr/bin/cleanup.sh'))->toBeTrue();
 });
 
 test('sync handles empty crontab', function () {
-    // Mock SSH to return empty crontab
     SSH::fake('');
 
     $this->actingAs($this->user)
@@ -73,12 +63,10 @@ test('sync handles empty crontab', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // Should not create any cronjobs
     $this->assertDatabaseCount('cron_jobs', 0);
 });
 
 test('sync skips comments and empty lines', function () {
-    // Mock SSH to return crontab with comments and empty lines
     SSH::fake("# This is a comment\n\n0 2 * * * /usr/bin/backup.sh\n# Another comment\n\n0 4 * * * /usr/bin/cleanup.sh\n");
 
     $this->actingAs($this->user)
@@ -86,7 +74,6 @@ test('sync skips comments and empty lines', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // Should only create the actual cronjobs, not comments
     $cronJobs = CronJob::where('server_id', $this->server->id)->get();
     expect($cronJobs)->toHaveCount(4);
 
@@ -95,7 +82,6 @@ test('sync skips comments and empty lines', function () {
 });
 
 test('sync creates disabled cronjobs for commented entries', function () {
-    // Mock SSH to return commented cronjobs
     SSH::fake("# 0 2 * * * /usr/bin/backup.sh\n# 0 4 * * * /usr/bin/cleanup.sh");
 
     $this->actingAs($this->user)
@@ -103,11 +89,9 @@ test('sync creates disabled cronjobs for commented entries', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // Should create 4 cronjobs (2 for root, 2 for vito) and they should be disabled
     $cronJobs = CronJob::where('server_id', $this->server->id)->get();
     expect($cronJobs)->toHaveCount(4);
 
-    // All should be disabled
     foreach ($cronJobs as $cronJob) {
         expect($cronJob->status)->toEqual(CronjobStatus::DISABLED);
     }
@@ -117,7 +101,6 @@ test('sync creates disabled cronjobs for commented entries', function () {
 });
 
 test('sync updates existing cronjobs based on comment status', function () {
-    // Create an existing enabled cronjob
     $existingCronJob = CronJob::factory()->create([
         'server_id' => $this->server->id,
         'user' => 'root',
@@ -127,7 +110,6 @@ test('sync updates existing cronjobs based on comment status', function () {
         'site_id' => null,
     ]);
 
-    // Mock SSH to return the same cronjob but commented (disabled)
     SSH::fake('# 0 2 * * * /usr/bin/backup.sh');
 
     $this->actingAs($this->user)
@@ -135,13 +117,11 @@ test('sync updates existing cronjobs based on comment status', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // The existing cronjob should now be disabled
     $existingCronJob->refresh();
     expect($existingCronJob->status)->toEqual(CronjobStatus::DISABLED);
 });
 
 test('sync enables existing disabled cronjobs when uncommented', function () {
-    // Create an existing disabled cronjob
     $existingCronJob = CronJob::factory()->create([
         'server_id' => $this->server->id,
         'user' => 'root',
@@ -151,7 +131,6 @@ test('sync enables existing disabled cronjobs when uncommented', function () {
         'site_id' => null,
     ]);
 
-    // Mock SSH to return the same cronjob but uncommented (enabled)
     SSH::fake('0 2 * * * /usr/bin/backup.sh');
 
     $this->actingAs($this->user)
@@ -159,13 +138,11 @@ test('sync enables existing disabled cronjobs when uncommented', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // The existing cronjob should now be enabled
     $existingCronJob->refresh();
     expect($existingCronJob->status)->toEqual(CronjobStatus::READY);
 });
 
 test('sync handles mixed commented and uncommented cronjobs', function () {
-    // Mock SSH to return mix of commented and uncommented cronjobs
     SSH::fake("0 2 * * * /usr/bin/backup.sh\n# 0 4 * * * /usr/bin/cleanup.sh");
 
     $this->actingAs($this->user)
@@ -173,11 +150,9 @@ test('sync handles mixed commented and uncommented cronjobs', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // Should create 4 cronjobs (2 for root, 2 for vito)
     $cronJobs = CronJob::where('server_id', $this->server->id)->get();
     expect($cronJobs)->toHaveCount(4);
 
-    // Check that backup.sh is enabled and cleanup.sh is disabled
     $backupCronJobs = $cronJobs->where('command', '/usr/bin/backup.sh');
     $cleanupCronJobs = $cronJobs->where('command', '/usr/bin/cleanup.sh');
 
@@ -191,7 +166,6 @@ test('sync handles mixed commented and uncommented cronjobs', function () {
 });
 
 test('sync disables vito cronjobs removed from server', function () {
-    // Create a Vito-managed cronjob
     $vitoCronJob = CronJob::factory()->create([
         'server_id' => $this->server->id,
         'user' => 'root',
@@ -201,7 +175,6 @@ test('sync disables vito cronjobs removed from server', function () {
         'site_id' => null,
     ]);
 
-    // Mock SSH to return empty crontab (cronjob was manually deleted)
     SSH::fake('');
 
     $this->actingAs($this->user)
@@ -209,13 +182,11 @@ test('sync disables vito cronjobs removed from server', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // The Vito cronjob should be marked as disabled
     $vitoCronJob->refresh();
     expect($vitoCronJob->status)->toEqual(CronjobStatus::DISABLED);
 });
 
 test('sync disables vito cronjobs not found on server', function () {
-    // Create multiple Vito-managed cronjobs
     $cronJob1 = CronJob::factory()->create([
         'server_id' => $this->server->id,
         'user' => 'root',
@@ -234,7 +205,6 @@ test('sync disables vito cronjobs not found on server', function () {
         'site_id' => null,
     ]);
 
-    // Mock SSH to return only one cronjob (the other was manually deleted)
     SSH::fake('0 2 * * * /usr/bin/backup.sh');
 
     $this->actingAs($this->user)
@@ -242,7 +212,6 @@ test('sync disables vito cronjobs not found on server', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // The first cronjob should remain enabled, the second should be disabled
     $cronJob1->refresh();
     $cronJob2->refresh();
 
@@ -251,27 +220,24 @@ test('sync disables vito cronjobs not found on server', function () {
 });
 
 test('sync does not affect site level cronjobs', function () {
-    // Create a site-level cronjob
     $siteCronJob = CronJob::factory()->create([
         'server_id' => $this->server->id,
         'user' => 'root',
         'command' => '/usr/bin/site-script.sh',
         'frequency' => '0 4 * * *',
         'status' => CronjobStatus::READY,
-        'site_id' => $this->site->id, // Site-level
+        'site_id' => $this->site->id,
     ]);
 
-    // Create a server-level cronjob
     $serverCronJob = CronJob::factory()->create([
         'server_id' => $this->server->id,
         'user' => 'root',
         'command' => '/usr/bin/server-script.sh',
         'frequency' => '0 2 * * *',
         'status' => CronjobStatus::READY,
-        'site_id' => null, // Server-level
+        'site_id' => null,
     ]);
 
-    // Mock SSH to return empty crontab
     SSH::fake('');
 
     $this->actingAs($this->user)
@@ -279,17 +245,14 @@ test('sync does not affect site level cronjobs', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // Site-level cronjob should remain unchanged
     $siteCronJob->refresh();
     expect($siteCronJob->status)->toEqual(CronjobStatus::READY);
 
-    // Server-level cronjob should be disabled
     $serverCronJob->refresh();
     expect($serverCronJob->status)->toEqual(CronjobStatus::DISABLED);
 });
 
 test('sync handles mixed scenarios with deletions', function () {
-    // Create Vito-managed cronjobs
     $cronJob1 = CronJob::factory()->create([
         'server_id' => $this->server->id,
         'user' => 'root',
@@ -308,7 +271,6 @@ test('sync handles mixed scenarios with deletions', function () {
         'site_id' => null,
     ]);
 
-    // Mock SSH to return one existing cronjob, one commented, and one new manual cronjob
     SSH::fake("0 2 * * * /usr/bin/backup.sh\n# 0 4 * * * /usr/bin/cleanup.sh\n0 6 * * * /usr/bin/new-script.sh");
 
     $this->actingAs($this->user)
@@ -316,17 +278,13 @@ test('sync handles mixed scenarios with deletions', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // Check results
     $cronJob1->refresh();
     $cronJob2->refresh();
 
-    // First cronjob should remain enabled
     expect($cronJob1->status)->toEqual(CronjobStatus::READY);
 
-    // Second cronjob should be disabled (commented on server)
     expect($cronJob2->status)->toEqual(CronjobStatus::DISABLED);
 
-    // New manual cronjob should be created
     $this->assertDatabaseHas('cron_jobs', [
         'server_id' => $this->server->id,
         'user' => 'root',
@@ -338,7 +296,6 @@ test('sync handles mixed scenarios with deletions', function () {
 });
 
 test('sync normalizes frequency with extra spaces', function () {
-    // Create a cronjob with normal spacing
     $existingCronJob = CronJob::factory()->create([
         'server_id' => $this->server->id,
         'user' => 'root',
@@ -348,7 +305,6 @@ test('sync normalizes frequency with extra spaces', function () {
         'site_id' => null,
     ]);
 
-    // Mock SSH to return the same cronjob with extra spaces
     SSH::fake('5  15   *    *  * /usr/bin/backup.sh');
 
     $this->actingAs($this->user)
@@ -356,22 +312,18 @@ test('sync normalizes frequency with extra spaces', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // Should not create duplicate, existing cronjob should remain
     $cronJobs = CronJob::where('server_id', $this->server->id)
         ->where('command', '/usr/bin/backup.sh')
         ->where('site_id', null)
         ->get();
 
-    // Should only have the one existing cronjob for each user (root + vito = 2 total)
     expect($cronJobs)->toHaveCount(2);
 
-    // The original cronjob should still be ready
     $existingCronJob->refresh();
     expect($existingCronJob->status)->toEqual(CronjobStatus::READY);
 });
 
 test('sync recognizes site level cronjobs', function () {
-    // Create a site-level cronjob with the same command as what will be on the server
     $siteCronJob = CronJob::factory()->create([
         'server_id' => $this->server->id,
         'user' => 'root',
@@ -381,7 +333,6 @@ test('sync recognizes site level cronjobs', function () {
         'site_id' => $this->site->id,
     ]);
 
-    // Mock SSH to return a cronjob with the same frequency and command
     SSH::fake('5 15 * * * /usr/bin/backup.sh');
 
     $countBefore = CronJob::where('server_id', $this->server->id)
@@ -397,29 +348,23 @@ test('sync recognizes site level cronjobs', function () {
         ->where('command', '/usr/bin/backup.sh')
         ->count();
 
-    // Before fix: would create duplicate with site_id = null
-    // After fix: recognizes site-level cronjob and doesn't duplicate it, only creates for vito user
-    // countBefore = 1 (site-level), countAfter should be 2 (site-level + vito user)
     expect($countAfter)->toEqual($countBefore + 1);
 
-    // The site-level cronjob should remain unchanged
     $siteCronJob->refresh();
     expect($siteCronJob->site_id)->toEqual($this->site->id);
     expect($siteCronJob->status)->toEqual(CronjobStatus::READY);
 });
 
 test('sync handles frequency with mixed spacing in db', function () {
-    // Create a cronjob with extra spaces in the frequency (simulating old data)
     $existingCronJob = CronJob::factory()->create([
         'server_id' => $this->server->id,
         'user' => 'root',
         'command' => '/usr/bin/backup.sh',
-        'frequency' => '5  15  *  *  *', // Double spaces
+        'frequency' => '5  15  *  *  *',
         'status' => CronjobStatus::READY,
         'site_id' => null,
     ]);
 
-    // Mock SSH to return the same cronjob with normalized spacing
     SSH::fake('5 15 * * * /usr/bin/backup.sh');
 
     $this->actingAs($this->user)
@@ -427,22 +372,18 @@ test('sync handles frequency with mixed spacing in db', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // Should not create duplicate
     $cronJobs = CronJob::where('server_id', $this->server->id)
         ->where('command', '/usr/bin/backup.sh')
         ->where('site_id', null)
         ->get();
 
-    // Should only have the one existing cronjob for each user (root + vito = 2 total)
     expect($cronJobs)->toHaveCount(2);
 
-    // The original cronjob should still be ready
     $existingCronJob->refresh();
     expect($existingCronJob->status)->toEqual(CronjobStatus::READY);
 });
 
 test('sync ignores crontab documentation comments', function () {
-    // Mock SSH to return crontab with documentation comments (like the default crontab header)
     $crontabWithComments = '# Edit this file to introduce tasks to be run by cron.
 #
 # Each task to run has to be defined through a single line
@@ -457,18 +398,14 @@ test('sync ignores crontab documentation comments', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // Should only create cronjobs for the actual cron line, not the documentation comments
     $cronJobs = CronJob::where('server_id', $this->server->id)->get();
 
-    // Should have 2 cronjobs (1 for root, 1 for vito), not 6 (which would include the comment lines)
     expect($cronJobs)->toHaveCount(2);
 
-    // Both should have the actual backup command
     expect($cronJobs->every(fn ($cronJob) => $cronJob->command === '/usr/bin/backup.sh'))->toBeTrue();
 });
 
 test('sync normalizes command with extra spaces', function () {
-    // Create a cronjob with normal spacing in command
     $existingCronJob = CronJob::factory()->create([
         'server_id' => $this->server->id,
         'user' => 'root',
@@ -478,7 +415,6 @@ test('sync normalizes command with extra spaces', function () {
         'site_id' => null,
     ]);
 
-    // Mock SSH to return the same cronjob with extra spaces in command
     SSH::fake('* * *  * * ls  -la');
 
     $this->actingAs($this->user)
@@ -486,15 +422,12 @@ test('sync normalizes command with extra spaces', function () {
         ->assertRedirect()
         ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-    // Should not create duplicate, existing cronjob should remain
     $cronJobs = CronJob::where('server_id', $this->server->id)
         ->where('site_id', null)
         ->get();
 
-    // Should only have the one existing cronjob for each user (root + vito = 2 total)
     expect($cronJobs)->toHaveCount(2);
 
-    // The original cronjob should still be ready
     $existingCronJob->refresh();
     expect($existingCronJob->status)->toEqual(CronjobStatus::READY);
     expect($existingCronJob->command)->toEqual('ls -la');

--- a/tests/Feature/SyncCronjobTest.php
+++ b/tests/Feature/SyncCronjobTest.php
@@ -3,8 +3,6 @@
 use App\Enums\CronjobStatus;
 use App\Facades\SSH;
 use App\Models\CronJob;
-use App\Models\Server;
-use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);

--- a/tests/Feature/SyncCronjobTest.php
+++ b/tests/Feature/SyncCronjobTest.php
@@ -1,524 +1,501 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\CronjobStatus;
 use App\Facades\SSH;
 use App\Models\CronJob;
 use App\Models\Server;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class SyncCronjobTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_sync_cronjobs_from_server(): void
-    {
-        // Mock SSH to return some existing cronjobs
-        SSH::fake("0 2 * * * /usr/bin/backup.sh\n0 4 * * * /usr/bin/cleanup.sh");
+test('sync cronjobs from server', function () {
+    // Mock SSH to return some existing cronjobs
+    SSH::fake("0 2 * * * /usr/bin/backup.sh\n0 4 * * * /usr/bin/cleanup.sh");
 
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-        // Check that cronjobs were created
-        $serverCronJobs = CronJob::where('server_id', $this->server->id)->get();
+    // Check that cronjobs were created
+    $serverCronJobs = CronJob::where('server_id', $this->server->id)->get();
 
-        // Should have 4 cronjobs (2 for root user, 2 for vito user)
-        $this->assertCount(4, $serverCronJobs);
+    // Should have 4 cronjobs (2 for root user, 2 for vito user)
+    expect($serverCronJobs)->toHaveCount(4);
 
-        // Check that we have the expected commands
-        $this->assertTrue($serverCronJobs->contains('command', '/usr/bin/backup.sh'));
-        $this->assertTrue($serverCronJobs->contains('command', '/usr/bin/cleanup.sh'));
-        $this->assertTrue($serverCronJobs->contains('frequency', '0 2 * * *'));
-        $this->assertTrue($serverCronJobs->contains('frequency', '0 4 * * *'));
+    // Check that we have the expected commands
+    expect($serverCronJobs->contains('command', '/usr/bin/backup.sh'))->toBeTrue();
+    expect($serverCronJobs->contains('command', '/usr/bin/cleanup.sh'))->toBeTrue();
+    expect($serverCronJobs->contains('frequency', '0 2 * * *'))->toBeTrue();
+    expect($serverCronJobs->contains('frequency', '0 4 * * *'))->toBeTrue();
 
-        // Check that we have cronjobs for both users
-        $rootCronJobs = $serverCronJobs->where('user', 'root');
-        $vitoCronJobs = $serverCronJobs->where('user', 'vito');
-        $this->assertCount(2, $rootCronJobs);
-        $this->assertCount(2, $vitoCronJobs);
+    // Check that we have cronjobs for both users
+    $rootCronJobs = $serverCronJobs->where('user', 'root');
+    $vitoCronJobs = $serverCronJobs->where('user', 'vito');
+    expect($rootCronJobs)->toHaveCount(2);
+    expect($vitoCronJobs)->toHaveCount(2);
+});
+
+test('sync skips existing cronjobs', function () {
+    // Create an existing cronjob
+    CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/backup.sh',
+        'frequency' => '0 2 * * *',
+        'status' => CronjobStatus::READY,
+    ]);
+
+    // Mock SSH to return the same cronjob plus a new one
+    SSH::fake("0 2 * * * /usr/bin/backup.sh\n0 4 * * * /usr/bin/cleanup.sh");
+
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
+
+    // Should have 4 cronjobs (1 existing + 3 new ones from sync)
+    $cronJobs = CronJob::where('server_id', $this->server->id)->get();
+    expect($cronJobs)->toHaveCount(4);
+
+    // Should have both the existing and new cronjob
+    expect($cronJobs->contains('command', '/usr/bin/backup.sh'))->toBeTrue();
+    expect($cronJobs->contains('command', '/usr/bin/cleanup.sh'))->toBeTrue();
+});
+
+test('sync handles empty crontab', function () {
+    // Mock SSH to return empty crontab
+    SSH::fake('');
+
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
+
+    // Should not create any cronjobs
+    $this->assertDatabaseCount('cron_jobs', 0);
+});
+
+test('sync skips comments and empty lines', function () {
+    // Mock SSH to return crontab with comments and empty lines
+    SSH::fake("# This is a comment\n\n0 2 * * * /usr/bin/backup.sh\n# Another comment\n\n0 4 * * * /usr/bin/cleanup.sh\n");
+
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
+
+    // Should only create the actual cronjobs, not comments
+    $cronJobs = CronJob::where('server_id', $this->server->id)->get();
+    expect($cronJobs)->toHaveCount(4);
+
+    expect($cronJobs->contains('command', '/usr/bin/backup.sh'))->toBeTrue();
+    expect($cronJobs->contains('command', '/usr/bin/cleanup.sh'))->toBeTrue();
+});
+
+test('sync creates disabled cronjobs for commented entries', function () {
+    // Mock SSH to return commented cronjobs
+    SSH::fake("# 0 2 * * * /usr/bin/backup.sh\n# 0 4 * * * /usr/bin/cleanup.sh");
+
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
+
+    // Should create 4 cronjobs (2 for root, 2 for vito) and they should be disabled
+    $cronJobs = CronJob::where('server_id', $this->server->id)->get();
+    expect($cronJobs)->toHaveCount(4);
+
+    // All should be disabled
+    foreach ($cronJobs as $cronJob) {
+        expect($cronJob->status)->toEqual(CronjobStatus::DISABLED);
     }
 
-    public function test_sync_skips_existing_cronjobs(): void
-    {
-        // Create an existing cronjob
-        CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/backup.sh',
-            'frequency' => '0 2 * * *',
-            'status' => CronjobStatus::READY,
-        ]);
+    expect($cronJobs->contains('command', '/usr/bin/backup.sh'))->toBeTrue();
+    expect($cronJobs->contains('command', '/usr/bin/cleanup.sh'))->toBeTrue();
+});
 
-        // Mock SSH to return the same cronjob plus a new one
-        SSH::fake("0 2 * * * /usr/bin/backup.sh\n0 4 * * * /usr/bin/cleanup.sh");
+test('sync updates existing cronjobs based on comment status', function () {
+    // Create an existing enabled cronjob
+    $existingCronJob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/backup.sh',
+        'frequency' => '0 2 * * *',
+        'status' => CronjobStatus::READY,
+        'site_id' => null,
+    ]);
 
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
+    // Mock SSH to return the same cronjob but commented (disabled)
+    SSH::fake('# 0 2 * * * /usr/bin/backup.sh');
 
-        // Should have 4 cronjobs (1 existing + 3 new ones from sync)
-        $cronJobs = CronJob::where('server_id', $this->server->id)->get();
-        $this->assertCount(4, $cronJobs);
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-        // Should have both the existing and new cronjob
-        $this->assertTrue($cronJobs->contains('command', '/usr/bin/backup.sh'));
-        $this->assertTrue($cronJobs->contains('command', '/usr/bin/cleanup.sh'));
+    // The existing cronjob should now be disabled
+    $existingCronJob->refresh();
+    expect($existingCronJob->status)->toEqual(CronjobStatus::DISABLED);
+});
+
+test('sync enables existing disabled cronjobs when uncommented', function () {
+    // Create an existing disabled cronjob
+    $existingCronJob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/backup.sh',
+        'frequency' => '0 2 * * *',
+        'status' => CronjobStatus::DISABLED,
+        'site_id' => null,
+    ]);
+
+    // Mock SSH to return the same cronjob but uncommented (enabled)
+    SSH::fake('0 2 * * * /usr/bin/backup.sh');
+
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
+
+    // The existing cronjob should now be enabled
+    $existingCronJob->refresh();
+    expect($existingCronJob->status)->toEqual(CronjobStatus::READY);
+});
+
+test('sync handles mixed commented and uncommented cronjobs', function () {
+    // Mock SSH to return mix of commented and uncommented cronjobs
+    SSH::fake("0 2 * * * /usr/bin/backup.sh\n# 0 4 * * * /usr/bin/cleanup.sh");
+
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
+
+    // Should create 4 cronjobs (2 for root, 2 for vito)
+    $cronJobs = CronJob::where('server_id', $this->server->id)->get();
+    expect($cronJobs)->toHaveCount(4);
+
+    // Check that backup.sh is enabled and cleanup.sh is disabled
+    $backupCronJobs = $cronJobs->where('command', '/usr/bin/backup.sh');
+    $cleanupCronJobs = $cronJobs->where('command', '/usr/bin/cleanup.sh');
+
+    foreach ($backupCronJobs as $cronJob) {
+        expect($cronJob->status)->toEqual(CronjobStatus::READY);
     }
 
-    public function test_sync_handles_empty_crontab(): void
-    {
-        // Mock SSH to return empty crontab
-        SSH::fake('');
-
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
-
-        // Should not create any cronjobs
-        $this->assertDatabaseCount('cron_jobs', 0);
+    foreach ($cleanupCronJobs as $cronJob) {
+        expect($cronJob->status)->toEqual(CronjobStatus::DISABLED);
     }
-
-    public function test_sync_skips_comments_and_empty_lines(): void
-    {
-        // Mock SSH to return crontab with comments and empty lines
-        SSH::fake("# This is a comment\n\n0 2 * * * /usr/bin/backup.sh\n# Another comment\n\n0 4 * * * /usr/bin/cleanup.sh\n");
-
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
-
-        // Should only create the actual cronjobs, not comments
-        $cronJobs = CronJob::where('server_id', $this->server->id)->get();
-        $this->assertCount(4, $cronJobs);
-
-        $this->assertTrue($cronJobs->contains('command', '/usr/bin/backup.sh'));
-        $this->assertTrue($cronJobs->contains('command', '/usr/bin/cleanup.sh'));
-    }
-
-    public function test_sync_creates_disabled_cronjobs_for_commented_entries(): void
-    {
-        // Mock SSH to return commented cronjobs
-        SSH::fake("# 0 2 * * * /usr/bin/backup.sh\n# 0 4 * * * /usr/bin/cleanup.sh");
-
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
-
-        // Should create 4 cronjobs (2 for root, 2 for vito) and they should be disabled
-        $cronJobs = CronJob::where('server_id', $this->server->id)->get();
-        $this->assertCount(4, $cronJobs);
-
-        // All should be disabled
-        foreach ($cronJobs as $cronJob) {
-            $this->assertEquals(CronjobStatus::DISABLED, $cronJob->status);
-        }
-
-        $this->assertTrue($cronJobs->contains('command', '/usr/bin/backup.sh'));
-        $this->assertTrue($cronJobs->contains('command', '/usr/bin/cleanup.sh'));
-    }
-
-    public function test_sync_updates_existing_cronjobs_based_on_comment_status(): void
-    {
-        // Create an existing enabled cronjob
-        $existingCronJob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/backup.sh',
-            'frequency' => '0 2 * * *',
-            'status' => CronjobStatus::READY,
-            'site_id' => null,
-        ]);
-
-        // Mock SSH to return the same cronjob but commented (disabled)
-        SSH::fake('# 0 2 * * * /usr/bin/backup.sh');
-
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
-
-        // The existing cronjob should now be disabled
-        $existingCronJob->refresh();
-        $this->assertEquals(CronjobStatus::DISABLED, $existingCronJob->status);
-    }
-
-    public function test_sync_enables_existing_disabled_cronjobs_when_uncommented(): void
-    {
-        // Create an existing disabled cronjob
-        $existingCronJob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/backup.sh',
-            'frequency' => '0 2 * * *',
-            'status' => CronjobStatus::DISABLED,
-            'site_id' => null,
-        ]);
-
-        // Mock SSH to return the same cronjob but uncommented (enabled)
-        SSH::fake('0 2 * * * /usr/bin/backup.sh');
-
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
-
-        // The existing cronjob should now be enabled
-        $existingCronJob->refresh();
-        $this->assertEquals(CronjobStatus::READY, $existingCronJob->status);
-    }
-
-    public function test_sync_handles_mixed_commented_and_uncommented_cronjobs(): void
-    {
-        // Mock SSH to return mix of commented and uncommented cronjobs
-        SSH::fake("0 2 * * * /usr/bin/backup.sh\n# 0 4 * * * /usr/bin/cleanup.sh");
-
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
-
-        // Should create 4 cronjobs (2 for root, 2 for vito)
-        $cronJobs = CronJob::where('server_id', $this->server->id)->get();
-        $this->assertCount(4, $cronJobs);
-
-        // Check that backup.sh is enabled and cleanup.sh is disabled
-        $backupCronJobs = $cronJobs->where('command', '/usr/bin/backup.sh');
-        $cleanupCronJobs = $cronJobs->where('command', '/usr/bin/cleanup.sh');
-
-        foreach ($backupCronJobs as $cronJob) {
-            $this->assertEquals(CronjobStatus::READY, $cronJob->status);
-        }
-
-        foreach ($cleanupCronJobs as $cronJob) {
-            $this->assertEquals(CronjobStatus::DISABLED, $cronJob->status);
-        }
-    }
-
-    public function test_sync_disables_vito_cronjobs_removed_from_server(): void
-    {
-        // Create a Vito-managed cronjob
-        $vitoCronJob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/backup.sh',
-            'frequency' => '0 2 * * *',
-            'status' => CronjobStatus::READY,
-            'site_id' => null,
-        ]);
-
-        // Mock SSH to return empty crontab (cronjob was manually deleted)
-        SSH::fake('');
-
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
-
-        // The Vito cronjob should be marked as disabled
-        $vitoCronJob->refresh();
-        $this->assertEquals(CronjobStatus::DISABLED, $vitoCronJob->status);
-    }
-
-    public function test_sync_disables_vito_cronjobs_not_found_on_server(): void
-    {
-        // Create multiple Vito-managed cronjobs
-        $cronJob1 = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/backup.sh',
-            'frequency' => '0 2 * * *',
-            'status' => CronjobStatus::READY,
-            'site_id' => null,
-        ]);
-
-        $cronJob2 = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/cleanup.sh',
-            'frequency' => '0 4 * * *',
-            'status' => CronjobStatus::READY,
-            'site_id' => null,
-        ]);
-
-        // Mock SSH to return only one cronjob (the other was manually deleted)
-        SSH::fake('0 2 * * * /usr/bin/backup.sh');
-
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
-
-        // The first cronjob should remain enabled, the second should be disabled
-        $cronJob1->refresh();
-        $cronJob2->refresh();
-
-        $this->assertEquals(CronjobStatus::READY, $cronJob1->status);
-        $this->assertEquals(CronjobStatus::DISABLED, $cronJob2->status);
-    }
-
-    public function test_sync_does_not_affect_site_level_cronjobs(): void
-    {
-        // Create a site-level cronjob
-        $siteCronJob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/site-script.sh',
-            'frequency' => '0 4 * * *',
-            'status' => CronjobStatus::READY,
-            'site_id' => $this->site->id, // Site-level
-        ]);
-
-        // Create a server-level cronjob
-        $serverCronJob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/server-script.sh',
-            'frequency' => '0 2 * * *',
-            'status' => CronjobStatus::READY,
-            'site_id' => null, // Server-level
-        ]);
-
-        // Mock SSH to return empty crontab
-        SSH::fake('');
-
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
-
-        // Site-level cronjob should remain unchanged
-        $siteCronJob->refresh();
-        $this->assertEquals(CronjobStatus::READY, $siteCronJob->status);
-
-        // Server-level cronjob should be disabled
-        $serverCronJob->refresh();
-        $this->assertEquals(CronjobStatus::DISABLED, $serverCronJob->status);
-    }
-
-    public function test_sync_handles_mixed_scenarios_with_deletions(): void
-    {
-        // Create Vito-managed cronjobs
-        $cronJob1 = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/backup.sh',
-            'frequency' => '0 2 * * *',
-            'status' => CronjobStatus::READY,
-            'site_id' => null,
-        ]);
-
-        $cronJob2 = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/cleanup.sh',
-            'frequency' => '0 4 * * *',
-            'status' => CronjobStatus::READY,
-            'site_id' => null,
-        ]);
-
-        // Mock SSH to return one existing cronjob, one commented, and one new manual cronjob
-        SSH::fake("0 2 * * * /usr/bin/backup.sh\n# 0 4 * * * /usr/bin/cleanup.sh\n0 6 * * * /usr/bin/new-script.sh");
-
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
-
-        // Check results
-        $cronJob1->refresh();
-        $cronJob2->refresh();
-
-        // First cronjob should remain enabled
-        $this->assertEquals(CronjobStatus::READY, $cronJob1->status);
-
-        // Second cronjob should be disabled (commented on server)
-        $this->assertEquals(CronjobStatus::DISABLED, $cronJob2->status);
-
-        // New manual cronjob should be created
-        $this->assertDatabaseHas('cron_jobs', [
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/new-script.sh',
-            'frequency' => '0 6 * * *',
-            'status' => CronjobStatus::READY,
-            'site_id' => null,
-        ]);
-    }
-
-    public function test_sync_normalizes_frequency_with_extra_spaces(): void
-    {
-        // Create a cronjob with normal spacing
-        $existingCronJob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/backup.sh',
-            'frequency' => '5 15 * * *',
-            'status' => CronjobStatus::READY,
-            'site_id' => null,
-        ]);
-
-        // Mock SSH to return the same cronjob with extra spaces
-        SSH::fake('5  15   *    *  * /usr/bin/backup.sh');
-
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
-
-        // Should not create duplicate, existing cronjob should remain
-        $cronJobs = CronJob::where('server_id', $this->server->id)
-            ->where('command', '/usr/bin/backup.sh')
-            ->where('site_id', null)
-            ->get();
-
-        // Should only have the one existing cronjob for each user (root + vito = 2 total)
-        $this->assertCount(2, $cronJobs);
-
-        // The original cronjob should still be ready
-        $existingCronJob->refresh();
-        $this->assertEquals(CronjobStatus::READY, $existingCronJob->status);
-    }
-
-    public function test_sync_recognizes_site_level_cronjobs(): void
-    {
-        // Create a site-level cronjob with the same command as what will be on the server
-        $siteCronJob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/backup.sh',
-            'frequency' => '5 15 * * *',
-            'status' => CronjobStatus::READY,
-            'site_id' => $this->site->id,
-        ]);
-
-        // Mock SSH to return a cronjob with the same frequency and command
-        SSH::fake('5 15 * * * /usr/bin/backup.sh');
-
-        $countBefore = CronJob::where('server_id', $this->server->id)
-            ->where('command', '/usr/bin/backup.sh')
-            ->count();
-
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
-
-        $countAfter = CronJob::where('server_id', $this->server->id)
-            ->where('command', '/usr/bin/backup.sh')
-            ->count();
-
-        // Before fix: would create duplicate with site_id = null
-        // After fix: recognizes site-level cronjob and doesn't duplicate it, only creates for vito user
-        // countBefore = 1 (site-level), countAfter should be 2 (site-level + vito user)
-        $this->assertEquals($countBefore + 1, $countAfter);
-
-        // The site-level cronjob should remain unchanged
-        $siteCronJob->refresh();
-        $this->assertEquals($this->site->id, $siteCronJob->site_id);
-        $this->assertEquals(CronjobStatus::READY, $siteCronJob->status);
-    }
-
-    public function test_sync_handles_frequency_with_mixed_spacing_in_db(): void
-    {
-        // Create a cronjob with extra spaces in the frequency (simulating old data)
-        $existingCronJob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => '/usr/bin/backup.sh',
-            'frequency' => '5  15  *  *  *', // Double spaces
-            'status' => CronjobStatus::READY,
-            'site_id' => null,
-        ]);
-
-        // Mock SSH to return the same cronjob with normalized spacing
-        SSH::fake('5 15 * * * /usr/bin/backup.sh');
-
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
-
-        // Should not create duplicate
-        $cronJobs = CronJob::where('server_id', $this->server->id)
-            ->where('command', '/usr/bin/backup.sh')
-            ->where('site_id', null)
-            ->get();
-
-        // Should only have the one existing cronjob for each user (root + vito = 2 total)
-        $this->assertCount(2, $cronJobs);
-
-        // The original cronjob should still be ready
-        $existingCronJob->refresh();
-        $this->assertEquals(CronjobStatus::READY, $existingCronJob->status);
-    }
-
-    public function test_sync_ignores_crontab_documentation_comments(): void
-    {
-        // Mock SSH to return crontab with documentation comments (like the default crontab header)
-        $crontabWithComments = '# Edit this file to introduce tasks to be run by cron.
+});
+
+test('sync disables vito cronjobs removed from server', function () {
+    // Create a Vito-managed cronjob
+    $vitoCronJob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/backup.sh',
+        'frequency' => '0 2 * * *',
+        'status' => CronjobStatus::READY,
+        'site_id' => null,
+    ]);
+
+    // Mock SSH to return empty crontab (cronjob was manually deleted)
+    SSH::fake('');
+
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
+
+    // The Vito cronjob should be marked as disabled
+    $vitoCronJob->refresh();
+    expect($vitoCronJob->status)->toEqual(CronjobStatus::DISABLED);
+});
+
+test('sync disables vito cronjobs not found on server', function () {
+    // Create multiple Vito-managed cronjobs
+    $cronJob1 = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/backup.sh',
+        'frequency' => '0 2 * * *',
+        'status' => CronjobStatus::READY,
+        'site_id' => null,
+    ]);
+
+    $cronJob2 = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/cleanup.sh',
+        'frequency' => '0 4 * * *',
+        'status' => CronjobStatus::READY,
+        'site_id' => null,
+    ]);
+
+    // Mock SSH to return only one cronjob (the other was manually deleted)
+    SSH::fake('0 2 * * * /usr/bin/backup.sh');
+
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
+
+    // The first cronjob should remain enabled, the second should be disabled
+    $cronJob1->refresh();
+    $cronJob2->refresh();
+
+    expect($cronJob1->status)->toEqual(CronjobStatus::READY);
+    expect($cronJob2->status)->toEqual(CronjobStatus::DISABLED);
+});
+
+test('sync does not affect site level cronjobs', function () {
+    // Create a site-level cronjob
+    $siteCronJob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/site-script.sh',
+        'frequency' => '0 4 * * *',
+        'status' => CronjobStatus::READY,
+        'site_id' => $this->site->id, // Site-level
+    ]);
+
+    // Create a server-level cronjob
+    $serverCronJob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/server-script.sh',
+        'frequency' => '0 2 * * *',
+        'status' => CronjobStatus::READY,
+        'site_id' => null, // Server-level
+    ]);
+
+    // Mock SSH to return empty crontab
+    SSH::fake('');
+
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
+
+    // Site-level cronjob should remain unchanged
+    $siteCronJob->refresh();
+    expect($siteCronJob->status)->toEqual(CronjobStatus::READY);
+
+    // Server-level cronjob should be disabled
+    $serverCronJob->refresh();
+    expect($serverCronJob->status)->toEqual(CronjobStatus::DISABLED);
+});
+
+test('sync handles mixed scenarios with deletions', function () {
+    // Create Vito-managed cronjobs
+    $cronJob1 = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/backup.sh',
+        'frequency' => '0 2 * * *',
+        'status' => CronjobStatus::READY,
+        'site_id' => null,
+    ]);
+
+    $cronJob2 = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/cleanup.sh',
+        'frequency' => '0 4 * * *',
+        'status' => CronjobStatus::READY,
+        'site_id' => null,
+    ]);
+
+    // Mock SSH to return one existing cronjob, one commented, and one new manual cronjob
+    SSH::fake("0 2 * * * /usr/bin/backup.sh\n# 0 4 * * * /usr/bin/cleanup.sh\n0 6 * * * /usr/bin/new-script.sh");
+
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
+
+    // Check results
+    $cronJob1->refresh();
+    $cronJob2->refresh();
+
+    // First cronjob should remain enabled
+    expect($cronJob1->status)->toEqual(CronjobStatus::READY);
+
+    // Second cronjob should be disabled (commented on server)
+    expect($cronJob2->status)->toEqual(CronjobStatus::DISABLED);
+
+    // New manual cronjob should be created
+    $this->assertDatabaseHas('cron_jobs', [
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/new-script.sh',
+        'frequency' => '0 6 * * *',
+        'status' => CronjobStatus::READY,
+        'site_id' => null,
+    ]);
+});
+
+test('sync normalizes frequency with extra spaces', function () {
+    // Create a cronjob with normal spacing
+    $existingCronJob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/backup.sh',
+        'frequency' => '5 15 * * *',
+        'status' => CronjobStatus::READY,
+        'site_id' => null,
+    ]);
+
+    // Mock SSH to return the same cronjob with extra spaces
+    SSH::fake('5  15   *    *  * /usr/bin/backup.sh');
+
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
+
+    // Should not create duplicate, existing cronjob should remain
+    $cronJobs = CronJob::where('server_id', $this->server->id)
+        ->where('command', '/usr/bin/backup.sh')
+        ->where('site_id', null)
+        ->get();
+
+    // Should only have the one existing cronjob for each user (root + vito = 2 total)
+    expect($cronJobs)->toHaveCount(2);
+
+    // The original cronjob should still be ready
+    $existingCronJob->refresh();
+    expect($existingCronJob->status)->toEqual(CronjobStatus::READY);
+});
+
+test('sync recognizes site level cronjobs', function () {
+    // Create a site-level cronjob with the same command as what will be on the server
+    $siteCronJob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/backup.sh',
+        'frequency' => '5 15 * * *',
+        'status' => CronjobStatus::READY,
+        'site_id' => $this->site->id,
+    ]);
+
+    // Mock SSH to return a cronjob with the same frequency and command
+    SSH::fake('5 15 * * * /usr/bin/backup.sh');
+
+    $countBefore = CronJob::where('server_id', $this->server->id)
+        ->where('command', '/usr/bin/backup.sh')
+        ->count();
+
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
+
+    $countAfter = CronJob::where('server_id', $this->server->id)
+        ->where('command', '/usr/bin/backup.sh')
+        ->count();
+
+    // Before fix: would create duplicate with site_id = null
+    // After fix: recognizes site-level cronjob and doesn't duplicate it, only creates for vito user
+    // countBefore = 1 (site-level), countAfter should be 2 (site-level + vito user)
+    expect($countAfter)->toEqual($countBefore + 1);
+
+    // The site-level cronjob should remain unchanged
+    $siteCronJob->refresh();
+    expect($siteCronJob->site_id)->toEqual($this->site->id);
+    expect($siteCronJob->status)->toEqual(CronjobStatus::READY);
+});
+
+test('sync handles frequency with mixed spacing in db', function () {
+    // Create a cronjob with extra spaces in the frequency (simulating old data)
+    $existingCronJob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => '/usr/bin/backup.sh',
+        'frequency' => '5  15  *  *  *', // Double spaces
+        'status' => CronjobStatus::READY,
+        'site_id' => null,
+    ]);
+
+    // Mock SSH to return the same cronjob with normalized spacing
+    SSH::fake('5 15 * * * /usr/bin/backup.sh');
+
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
+
+    // Should not create duplicate
+    $cronJobs = CronJob::where('server_id', $this->server->id)
+        ->where('command', '/usr/bin/backup.sh')
+        ->where('site_id', null)
+        ->get();
+
+    // Should only have the one existing cronjob for each user (root + vito = 2 total)
+    expect($cronJobs)->toHaveCount(2);
+
+    // The original cronjob should still be ready
+    $existingCronJob->refresh();
+    expect($existingCronJob->status)->toEqual(CronjobStatus::READY);
+});
+
+test('sync ignores crontab documentation comments', function () {
+    // Mock SSH to return crontab with documentation comments (like the default crontab header)
+    $crontabWithComments = '# Edit this file to introduce tasks to be run by cron.
 #
 # Each task to run has to be defined through a single line
 # m h  dom mon dow   command
 #
 0 2 * * * /usr/bin/backup.sh';
 
-        SSH::fake($crontabWithComments);
+    SSH::fake($crontabWithComments);
 
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-        // Should only create cronjobs for the actual cron line, not the documentation comments
-        $cronJobs = CronJob::where('server_id', $this->server->id)->get();
+    // Should only create cronjobs for the actual cron line, not the documentation comments
+    $cronJobs = CronJob::where('server_id', $this->server->id)->get();
 
-        // Should have 2 cronjobs (1 for root, 1 for vito), not 6 (which would include the comment lines)
-        $this->assertCount(2, $cronJobs);
+    // Should have 2 cronjobs (1 for root, 1 for vito), not 6 (which would include the comment lines)
+    expect($cronJobs)->toHaveCount(2);
 
-        // Both should have the actual backup command
-        $this->assertTrue($cronJobs->every(fn ($cronJob) => $cronJob->command === '/usr/bin/backup.sh'));
-    }
+    // Both should have the actual backup command
+    expect($cronJobs->every(fn ($cronJob) => $cronJob->command === '/usr/bin/backup.sh'))->toBeTrue();
+});
 
-    public function test_sync_normalizes_command_with_extra_spaces(): void
-    {
-        // Create a cronjob with normal spacing in command
-        $existingCronJob = CronJob::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'root',
-            'command' => 'ls -la',
-            'frequency' => '* * * * *',
-            'status' => CronjobStatus::READY,
-            'site_id' => null,
-        ]);
+test('sync normalizes command with extra spaces', function () {
+    // Create a cronjob with normal spacing in command
+    $existingCronJob = CronJob::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'root',
+        'command' => 'ls -la',
+        'frequency' => '* * * * *',
+        'status' => CronjobStatus::READY,
+        'site_id' => null,
+    ]);
 
-        // Mock SSH to return the same cronjob with extra spaces in command
-        SSH::fake('* * *  * * ls  -la');
+    // Mock SSH to return the same cronjob with extra spaces in command
+    SSH::fake('* * *  * * ls  -la');
 
-        $this->actingAs($this->user)
-            ->post(route('cronjobs.sync', $this->server))
-            ->assertRedirect()
-            ->assertSessionHas('success', 'Cron jobs synced successfully.');
+    $this->actingAs($this->user)
+        ->post(route('cronjobs.sync', $this->server))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Cron jobs synced successfully.');
 
-        // Should not create duplicate, existing cronjob should remain
-        $cronJobs = CronJob::where('server_id', $this->server->id)
-            ->where('site_id', null)
-            ->get();
+    // Should not create duplicate, existing cronjob should remain
+    $cronJobs = CronJob::where('server_id', $this->server->id)
+        ->where('site_id', null)
+        ->get();
 
-        // Should only have the one existing cronjob for each user (root + vito = 2 total)
-        $this->assertCount(2, $cronJobs);
+    // Should only have the one existing cronjob for each user (root + vito = 2 total)
+    expect($cronJobs)->toHaveCount(2);
 
-        // The original cronjob should still be ready
-        $existingCronJob->refresh();
-        $this->assertEquals(CronjobStatus::READY, $existingCronJob->status);
-        $this->assertEquals('ls -la', $existingCronJob->command);
-    }
-}
+    // The original cronjob should still be ready
+    $existingCronJob->refresh();
+    expect($existingCronJob->status)->toEqual(CronjobStatus::READY);
+    expect($existingCronJob->command)->toEqual('ls -la');
+});

--- a/tests/Feature/ThrowingSupervisor.php
+++ b/tests/Feature/ThrowingSupervisor.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Exceptions\SSHCommandError;
+use App\Models\ServerLog;
+use App\Services\ProcessManager\Supervisor;
+
+class ThrowingSupervisor extends Supervisor
+{
+    public function restartMany(array $ids, ?int $siteId = null): string
+    {
+        $log = ServerLog::log($this->service->server, 'restart-workers', '');
+
+        throw new SSHCommandError(message: 'restart failed', log: $log);
+    }
+}

--- a/tests/Feature/ThrowingSupervisor.php
+++ b/tests/Feature/ThrowingSupervisor.php
@@ -8,6 +8,9 @@ use App\Services\ProcessManager\Supervisor;
 
 class ThrowingSupervisor extends Supervisor
 {
+    /**
+     * @param  array<int, int>  $ids
+     */
     public function restartMany(array $ids, ?int $siteId = null): string
     {
         $log = ServerLog::log($this->service->server, 'restart-workers', '');

--- a/tests/Feature/UniqueQueueTest.php
+++ b/tests/Feature/UniqueQueueTest.php
@@ -1,64 +1,54 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Traits\UniqueQueue;
 use Illuminate\Contracts\Queue\Job as JobContract;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Mockery;
-use RuntimeException;
-use Tests\TestCase;
 
-class UniqueQueueTest extends TestCase
+uses(RefreshDatabase::class);
+
+function vitoPestFeatureUniqueQueueTestMakeJob(callable $callback): object
 {
-    use RefreshDatabase;
-
-    private function makeJob(callable $callback): object
+    return new class($callback)
     {
-        return new class($callback)
+        use Queueable;
+        use UniqueQueue;
+
+        /** @var callable */
+        private $callback;
+
+        public function __construct(callable $callback)
         {
-            use Queueable;
-            use UniqueQueue;
+            $this->callback = $callback;
+        }
 
-            /** @var callable */
-            private $callback;
-
-            public function __construct(callable $callback)
-            {
-                $this->callback = $callback;
-            }
-
-            public function execute(): void
-            {
-                $this->run('unique-queue-test', $this->callback);
-            }
-        };
-    }
-
-    public function test_transient_database_lock_is_released_for_retry(): void
-    {
-        $job = $this->makeJob(fn () => throw new RuntimeException('SQLSTATE[HY000]: General error: 5 database is locked'));
-
-        $queueJob = Mockery::mock(JobContract::class);
-        $queueJob->shouldReceive('attempts')->andReturn(1);
-        $queueJob->shouldReceive('release')->once();
-        $queueJob->shouldReceive('fail')->never();
-        $job->setJob($queueJob);
-
-        $job->execute();
-    }
-
-    public function test_non_transient_error_fails_the_job(): void
-    {
-        $job = $this->makeJob(fn () => throw new RuntimeException('something else broke'));
-
-        $queueJob = Mockery::mock(JobContract::class);
-        $queueJob->shouldReceive('attempts')->andReturn(1);
-        $queueJob->shouldReceive('fail')->once();
-        $queueJob->shouldReceive('release')->never();
-        $job->setJob($queueJob);
-
-        $job->execute();
-    }
+        public function execute(): void
+        {
+            $this->run('unique-queue-test', $this->callback);
+        }
+    };
 }
+
+test('transient database lock is released for retry', function () {
+    $job = vitoPestFeatureUniqueQueueTestMakeJob(fn () => throw new RuntimeException('SQLSTATE[HY000]: General error: 5 database is locked'));
+
+    $queueJob = Mockery::mock(JobContract::class);
+    $queueJob->shouldReceive('attempts')->andReturn(1);
+    $queueJob->shouldReceive('release')->once();
+    $queueJob->shouldReceive('fail')->never();
+    $job->setJob($queueJob);
+
+    $job->execute();
+});
+
+test('non transient error fails the job', function () {
+    $job = vitoPestFeatureUniqueQueueTestMakeJob(fn () => throw new RuntimeException('something else broke'));
+
+    $queueJob = Mockery::mock(JobContract::class);
+    $queueJob->shouldReceive('attempts')->andReturn(1);
+    $queueJob->shouldReceive('fail')->once();
+    $queueJob->shouldReceive('release')->never();
+    $job->setJob($queueJob);
+
+    $job->execute();
+});

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -1,100 +1,88 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\UserRole;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class UserTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_user(): void
-    {
-        $this->actingAs($this->user);
+test('create user', function () {
+    $this->actingAs($this->user);
 
-        $this->post(route('users.store'), [
-            'name' => 'new user',
-            'email' => 'newuser@example.com',
-            'password' => 'password',
-            'role' => UserRole::USER->value,
-        ])
-            ->assertSessionDoesntHaveErrors()
-            ->assertRedirect(route('users'));
+    $this->post(route('users.store'), [
+        'name' => 'new user',
+        'email' => 'newuser@example.com',
+        'password' => 'password',
+        'role' => UserRole::USER->value,
+    ])
+        ->assertSessionDoesntHaveErrors()
+        ->assertRedirect(route('users'));
 
-        $this->assertDatabaseHas('users', [
-            'name' => 'new user',
-            'email' => 'newuser@example.com',
-            'is_admin' => false,
-        ]);
-    }
+    $this->assertDatabaseHas('users', [
+        'name' => 'new user',
+        'email' => 'newuser@example.com',
+        'is_admin' => false,
+    ]);
+});
 
-    public function test_see_users_list(): void
-    {
-        $this->actingAs($this->user);
+test('see users list', function () {
+    $this->actingAs($this->user);
 
-        User::factory()->create();
+    User::factory()->create();
 
-        $this->get(route('users'))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('users/index'));
-    }
+    $this->get(route('users'))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('users/index'));
+});
 
-    public function test_must_be_admin_to_see_users_list(): void
-    {
-        $this->user->is_admin = false;
-        $this->user->save();
+test('must be admin to see users list', function () {
+    $this->user->is_admin = false;
+    $this->user->save();
 
-        $this->actingAs($this->user);
+    $this->actingAs($this->user);
 
-        $this->get(route('users'))
-            ->assertNotFound();
-    }
+    $this->get(route('users'))
+        ->assertNotFound();
+});
 
-    public function test_delete_user(): void
-    {
-        $this->actingAs($this->user);
+test('delete user', function () {
+    $this->actingAs($this->user);
 
-        $user = User::factory()->create();
+    $user = User::factory()->create();
 
-        $this->delete(route('users.destroy', $user))
-            ->assertSessionDoesntHaveErrors()
-            ->assertRedirect(route('users'));
+    $this->delete(route('users.destroy', $user))
+        ->assertSessionDoesntHaveErrors()
+        ->assertRedirect(route('users'));
 
-        $this->assertDatabaseMissing('users', [
-            'id' => $user->id,
-        ]);
-    }
+    $this->assertDatabaseMissing('users', [
+        'id' => $user->id,
+    ]);
+});
 
-    public function test_cannot_delete_yourself(): void
-    {
-        $this->actingAs($this->user);
+test('cannot delete yourself', function () {
+    $this->actingAs($this->user);
 
-        $this->delete(route('users.destroy', $this->user))
-            ->assertForbidden();
-    }
+    $this->delete(route('users.destroy', $this->user))
+        ->assertForbidden();
+});
 
-    public function test_edit_user_info(): void
-    {
-        $this->actingAs($this->user);
+test('edit user info', function () {
+    $this->actingAs($this->user);
 
-        $user = User::factory()->create();
+    $user = User::factory()->create();
 
-        $this->patch(route('users.update', $user), [
-            'name' => 'new-name',
-            'email' => 'newemail@example.com',
-            'role' => UserRole::ADMIN->value,
-        ])
-            ->assertRedirect(route('users'));
+    $this->patch(route('users.update', $user), [
+        'name' => 'new-name',
+        'email' => 'newemail@example.com',
+        'role' => UserRole::ADMIN->value,
+    ])
+        ->assertRedirect(route('users'));
 
-        $this->assertDatabaseHas('users', [
-            'id' => $user->id,
-            'name' => 'new-name',
-            'email' => 'newemail@example.com',
-            'is_admin' => true,
-        ]);
-    }
-}
+    $this->assertDatabaseHas('users', [
+        'id' => $user->id,
+        'name' => 'new-name',
+        'email' => 'newemail@example.com',
+        'is_admin' => true,
+    ]);
+});

--- a/tests/Feature/VitoSettingsTest.php
+++ b/tests/Feature/VitoSettingsTest.php
@@ -1,19 +1,12 @@
 <?php
 
-namespace Tests\Feature;
-
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class VitoSettingsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_export_settings(): void
-    {
-        $this->actingAs($this->user);
+test('export settings', function () {
+    $this->actingAs($this->user);
 
-        $this->get(route('vito-settings.export'))
-            ->assertDownload('vito-backup-'.date('Y-m-d').'.zip');
-    }
-}
+    $this->get(route('vito-settings.export'))
+        ->assertDownload('vito-backup-'.date('Y-m-d').'.zip');
+});

--- a/tests/Feature/WarningsBroadcastTest.php
+++ b/tests/Feature/WarningsBroadcastTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\HostedDomain\ActivateHostedDomain;
 use App\Actions\Site\DisableSsl;
 use App\Actions\Site\EnableSsl;
@@ -22,307 +20,289 @@ use App\SiteTypes\NodeSite;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
-use Tests\TestCase;
 
-class WarningsBroadcastTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_server_resource_includes_warnings(): void
-    {
-        $this->server->update(['updates' => 5]);
+test('server resource includes warnings', function () {
+    $this->server->update(['updates' => 5]);
 
-        $resource = (new ServerResource($this->server->fresh()))->toArray(new Request);
+    $resource = (new ServerResource($this->server->fresh()))->toArray(new Request);
 
-        $this->assertArrayHasKey('warnings', $resource);
-        $this->assertEquals('updates_available', $resource['warnings'][0]['key']);
-        $this->assertEquals(5, $resource['warnings'][0]['count']);
-    }
+    expect($resource)->toHaveKey('warnings');
+    expect($resource['warnings'][0]['key'])->toEqual('updates_available');
+    expect($resource['warnings'][0]['count'])->toEqual(5);
+});
 
-    public function test_enable_ssl_broadcasts_site_updated(): void
-    {
-        SSH::fake();
-        Event::fake([SocketEvent::class]);
+test('enable ssl broadcasts site updated', function () {
+    SSH::fake();
+    Event::fake([SocketEvent::class]);
 
-        $this->site->update(['ssl_enabled' => false]);
+    $this->site->update(['ssl_enabled' => false]);
 
-        app(EnableSsl::class)->enable($this->site);
+    app(EnableSsl::class)->enable($this->site);
 
-        Event::assertDispatched(
-            SocketEvent::class,
-            fn (SocketEvent $event) => $event->data->type === 'site.updated'
-                && ($event->data->data['id'] ?? null) === $this->site->id
-        );
-    }
+    Event::assertDispatched(
+        SocketEvent::class,
+        fn (SocketEvent $event) => $event->data->type === 'site.updated'
+            && ($event->data->data['id'] ?? null) === $this->site->id
+    );
+});
 
-    public function test_disable_ssl_broadcasts_site_updated(): void
-    {
-        SSH::fake();
-        Event::fake([SocketEvent::class]);
+test('disable ssl broadcasts site updated', function () {
+    SSH::fake();
+    Event::fake([SocketEvent::class]);
 
-        $this->site->update(['ssl_enabled' => true]);
+    $this->site->update(['ssl_enabled' => true]);
 
-        app(DisableSsl::class)->disable($this->site);
+    app(DisableSsl::class)->disable($this->site);
 
-        Event::assertDispatched(
-            SocketEvent::class,
-            fn (SocketEvent $event) => $event->data->type === 'site.updated'
-                && ($event->data->data['id'] ?? null) === $this->site->id
-        );
-    }
+    Event::assertDispatched(
+        SocketEvent::class,
+        fn (SocketEvent $event) => $event->data->type === 'site.updated'
+            && ($event->data->data['id'] ?? null) === $this->site->id
+    );
+});
 
-    public function test_activate_hosted_domain_broadcasts_site_updated(): void
-    {
-        SSH::fake();
-        Event::fake([SocketEvent::class]);
+test('activate hosted domain broadcasts site updated', function () {
+    SSH::fake();
+    Event::fake([SocketEvent::class]);
 
-        $hostedDomain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'example.com',
-            'status' => HostedDomainStatus::PENDING,
-            'ssl_method' => SslMethod::NONE,
-        ]);
+    $hostedDomain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'example.com',
+        'status' => HostedDomainStatus::PENDING,
+        'ssl_method' => SslMethod::NONE,
+    ]);
 
-        app(ActivateHostedDomain::class)->activate($hostedDomain);
+    app(ActivateHostedDomain::class)->activate($hostedDomain);
 
-        Event::assertDispatched(
-            SocketEvent::class,
-            fn (SocketEvent $event) => $event->data->type === 'site.updated'
-                && ($event->data->data['id'] ?? null) === $this->site->id
-        );
-    }
+    Event::assertDispatched(
+        SocketEvent::class,
+        fn (SocketEvent $event) => $event->data->type === 'site.updated'
+            && ($event->data->data['id'] ?? null) === $this->site->id
+    );
+});
 
-    public function test_proxied_site_broadcast_carries_needs_first_deploy_warning(): void
-    {
-        SSH::fake();
+test('proxied site broadcast carries needs first deploy warning', function () {
+    SSH::fake();
 
-        /** @var Site $proxiedSite */
-        $proxiedSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'isolated-foo',
-            'type' => NodeSite::id(),
-            'port' => 3000,
-            'type_data' => ['node_version' => '22', 'package_manager' => 'npm'],
-        ]);
+    /** @var Site $proxiedSite */
+    $proxiedSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'isolated-foo',
+        'type' => NodeSite::id(),
+        'port' => 3000,
+        'type_data' => ['node_version' => '22', 'package_manager' => 'npm'],
+    ]);
 
-        Event::fake([SocketEvent::class]);
+    Event::fake([SocketEvent::class]);
 
-        app(UpdatePort::class)->update($proxiedSite, ['port' => 4000]);
+    app(UpdatePort::class)->update($proxiedSite, ['port' => 4000]);
 
-        Event::assertDispatched(
-            SocketEvent::class,
-            fn (SocketEvent $event) => $event->data->type === 'site.updated'
-                && ($event->data->data['id'] ?? null) === $proxiedSite->id
-                && collect($event->data->data['warnings'] ?? [])->contains(fn ($w) => $w['key'] === 'needs_first_deploy'),
-        );
-    }
+    Event::assertDispatched(
+        SocketEvent::class,
+        fn (SocketEvent $event) => $event->data->type === 'site.updated'
+            && ($event->data->data['id'] ?? null) === $proxiedSite->id
+            && collect($event->data->data['warnings'] ?? [])->contains(fn ($w) => $w['key'] === 'needs_first_deploy'),
+    );
+});
 
-    public function test_proxied_site_broadcast_omits_warning_after_finished_deployment(): void
-    {
-        SSH::fake();
+test('proxied site broadcast omits warning after finished deployment', function () {
+    SSH::fake();
 
-        /** @var Site $proxiedSite */
-        $proxiedSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'isolated-foo',
-            'type' => NodeSite::id(),
-            'port' => 3000,
-            'type_data' => ['node_version' => '22', 'package_manager' => 'npm'],
-        ]);
+    /** @var Site $proxiedSite */
+    $proxiedSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'isolated-foo',
+        'type' => NodeSite::id(),
+        'port' => 3000,
+        'type_data' => ['node_version' => '22', 'package_manager' => 'npm'],
+    ]);
 
-        Deployment::factory()->create([
-            'site_id' => $proxiedSite->id,
-            'status' => DeploymentStatus::FINISHED,
-        ]);
+    Deployment::factory()->create([
+        'site_id' => $proxiedSite->id,
+        'status' => DeploymentStatus::FINISHED,
+    ]);
 
-        Event::fake([SocketEvent::class]);
+    Event::fake([SocketEvent::class]);
 
-        app(UpdatePort::class)->update($proxiedSite, ['port' => 4000]);
+    app(UpdatePort::class)->update($proxiedSite, ['port' => 4000]);
 
-        Event::assertDispatched(
-            SocketEvent::class,
-            fn (SocketEvent $event) => $event->data->type === 'site.updated'
-                && ($event->data->data['id'] ?? null) === $proxiedSite->id
-                && ! collect($event->data->data['warnings'] ?? [])->contains(fn ($w) => $w['key'] === 'needs_first_deploy'),
-        );
-    }
+    Event::assertDispatched(
+        SocketEvent::class,
+        fn (SocketEvent $event) => $event->data->type === 'site.updated'
+            && ($event->data->data['id'] ?? null) === $proxiedSite->id
+            && ! collect($event->data->data['warnings'] ?? [])->contains(fn ($w) => $w['key'] === 'needs_first_deploy'),
+    );
+});
 
-    public function test_proxied_site_warns_when_worker_failed_with_error(): void
-    {
-        /** @var Site $proxiedSite */
-        $proxiedSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'isolated-foo',
-            'type' => NodeSite::id(),
-            'port' => 3000,
-            'type_data' => ['node_version' => '22', 'package_manager' => 'npm'],
-        ]);
+test('proxied site warns when worker failed with error', function () {
+    /** @var Site $proxiedSite */
+    $proxiedSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'isolated-foo',
+        'type' => NodeSite::id(),
+        'port' => 3000,
+        'type_data' => ['node_version' => '22', 'package_manager' => 'npm'],
+    ]);
 
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $proxiedSite->id,
-            'name' => 'app',
-            'status' => WorkerStatus::FAILED,
-            'error' => '10:10_00: ERROR (no such file)',
-        ]);
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $proxiedSite->id,
+        'name' => 'app',
+        'status' => WorkerStatus::FAILED,
+        'error' => '10:10_00: ERROR (no such file)',
+    ]);
 
-        $proxiedSite->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
-        $proxiedSite->load('workers');
+    $proxiedSite->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
+    $proxiedSite->load('workers');
 
-        $warning = collect($proxiedSite->getWarnings())->firstWhere('key', 'worker_not_running');
+    $warning = collect($proxiedSite->getWarnings())->firstWhere('key', 'worker_not_running');
 
-        $this->assertNotNull($warning);
-        $this->assertSame('10:10_00: ERROR (no such file)', $warning['error']);
-    }
+    expect($warning)->not->toBeNull();
+    expect($warning['error'])->toBe('10:10_00: ERROR (no such file)');
+});
 
-    public function test_proxied_site_does_not_warn_for_running_worker(): void
-    {
-        /** @var Site $proxiedSite */
-        $proxiedSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'isolated-foo',
-            'type' => NodeSite::id(),
-            'port' => 3000,
-            'type_data' => ['node_version' => '22', 'package_manager' => 'npm'],
-        ]);
+test('proxied site does not warn for running worker', function () {
+    /** @var Site $proxiedSite */
+    $proxiedSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'isolated-foo',
+        'type' => NodeSite::id(),
+        'port' => 3000,
+        'type_data' => ['node_version' => '22', 'package_manager' => 'npm'],
+    ]);
 
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $proxiedSite->id,
-            'name' => 'app',
-            'status' => WorkerStatus::RUNNING,
-        ]);
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $proxiedSite->id,
+        'name' => 'app',
+        'status' => WorkerStatus::RUNNING,
+    ]);
 
-        $proxiedSite->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
-        $proxiedSite->load('workers');
+    $proxiedSite->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
+    $proxiedSite->load('workers');
 
-        $this->assertNull(collect($proxiedSite->getWarnings())->firstWhere('key', 'worker_not_running'));
-    }
+    expect(collect($proxiedSite->getWarnings())->firstWhere('key', 'worker_not_running'))->toBeNull();
+});
 
-    public function test_proxied_site_does_not_warn_for_transient_worker_status(): void
-    {
-        /** @var Site $proxiedSite */
-        $proxiedSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'isolated-foo',
-            'type' => NodeSite::id(),
-            'port' => 3000,
-            'type_data' => ['node_version' => '22', 'package_manager' => 'npm'],
-        ]);
+test('proxied site does not warn for transient worker status', function () {
+    /** @var Site $proxiedSite */
+    $proxiedSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'isolated-foo',
+        'type' => NodeSite::id(),
+        'port' => 3000,
+        'type_data' => ['node_version' => '22', 'package_manager' => 'npm'],
+    ]);
 
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $proxiedSite->id,
-            'name' => 'app',
-            'status' => WorkerStatus::RESTARTING,
-        ]);
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $proxiedSite->id,
+        'name' => 'app',
+        'status' => WorkerStatus::RESTARTING,
+    ]);
 
-        $proxiedSite->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
-        $proxiedSite->load('workers');
+    $proxiedSite->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
+    $proxiedSite->load('workers');
 
-        $this->assertNull(collect($proxiedSite->getWarnings())->firstWhere('key', 'worker_not_running'));
-    }
+    expect(collect($proxiedSite->getWarnings())->firstWhere('key', 'worker_not_running'))->toBeNull();
+});
 
-    public function test_non_proxied_site_warns_when_any_worker_failed(): void
-    {
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'name' => 'queue',
-            'status' => WorkerStatus::FAILED,
-            'error' => 'queue: ERROR (spawn error)',
-        ]);
+test('non proxied site warns when any worker failed', function () {
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'name' => 'queue',
+        'status' => WorkerStatus::FAILED,
+        'error' => 'queue: ERROR (spawn error)',
+    ]);
 
-        $this->site->load('workers');
+    $this->site->load('workers');
 
-        $warning = collect($this->site->getWarnings())->firstWhere('key', 'worker_not_running');
+    $warning = collect($this->site->getWarnings())->firstWhere('key', 'worker_not_running');
 
-        $this->assertNotNull($warning);
-        $this->assertSame($worker->id, $warning['worker_id']);
-        $this->assertSame('queue', $warning['name']);
-        $this->assertSame('queue: ERROR (spawn error)', $warning['error']);
-    }
+    expect($warning)->not->toBeNull();
+    expect($warning['worker_id'])->toBe($worker->id);
+    expect($warning['name'])->toBe('queue');
+    expect($warning['error'])->toBe('queue: ERROR (spawn error)');
+});
 
-    public function test_non_proxied_site_does_not_warn_for_intentionally_stopped_worker(): void
-    {
-        Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'name' => 'queue',
-            'status' => WorkerStatus::STOPPED,
-        ]);
+test('non proxied site does not warn for intentionally stopped worker', function () {
+    Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'name' => 'queue',
+        'status' => WorkerStatus::STOPPED,
+    ]);
 
-        $this->site->load('workers');
+    $this->site->load('workers');
 
-        $this->assertNull(collect($this->site->getWarnings())->firstWhere('key', 'worker_not_running'));
-    }
+    expect(collect($this->site->getWarnings())->firstWhere('key', 'worker_not_running'))->toBeNull();
+});
 
-    public function test_metric_observer_broadcasts_on_reboot_required_transition(): void
-    {
-        Metric::factory()->create([
-            'server_id' => $this->server->id,
-            'reboot_required' => false,
-        ]);
+test('metric observer broadcasts on reboot required transition', function () {
+    Metric::factory()->create([
+        'server_id' => $this->server->id,
+        'reboot_required' => false,
+    ]);
 
-        Event::fake([SocketEvent::class]);
+    Event::fake([SocketEvent::class]);
 
-        Metric::factory()->create([
-            'server_id' => $this->server->id,
-            'reboot_required' => true,
-        ]);
+    Metric::factory()->create([
+        'server_id' => $this->server->id,
+        'reboot_required' => true,
+    ]);
 
-        Event::assertDispatched(
-            SocketEvent::class,
-            fn (SocketEvent $event) => $event->data->type === 'server.updated'
-                && ($event->data->data['id'] ?? null) === $this->server->id
-        );
-    }
+    Event::assertDispatched(
+        SocketEvent::class,
+        fn (SocketEvent $event) => $event->data->type === 'server.updated'
+            && ($event->data->data['id'] ?? null) === $this->server->id
+    );
+});
 
-    public function test_metric_observer_does_not_broadcast_when_reboot_required_unchanged(): void
-    {
-        Metric::factory()->create([
-            'server_id' => $this->server->id,
-            'reboot_required' => false,
-        ]);
+test('metric observer does not broadcast when reboot required unchanged', function () {
+    Metric::factory()->create([
+        'server_id' => $this->server->id,
+        'reboot_required' => false,
+    ]);
 
-        Event::fake([SocketEvent::class]);
+    Event::fake([SocketEvent::class]);
 
-        Metric::factory()->create([
-            'server_id' => $this->server->id,
-            'reboot_required' => false,
-        ]);
+    Metric::factory()->create([
+        'server_id' => $this->server->id,
+        'reboot_required' => false,
+    ]);
 
-        Event::assertNotDispatched(SocketEvent::class);
-    }
+    Event::assertNotDispatched(SocketEvent::class);
+});
 
-    public function test_metric_observer_fires_when_metric_created_directly_on_relation(): void
-    {
-        Metric::factory()->create([
-            'server_id' => $this->server->id,
-            'reboot_required' => false,
-        ]);
+test('metric observer fires when metric created directly on relation', function () {
+    Metric::factory()->create([
+        'server_id' => $this->server->id,
+        'reboot_required' => false,
+    ]);
 
-        Event::fake([SocketEvent::class]);
+    Event::fake([SocketEvent::class]);
 
-        $this->server->metrics()->create([
-            'load' => 0.1,
-            'memory_total' => 1000,
-            'memory_used' => 100,
-            'memory_free' => 900,
-            'disk_total' => 1000,
-            'disk_used' => 100,
-            'disk_free' => 900,
-            'reboot_required' => true,
-        ]);
+    $this->server->metrics()->create([
+        'load' => 0.1,
+        'memory_total' => 1000,
+        'memory_used' => 100,
+        'memory_free' => 900,
+        'disk_total' => 1000,
+        'disk_used' => 100,
+        'disk_free' => 900,
+        'reboot_required' => true,
+    ]);
 
-        Event::assertDispatched(
-            SocketEvent::class,
-            fn (SocketEvent $event) => $event->data->type === 'server.updated'
-                && ($event->data->data['id'] ?? null) === $this->server->id
-        );
-    }
-}
+    Event::assertDispatched(
+        SocketEvent::class,
+        fn (SocketEvent $event) => $event->data->type === 'server.updated'
+            && ($event->data->data['id'] ?? null) === $this->server->id
+    );
+});

--- a/tests/Feature/Webserver/RedirectBlockTest.php
+++ b/tests/Feature/Webserver/RedirectBlockTest.php
@@ -1,65 +1,57 @@
 <?php
 
-namespace Tests\Feature\Webserver;
-
 use App\Enums\RedirectStatus;
 use App\Models\HostedDomain;
 use App\Models\Redirect;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class RedirectBlockTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_nginx_renders_websocket_upgrade_headers_for_proxy_redirect(): void
-    {
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
+test('nginx renders websocket upgrade headers for proxy redirect', function () {
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
 
-        Redirect::factory()->create([
-            'site_id' => $this->site->id,
-            'from' => '/app',
-            'to' => 'https://backend.example.com',
-            'mode' => 1000,
-            'websocket' => true,
-            'status' => RedirectStatus::READY,
-        ]);
+    Redirect::factory()->create([
+        'site_id' => $this->site->id,
+        'from' => '/app',
+        'to' => 'https://backend.example.com',
+        'mode' => 1000,
+        'websocket' => true,
+        'status' => RedirectStatus::READY,
+    ]);
 
-        $vhost = $this->site->webserver()->generateVhost($this->site);
+    $vhost = $this->site->webserver()->generateVhost($this->site);
 
-        $this->assertStringContainsString('location /app {', $vhost);
-        $this->assertStringContainsString('proxy_pass https://backend.example.com;', $vhost);
-        $this->assertStringContainsString('proxy_http_version 1.1;', $vhost);
-        $this->assertStringContainsString('proxy_set_header Upgrade $http_upgrade;', $vhost);
-        $this->assertStringContainsString('proxy_set_header Connection "upgrade";', $vhost);
-        $this->assertStringContainsString('proxy_read_timeout 60s;', $vhost);
-        $this->assertStringContainsString('proxy_ssl_server_name on;', $vhost);
-    }
+    $this->assertStringContainsString('location /app {', $vhost);
+    $this->assertStringContainsString('proxy_pass https://backend.example.com;', $vhost);
+    $this->assertStringContainsString('proxy_http_version 1.1;', $vhost);
+    $this->assertStringContainsString('proxy_set_header Upgrade $http_upgrade;', $vhost);
+    $this->assertStringContainsString('proxy_set_header Connection "upgrade";', $vhost);
+    $this->assertStringContainsString('proxy_read_timeout 60s;', $vhost);
+    $this->assertStringContainsString('proxy_ssl_server_name on;', $vhost);
+});
 
-    public function test_nginx_renders_plain_proxy_block_without_websocket(): void
-    {
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
+test('nginx renders plain proxy block without websocket', function () {
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
 
-        Redirect::factory()->create([
-            'site_id' => $this->site->id,
-            'from' => '/app',
-            'to' => 'https://backend.example.com',
-            'mode' => 1000,
-            'websocket' => false,
-            'status' => RedirectStatus::READY,
-        ]);
+    Redirect::factory()->create([
+        'site_id' => $this->site->id,
+        'from' => '/app',
+        'to' => 'https://backend.example.com',
+        'mode' => 1000,
+        'websocket' => false,
+        'status' => RedirectStatus::READY,
+    ]);
 
-        $vhost = $this->site->webserver()->generateVhost($this->site);
+    $vhost = $this->site->webserver()->generateVhost($this->site);
 
-        $this->assertStringContainsString('location /app {', $vhost);
-        $this->assertStringContainsString('proxy_set_header Host backend.example.com;', $vhost);
-        $this->assertStringContainsString('proxy_ssl_server_name on;', $vhost);
-        $this->assertStringNotContainsString('proxy_set_header Upgrade $http_upgrade;', $vhost);
-    }
-}
+    $this->assertStringContainsString('location /app {', $vhost);
+    $this->assertStringContainsString('proxy_set_header Host backend.example.com;', $vhost);
+    $this->assertStringContainsString('proxy_ssl_server_name on;', $vhost);
+    $this->assertStringNotContainsString('proxy_set_header Upgrade $http_upgrade;', $vhost);
+});

--- a/tests/Feature/Webserver/VerificationBlockTest.php
+++ b/tests/Feature/Webserver/VerificationBlockTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Webserver;
-
 use App\Actions\Webserver\GenerateNginxConfig;
 use App\Enums\ServiceStatus;
 use App\Enums\SslStatus;
@@ -10,173 +8,162 @@ use App\Models\Service;
 use App\Models\Ssl;
 use App\Services\Webserver\Caddy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class VerificationBlockTest extends TestCase
+uses(RefreshDatabase::class);
+
+test('nginx renders verification location when key present', function () {
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
+
+    $this->site->verification_key = 'abc123XYZverification';
+    $this->site->save();
+
+    $vhost = $this->site->webserver()->generateVhost($this->site);
+
+    $this->assertStringContainsString('location ^~ /.well-known/vito/abc123XYZverification/', $vhost);
+    $this->assertStringContainsString('alias /var/lib/vito/verify/abc123XYZverification/', $vhost);
+    $this->assertStringContainsString('add_header Cache-Control "no-store"', $vhost);
+});
+
+test('nginx omits verification location when key missing', function () {
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
+
+    $this->site->verification_key = null;
+    $this->site->vhost_template = null;
+    $this->site->vhost_generation_enabled = false;
+    $this->site->save();
+
+    $vhost = app(GenerateNginxConfig::class)->generate($this->site);
+
+    $this->assertStringNotContainsString('/.well-known/vito/', $vhost);
+});
+
+test('nginx acme location renders outside basic auth', function () {
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
+
+    $vhost = $this->site->webserver()->generateVhost($this->site);
+
+    $this->assertStringContainsString('location ^~ /.well-known/acme-challenge/', $vhost);
+});
+
+test('caddy renders verification handle when key present', function () {
+    $this->server->services()->where('type', 'webserver')->delete();
+    $this->server->services()->create([
+        'type' => Caddy::type(),
+        'name' => Caddy::id(),
+        'version' => 'latest',
+    ]);
+    $this->server->services()->update([
+        'status' => ServiceStatus::READY,
+    ]);
+    $this->server->refresh();
+
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
+
+    $this->site->verification_key = 'caddyKey99';
+    $this->site->save();
+
+    /** @var Service $webserver */
+    $webserver = $this->server->webserver();
+    $vhost = $webserver->handler()->generateVhost($this->site);
+
+    $this->assertStringContainsString('handle_path /.well-known/vito/caddyKey99/*', $vhost);
+    $this->assertStringContainsString('root * /var/lib/vito/verify/caddyKey99', $vhost);
+});
+
+test('nginx force ssl redirect serves and exempts verification challenge', function () {
+    $ssl = Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => SslStatus::CREATED,
+        'type' => 'letsencrypt',
+        'domains' => [$this->site->domain],
+    ]);
+
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+        'ssl_id' => $ssl->id,
+    ]);
+
+    $this->site->update([
+        'ssl_enabled' => true,
+        'force_ssl' => true,
+        'verification_key' => 'forcedKey55',
+    ]);
+    $this->site->refresh();
+
+    $vhost = $this->site->webserver()->generateVhost($this->site);
+
+    $this->assertStringContainsString('location ^~ /.well-known/vito/forcedKey55/', $vhost);
+    $this->assertStringContainsString('alias /var/lib/vito/verify/forcedKey55/', $vhost);
+    $this->assertStringContainsString(
+        "location / {\n        return 301 https://\$host\$request_uri;\n    }",
+        $vhost,
+        'The force-SSL port-80 redirect must be scoped to location / so the verification path is served instead of 301-redirected.'
+    );
+});
+
+test('caddy serves verification over http when using auto https', function () {
+    vitoPestFeatureWebserverVerificationBlockTestSwitchToCaddy();
+
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
+
+    $this->site->update([
+        'ssl_enabled' => true,
+        'verification_key' => 'caddyForce42',
+    ]);
+    $this->site->refresh();
+
+    $vhost = $this->server->webserver()->handler()->generateVhost($this->site);
+
+    $this->assertStringContainsString('http://'.$this->site->domain.' {', $vhost);
+    $this->assertStringContainsString('handle_path /.well-known/vito/caddyForce42/*', $vhost);
+    $this->assertStringContainsString('redir https://{host}{uri} permanent', $vhost);
+});
+
+test('caddy omits http verification block for http only site', function () {
+    vitoPestFeatureWebserverVerificationBlockTestSwitchToCaddy();
+
+    HostedDomain::factory()->primary()->create([
+        'site_id' => $this->site->id,
+        'domain' => $this->site->domain,
+    ]);
+
+    $this->site->update([
+        'ssl_enabled' => false,
+        'verification_key' => 'caddyPlain1',
+    ]);
+    $this->site->refresh();
+
+    $vhost = $this->server->webserver()->handler()->generateVhost($this->site);
+
+    $this->assertStringContainsString('handle_path /.well-known/vito/caddyPlain1/*', $vhost);
+    $this->assertStringNotContainsString('redir https://{host}{uri} permanent', $vhost);
+});
+
+function vitoPestFeatureWebserverVerificationBlockTestSwitchToCaddy(): void
 {
-    use RefreshDatabase;
-
-    public function test_nginx_renders_verification_location_when_key_present(): void
-    {
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
-
-        $this->site->verification_key = 'abc123XYZverification';
-        $this->site->save();
-
-        $vhost = $this->site->webserver()->generateVhost($this->site);
-
-        $this->assertStringContainsString('location ^~ /.well-known/vito/abc123XYZverification/', $vhost);
-        $this->assertStringContainsString('alias /var/lib/vito/verify/abc123XYZverification/', $vhost);
-        $this->assertStringContainsString('add_header Cache-Control "no-store"', $vhost);
-    }
-
-    public function test_nginx_omits_verification_location_when_key_missing(): void
-    {
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
-
-        $this->site->verification_key = null;
-        $this->site->vhost_template = null;
-        $this->site->vhost_generation_enabled = false;
-        $this->site->save();
-
-        $vhost = app(GenerateNginxConfig::class)->generate($this->site);
-
-        $this->assertStringNotContainsString('/.well-known/vito/', $vhost);
-    }
-
-    public function test_nginx_acme_location_renders_outside_basic_auth(): void
-    {
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
-
-        $vhost = $this->site->webserver()->generateVhost($this->site);
-
-        $this->assertStringContainsString('location ^~ /.well-known/acme-challenge/', $vhost);
-    }
-
-    public function test_caddy_renders_verification_handle_when_key_present(): void
-    {
-        $this->server->services()->where('type', 'webserver')->delete();
-        $this->server->services()->create([
-            'type' => Caddy::type(),
-            'name' => Caddy::id(),
-            'version' => 'latest',
-        ]);
-        $this->server->services()->update([
-            'status' => ServiceStatus::READY,
-        ]);
-        $this->server->refresh();
-
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
-
-        $this->site->verification_key = 'caddyKey99';
-        $this->site->save();
-
-        /** @var Service $webserver */
-        $webserver = $this->server->webserver();
-        $vhost = $webserver->handler()->generateVhost($this->site);
-
-        $this->assertStringContainsString('handle_path /.well-known/vito/caddyKey99/*', $vhost);
-        $this->assertStringContainsString('root * /var/lib/vito/verify/caddyKey99', $vhost);
-    }
-
-    public function test_nginx_force_ssl_redirect_serves_and_exempts_verification_challenge(): void
-    {
-        $ssl = Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => SslStatus::CREATED,
-            'type' => 'letsencrypt',
-            'domains' => [$this->site->domain],
-        ]);
-
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-            'ssl_id' => $ssl->id,
-        ]);
-
-        $this->site->update([
-            'ssl_enabled' => true,
-            'force_ssl' => true,
-            'verification_key' => 'forcedKey55',
-        ]);
-        $this->site->refresh();
-
-        $vhost = $this->site->webserver()->generateVhost($this->site);
-
-        $this->assertStringContainsString('location ^~ /.well-known/vito/forcedKey55/', $vhost);
-        $this->assertStringContainsString('alias /var/lib/vito/verify/forcedKey55/', $vhost);
-        $this->assertStringContainsString(
-            "location / {\n        return 301 https://\$host\$request_uri;\n    }",
-            $vhost,
-            'The force-SSL port-80 redirect must be scoped to location / so the verification path is served instead of 301-redirected.'
-        );
-    }
-
-    public function test_caddy_serves_verification_over_http_when_using_auto_https(): void
-    {
-        $this->switchToCaddy();
-
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
-
-        $this->site->update([
-            'ssl_enabled' => true,
-            'verification_key' => 'caddyForce42',
-        ]);
-        $this->site->refresh();
-
-        $vhost = $this->server->webserver()->handler()->generateVhost($this->site);
-
-        $this->assertStringContainsString('http://'.$this->site->domain.' {', $vhost);
-        $this->assertStringContainsString('handle_path /.well-known/vito/caddyForce42/*', $vhost);
-        $this->assertStringContainsString('redir https://{host}{uri} permanent', $vhost);
-    }
-
-    public function test_caddy_omits_http_verification_block_for_http_only_site(): void
-    {
-        $this->switchToCaddy();
-
-        HostedDomain::factory()->primary()->create([
-            'site_id' => $this->site->id,
-            'domain' => $this->site->domain,
-        ]);
-
-        $this->site->update([
-            'ssl_enabled' => false,
-            'verification_key' => 'caddyPlain1',
-        ]);
-        $this->site->refresh();
-
-        $vhost = $this->server->webserver()->handler()->generateVhost($this->site);
-
-        $this->assertStringContainsString('handle_path /.well-known/vito/caddyPlain1/*', $vhost);
-        $this->assertStringNotContainsString('redir https://{host}{uri} permanent', $vhost);
-    }
-
-    private function switchToCaddy(): void
-    {
-        $this->server->services()->where('type', 'webserver')->delete();
-        $this->server->services()->create([
-            'type' => Caddy::type(),
-            'name' => Caddy::id(),
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-        $this->server->refresh();
-    }
+    test()->server->services()->where('type', 'webserver')->delete();
+    test()->server->services()->create([
+        'type' => Caddy::type(),
+        'name' => Caddy::id(),
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+    test()->server->refresh();
 }

--- a/tests/Feature/Webserver/VerificationBlockTest.php
+++ b/tests/Feature/Webserver/VerificationBlockTest.php
@@ -55,16 +55,7 @@ test('nginx acme location renders outside basic auth', function () {
 });
 
 test('caddy renders verification handle when key present', function () {
-    $this->server->services()->where('type', 'webserver')->delete();
-    $this->server->services()->create([
-        'type' => Caddy::type(),
-        'name' => Caddy::id(),
-        'version' => 'latest',
-    ]);
-    $this->server->services()->update([
-        'status' => ServiceStatus::READY,
-    ]);
-    $this->server->refresh();
+    vitoPestFeatureWebserverVerificationBlockTestSwitchToCaddy();
 
     HostedDomain::factory()->primary()->create([
         'site_id' => $this->site->id,

--- a/tests/Feature/WorkerEnvironmentMigrationTest.php
+++ b/tests/Feature/WorkerEnvironmentMigrationTest.php
@@ -1,79 +1,70 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\Worker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
-use Tests\TestCase;
 
-class WorkerEnvironmentMigrationTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_transform_converts_plaintext_map_rows_to_encrypted_list(): void
-    {
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+test('transform converts plaintext map rows to encrypted list', function () {
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        DB::table('workers')->where('id', $worker->id)->update([
-            'environment' => json_encode([
-                'API_KEY' => 'secret-value',
-                'NODE_ENV' => 'production',
-            ]),
-        ]);
+    DB::table('workers')->where('id', $worker->id)->update([
+        'environment' => json_encode([
+            'API_KEY' => 'secret-value',
+            'NODE_ENV' => 'production',
+        ]),
+    ]);
 
-        $this->runMigration();
+    vitoPestFeatureWorkerEnvironmentMigrationTestRunMigration();
 
-        $environment = Worker::query()->findOrFail($worker->id)->environment;
+    $environment = Worker::query()->findOrFail($worker->id)->environment;
 
-        $this->assertEquals([
-            ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
+    expect($environment)->toEqual([
+        ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
+        ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+    ]);
+
+    $raw = (string) DB::table('workers')->where('id', $worker->id)->value('environment');
+    $this->assertStringNotContainsString('secret-value', $raw);
+});
+
+test('transform re encrypts plaintext empty rows', function () {
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    DB::table('workers')->where('id', $worker->id)->update([
+        'environment' => '[]',
+    ]);
+
+    vitoPestFeatureWorkerEnvironmentMigrationTestRunMigration();
+
+    expect(Worker::query()->findOrFail($worker->id)->environment)->toBe([]);
+});
+
+test('transform skips already encrypted rows', function () {
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'environment' => [
             ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-        ], $environment);
+        ],
+    ]);
 
-        $raw = (string) DB::table('workers')->where('id', $worker->id)->value('environment');
-        $this->assertStringNotContainsString('secret-value', $raw);
-    }
+    $encrypted = (string) DB::table('workers')->where('id', $worker->id)->value('environment');
 
-    public function test_transform_re_encrypts_plaintext_empty_rows(): void
-    {
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+    vitoPestFeatureWorkerEnvironmentMigrationTestRunMigration();
 
-        DB::table('workers')->where('id', $worker->id)->update([
-            'environment' => '[]',
-        ]);
+    expect((string) DB::table('workers')->where('id', $worker->id)->value('environment'))->toBe($encrypted);
+});
 
-        $this->runMigration();
+function vitoPestFeatureWorkerEnvironmentMigrationTestRunMigration(): void
+{
+    $paths = glob(database_path('migrations/*_add_worker_environment_support.php')) ?: [];
+    expect($paths)->not->toBeEmpty('Worker environment migration not found.');
 
-        $this->assertSame([], Worker::query()->findOrFail($worker->id)->environment);
-    }
-
-    public function test_transform_skips_already_encrypted_rows(): void
-    {
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'environment' => [
-                ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-            ],
-        ]);
-
-        $encrypted = (string) DB::table('workers')->where('id', $worker->id)->value('environment');
-
-        $this->runMigration();
-
-        $this->assertSame($encrypted, (string) DB::table('workers')->where('id', $worker->id)->value('environment'));
-    }
-
-    private function runMigration(): void
-    {
-        $paths = glob(database_path('migrations/*_add_worker_environment_support.php')) ?: [];
-        $this->assertNotEmpty($paths, 'Worker environment migration not found.');
-
-        $migration = require $paths[0];
-        $migration->up();
-    }
+    $migration = require $paths[0];
+    $migration->up();
 }

--- a/tests/Feature/WorkerEnvironmentTest.php
+++ b/tests/Feature/WorkerEnvironmentTest.php
@@ -1,244 +1,229 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Enums\UserRole;
 use App\Enums\WorkerStatus;
 use App\Facades\SSH;
 use App\Models\Worker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
-use Tests\TestCase;
 
-class WorkerEnvironmentTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_get_env_masks_secret_values(): void
-    {
-        $this->actingAs($this->user);
+test('get env masks secret values', function () {
+    $this->actingAs($this->user);
 
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'environment' => [
-                ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-                ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
-            ],
-        ]);
-
-        $this->get(route('workers.env', ['server' => $this->server, 'worker' => $worker]))
-            ->assertOk()
-            ->assertJson([
-                'variables' => [
-                    ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-                    ['key' => 'API_KEY', 'value' => '', 'is_secret' => true],
-                ],
-            ]);
-    }
-
-    public function test_update_env_without_restart_rewrites_config_only(): void
-    {
-        $fake = SSH::fake();
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
-            'variables' => [
-                ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-            ],
-        ])->assertRedirect()
-            ->assertSessionHas('warning');
-
-        $worker->refresh();
-        $this->assertEquals([
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'environment' => [
             ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-        ], $worker->environment);
-        $this->assertSame(WorkerStatus::RUNNING, $worker->status);
+            ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
+        ],
+    ]);
 
-        $raw = (string) DB::table('workers')->where('id', $worker->id)->value('environment');
-        $this->assertStringNotContainsString('production', $raw);
-
-        $fake->assertExecutedContains("/etc/supervisor/conf.d/{$worker->id}.conf");
-        $fake->assertNotExecutedContains('supervisorctl restart');
-    }
-
-    public function test_update_env_with_restart_restarts_worker(): void
-    {
-        $fake = SSH::fake();
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
+    $this->get(route('workers.env', ['server' => $this->server, 'worker' => $worker]))
+        ->assertOk()
+        ->assertJson([
             'variables' => [
                 ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-            ],
-            'restart' => true,
-        ])->assertRedirect()
-            ->assertSessionHas('info');
-
-        $fake->assertExecutedContains("/etc/supervisor/conf.d/{$worker->id}.conf");
-        $fake->assertExecutedContains("supervisorctl restart {$worker->id}:*");
-    }
-
-    public function test_update_env_keeps_stored_secret_when_value_is_empty(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'environment' => [
-                ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
-            ],
-        ]);
-
-        $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
-            'variables' => [
                 ['key' => 'API_KEY', 'value' => '', 'is_secret' => true],
-                ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-            ],
-        ])->assertSessionDoesntHaveErrors();
-
-        $worker->refresh();
-        $this->assertEquals([
-            ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
-            ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-        ], $worker->environment);
-    }
-
-    public function test_update_env_replaces_secret_when_new_value_given(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'environment' => [
-                ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
             ],
         ]);
+});
 
-        $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
-            'variables' => [
-                ['key' => 'API_KEY', 'value' => 'new-secret', 'is_secret' => true],
-            ],
-        ])->assertSessionDoesntHaveErrors();
+test('update env without restart rewrites config only', function () {
+    $fake = SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->assertEquals([
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
+        'variables' => [
+            ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+        ],
+    ])->assertRedirect()
+        ->assertSessionHas('warning');
+
+    $worker->refresh();
+    expect($worker->environment)->toEqual([
+        ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+    ]);
+    expect($worker->status)->toBe(WorkerStatus::RUNNING);
+
+    $raw = (string) DB::table('workers')->where('id', $worker->id)->value('environment');
+    $this->assertStringNotContainsString('production', $raw);
+
+    $fake->assertExecutedContains("/etc/supervisor/conf.d/{$worker->id}.conf");
+    $fake->assertNotExecutedContains('supervisorctl restart');
+});
+
+test('update env with restart restarts worker', function () {
+    $fake = SSH::fake();
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
+        'variables' => [
+            ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+        ],
+        'restart' => true,
+    ])->assertRedirect()
+        ->assertSessionHas('info');
+
+    $fake->assertExecutedContains("/etc/supervisor/conf.d/{$worker->id}.conf");
+    $fake->assertExecutedContains("supervisorctl restart {$worker->id}:*");
+});
+
+test('update env keeps stored secret when value is empty', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'environment' => [
+            ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
+        ],
+    ]);
+
+    $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
+        'variables' => [
+            ['key' => 'API_KEY', 'value' => '', 'is_secret' => true],
+            ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+        ],
+    ])->assertSessionDoesntHaveErrors();
+
+    $worker->refresh();
+    expect($worker->environment)->toEqual([
+        ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
+        ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+    ]);
+});
+
+test('update env replaces secret when new value given', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'environment' => [
+            ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
+        ],
+    ]);
+
+    $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
+        'variables' => [
             ['key' => 'API_KEY', 'value' => 'new-secret', 'is_secret' => true],
-        ], $worker->refresh()->environment);
-    }
+        ],
+    ])->assertSessionDoesntHaveErrors();
 
-    public function test_update_env_stored_secret_cannot_be_wiped_by_marking_it_non_secret(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
+    expect($worker->refresh()->environment)->toEqual([
+        ['key' => 'API_KEY', 'value' => 'new-secret', 'is_secret' => true],
+    ]);
+});
 
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'environment' => [
-                ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
-            ],
-        ]);
+test('update env stored secret cannot be wiped by marking it non secret', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
-            'variables' => [
-                ['key' => 'API_KEY', 'value' => '', 'is_secret' => false],
-            ],
-        ])->assertSessionDoesntHaveErrors();
-
-        $this->assertEquals([
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'environment' => [
             ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
-        ], $worker->refresh()->environment);
-    }
+        ],
+    ]);
 
-    public function test_update_env_validates_input(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
+    $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
+        'variables' => [
+            ['key' => 'API_KEY', 'value' => '', 'is_secret' => false],
+        ],
+    ])->assertSessionDoesntHaveErrors();
 
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+    expect($worker->refresh()->environment)->toEqual([
+        ['key' => 'API_KEY', 'value' => 'secret-value', 'is_secret' => true],
+    ]);
+});
 
-        $url = route('workers.update-env', ['server' => $this->server, 'worker' => $worker]);
+test('update env validates input', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->patch($url, [
-            'variables' => [['key' => 'foo bar', 'value' => 'x', 'is_secret' => false]],
-        ])->assertSessionHasErrors('variables.0.key');
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        $this->patch($url, [
-            'variables' => [['key' => '1INVALID', 'value' => 'x', 'is_secret' => false]],
-        ])->assertSessionHasErrors('variables.0.key');
+    $url = route('workers.update-env', ['server' => $this->server, 'worker' => $worker]);
 
-        $this->patch($url, [
-            'variables' => [['key' => 'FOO', 'value' => "a\nb", 'is_secret' => false]],
-        ])->assertSessionHasErrors('variables.0.value');
+    $this->patch($url, [
+        'variables' => [['key' => 'foo bar', 'value' => 'x', 'is_secret' => false]],
+    ])->assertSessionHasErrors('variables.0.key');
 
-        $this->patch($url, [
-            'variables' => [['key' => 'FOO', 'value' => 'a"b', 'is_secret' => false]],
-        ])->assertSessionHasErrors('variables.0.value');
+    $this->patch($url, [
+        'variables' => [['key' => '1INVALID', 'value' => 'x', 'is_secret' => false]],
+    ])->assertSessionHasErrors('variables.0.key');
 
-        $this->patch($url, [
-            'variables' => [
-                ['key' => 'FOO', 'value' => 'a', 'is_secret' => false],
-                ['key' => 'FOO', 'value' => 'b', 'is_secret' => false],
-            ],
-        ])->assertSessionHasErrors(['variables.0.key', 'variables.1.key']);
+    $this->patch($url, [
+        'variables' => [['key' => 'FOO', 'value' => "a\nb", 'is_secret' => false]],
+    ])->assertSessionHasErrors('variables.0.value');
 
-        $this->patch($url, [
-            'variables' => collect(range(1, 101))
-                ->map(fn (int $i): array => ['key' => "VAR_{$i}", 'value' => 'x', 'is_secret' => false])
-                ->all(),
-        ])->assertSessionHasErrors('variables');
-    }
+    $this->patch($url, [
+        'variables' => [['key' => 'FOO', 'value' => 'a"b', 'is_secret' => false]],
+    ])->assertSessionHasErrors('variables.0.value');
 
-    public function test_update_env_allowed_for_site_bootstrap_worker(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
+    $this->patch($url, [
+        'variables' => [
+            ['key' => 'FOO', 'value' => 'a', 'is_secret' => false],
+            ['key' => 'FOO', 'value' => 'b', 'is_secret' => false],
+        ],
+    ])->assertSessionHasErrors(['variables.0.key', 'variables.1.key']);
 
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'name' => 'app',
-            'status' => WorkerStatus::RUNNING,
-        ]);
-        $this->site->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
+    $this->patch($url, [
+        'variables' => collect(range(1, 101))
+            ->map(fn (int $i): array => ['key' => "VAR_{$i}", 'value' => 'x', 'is_secret' => false])
+            ->all(),
+    ])->assertSessionHasErrors('variables');
+});
 
-        $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
-            'variables' => [
-                ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-            ],
-        ])->assertSessionDoesntHaveErrors();
+test('update env allowed for site bootstrap worker', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
 
-        $this->assertEquals([
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'name' => 'app',
+        'status' => WorkerStatus::RUNNING,
+    ]);
+    $this->site->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
+
+    $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
+        'variables' => [
             ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-        ], $worker->refresh()->environment);
-    }
+        ],
+    ])->assertSessionDoesntHaveErrors();
 
-    public function test_read_only_user_cannot_update_env(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::USER,
-        ]);
+    expect($worker->refresh()->environment)->toEqual([
+        ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+    ]);
+});
 
-        $this->actingAs($this->user);
+test('read only user cannot update env', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::USER,
+    ]);
 
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+    $this->actingAs($this->user);
 
-        $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
-            'variables' => [],
-        ])->assertForbidden();
-    }
-}
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->patch(route('workers.update-env', ['server' => $this->server, 'worker' => $worker]), [
+        'variables' => [],
+    ])->assertForbidden();
+});

--- a/tests/Feature/WorkerToolingTest.php
+++ b/tests/Feature/WorkerToolingTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\Worker\RefreshSiteWorkerConfigs;
 use App\Enums\SiteStatus;
 use App\Enums\WorkerStatus;
@@ -15,250 +13,231 @@ use App\SourceControlProviders\Github;
 use App\Support\Testing\SSHFake;
 use App\Tooling\ToolingRegistry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class WorkerToolingTest extends TestCase
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->isolatedSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'domain' => 'iso.test',
+        'user' => 'isolated-foo',
+        'path' => '/home/isolated-foo/iso.test',
+        'source_control_id' => $sourceControl->id,
+        'type' => Laravel::id(),
+        'status' => SiteStatus::READY,
+        'type_data' => [],
+    ]);
+});
+
+test('effective environment is empty when no tooling installed', function () {
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->isolatedSite->id,
+        'user' => 'isolated-foo',
+        'command' => 'php artisan queue:work',
+        'environment' => null,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    expect($worker->effectiveEnvironment())->toBe([]);
+});
+
+test('effective environment includes tooling when installed', function () {
+    $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->isolatedSite->id,
+        'user' => 'isolated-foo',
+        'command' => 'php artisan queue:work',
+        'environment' => null,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    $env = $worker->effectiveEnvironment();
+
+    expect($env)->toHaveKey('PATH');
+    $this->assertStringContainsString('/home/isolated-foo/.local/share/mise/shims', $env['PATH']);
+});
+
+test('effective environment overlays tooling over user supplied', function () {
+    $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
+
+    $worker = Worker::factory()->withEnvironment(['CUSTOM' => 'value', 'PATH' => '/user/path'])->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->isolatedSite->id,
+        'user' => 'isolated-foo',
+        'command' => 'php artisan queue:work',
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    $env = $worker->effectiveEnvironment();
+
+    expect($env['CUSTOM'])->toBe('value');
+    $this->assertStringContainsString('/home/isolated-foo/.local/share/mise/shims', $env['PATH']);
+    $this->assertStringNotContainsString('/user/path', $env['PATH']);
+});
+
+test('server bound worker skips tooling', function () {
+    $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
+
+    $worker = Worker::factory()->withEnvironment(['CUSTOM' => 'value'])->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'user' => 'vito',
+        'command' => 'php artisan queue:work',
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    expect($worker->effectiveEnvironment())->toBe(['CUSTOM' => 'value']);
+});
+
+test('command references detects token uses', function () {
+    expect(ToolingRegistry::commandReferences('node app.js', 'node'))->toBeTrue();
+    expect(ToolingRegistry::commandReferences('npm run worker', 'node'))->toBeTrue();
+    expect(ToolingRegistry::commandReferences('cd /path && node app.js', 'node'))->toBeTrue();
+    expect(ToolingRegistry::commandReferences('node', 'node'))->toBeTrue();
+    expect(ToolingRegistry::commandReferences('bun run start', 'bun'))->toBeTrue();
+
+    expect(ToolingRegistry::commandReferences('php run-node.sh', 'node'))->toBeFalse();
+    expect(ToolingRegistry::commandReferences('nodejs app.js', 'node'))->toBeFalse();
+    expect(ToolingRegistry::commandReferences('php artisan queue:work', 'node'))->toBeFalse();
+    expect(ToolingRegistry::commandReferences('node-app.js', 'node'))->toBeFalse();
+    expect(ToolingRegistry::commandReferences('node app.js', 'rustup'))->toBeFalse();
+});
+
+test('refresh rewrites conf for worker on origin site', function () {
+    $fake = SSH::fake();
+
+    $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->isolatedSite->id,
+        'user' => 'isolated-foo',
+        'command' => 'php artisan queue:work',
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    app(RefreshSiteWorkerConfigs::class)->refresh($this->isolatedSite, 'node');
+
+    $fake->assertExecutedContains("/etc/supervisor/conf.d/{$worker->id}.conf");
+    $this->assertStringContainsString(
+        '/home/isolated-foo/.local/share/mise/shims',
+        vitoPestFeatureWorkerToolingTestLastUploadedContent($fake),
+    );
+});
+
+function vitoPestFeatureWorkerToolingTestLastUploadedContent(SSHFake $fake): string
 {
-    use RefreshDatabase;
+    $ref = new ReflectionProperty($fake, 'uploadedContent');
 
-    private Site $isolatedSite;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Github::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $this->isolatedSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'domain' => 'iso.test',
-            'user' => 'isolated-foo',
-            'path' => '/home/isolated-foo/iso.test',
-            'source_control_id' => $sourceControl->id,
-            'type' => Laravel::id(),
-            'status' => SiteStatus::READY,
-            'type_data' => [],
-        ]);
-    }
-
-    public function test_effective_environment_is_empty_when_no_tooling_installed(): void
-    {
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->isolatedSite->id,
-            'user' => 'isolated-foo',
-            'command' => 'php artisan queue:work',
-            'environment' => null,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        $this->assertSame([], $worker->effectiveEnvironment());
-    }
-
-    public function test_effective_environment_includes_tooling_when_installed(): void
-    {
-        $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->isolatedSite->id,
-            'user' => 'isolated-foo',
-            'command' => 'php artisan queue:work',
-            'environment' => null,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        $env = $worker->effectiveEnvironment();
-
-        $this->assertArrayHasKey('PATH', $env);
-        $this->assertStringContainsString('/home/isolated-foo/.local/share/mise/shims', $env['PATH']);
-    }
-
-    public function test_effective_environment_overlays_tooling_over_user_supplied(): void
-    {
-        $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
-
-        $worker = Worker::factory()->withEnvironment(['CUSTOM' => 'value', 'PATH' => '/user/path'])->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->isolatedSite->id,
-            'user' => 'isolated-foo',
-            'command' => 'php artisan queue:work',
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        $env = $worker->effectiveEnvironment();
-
-        $this->assertSame('value', $env['CUSTOM']);
-        $this->assertStringContainsString('/home/isolated-foo/.local/share/mise/shims', $env['PATH']);
-        $this->assertStringNotContainsString('/user/path', $env['PATH']);
-    }
-
-    public function test_server_bound_worker_skips_tooling(): void
-    {
-        $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
-
-        $worker = Worker::factory()->withEnvironment(['CUSTOM' => 'value'])->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'user' => 'vito',
-            'command' => 'php artisan queue:work',
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        $this->assertSame(['CUSTOM' => 'value'], $worker->effectiveEnvironment());
-    }
-
-    public function test_command_references_detects_token_uses(): void
-    {
-        $this->assertTrue(ToolingRegistry::commandReferences('node app.js', 'node'));
-        $this->assertTrue(ToolingRegistry::commandReferences('npm run worker', 'node'));
-        $this->assertTrue(ToolingRegistry::commandReferences('cd /path && node app.js', 'node'));
-        $this->assertTrue(ToolingRegistry::commandReferences('node', 'node'));
-        $this->assertTrue(ToolingRegistry::commandReferences('bun run start', 'bun'));
-
-        $this->assertFalse(ToolingRegistry::commandReferences('php run-node.sh', 'node'));
-        $this->assertFalse(ToolingRegistry::commandReferences('nodejs app.js', 'node'));
-        $this->assertFalse(ToolingRegistry::commandReferences('php artisan queue:work', 'node'));
-        $this->assertFalse(ToolingRegistry::commandReferences('node-app.js', 'node'));
-        $this->assertFalse(ToolingRegistry::commandReferences('node app.js', 'rustup'));
-    }
-
-    public function test_refresh_rewrites_conf_for_worker_on_origin_site(): void
-    {
-        $fake = SSH::fake();
-
-        $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->isolatedSite->id,
-            'user' => 'isolated-foo',
-            'command' => 'php artisan queue:work',
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        app(RefreshSiteWorkerConfigs::class)->refresh($this->isolatedSite, 'node');
-
-        $fake->assertExecutedContains("/etc/supervisor/conf.d/{$worker->id}.conf");
-        $this->assertStringContainsString(
-            '/home/isolated-foo/.local/share/mise/shims',
-            $this->lastUploadedContent($fake),
-        );
-    }
-
-    private function lastUploadedContent(SSHFake $fake): string
-    {
-        $ref = new \ReflectionProperty($fake, 'uploadedContent');
-
-        return (string) $ref->getValue($fake);
-    }
-
-    public function test_refresh_propagates_to_sibling_site_workers(): void
-    {
-        $fake = SSH::fake();
-
-        $sourceControl = SourceControl::factory()->create([
-            'provider' => Github::id(),
-            'user_id' => $this->user->id,
-        ]);
-
-        $sibling = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'domain' => 'iso-two.test',
-            'user' => 'isolated-foo',
-            'path' => '/home/isolated-foo/iso-two.test',
-            'source_control_id' => $sourceControl->id,
-            'type' => Laravel::id(),
-            'status' => SiteStatus::READY,
-            'type_data' => [],
-        ]);
-
-        $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
-
-        $siblingWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $sibling->id,
-            'user' => 'isolated-foo',
-            'command' => 'php artisan schedule:work',
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        app(RefreshSiteWorkerConfigs::class)->refresh($this->isolatedSite, 'node');
-
-        $fake->assertExecutedContains("/etc/supervisor/conf.d/{$siblingWorker->id}.conf");
-        $this->addToAssertionCount(1);
-    }
-
-    public function test_refresh_restarts_worker_whose_command_references_changed_tool(): void
-    {
-        $fake = SSH::fake();
-
-        $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
-
-        Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->isolatedSite->id,
-            'user' => 'isolated-foo',
-            'command' => 'node app.js',
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        app(RefreshSiteWorkerConfigs::class)->refresh($this->isolatedSite, 'node');
-
-        $fake->assertExecutedContains('supervisorctl restart');
-        $this->addToAssertionCount(1);
-    }
-
-    public function test_refresh_does_not_restart_when_command_unrelated(): void
-    {
-        $fake = SSH::fake();
-
-        $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
-
-        Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->isolatedSite->id,
-            'user' => 'isolated-foo',
-            'command' => 'php artisan queue:work',
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        app(RefreshSiteWorkerConfigs::class)->refresh($this->isolatedSite, 'node');
-
-        $fake->assertNotExecutedContains('supervisorctl restart');
-        $this->addToAssertionCount(1);
-    }
-
-    public function test_refresh_skips_workers_on_sites_that_do_not_support_tooling(): void
-    {
-        $fake = SSH::fake();
-
-        $loadBalancer = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'domain' => 'lb.test',
-            'user' => 'isolated-foo',
-            'path' => '/home/isolated-foo/lb.test',
-            'type' => LoadBalancer::id(),
-            'status' => SiteStatus::READY,
-            'type_data' => [],
-        ]);
-
-        $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
-
-        $lbWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $loadBalancer->id,
-            'user' => 'isolated-foo',
-            'command' => 'node app.js',
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        app(RefreshSiteWorkerConfigs::class)->refresh($this->isolatedSite, 'node');
-
-        $fake->assertNotExecutedContains("/etc/supervisor/conf.d/{$lbWorker->id}.conf");
-        $this->addToAssertionCount(1);
-    }
+    return (string) $ref->getValue($fake);
 }
+
+test('refresh propagates to sibling site workers', function () {
+    $fake = SSH::fake();
+
+    $sourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    $sibling = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'domain' => 'iso-two.test',
+        'user' => 'isolated-foo',
+        'path' => '/home/isolated-foo/iso-two.test',
+        'source_control_id' => $sourceControl->id,
+        'type' => Laravel::id(),
+        'status' => SiteStatus::READY,
+        'type_data' => [],
+    ]);
+
+    $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
+
+    $siblingWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $sibling->id,
+        'user' => 'isolated-foo',
+        'command' => 'php artisan schedule:work',
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    app(RefreshSiteWorkerConfigs::class)->refresh($this->isolatedSite, 'node');
+
+    $fake->assertExecutedContains("/etc/supervisor/conf.d/{$siblingWorker->id}.conf");
+    $this->addToAssertionCount(1);
+});
+
+test('refresh restarts worker whose command references changed tool', function () {
+    $fake = SSH::fake();
+
+    $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
+
+    Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->isolatedSite->id,
+        'user' => 'isolated-foo',
+        'command' => 'node app.js',
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    app(RefreshSiteWorkerConfigs::class)->refresh($this->isolatedSite, 'node');
+
+    $fake->assertExecutedContains('supervisorctl restart');
+    $this->addToAssertionCount(1);
+});
+
+test('refresh does not restart when command unrelated', function () {
+    $fake = SSH::fake();
+
+    $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
+
+    Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->isolatedSite->id,
+        'user' => 'isolated-foo',
+        'command' => 'php artisan queue:work',
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    app(RefreshSiteWorkerConfigs::class)->refresh($this->isolatedSite, 'node');
+
+    $fake->assertNotExecutedContains('supervisorctl restart');
+    $this->addToAssertionCount(1);
+});
+
+test('refresh skips workers on sites that do not support tooling', function () {
+    $fake = SSH::fake();
+
+    $loadBalancer = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'domain' => 'lb.test',
+        'user' => 'isolated-foo',
+        'path' => '/home/isolated-foo/lb.test',
+        'type' => LoadBalancer::id(),
+        'status' => SiteStatus::READY,
+        'type_data' => [],
+    ]);
+
+    $this->isolatedSite->isolatedUser->setToolingVersion('node', '22');
+
+    $lbWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $loadBalancer->id,
+        'user' => 'isolated-foo',
+        'command' => 'node app.js',
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    app(RefreshSiteWorkerConfigs::class)->refresh($this->isolatedSite, 'node');
+
+    $fake->assertNotExecutedContains("/etc/supervisor/conf.d/{$lbWorker->id}.conf");
+    $this->addToAssertionCount(1);
+});

--- a/tests/Feature/WorkerToolingTest.php
+++ b/tests/Feature/WorkerToolingTest.php
@@ -10,7 +10,6 @@ use App\Models\Worker;
 use App\SiteTypes\Laravel;
 use App\SiteTypes\LoadBalancer;
 use App\SourceControlProviders\Github;
-use App\Support\Testing\SSHFake;
 use App\Tooling\ToolingRegistry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -129,16 +128,9 @@ test('refresh rewrites conf for worker on origin site', function () {
     $fake->assertExecutedContains("/etc/supervisor/conf.d/{$worker->id}.conf");
     $this->assertStringContainsString(
         '/home/isolated-foo/.local/share/mise/shims',
-        vitoPestFeatureWorkerToolingTestLastUploadedContent($fake),
+        $fake->getUploadedContent(),
     );
 });
-
-function vitoPestFeatureWorkerToolingTestLastUploadedContent(SSHFake $fake): string
-{
-    $ref = new ReflectionProperty($fake, 'uploadedContent');
-
-    return (string) $ref->getValue($fake);
-}
 
 test('refresh propagates to sibling site workers', function () {
     $fake = SSH::fake();

--- a/tests/Feature/WorkersTest.php
+++ b/tests/Feature/WorkersTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\Worker\ManageWorker;
 use App\Enums\UserRole;
 use App\Enums\WorkerStatus;
@@ -16,1019 +14,974 @@ use App\Services\ProcessManager\ProcessManager;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
-
-class WorkersTest extends TestCase
-{
-    use RefreshDatabase;
-
-    public function test_see_workers(): void
-    {
-        $this->actingAs($this->user);
-
-        Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-        ]);
-
-        $this->get(route('workers', [
-            'server' => $this->server,
-        ]))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('workers/index'));
-
-    }
-
-    public function test_delete_worker(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-        ]);
-
-        $this->delete(route('workers.destroy', [
-            'server' => $this->server,
-            'worker' => $worker,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('workers', [
-            'id' => $worker->id,
-        ]);
-    }
-
-    public function test_create_worker(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('workers.store', [
-            'server' => $this->server,
-        ]), [
-            'name' => 'Test Worker',
-            'command' => 'php artisan worker:work',
-            'user' => 'vito',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 1,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('workers', [
-            'server_id' => $this->server->id,
-            'name' => 'Test Worker',
-            'command' => 'php artisan worker:work',
-            'user' => 'vito',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 1,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-    }
-
-    public function test_create_worker_as_isolated_user(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->site->user = 'example';
-        $this->site->save();
-
-        $this->post(route('workers.store', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'name' => 'Test Worker',
-            'command' => 'php artisan worker:work',
-            'user' => 'example',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 1,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('workers', [
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'command' => 'php artisan worker:work',
-            'user' => 'example',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 1,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-    }
-
-    public function test_cannot_create_worker_as_invalid_user(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('workers.store', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'name' => 'Test Worker',
-            'command' => 'php artisan worker:work',
-            'user' => 'example',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 1,
-        ])
-            ->assertSessionHasErrors();
-
-        $this->assertDatabaseMissing('workers', [
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'user' => 'example',
-        ]);
-    }
-
-    public function test_cannot_create_worker_on_another_sites_user(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'example',
-        ]);
-
-        $this->post(route('workers.store', [
-            'server' => $this->server,
-            'site' => $this->site,
-        ]), [
-            'name' => 'Test Worker',
-            'command' => 'php artisan worker:work',
-            'user' => 'example',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 1,
-        ])
-            ->assertSessionHasErrors();
-
-        $this->assertDatabaseMissing('workers', [
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'user' => 'example',
-        ]);
-    }
-
-    public function test_start_worker(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::STOPPED,
-        ]);
-
-        $this->post(route('workers.start', [
-            'server' => $this->server,
-            'worker' => $worker,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('workers', [
-            'id' => $worker->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-    }
-
-    public function test_start_worker_reloads_config_before_starting(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::STOPPED,
-        ]);
-
-        $this->post(route('workers.start', [
-            'server' => $this->server,
-            'worker' => $worker,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        SSH::assertExecutedContains('supervisorctl reread');
-        SSH::assertExecutedContains("supervisorctl update {$worker->id}");
-        SSH::assertExecutedContains("supervisorctl start {$worker->id}:*");
-    }
-
-    public function test_start_and_restart_clear_error_optimistically(): void
-    {
-        Queue::fake();
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::FAILED,
-            'error' => '10:10_00: ERROR (no such file)',
-        ]);
-
-        app(ManageWorker::class)->restart($worker);
-
-        $worker->refresh();
-        $this->assertSame(WorkerStatus::RESTARTING, $worker->status);
-        $this->assertNull($worker->error);
-
-        $worker->status = WorkerStatus::FAILED;
-        $worker->error = 'boom';
-        $worker->save();
-
-        app(ManageWorker::class)->start($worker);
-
-        $worker->refresh();
-        $this->assertSame(WorkerStatus::STARTING, $worker->status);
-        $this->assertNull($worker->error);
-
-        Queue::assertPushed(ManageJob::class, 2);
-    }
-
-    public function test_start_worker_clears_previous_error(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::FAILED,
-            'error' => '10:10_00: ERROR (no such file)',
-        ]);
-
-        $this->post(route('workers.start', [
-            'server' => $this->server,
-            'worker' => $worker,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $worker->refresh();
-
-        $this->assertSame(WorkerStatus::RUNNING, $worker->status);
-        $this->assertNull($worker->error);
-    }
-
-    public function test_stop_worker(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        $this->post(route('workers.stop', [
-            'server' => $this->server,
-            'worker' => $worker,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('workers', [
-            'id' => $worker->id,
-            'status' => WorkerStatus::STOPPED,
-        ]);
-    }
-
-    public function test_restart_worker(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        $this->post(route('workers.restart', [
-            'server' => $this->server,
-            'worker' => $worker,
-        ]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('workers', [
-            'id' => $worker->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-    }
-
-    public function test_show_logs(): void
-    {
-        SSH::fake('logs');
-
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        $this->get(route('workers.logs', [
-            'server' => $this->server,
-            'worker' => $worker,
-        ]))
-            ->assertSuccessful();
-    }
-
-    public function test_create_worker_with_valid_site_id(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->post(route('workers.store', [
-            'server' => $this->server,
-        ]), [
-            'name' => 'Test Worker',
-            'command' => 'php artisan worker:work',
-            'user' => 'vito',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 1,
-            'site_id' => $site->id,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('workers', [
-            'server_id' => $this->server->id,
-            'site_id' => $site->id,
-            'name' => 'Test Worker',
-            'command' => 'php artisan worker:work',
-            'user' => 'vito',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 1,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-    }
-
-    public function test_cannot_create_worker_with_invalid_site_id(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        $this->post(route('workers.store', [
-            'server' => $this->server,
-        ]), [
-            'name' => 'Test Worker',
-            'command' => 'php artisan worker:work',
-            'user' => 'vito',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 1,
-            'site_id' => 99999, // Non-existent site ID
-        ])
-            ->assertSessionHasErrors(['site_id']);
-
-        $this->assertDatabaseMissing('workers', [
-            'server_id' => $this->server->id,
-            'site_id' => 99999,
-        ]);
-    }
-
-    public function test_cannot_create_worker_with_site_id_from_different_server(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        /** @var Server $otherServer */
-        $otherServer = Server::factory()->create(['user_id' => 1]);
-
-        /** @var Site $otherSite */
-        $otherSite = Site::factory()->create([
-            'server_id' => $otherServer->id,
-        ]);
-
-        $this->post(route('workers.store', [
-            'server' => $this->server,
-        ]), [
-            'name' => 'Test Worker',
-            'command' => 'php artisan worker:work',
-            'user' => 'vito',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 1,
-            'site_id' => $otherSite->id,
-        ])
-            ->assertSessionHasErrors(['site_id']);
-
-        $this->assertDatabaseMissing('workers', [
-            'server_id' => $this->server->id,
-            'site_id' => $otherSite->id,
-        ]);
-    }
-
-    public function test_edit_worker_with_valid_site_id(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->put(route('workers.update', [
-            'server' => $this->server,
-            'worker' => $worker,
-        ]), [
-            'name' => $worker->name,
-            'command' => 'updated command',
-            'user' => 'vito',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 2,
-            'site_id' => $site->id,
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $worker->refresh();
-
-        $this->assertEquals($site->id, $worker->site_id);
-        $this->assertEquals('updated command', $worker->command);
-        $this->assertEquals(2, $worker->numprocs);
-    }
-
-    public function test_cannot_edit_worker_with_invalid_site_id(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->put(route('workers.update', [
-            'server' => $this->server,
-            'worker' => $worker,
-        ]), [
-            'name' => $worker->name,
-            'command' => 'updated command',
-            'user' => 'vito',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 2,
-            'site_id' => 99999, // Non-existent site ID
-        ])
-            ->assertSessionHasErrors(['site_id']);
-
-        $worker->refresh();
-
-        $this->assertNotEquals(99999, $worker->site_id);
-    }
-
-    public function test_cannot_edit_worker_with_site_id_from_different_server(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        /** @var Server $otherServer */
-        $otherServer = Server::factory()->create(['user_id' => 1]);
-
-        /** @var Site $otherSite */
-        $otherSite = Site::factory()->create([
-            'server_id' => $otherServer->id,
-        ]);
-
-        $this->put(route('workers.update', [
-            'server' => $this->server,
-            'worker' => $worker,
-        ]), [
-            'name' => $worker->name,
-            'command' => 'updated command',
-            'user' => 'vito',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 2,
-            'site_id' => $otherSite->id,
-        ])
-            ->assertSessionHasErrors(['site_id']);
-
-        $worker->refresh();
-
-        $this->assertNotEquals($otherSite->id, $worker->site_id);
-    }
-
-    public function test_create_worker_with_environment(): void
-    {
-        SSH::fake();
-
-        $this->actingAs($this->user);
-
-        $this->post(route('workers.store', [
-            'server' => $this->server,
-        ]), [
-            'name' => 'Test Worker',
-            'command' => 'npm run start',
-            'user' => 'vito',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 1,
-            'environment' => [
-                ['key' => 'PATH', 'value' => '/home/vito/.local/share/mise/shims:/usr/local/bin:/usr/bin:/bin', 'is_secret' => false],
-                ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-            ],
-        ])
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('workers', [
-            'server_id' => $this->server->id,
-            'name' => 'Test Worker',
-            'command' => 'npm run start',
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        $worker = Worker::where('name', 'Test Worker')->first();
-        $this->assertNotNull($worker);
-        $this->assertEquals([
+
+uses(RefreshDatabase::class);
+
+test('see workers', function () {
+    $this->actingAs($this->user);
+
+    Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+    ]);
+
+    $this->get(route('workers', [
+        'server' => $this->server,
+    ]))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('workers/index'));
+});
+
+test('delete worker', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+    ]);
+
+    $this->delete(route('workers.destroy', [
+        'server' => $this->server,
+        'worker' => $worker,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseMissing('workers', [
+        'id' => $worker->id,
+    ]);
+});
+
+test('create worker', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('workers.store', [
+        'server' => $this->server,
+    ]), [
+        'name' => 'Test Worker',
+        'command' => 'php artisan worker:work',
+        'user' => 'vito',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 1,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('workers', [
+        'server_id' => $this->server->id,
+        'name' => 'Test Worker',
+        'command' => 'php artisan worker:work',
+        'user' => 'vito',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 1,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+});
+
+test('create worker as isolated user', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->site->user = 'example';
+    $this->site->save();
+
+    $this->post(route('workers.store', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'name' => 'Test Worker',
+        'command' => 'php artisan worker:work',
+        'user' => 'example',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 1,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('workers', [
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'command' => 'php artisan worker:work',
+        'user' => 'example',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 1,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+});
+
+test('cannot create worker as invalid user', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('workers.store', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'name' => 'Test Worker',
+        'command' => 'php artisan worker:work',
+        'user' => 'example',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 1,
+    ])
+        ->assertSessionHasErrors();
+
+    $this->assertDatabaseMissing('workers', [
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'user' => 'example',
+    ]);
+});
+
+test('cannot create worker on another sites user', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'example',
+    ]);
+
+    $this->post(route('workers.store', [
+        'server' => $this->server,
+        'site' => $this->site,
+    ]), [
+        'name' => 'Test Worker',
+        'command' => 'php artisan worker:work',
+        'user' => 'example',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 1,
+    ])
+        ->assertSessionHasErrors();
+
+    $this->assertDatabaseMissing('workers', [
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'user' => 'example',
+    ]);
+});
+
+test('start worker', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::STOPPED,
+    ]);
+
+    $this->post(route('workers.start', [
+        'server' => $this->server,
+        'worker' => $worker,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('workers', [
+        'id' => $worker->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+});
+
+test('start worker reloads config before starting', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::STOPPED,
+    ]);
+
+    $this->post(route('workers.start', [
+        'server' => $this->server,
+        'worker' => $worker,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    SSH::assertExecutedContains('supervisorctl reread');
+    SSH::assertExecutedContains("supervisorctl update {$worker->id}");
+    SSH::assertExecutedContains("supervisorctl start {$worker->id}:*");
+});
+
+test('start and restart clear error optimistically', function () {
+    Queue::fake();
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::FAILED,
+        'error' => '10:10_00: ERROR (no such file)',
+    ]);
+
+    app(ManageWorker::class)->restart($worker);
+
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::RESTARTING);
+    expect($worker->error)->toBeNull();
+
+    $worker->status = WorkerStatus::FAILED;
+    $worker->error = 'boom';
+    $worker->save();
+
+    app(ManageWorker::class)->start($worker);
+
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::STARTING);
+    expect($worker->error)->toBeNull();
+
+    Queue::assertPushed(ManageJob::class, 2);
+});
+
+test('start worker clears previous error', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::FAILED,
+        'error' => '10:10_00: ERROR (no such file)',
+    ]);
+
+    $this->post(route('workers.start', [
+        'server' => $this->server,
+        'worker' => $worker,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $worker->refresh();
+
+    expect($worker->status)->toBe(WorkerStatus::RUNNING);
+    expect($worker->error)->toBeNull();
+});
+
+test('stop worker', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    $this->post(route('workers.stop', [
+        'server' => $this->server,
+        'worker' => $worker,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('workers', [
+        'id' => $worker->id,
+        'status' => WorkerStatus::STOPPED,
+    ]);
+});
+
+test('restart worker', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    $this->post(route('workers.restart', [
+        'server' => $this->server,
+        'worker' => $worker,
+    ]))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('workers', [
+        'id' => $worker->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+});
+
+test('show logs', function () {
+    SSH::fake('logs');
+
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    $this->get(route('workers.logs', [
+        'server' => $this->server,
+        'worker' => $worker,
+    ]))
+        ->assertSuccessful();
+});
+
+test('create worker with valid site id', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->post(route('workers.store', [
+        'server' => $this->server,
+    ]), [
+        'name' => 'Test Worker',
+        'command' => 'php artisan worker:work',
+        'user' => 'vito',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 1,
+        'site_id' => $site->id,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('workers', [
+        'server_id' => $this->server->id,
+        'site_id' => $site->id,
+        'name' => 'Test Worker',
+        'command' => 'php artisan worker:work',
+        'user' => 'vito',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 1,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+});
+
+test('cannot create worker with invalid site id', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    $this->post(route('workers.store', [
+        'server' => $this->server,
+    ]), [
+        'name' => 'Test Worker',
+        'command' => 'php artisan worker:work',
+        'user' => 'vito',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 1,
+        'site_id' => 99999, // Non-existent site ID
+    ])
+        ->assertSessionHasErrors(['site_id']);
+
+    $this->assertDatabaseMissing('workers', [
+        'server_id' => $this->server->id,
+        'site_id' => 99999,
+    ]);
+});
+
+test('cannot create worker with site id from different server', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    /** @var Server $otherServer */
+    $otherServer = Server::factory()->create(['user_id' => 1]);
+
+    /** @var Site $otherSite */
+    $otherSite = Site::factory()->create([
+        'server_id' => $otherServer->id,
+    ]);
+
+    $this->post(route('workers.store', [
+        'server' => $this->server,
+    ]), [
+        'name' => 'Test Worker',
+        'command' => 'php artisan worker:work',
+        'user' => 'vito',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 1,
+        'site_id' => $otherSite->id,
+    ])
+        ->assertSessionHasErrors(['site_id']);
+
+    $this->assertDatabaseMissing('workers', [
+        'server_id' => $this->server->id,
+        'site_id' => $otherSite->id,
+    ]);
+});
+
+test('edit worker with valid site id', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->put(route('workers.update', [
+        'server' => $this->server,
+        'worker' => $worker,
+    ]), [
+        'name' => $worker->name,
+        'command' => 'updated command',
+        'user' => 'vito',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 2,
+        'site_id' => $site->id,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $worker->refresh();
+
+    expect($worker->site_id)->toEqual($site->id);
+    expect($worker->command)->toEqual('updated command');
+    expect($worker->numprocs)->toEqual(2);
+});
+
+test('cannot edit worker with invalid site id', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->put(route('workers.update', [
+        'server' => $this->server,
+        'worker' => $worker,
+    ]), [
+        'name' => $worker->name,
+        'command' => 'updated command',
+        'user' => 'vito',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 2,
+        'site_id' => 99999, // Non-existent site ID
+    ])
+        ->assertSessionHasErrors(['site_id']);
+
+    $worker->refresh();
+
+    $this->assertNotEquals(99999, $worker->site_id);
+});
+
+test('cannot edit worker with site id from different server', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    /** @var Server $otherServer */
+    $otherServer = Server::factory()->create(['user_id' => 1]);
+
+    /** @var Site $otherSite */
+    $otherSite = Site::factory()->create([
+        'server_id' => $otherServer->id,
+    ]);
+
+    $this->put(route('workers.update', [
+        'server' => $this->server,
+        'worker' => $worker,
+    ]), [
+        'name' => $worker->name,
+        'command' => 'updated command',
+        'user' => 'vito',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 2,
+        'site_id' => $otherSite->id,
+    ])
+        ->assertSessionHasErrors(['site_id']);
+
+    $worker->refresh();
+
+    $this->assertNotEquals($otherSite->id, $worker->site_id);
+});
+
+test('create worker with environment', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->post(route('workers.store', [
+        'server' => $this->server,
+    ]), [
+        'name' => 'Test Worker',
+        'command' => 'npm run start',
+        'user' => 'vito',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 1,
+        'environment' => [
             ['key' => 'PATH', 'value' => '/home/vito/.local/share/mise/shims:/usr/local/bin:/usr/bin:/bin', 'is_secret' => false],
             ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
-        ], $worker->environment);
-    }
+        ],
+    ])
+        ->assertSessionDoesntHaveErrors();
 
-    public function test_cannot_create_worker_with_legacy_environment_map(): void
-    {
-        SSH::fake();
+    $this->assertDatabaseHas('workers', [
+        'server_id' => $this->server->id,
+        'name' => 'Test Worker',
+        'command' => 'npm run start',
+        'status' => WorkerStatus::RUNNING,
+    ]);
 
-        $this->actingAs($this->user);
+    $worker = Worker::where('name', 'Test Worker')->first();
+    expect($worker)->not->toBeNull();
+    expect($worker->environment)->toEqual([
+        ['key' => 'PATH', 'value' => '/home/vito/.local/share/mise/shims:/usr/local/bin:/usr/bin:/bin', 'is_secret' => false],
+        ['key' => 'NODE_ENV', 'value' => 'production', 'is_secret' => false],
+    ]);
+});
 
-        $this->post(route('workers.store', [
-            'server' => $this->server,
-        ]), [
-            'name' => 'Test Worker',
-            'command' => 'npm run start',
-            'user' => 'vito',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 1,
-            'environment' => [
-                'NODE_ENV' => 'production',
-            ],
-        ])
-            ->assertSessionHasErrors();
-    }
+test('cannot create worker with legacy environment map', function () {
+    SSH::fake();
 
-    public function test_worker_environment_is_stored_as_array(): void
-    {
-        $worker = Worker::factory()->withEnvironment([
-            'PATH' => '/custom/path',
+    $this->actingAs($this->user);
+
+    $this->post(route('workers.store', [
+        'server' => $this->server,
+    ]), [
+        'name' => 'Test Worker',
+        'command' => 'npm run start',
+        'user' => 'vito',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 1,
+        'environment' => [
             'NODE_ENV' => 'production',
-        ])->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->assertIsArray($worker->environment);
-        $this->assertEquals('/custom/path', $worker->environmentMap()['PATH']);
-        $this->assertEquals('production', $worker->environmentMap()['NODE_ENV']);
-    }
-
-    public function test_cannot_edit_site_bootstrap_worker(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-        ]);
-
-        $this->site->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
-
-        $this->put(route('workers.update', [
-            'server' => $this->server,
-            'worker' => $worker,
-        ]), [
-            'name' => 'renamed',
-            'command' => 'renamed command',
-            'user' => 'vito',
-            'auto_start' => 1,
-            'auto_restart' => 1,
-            'numprocs' => 1,
-        ])
-            ->assertSessionHasErrors(['name']);
-
-        $this->assertDatabaseMissing('workers', [
-            'id' => $worker->id,
-            'command' => 'renamed command',
-        ]);
-    }
-
-    public function test_cannot_delete_site_bootstrap_worker(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-        ]);
-
-        $this->site->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
-
-        $this->delete(route('workers.destroy', [
-            'server' => $this->server,
-            'worker' => $worker,
-        ]))
-            ->assertForbidden();
-
-        $this->assertDatabaseHas('workers', ['id' => $worker->id]);
-    }
-
-    public function test_can_still_start_stop_restart_bootstrap_worker(): void
-    {
-        SSH::fake();
-        $this->actingAs($this->user);
-
-        /** @var Worker $worker */
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::STOPPED,
-        ]);
-
-        $this->site->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
-
-        $this->post(route('workers.start', [
-            'server' => $this->server,
-            'worker' => $worker,
-        ]))->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseHas('workers', [
-            'id' => $worker->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-    }
-
-    public function test_restart_all_with_site_id_restarts_only_site_workers(): void
-    {
-        SSH::fake();
-
-        $siteWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-        $serverWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-        $creatingWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::CREATING,
-        ]);
-
-        /** @var ProcessManager $handler */
-        $handler = $this->server->processManager()->handler();
-        $handler->restartAll($this->site->id);
-
-        SSH::assertExecutedContains("supervisorctl update {$siteWorker->id};");
-        SSH::assertExecutedContains("restart {$siteWorker->id}:*");
-        SSH::assertNotExecutedContains("restart {$serverWorker->id}:*");
-        SSH::assertNotExecutedContains("supervisorctl update {$creatingWorker->id};");
-        SSH::assertNotExecutedContains('supervisorctl restart all');
-    }
-
-    public function test_restart_all_without_site_id_updates_config_and_restarts_all(): void
-    {
-        SSH::fake();
-
-        /** @var ProcessManager $handler */
-        $handler = $this->server->processManager()->handler();
-        $handler->restartAll();
-
-        SSH::assertExecutedContains('supervisorctl update');
-        SSH::assertExecutedContains('supervisorctl restart all');
-    }
-
-    public function test_restart_all_with_site_id_without_workers_executes_nothing(): void
-    {
-        SSH::fake();
-
-        Worker::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
-
-        /** @var ProcessManager $handler */
-        $handler = $this->server->processManager()->handler();
-        $handler->restartAll($this->site->id);
-
-        SSH::assertNotExecutedContains('supervisorctl');
-    }
-
-    public function test_resync_updates_worker_statuses(): void
-    {
-        $this->actingAs($this->user);
-
-        $siteWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::FAILED,
-            'error' => 'old error',
-        ]);
-        $serverWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        SSH::fake(
-            "{$siteWorker->id}:{$siteWorker->id}_00   RUNNING   pid 100, uptime 0:00:05\n".
-            "{$serverWorker->id}:{$serverWorker->id}_00   STOPPED   Jun 06 10:00 AM"
-        );
-
-        $this->post(route('workers.resync', ['server' => $this->server]))
-            ->assertSessionDoesntHaveErrors()
-            ->assertSessionHas('success');
-
-        SSH::assertExecutedContains('supervisorctl status');
-
-        $siteWorker->refresh();
-        $serverWorker->refresh();
-        $this->assertSame(WorkerStatus::RUNNING, $siteWorker->status);
-        $this->assertNull($siteWorker->error);
-        $this->assertSame(WorkerStatus::STOPPED, $serverWorker->status);
-    }
-
-    public function test_resync_marks_fatal_worker_failed_with_error(): void
-    {
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        SSH::fake("{$worker->id}:{$worker->id}_00   FATAL   Exited too quickly (process log may have details)");
-
-        $this->post(route('workers.resync', ['server' => $this->server]))
-            ->assertSessionDoesntHaveErrors();
-
-        $worker->refresh();
-        $this->assertSame(WorkerStatus::FAILED, $worker->status);
-        $this->assertStringContainsString('FATAL Exited too quickly', (string) $worker->error);
-
-        $this->assertDatabaseHas('server_logs', [
-            'server_id' => $this->server->id,
-            'type' => 'sync-worker-statuses-failed',
-        ]);
-    }
-
-    public function test_resync_does_not_relog_unchanged_failed_worker(): void
-    {
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::FAILED,
-        ]);
-        $worker->error = "{$worker->id}:{$worker->id}_00: FATAL Exited too quickly";
-        $worker->save();
-
-        SSH::fake("{$worker->id}:{$worker->id}_00   FATAL   Exited too quickly");
-
-        $this->post(route('workers.resync', ['server' => $this->server]))
-            ->assertSessionDoesntHaveErrors();
-
-        $this->assertDatabaseMissing('server_logs', [
-            'type' => 'sync-worker-statuses-failed',
-        ]);
-
-        $worker->refresh();
-        $this->assertSame(WorkerStatus::FAILED, $worker->status);
-    }
-
-    public function test_resync_marks_missing_worker_failed(): void
-    {
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        SSH::fake('unix:///var/run/supervisor.sock no such file');
-
-        $this->post(route('workers.resync', ['server' => $this->server]))
-            ->assertSessionDoesntHaveErrors();
-
-        $worker->refresh();
-        $this->assertSame(WorkerStatus::FAILED, $worker->status);
-        $this->assertSame('Process not found in supervisor', $worker->error);
-    }
-
-    public function test_resync_site_scope_does_not_touch_server_workers(): void
-    {
-        $this->actingAs($this->user);
-
-        $siteWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-        $serverWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        SSH::fake("{$siteWorker->id}:{$siteWorker->id}_00   STOPPED   Jun 06 10:00 AM");
-
-        $this->post(route('workers.resync', ['server' => $this->server, 'site' => $this->site]))
-            ->assertSessionDoesntHaveErrors();
-
-        $siteWorker->refresh();
-        $serverWorker->refresh();
-        $this->assertSame(WorkerStatus::STOPPED, $siteWorker->status);
-        $this->assertSame(WorkerStatus::RUNNING, $serverWorker->status);
-    }
-
-    public function test_resync_skips_creating_workers(): void
-    {
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::CREATING,
-        ]);
-
-        SSH::fake("{$worker->id}:{$worker->id}_00   RUNNING   pid 100, uptime 0:00:05");
-
-        $this->post(route('workers.resync', ['server' => $this->server]))
-            ->assertSessionDoesntHaveErrors();
-
-        SSH::assertNotExecutedContains('supervisorctl status');
-
-        $worker->refresh();
-        $this->assertSame(WorkerStatus::CREATING, $worker->status);
-    }
-
-    public function test_restart_all_endpoint_sets_restarting_and_dispatches_job(): void
-    {
-        Queue::fake();
-
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::STOPPED,
-            'error' => 'old error',
-        ]);
-        $creatingWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => WorkerStatus::CREATING,
-        ]);
-
-        $this->post(route('workers.restart-all', ['server' => $this->server]))
-            ->assertSessionDoesntHaveErrors();
-
-        $worker->refresh();
-        $creatingWorker->refresh();
-        $this->assertSame(WorkerStatus::RESTARTING, $worker->status);
-        $this->assertNull($worker->error);
-        $this->assertSame(WorkerStatus::CREATING, $creatingWorker->status);
-
-        Queue::assertPushed(RestartAllJob::class);
-    }
-
-    public function test_restart_all_endpoint_full_flow_settles_statuses(): void
-    {
-        $this->actingAs($this->user);
-
-        $worker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => WorkerStatus::STOPPED,
-        ]);
-
-        SSH::fake("{$worker->id}:{$worker->id}_00   RUNNING   pid 100, uptime 0:00:05");
-
-        $this->post(route('workers.restart-all', ['server' => $this->server]))
-            ->assertSessionDoesntHaveErrors();
-
-        SSH::assertExecutedContains('supervisorctl restart all');
-        SSH::assertExecutedContains('supervisorctl status');
-
-        $worker->refresh();
-        $this->assertSame(WorkerStatus::RUNNING, $worker->status);
-    }
-
-    public function test_restart_all_endpoint_site_scope_uses_restart_many(): void
-    {
-        $this->actingAs($this->user);
-
-        $siteWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RUNNING,
-        ]);
-
-        SSH::fake("{$siteWorker->id}:{$siteWorker->id}_00   RUNNING   pid 100, uptime 0:00:05");
-
-        $this->post(route('workers.restart-all', ['server' => $this->server, 'site' => $this->site]))
-            ->assertSessionDoesntHaveErrors();
-
-        SSH::assertExecutedContains("restart {$siteWorker->id}:*");
-        SSH::assertNotExecutedContains('supervisorctl restart all');
-
-        $siteWorker->refresh();
-        $this->assertSame(WorkerStatus::RUNNING, $siteWorker->status);
-    }
-
-    public function test_restart_all_job_failed_marks_restarting_workers_failed(): void
-    {
-        $restartingWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => WorkerStatus::RESTARTING,
-        ]);
-        $stoppedWorker = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'status' => WorkerStatus::STOPPED,
-        ]);
-
-        (new RestartAllJob($this->server))->failed(new SSHCommandError('boom'));
-
-        $restartingWorker->refresh();
-        $stoppedWorker->refresh();
-        $this->assertSame(WorkerStatus::FAILED, $restartingWorker->status);
-        $this->assertSame('boom', $restartingWorker->error);
-        $this->assertSame(WorkerStatus::STOPPED, $stoppedWorker->status);
-    }
-
-    public function test_user_role_cannot_resync_or_restart_all(): void
-    {
-        $this->server->project->users()->where('user_id', $this->user->id)->update([
-            'role' => UserRole::USER,
-        ]);
-
-        $this->actingAs($this->user);
-
-        $this->post(route('workers.resync', ['server' => $this->server]))
-            ->assertForbidden();
-
-        $this->post(route('workers.restart-all', ['server' => $this->server]))
-            ->assertForbidden();
-    }
-
-    public function test_worker_resource_marks_site_bootstrap(): void
-    {
-        $bootstrap = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-        ]);
-        $other = Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-        ]);
-
-        $this->site->jsonUpdate('type_data', 'bootstrap_worker_id', $bootstrap->id);
-        $bootstrap->refresh();
-        $other->refresh();
-
-        $this->assertTrue($bootstrap->isSiteBootstrap());
-        $this->assertFalse($other->isSiteBootstrap());
-    }
-}
+        ],
+    ])
+        ->assertSessionHasErrors();
+});
+
+test('worker environment is stored as array', function () {
+    $worker = Worker::factory()->withEnvironment([
+        'PATH' => '/custom/path',
+        'NODE_ENV' => 'production',
+    ])->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    expect($worker->environment)->toBeArray();
+    expect($worker->environmentMap()['PATH'])->toEqual('/custom/path');
+    expect($worker->environmentMap()['NODE_ENV'])->toEqual('production');
+});
+
+test('cannot edit site bootstrap worker', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+    ]);
+
+    $this->site->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
+
+    $this->put(route('workers.update', [
+        'server' => $this->server,
+        'worker' => $worker,
+    ]), [
+        'name' => 'renamed',
+        'command' => 'renamed command',
+        'user' => 'vito',
+        'auto_start' => 1,
+        'auto_restart' => 1,
+        'numprocs' => 1,
+    ])
+        ->assertSessionHasErrors(['name']);
+
+    $this->assertDatabaseMissing('workers', [
+        'id' => $worker->id,
+        'command' => 'renamed command',
+    ]);
+});
+
+test('cannot delete site bootstrap worker', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+    ]);
+
+    $this->site->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
+
+    $this->delete(route('workers.destroy', [
+        'server' => $this->server,
+        'worker' => $worker,
+    ]))
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('workers', ['id' => $worker->id]);
+});
+
+test('can still start stop restart bootstrap worker', function () {
+    SSH::fake();
+    $this->actingAs($this->user);
+
+    /** @var Worker $worker */
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::STOPPED,
+    ]);
+
+    $this->site->jsonUpdate('type_data', 'bootstrap_worker_id', $worker->id);
+
+    $this->post(route('workers.start', [
+        'server' => $this->server,
+        'worker' => $worker,
+    ]))->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseHas('workers', [
+        'id' => $worker->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+});
+
+test('restart all with site id restarts only site workers', function () {
+    SSH::fake();
+
+    $siteWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+    $serverWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+    $creatingWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::CREATING,
+    ]);
+
+    /** @var ProcessManager $handler */
+    $handler = $this->server->processManager()->handler();
+    $handler->restartAll($this->site->id);
+
+    SSH::assertExecutedContains("supervisorctl update {$siteWorker->id};");
+    SSH::assertExecutedContains("restart {$siteWorker->id}:*");
+    SSH::assertNotExecutedContains("restart {$serverWorker->id}:*");
+    SSH::assertNotExecutedContains("supervisorctl update {$creatingWorker->id};");
+    SSH::assertNotExecutedContains('supervisorctl restart all');
+});
+
+test('restart all without site id updates config and restarts all', function () {
+    SSH::fake();
+
+    /** @var ProcessManager $handler */
+    $handler = $this->server->processManager()->handler();
+    $handler->restartAll();
+
+    SSH::assertExecutedContains('supervisorctl update');
+    SSH::assertExecutedContains('supervisorctl restart all');
+});
+
+test('restart all with site id without workers executes nothing', function () {
+    SSH::fake();
+
+    Worker::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+
+    /** @var ProcessManager $handler */
+    $handler = $this->server->processManager()->handler();
+    $handler->restartAll($this->site->id);
+
+    SSH::assertNotExecutedContains('supervisorctl');
+});
+
+test('resync updates worker statuses', function () {
+    $this->actingAs($this->user);
+
+    $siteWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::FAILED,
+        'error' => 'old error',
+    ]);
+    $serverWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    SSH::fake(
+        "{$siteWorker->id}:{$siteWorker->id}_00   RUNNING   pid 100, uptime 0:00:05\n".
+        "{$serverWorker->id}:{$serverWorker->id}_00   STOPPED   Jun 06 10:00 AM"
+    );
+
+    $this->post(route('workers.resync', ['server' => $this->server]))
+        ->assertSessionDoesntHaveErrors()
+        ->assertSessionHas('success');
+
+    SSH::assertExecutedContains('supervisorctl status');
+
+    $siteWorker->refresh();
+    $serverWorker->refresh();
+    expect($siteWorker->status)->toBe(WorkerStatus::RUNNING);
+    expect($siteWorker->error)->toBeNull();
+    expect($serverWorker->status)->toBe(WorkerStatus::STOPPED);
+});
+
+test('resync marks fatal worker failed with error', function () {
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    SSH::fake("{$worker->id}:{$worker->id}_00   FATAL   Exited too quickly (process log may have details)");
+
+    $this->post(route('workers.resync', ['server' => $this->server]))
+        ->assertSessionDoesntHaveErrors();
+
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::FAILED);
+    $this->assertStringContainsString('FATAL Exited too quickly', (string) $worker->error);
+
+    $this->assertDatabaseHas('server_logs', [
+        'server_id' => $this->server->id,
+        'type' => 'sync-worker-statuses-failed',
+    ]);
+});
+
+test('resync does not relog unchanged failed worker', function () {
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::FAILED,
+    ]);
+    $worker->error = "{$worker->id}:{$worker->id}_00: FATAL Exited too quickly";
+    $worker->save();
+
+    SSH::fake("{$worker->id}:{$worker->id}_00   FATAL   Exited too quickly");
+
+    $this->post(route('workers.resync', ['server' => $this->server]))
+        ->assertSessionDoesntHaveErrors();
+
+    $this->assertDatabaseMissing('server_logs', [
+        'type' => 'sync-worker-statuses-failed',
+    ]);
+
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::FAILED);
+});
+
+test('resync marks missing worker failed', function () {
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    SSH::fake('unix:///var/run/supervisor.sock no such file');
+
+    $this->post(route('workers.resync', ['server' => $this->server]))
+        ->assertSessionDoesntHaveErrors();
+
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::FAILED);
+    expect($worker->error)->toBe('Process not found in supervisor');
+});
+
+test('resync site scope does not touch server workers', function () {
+    $this->actingAs($this->user);
+
+    $siteWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+    $serverWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    SSH::fake("{$siteWorker->id}:{$siteWorker->id}_00   STOPPED   Jun 06 10:00 AM");
+
+    $this->post(route('workers.resync', ['server' => $this->server, 'site' => $this->site]))
+        ->assertSessionDoesntHaveErrors();
+
+    $siteWorker->refresh();
+    $serverWorker->refresh();
+    expect($siteWorker->status)->toBe(WorkerStatus::STOPPED);
+    expect($serverWorker->status)->toBe(WorkerStatus::RUNNING);
+});
+
+test('resync skips creating workers', function () {
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::CREATING,
+    ]);
+
+    SSH::fake("{$worker->id}:{$worker->id}_00   RUNNING   pid 100, uptime 0:00:05");
+
+    $this->post(route('workers.resync', ['server' => $this->server]))
+        ->assertSessionDoesntHaveErrors();
+
+    SSH::assertNotExecutedContains('supervisorctl status');
+
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::CREATING);
+});
+
+test('restart all endpoint sets restarting and dispatches job', function () {
+    Queue::fake();
+
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::STOPPED,
+        'error' => 'old error',
+    ]);
+    $creatingWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => WorkerStatus::CREATING,
+    ]);
+
+    $this->post(route('workers.restart-all', ['server' => $this->server]))
+        ->assertSessionDoesntHaveErrors();
+
+    $worker->refresh();
+    $creatingWorker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::RESTARTING);
+    expect($worker->error)->toBeNull();
+    expect($creatingWorker->status)->toBe(WorkerStatus::CREATING);
+
+    Queue::assertPushed(RestartAllJob::class);
+});
+
+test('restart all endpoint full flow settles statuses', function () {
+    $this->actingAs($this->user);
+
+    $worker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => WorkerStatus::STOPPED,
+    ]);
+
+    SSH::fake("{$worker->id}:{$worker->id}_00   RUNNING   pid 100, uptime 0:00:05");
+
+    $this->post(route('workers.restart-all', ['server' => $this->server]))
+        ->assertSessionDoesntHaveErrors();
+
+    SSH::assertExecutedContains('supervisorctl restart all');
+    SSH::assertExecutedContains('supervisorctl status');
+
+    $worker->refresh();
+    expect($worker->status)->toBe(WorkerStatus::RUNNING);
+});
+
+test('restart all endpoint site scope uses restart many', function () {
+    $this->actingAs($this->user);
+
+    $siteWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RUNNING,
+    ]);
+
+    SSH::fake("{$siteWorker->id}:{$siteWorker->id}_00   RUNNING   pid 100, uptime 0:00:05");
+
+    $this->post(route('workers.restart-all', ['server' => $this->server, 'site' => $this->site]))
+        ->assertSessionDoesntHaveErrors();
+
+    SSH::assertExecutedContains("restart {$siteWorker->id}:*");
+    SSH::assertNotExecutedContains('supervisorctl restart all');
+
+    $siteWorker->refresh();
+    expect($siteWorker->status)->toBe(WorkerStatus::RUNNING);
+});
+
+test('restart all job failed marks restarting workers failed', function () {
+    $restartingWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => WorkerStatus::RESTARTING,
+    ]);
+    $stoppedWorker = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'status' => WorkerStatus::STOPPED,
+    ]);
+
+    (new RestartAllJob($this->server))->failed(new SSHCommandError('boom'));
+
+    $restartingWorker->refresh();
+    $stoppedWorker->refresh();
+    expect($restartingWorker->status)->toBe(WorkerStatus::FAILED);
+    expect($restartingWorker->error)->toBe('boom');
+    expect($stoppedWorker->status)->toBe(WorkerStatus::STOPPED);
+});
+
+test('user role cannot resync or restart all', function () {
+    $this->server->project->users()->where('user_id', $this->user->id)->update([
+        'role' => UserRole::USER,
+    ]);
+
+    $this->actingAs($this->user);
+
+    $this->post(route('workers.resync', ['server' => $this->server]))
+        ->assertForbidden();
+
+    $this->post(route('workers.restart-all', ['server' => $this->server]))
+        ->assertForbidden();
+});
+
+test('worker resource marks site bootstrap', function () {
+    $bootstrap = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+    ]);
+    $other = Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+    ]);
+
+    $this->site->jsonUpdate('type_data', 'bootstrap_worker_id', $bootstrap->id);
+    $bootstrap->refresh();
+    $other->refresh();
+
+    expect($bootstrap->isSiteBootstrap())->toBeTrue();
+    expect($other->isSiteBootstrap())->toBeFalse();
+});

--- a/tests/Feature/WorkflowActions/CreateSiteActionTest.php
+++ b/tests/Feature/WorkflowActions/CreateSiteActionTest.php
@@ -15,7 +15,6 @@ uses(RefreshDatabase::class);
 test('create site action fails with foreign server', function () {
     SSH::fake();
 
-    // Create a second project with a server that the user has no access to
     $otherUser = User::factory()->create();
     $otherProject = Project::factory()->create();
     $otherProject->users()->create([
@@ -27,7 +26,6 @@ test('create site action fails with foreign server', function () {
         'project_id' => $otherProject->id,
     ]);
 
-    // Create a workflow in the user's own project
     $workflow = Workflow::factory()->create([
         'user_id' => $this->user->id,
         'project_id' => $this->user->current_project_id,

--- a/tests/Feature/WorkflowActions/CreateSiteActionTest.php
+++ b/tests/Feature/WorkflowActions/CreateSiteActionTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\WorkflowActions;
-
 use App\Enums\UserRole;
 use App\Facades\SSH;
 use App\Models\Project;
@@ -11,68 +9,62 @@ use App\Models\Workflow;
 use App\WorkflowActions\Site\CreatePHPBlankSite;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class CreateSiteActionTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_site_action_fails_with_foreign_server(): void
-    {
-        SSH::fake();
+test('create site action fails with foreign server', function () {
+    SSH::fake();
 
-        // Create a second project with a server that the user has no access to
-        $otherUser = User::factory()->create();
-        $otherProject = Project::factory()->create();
-        $otherProject->users()->create([
-            'user_id' => $otherUser->id,
-            'role' => UserRole::OWNER,
-        ]);
-        $otherServer = Server::factory()->create([
-            'user_id' => $otherUser->id,
-            'project_id' => $otherProject->id,
-        ]);
+    // Create a second project with a server that the user has no access to
+    $otherUser = User::factory()->create();
+    $otherProject = Project::factory()->create();
+    $otherProject->users()->create([
+        'user_id' => $otherUser->id,
+        'role' => UserRole::OWNER,
+    ]);
+    $otherServer = Server::factory()->create([
+        'user_id' => $otherUser->id,
+        'project_id' => $otherProject->id,
+    ]);
 
-        // Create a workflow in the user's own project
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    // Create a workflow in the user's own project
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        $action = new CreatePHPBlankSite($this->user, $workflow);
+    $action = new CreatePHPBlankSite($this->user, $workflow);
 
-        $this->expectException(AuthorizationException::class);
+    $this->expectException(AuthorizationException::class);
 
-        $action->run([
-            'server_id' => $otherServer->id,
-            'type' => 'php-blank',
-            'domain' => 'cross-project.example.com',
-            'php_version' => '8.2',
-            'web_directory' => 'public',
-        ]);
-    }
+    $action->run([
+        'server_id' => $otherServer->id,
+        'type' => 'php-blank',
+        'domain' => 'cross-project.example.com',
+        'php_version' => '8.2',
+        'web_directory' => 'public',
+    ]);
+});
 
-    public function test_create_site_action_succeeds_with_own_server(): void
-    {
-        SSH::fake();
+test('create site action succeeds with own server', function () {
+    SSH::fake();
 
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        $action = new CreatePHPBlankSite($this->user, $workflow);
+    $action = new CreatePHPBlankSite($this->user, $workflow);
 
-        $result = $action->run([
-            'server_id' => $this->server->id,
-            'type' => 'php-blank',
-            'domain' => 'my-site.example.com',
-            'user' => 'mysiteuser',
-            'php_version' => '8.2',
-            'web_directory' => 'public',
-        ]);
+    $result = $action->run([
+        'server_id' => $this->server->id,
+        'type' => 'php-blank',
+        'domain' => 'my-site.example.com',
+        'user' => 'mysiteuser',
+        'php_version' => '8.2',
+        'web_directory' => 'public',
+    ]);
 
-        $this->assertArrayHasKey('site_id', $result);
-        $this->assertEquals('my-site.example.com', $result['site_domain']);
-    }
-}
+    expect($result)->toHaveKey('site_id');
+    expect($result['site_domain'])->toEqual('my-site.example.com');
+});

--- a/tests/Feature/WorkflowInputResolutionTest.php
+++ b/tests/Feature/WorkflowInputResolutionTest.php
@@ -30,7 +30,7 @@ test('resolve inputs replaces placeholders with previous outputs', function () {
         'server_id' => 123,
         'server_ip' => '192.168.1.100',
         'server_status' => 'active',
-        'command' => 'echo "Hello from server 123"', // String interpolation now handled
+        'command' => 'echo "Hello from server 123"',
         'user' => 'root',
         'custom_value' => 'static_value',
     ]);
@@ -56,7 +56,7 @@ test('resolve inputs handles missing placeholders', function () {
 
     expect($result)->toEqual([
         'server_id' => 123,
-        'missing_key' => '{missing_key}', // Kept as placeholder since not found in previous outputs
+        'missing_key' => '{missing_key}',
         'regular_value' => 'test',
     ]);
 });
@@ -106,7 +106,6 @@ test('resolve inputs merges previous outputs with action inputs', function () {
 
     $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
 
-    // Should include all previous outputs plus resolved action inputs
     expect($result)->toEqual([
         'server_id' => 123,
         'service_id' => 456,
@@ -156,9 +155,9 @@ test('resolve inputs handles mixed placeholders and interpolation', function () 
     ];
 
     $actionInputs = [
-        'server_id' => '{server_id}', // Exact placeholder
-        'command' => 'echo "Server {server_id} at {server_ip}"', // String interpolation
-        'missing_placeholder' => 'echo {missing_key}', // Missing placeholder
+        'server_id' => '{server_id}',
+        'command' => 'echo "Server {server_id} at {server_ip}"',
+        'missing_placeholder' => 'echo {missing_key}',
     ];
 
     $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
@@ -167,7 +166,7 @@ test('resolve inputs handles mixed placeholders and interpolation', function () 
         'server_id' => 123,
         'server_ip' => '192.168.1.100',
         'command' => 'echo "Server 123 at 192.168.1.100"',
-        'missing_placeholder' => 'echo {missing_key}', // Kept as-is since missing_key not found
+        'missing_placeholder' => 'echo {missing_key}',
     ]);
 });
 
@@ -183,9 +182,9 @@ test('resolve inputs handles double curly braces', function () {
     ];
 
     $actionInputs = [
-        'service_id' => '{{service_id}}', // Exact double placeholder
-        'command' => 'echo "${{service_id}} installed"', // String interpolation with double braces
-        'server_id' => '{{server_id}}', // Exact double placeholder
+        'service_id' => '{{service_id}}',
+        'command' => 'echo "${{service_id}} installed"',
+        'server_id' => '{{server_id}}',
     ];
 
     $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
@@ -197,19 +196,19 @@ test('resolve inputs handles double curly braces', function () {
     ]);
 });
 
-test('resolve inputs prioritizes previous outputs over action inputs', function () {
+test('resolve inputs keeps action values while interpolating previous outputs', function () {
     $runWorkflow = new RunWorkflow;
 
     $reflection = new ReflectionClass($runWorkflow);
     $method = $reflection->getMethod('resolveInputs');
 
     $previousOutputs = [
-        'server_id' => 123, // This should take priority
+        'server_id' => 123,
         'server_ip' => '192.168.1.100',
     ];
 
     $actionInputs = [
-        'server_id' => 999, // This should be overridden
+        'server_id' => 999,
         'command' => 'echo "Using server {server_id}"',
     ];
 

--- a/tests/Feature/WorkflowInputResolutionTest.php
+++ b/tests/Feature/WorkflowInputResolutionTest.php
@@ -1,237 +1,223 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Actions\Workflow\RunWorkflow;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class WorkflowInputResolutionTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_resolve_inputs_replaces_placeholders_with_previous_outputs(): void
-    {
-        $runWorkflow = new RunWorkflow;
+test('resolve inputs replaces placeholders with previous outputs', function () {
+    $runWorkflow = new RunWorkflow;
 
-        $reflection = new \ReflectionClass($runWorkflow);
-        $method = $reflection->getMethod('resolveInputs');
+    $reflection = new ReflectionClass($runWorkflow);
+    $method = $reflection->getMethod('resolveInputs');
 
-        $previousOutputs = [
-            'server_id' => 123,
-            'server_ip' => '192.168.1.100',
-            'server_status' => 'active',
-        ];
+    $previousOutputs = [
+        'server_id' => 123,
+        'server_ip' => '192.168.1.100',
+        'server_status' => 'active',
+    ];
 
-        $actionInputs = [
-            'server_id' => '{server_id}',
-            'command' => 'echo "Hello from server {server_id}"',
-            'user' => 'root',
-            'custom_value' => 'static_value',
-        ];
+    $actionInputs = [
+        'server_id' => '{server_id}',
+        'command' => 'echo "Hello from server {server_id}"',
+        'user' => 'root',
+        'custom_value' => 'static_value',
+    ];
 
-        $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
+    $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
 
-        $this->assertEquals([
-            'server_id' => 123,
-            'server_ip' => '192.168.1.100',
-            'server_status' => 'active',
-            'command' => 'echo "Hello from server 123"', // String interpolation now handled
-            'user' => 'root',
-            'custom_value' => 'static_value',
-        ], $result);
-    }
+    expect($result)->toEqual([
+        'server_id' => 123,
+        'server_ip' => '192.168.1.100',
+        'server_status' => 'active',
+        'command' => 'echo "Hello from server 123"', // String interpolation now handled
+        'user' => 'root',
+        'custom_value' => 'static_value',
+    ]);
+});
 
-    public function test_resolve_inputs_handles_missing_placeholders(): void
-    {
-        $runWorkflow = new RunWorkflow;
+test('resolve inputs handles missing placeholders', function () {
+    $runWorkflow = new RunWorkflow;
 
-        $reflection = new \ReflectionClass($runWorkflow);
-        $method = $reflection->getMethod('resolveInputs');
+    $reflection = new ReflectionClass($runWorkflow);
+    $method = $reflection->getMethod('resolveInputs');
 
-        $previousOutputs = [
-            'server_id' => 123,
-        ];
+    $previousOutputs = [
+        'server_id' => 123,
+    ];
 
-        $actionInputs = [
-            'server_id' => '{server_id}',
-            'missing_key' => '{missing_key}',
-            'regular_value' => 'test',
-        ];
+    $actionInputs = [
+        'server_id' => '{server_id}',
+        'missing_key' => '{missing_key}',
+        'regular_value' => 'test',
+    ];
 
-        $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
+    $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
 
-        $this->assertEquals([
-            'server_id' => 123,
-            'missing_key' => '{missing_key}', // Kept as placeholder since not found in previous outputs
-            'regular_value' => 'test',
-        ], $result);
-    }
+    expect($result)->toEqual([
+        'server_id' => 123,
+        'missing_key' => '{missing_key}', // Kept as placeholder since not found in previous outputs
+        'regular_value' => 'test',
+    ]);
+});
 
-    public function test_resolve_inputs_handles_non_string_values(): void
-    {
-        $runWorkflow = new RunWorkflow;
+test('resolve inputs handles non string values', function () {
+    $runWorkflow = new RunWorkflow;
 
-        $reflection = new \ReflectionClass($runWorkflow);
-        $method = $reflection->getMethod('resolveInputs');
+    $reflection = new ReflectionClass($runWorkflow);
+    $method = $reflection->getMethod('resolveInputs');
 
-        $previousOutputs = [
-            'server_id' => 123,
-        ];
+    $previousOutputs = [
+        'server_id' => 123,
+    ];
 
-        $actionInputs = [
-            'server_id' => '{server_id}',
-            'numeric_value' => 456,
-            'array_value' => ['key' => 'value'],
-            'boolean_value' => true,
-        ];
+    $actionInputs = [
+        'server_id' => '{server_id}',
+        'numeric_value' => 456,
+        'array_value' => ['key' => 'value'],
+        'boolean_value' => true,
+    ];
 
-        $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
+    $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
 
-        $this->assertEquals([
-            'server_id' => 123,
-            'numeric_value' => 456,
-            'array_value' => ['key' => 'value'],
-            'boolean_value' => true,
-        ], $result);
-    }
+    expect($result)->toEqual([
+        'server_id' => 123,
+        'numeric_value' => 456,
+        'array_value' => ['key' => 'value'],
+        'boolean_value' => true,
+    ]);
+});
 
-    public function test_resolve_inputs_merges_previous_outputs_with_action_inputs(): void
-    {
-        $runWorkflow = new RunWorkflow;
+test('resolve inputs merges previous outputs with action inputs', function () {
+    $runWorkflow = new RunWorkflow;
 
-        $reflection = new \ReflectionClass($runWorkflow);
-        $method = $reflection->getMethod('resolveInputs');
+    $reflection = new ReflectionClass($runWorkflow);
+    $method = $reflection->getMethod('resolveInputs');
 
-        $previousOutputs = [
-            'server_id' => 123,
-            'service_id' => 456,
-        ];
+    $previousOutputs = [
+        'server_id' => 123,
+        'service_id' => 456,
+    ];
 
-        $actionInputs = [
-            'server_id' => '{server_id}',
-            'command' => 'install package',
-        ];
+    $actionInputs = [
+        'server_id' => '{server_id}',
+        'command' => 'install package',
+    ];
 
-        $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
+    $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
 
-        // Should include all previous outputs plus resolved action inputs
-        $this->assertEquals([
-            'server_id' => 123,
-            'service_id' => 456,
-            'command' => 'install package',
-        ], $result);
-    }
+    // Should include all previous outputs plus resolved action inputs
+    expect($result)->toEqual([
+        'server_id' => 123,
+        'service_id' => 456,
+        'command' => 'install package',
+    ]);
+});
 
-    public function test_resolve_inputs_handles_string_interpolation(): void
-    {
-        $runWorkflow = new RunWorkflow;
+test('resolve inputs handles string interpolation', function () {
+    $runWorkflow = new RunWorkflow;
 
-        $reflection = new \ReflectionClass($runWorkflow);
-        $method = $reflection->getMethod('resolveInputs');
+    $reflection = new ReflectionClass($runWorkflow);
+    $method = $reflection->getMethod('resolveInputs');
 
-        $previousOutputs = [
-            'server_id' => 123,
-            'server_ip' => '192.168.1.100',
-            'service_name' => 'nginx',
-        ];
+    $previousOutputs = [
+        'server_id' => 123,
+        'server_ip' => '192.168.1.100',
+        'service_name' => 'nginx',
+    ];
 
-        $actionInputs = [
-            'command' => 'echo "Server {server_id} is running at {server_ip}"',
-            'log_message' => 'Installing {service_name} on server {server_id}',
-            'status_check' => 'curl -f http://{server_ip}/health',
-        ];
+    $actionInputs = [
+        'command' => 'echo "Server {server_id} is running at {server_ip}"',
+        'log_message' => 'Installing {service_name} on server {server_id}',
+        'status_check' => 'curl -f http://{server_ip}/health',
+    ];
 
-        $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
+    $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
 
-        $this->assertEquals([
-            'server_id' => 123,
-            'server_ip' => '192.168.1.100',
-            'service_name' => 'nginx',
-            'command' => 'echo "Server 123 is running at 192.168.1.100"',
-            'log_message' => 'Installing nginx on server 123',
-            'status_check' => 'curl -f http://192.168.1.100/health',
-        ], $result);
-    }
+    expect($result)->toEqual([
+        'server_id' => 123,
+        'server_ip' => '192.168.1.100',
+        'service_name' => 'nginx',
+        'command' => 'echo "Server 123 is running at 192.168.1.100"',
+        'log_message' => 'Installing nginx on server 123',
+        'status_check' => 'curl -f http://192.168.1.100/health',
+    ]);
+});
 
-    public function test_resolve_inputs_handles_mixed_placeholders_and_interpolation(): void
-    {
-        $runWorkflow = new RunWorkflow;
+test('resolve inputs handles mixed placeholders and interpolation', function () {
+    $runWorkflow = new RunWorkflow;
 
-        $reflection = new \ReflectionClass($runWorkflow);
-        $method = $reflection->getMethod('resolveInputs');
+    $reflection = new ReflectionClass($runWorkflow);
+    $method = $reflection->getMethod('resolveInputs');
 
-        $previousOutputs = [
-            'server_id' => 123,
-            'server_ip' => '192.168.1.100',
-        ];
+    $previousOutputs = [
+        'server_id' => 123,
+        'server_ip' => '192.168.1.100',
+    ];
 
-        $actionInputs = [
-            'server_id' => '{server_id}', // Exact placeholder
-            'command' => 'echo "Server {server_id} at {server_ip}"', // String interpolation
-            'missing_placeholder' => 'echo {missing_key}', // Missing placeholder
-        ];
+    $actionInputs = [
+        'server_id' => '{server_id}', // Exact placeholder
+        'command' => 'echo "Server {server_id} at {server_ip}"', // String interpolation
+        'missing_placeholder' => 'echo {missing_key}', // Missing placeholder
+    ];
 
-        $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
+    $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
 
-        $this->assertEquals([
-            'server_id' => 123,
-            'server_ip' => '192.168.1.100',
-            'command' => 'echo "Server 123 at 192.168.1.100"',
-            'missing_placeholder' => 'echo {missing_key}', // Kept as-is since missing_key not found
-        ], $result);
-    }
+    expect($result)->toEqual([
+        'server_id' => 123,
+        'server_ip' => '192.168.1.100',
+        'command' => 'echo "Server 123 at 192.168.1.100"',
+        'missing_placeholder' => 'echo {missing_key}', // Kept as-is since missing_key not found
+    ]);
+});
 
-    public function test_resolve_inputs_handles_double_curly_braces(): void
-    {
-        $runWorkflow = new RunWorkflow;
+test('resolve inputs handles double curly braces', function () {
+    $runWorkflow = new RunWorkflow;
 
-        $reflection = new \ReflectionClass($runWorkflow);
-        $method = $reflection->getMethod('resolveInputs');
+    $reflection = new ReflectionClass($runWorkflow);
+    $method = $reflection->getMethod('resolveInputs');
 
-        $previousOutputs = [
-            'service_id' => 456,
-            'server_id' => 123,
-        ];
+    $previousOutputs = [
+        'service_id' => 456,
+        'server_id' => 123,
+    ];
 
-        $actionInputs = [
-            'service_id' => '{{service_id}}', // Exact double placeholder
-            'command' => 'echo "${{service_id}} installed"', // String interpolation with double braces
-            'server_id' => '{{server_id}}', // Exact double placeholder
-        ];
+    $actionInputs = [
+        'service_id' => '{{service_id}}', // Exact double placeholder
+        'command' => 'echo "${{service_id}} installed"', // String interpolation with double braces
+        'server_id' => '{{server_id}}', // Exact double placeholder
+    ];
 
-        $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
+    $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
 
-        $this->assertEquals([
-            'service_id' => 456,
-            'server_id' => 123,
-            'command' => 'echo "$456 installed"',
-        ], $result);
-    }
+    expect($result)->toEqual([
+        'service_id' => 456,
+        'server_id' => 123,
+        'command' => 'echo "$456 installed"',
+    ]);
+});
 
-    public function test_resolve_inputs_prioritizes_previous_outputs_over_action_inputs(): void
-    {
-        $runWorkflow = new RunWorkflow;
+test('resolve inputs prioritizes previous outputs over action inputs', function () {
+    $runWorkflow = new RunWorkflow;
 
-        $reflection = new \ReflectionClass($runWorkflow);
-        $method = $reflection->getMethod('resolveInputs');
+    $reflection = new ReflectionClass($runWorkflow);
+    $method = $reflection->getMethod('resolveInputs');
 
-        $previousOutputs = [
-            'server_id' => 123, // This should take priority
-            'server_ip' => '192.168.1.100',
-        ];
+    $previousOutputs = [
+        'server_id' => 123, // This should take priority
+        'server_ip' => '192.168.1.100',
+    ];
 
-        $actionInputs = [
-            'server_id' => 999, // This should be overridden
-            'command' => 'echo "Using server {server_id}"',
-        ];
+    $actionInputs = [
+        'server_id' => 999, // This should be overridden
+        'command' => 'echo "Using server {server_id}"',
+    ];
 
-        $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
+    $result = $method->invoke($runWorkflow, $previousOutputs, $actionInputs);
 
-        $this->assertEquals([
-            'server_id' => 999,
-            'server_ip' => '192.168.1.100',
-            'command' => 'echo "Using server 123"',
-        ], $result);
-    }
-}
+    expect($result)->toEqual([
+        'server_id' => 999,
+        'server_ip' => '192.168.1.100',
+        'command' => 'echo "Using server 123"',
+    ]);
+});

--- a/tests/Feature/WorkflowTest.php
+++ b/tests/Feature/WorkflowTest.php
@@ -1,74 +1,64 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\Workflow;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
-use Tests\TestCase;
 
-class WorkflowTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_see_workflows_list(): void
-    {
-        $this->actingAs($this->user);
+test('see workflows list', function () {
+    $this->actingAs($this->user);
 
-        Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        $this->get(route('workflows'))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('workflows/index'));
-    }
+    $this->get(route('workflows'))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('workflows/index'));
+});
 
-    public function test_see_workflow(): void
-    {
-        $this->actingAs($this->user);
+test('see workflow', function () {
+    $this->actingAs($this->user);
 
-        /** @var Workflow $workflow */
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    /** @var Workflow $workflow */
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        $this->get(route('workflows.show', $workflow))
-            ->assertSuccessful()
-            ->assertInertia(fn (AssertableInertia $page) => $page->component('workflows/show'));
-    }
+    $this->get(route('workflows.show', $workflow))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('workflows/show'));
+});
 
-    public function test_create_workflow(): void
-    {
-        $this->actingAs($this->user);
+test('create workflow', function () {
+    $this->actingAs($this->user);
 
-        $this->post(route('workflows.store'), [
-            'name' => 'My Workflow',
-        ])->assertRedirect();
+    $this->post(route('workflows.store'), [
+        'name' => 'My Workflow',
+    ])->assertRedirect();
 
-        $this->assertDatabaseHas('workflows', [
-            'project_id' => $this->user->current_project_id,
-            'name' => 'My Workflow',
-        ]);
-    }
+    $this->assertDatabaseHas('workflows', [
+        'project_id' => $this->user->current_project_id,
+        'name' => 'My Workflow',
+    ]);
+});
 
-    public function test_delete_workflow(): void
-    {
-        $this->actingAs($this->user);
+test('delete workflow', function () {
+    $this->actingAs($this->user);
 
-        /** @var Workflow $workflow */
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-        ]);
+    /** @var Workflow $workflow */
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+    ]);
 
-        $this->delete(route('workflows.destroy', $workflow))
-            ->assertRedirect();
+    $this->delete(route('workflows.destroy', $workflow))
+        ->assertRedirect();
 
-        $this->assertSoftDeleted('workflows', [
-            'id' => $workflow->id,
-        ]);
-    }
-}
+    $this->assertSoftDeleted('workflows', [
+        'id' => $workflow->id,
+    ]);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,135 @@
+<?php
+
+use App\Enums\LoadBalancerMethod;
+use App\SiteTypes\BunSite;
+use App\SiteTypes\Laravel;
+use App\SiteTypes\LoadBalancer;
+use App\SiteTypes\NodeSite;
+use App\SiteTypes\PHPBlank;
+use App\SiteTypes\PHPMyAdmin;
+use App\SiteTypes\Wordpress;
+use Tests\TestCase;
+
+pest()->extend(TestCase::class)->in('Feature', 'Unit');
+
+/**
+ * @return array<array<array<string, mixed>>>
+ */
+function vitoPestSiteCreateData(): array
+{
+    return [
+        [
+            [
+                'type' => Laravel::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'repository' => 'test/test',
+                'branch' => 'main',
+                'composer' => true,
+                'node_version' => 'none',
+                'user' => 'example',
+            ],
+        ],
+        [
+            [
+                'type' => Wordpress::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'title' => 'Example',
+                'username' => 'example',
+                'email' => 'email@example.com',
+                'password' => 'password',
+                'database' => '1',
+                'database_user' => '1',
+                'user' => 'example',
+            ],
+        ],
+        [
+            [
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'example',
+            ],
+        ],
+        [
+            [
+                'type' => PHPMyAdmin::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'version' => '5.1.2',
+                'user' => 'example',
+            ],
+        ],
+        [
+            [
+                'type' => LoadBalancer::id(),
+                'domain' => 'example.com',
+                'user' => 'example',
+                'method' => LoadBalancerMethod::ROUND_ROBIN->value,
+            ],
+        ],
+        [
+            [
+                'type' => NodeSite::id(),
+                'domain' => 'example.com',
+                'node_version' => '23',
+                'package_manager' => 'node',
+                'port' => '3000',
+                'repository' => 'test/test',
+                'branch' => 'main',
+                'user' => 'example',
+            ],
+        ],
+        [
+            [
+                'type' => NodeSite::id(),
+                'domain' => 'example.com',
+                'node_version' => '22',
+                'package_manager' => 'yarn',
+                'yarn_version' => '4',
+                'port' => '3000',
+                'repository' => 'test/test',
+                'branch' => 'main',
+                'user' => 'example',
+            ],
+        ],
+        [
+            [
+                'type' => NodeSite::id(),
+                'domain' => 'example.com',
+                'node_version' => '22',
+                'package_manager' => 'pnpm',
+                'pnpm_version' => '9',
+                'port' => '3000',
+                'repository' => 'test/test',
+                'branch' => 'main',
+                'user' => 'example',
+            ],
+        ],
+        [
+            [
+                'type' => BunSite::id(),
+                'domain' => 'example.com',
+                'bun_version' => '1.2',
+                'port' => '3000',
+                'repository' => 'test/test',
+                'branch' => 'main',
+                'user' => 'example',
+            ],
+        ],
+        [
+            [
+                'type' => BunSite::id(),
+                'domain' => 'example.com',
+                'bun_version' => '1.1',
+                'port' => '3000',
+                'repository' => 'test/test',
+                'branch' => 'main',
+                'user' => 'example',
+            ],
+        ],
+    ];
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -10,7 +10,16 @@ use App\SiteTypes\PHPMyAdmin;
 use App\SiteTypes\Wordpress;
 use Tests\TestCase;
 
-pest()->extend(TestCase::class)->in('Feature', 'Unit');
+pest()->extend(TestCase::class)->in(
+    'Feature',
+    'Unit/*/',
+    'Unit/AbstractProxiedSiteTypeTest.php',
+    'Unit/BunSiteTest.php',
+    'Unit/IsolatedUserModelTest.php',
+    'Unit/NodeSiteTest.php',
+    'Unit/SiteEnvPathTest.php',
+    'Unit/SiteShellEnvironmentTest.php',
+);
 
 /**
  * @return array<array<array<string, mixed>>>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -44,6 +44,7 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
+        $this->withoutVite();
         Sleep::fake();
         config()->set('queue.connections.ssh.driver', 'sync');
         config()->set('queue.connections.default.driver', 'sync');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,15 +26,15 @@ abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
 
-    protected User $user;
+    public User $user;
 
-    protected Server $server;
+    public Server $server;
 
-    protected Site $site;
+    public Site $site;
 
-    protected Redirect $redirect;
+    public Redirect $redirect;
 
-    protected NotificationChannel $notificationChannel;
+    public NotificationChannel $notificationChannel;
 
     public const EXPECT_SUCCESS = true;
 

--- a/tests/Unit/AbstractProxiedSiteTypeTest.php
+++ b/tests/Unit/AbstractProxiedSiteTypeTest.php
@@ -1,103 +1,85 @@
 <?php
 
-namespace Tests\Unit;
-
 use App\Models\Site;
 use App\Services\ProcessManager\Supervisor;
 use App\SiteTypes\NodeSite;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class AbstractProxiedSiteTypeTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    protected Site $proxiedSite;
+beforeEach(function () {
+    $this->proxiedSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'testuser',
+        'path' => '/home/testuser/example.com',
+        'type' => NodeSite::id(),
+        'type_data' => [
+            'node_version' => '22',
+            'package_manager' => 'npm',
+            'build_command' => 'npm run build',
+            'start_command' => 'npm run start',
+        ],
+    ]);
+    $this->siteType = new NodeSite($this->proxiedSite);
+});
 
-    protected NodeSite $siteType;
+test('start command returns type data value', function () {
+    $reflection = new ReflectionMethod($this->siteType, 'startCommand');
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+    expect($reflection->invoke($this->siteType))->toEqual('npm run start');
+});
 
-        $this->proxiedSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'testuser',
-            'path' => '/home/testuser/example.com',
-            'type' => NodeSite::id(),
-            'type_data' => [
-                'node_version' => '22',
-                'package_manager' => 'npm',
-                'build_command' => 'npm run build',
-                'start_command' => 'npm run start',
-            ],
-        ]);
-        $this->siteType = new NodeSite($this->proxiedSite);
-    }
-
-    public function test_start_command_returns_type_data_value(): void
-    {
-        $reflection = new \ReflectionMethod($this->siteType, 'startCommand');
-
-        $this->assertEquals('npm run start', $reflection->invoke($this->siteType));
-    }
-
-    public function test_supervisor_worker_template_renders_environment(): void
-    {
-        $rendered = view('ssh.services.process-manager.supervisor.worker', [
-            'name' => '1',
-            'directory' => '/home/testuser/example.com',
-            'command' => 'npm run start',
-            'user' => 'testuser',
-            'autoStart' => 'true',
-            'autoRestart' => 'true',
-            'numprocs' => '1',
-            'logFile' => '/home/testuser/.logs/workers/1.log',
-            'environment' => Supervisor::formatEnvironment([
-                'PATH' => '/home/testuser/.local/share/mise/shims:/usr/local/bin:/usr/bin:/bin',
-                'NODE_ENV' => 'production',
-            ]),
-        ])->render();
-
-        $this->assertStringContainsString('[program:1]', $rendered);
-        $this->assertStringContainsString('command=npm run start', $rendered);
-        $this->assertStringContainsString('environment=PATH="/home/testuser/.local/share/mise/shims:/usr/local/bin:/usr/bin:/bin",NODE_ENV="production"', $rendered);
-    }
-
-    public function test_supervisor_worker_template_without_environment(): void
-    {
-        $rendered = view('ssh.services.process-manager.supervisor.worker', [
-            'name' => '1',
-            'directory' => '/home/testuser/example.com',
-            'command' => 'php artisan queue:work',
-            'user' => 'testuser',
-            'autoStart' => 'true',
-            'autoRestart' => 'true',
-            'numprocs' => '1',
-            'logFile' => '/home/testuser/.logs/workers/1.log',
-            'environment' => Supervisor::formatEnvironment([]),
-        ])->render();
-
-        $this->assertStringContainsString('[program:1]', $rendered);
-        $this->assertStringContainsString('command=php artisan queue:work', $rendered);
-        $this->assertStringNotContainsString('environment=', $rendered);
-    }
-
-    public function test_format_environment_escapes_unsafe_values(): void
-    {
-        $formatted = Supervisor::formatEnvironment([
-            'PERCENT' => 'a%b',
-            'QUOTED' => 'a"b',
-            'MULTILINE' => "a\r\nb",
-            '1INVALID' => 'dropped',
+test('supervisor worker template renders environment', function () {
+    $rendered = view('ssh.services.process-manager.supervisor.worker', [
+        'name' => '1',
+        'directory' => '/home/testuser/example.com',
+        'command' => 'npm run start',
+        'user' => 'testuser',
+        'autoStart' => 'true',
+        'autoRestart' => 'true',
+        'numprocs' => '1',
+        'logFile' => '/home/testuser/.logs/workers/1.log',
+        'environment' => Supervisor::formatEnvironment([
+            'PATH' => '/home/testuser/.local/share/mise/shims:/usr/local/bin:/usr/bin:/bin',
             'NODE_ENV' => 'production',
-        ]);
+        ]),
+    ])->render();
 
-        $this->assertSame('PERCENT="a%%b",QUOTED="ab",MULTILINE="ab",NODE_ENV="production"', $formatted);
-    }
+    $this->assertStringContainsString('[program:1]', $rendered);
+    $this->assertStringContainsString('command=npm run start', $rendered);
+    $this->assertStringContainsString('environment=PATH="/home/testuser/.local/share/mise/shims:/usr/local/bin:/usr/bin:/bin",NODE_ENV="production"', $rendered);
+});
 
-    public function test_format_environment_returns_empty_string_for_empty_map(): void
-    {
-        $this->assertSame('', Supervisor::formatEnvironment([]));
-    }
-}
+test('supervisor worker template without environment', function () {
+    $rendered = view('ssh.services.process-manager.supervisor.worker', [
+        'name' => '1',
+        'directory' => '/home/testuser/example.com',
+        'command' => 'php artisan queue:work',
+        'user' => 'testuser',
+        'autoStart' => 'true',
+        'autoRestart' => 'true',
+        'numprocs' => '1',
+        'logFile' => '/home/testuser/.logs/workers/1.log',
+        'environment' => Supervisor::formatEnvironment([]),
+    ])->render();
+
+    $this->assertStringContainsString('[program:1]', $rendered);
+    $this->assertStringContainsString('command=php artisan queue:work', $rendered);
+    $this->assertStringNotContainsString('environment=', $rendered);
+});
+
+test('format environment escapes unsafe values', function () {
+    $formatted = Supervisor::formatEnvironment([
+        'PERCENT' => 'a%b',
+        'QUOTED' => 'a"b',
+        'MULTILINE' => "a\r\nb",
+        '1INVALID' => 'dropped',
+        'NODE_ENV' => 'production',
+    ]);
+
+    expect($formatted)->toBe('PERCENT="a%%b",QUOTED="ab",MULTILINE="ab",NODE_ENV="production"');
+});
+
+test('format environment returns empty string for empty map', function () {
+    expect(Supervisor::formatEnvironment([]))->toBe('');
+});

--- a/tests/Unit/Actions/HostedDomain/VerifyHostedDomainTest.php
+++ b/tests/Unit/Actions/HostedDomain/VerifyHostedDomainTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Unit\Actions\HostedDomain;
-
 use App\Actions\HostedDomain\VerifyHostedDomain;
 use App\Actions\Site\EnsureSiteVerificationKey;
 use App\Enums\HostedDomainStatus;
@@ -10,160 +8,151 @@ use App\Models\HostedDomain;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use Tests\TestCase;
 
-class VerifyHostedDomainTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_succeeds_when_server_returns_expected_hmac(): void
-    {
-        SSH::fake();
+test('succeeds when server returns expected hmac', function () {
+    SSH::fake();
 
-        $domain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'verifies.example.com',
-            'status' => HostedDomainStatus::PENDING,
-        ]);
+    $domain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'verifies.example.com',
+        'status' => HostedDomainStatus::PENDING,
+    ]);
 
-        Http::fake(function (Request $request) use ($domain) {
-            $url = $request->url();
+    Http::fake(function (Request $request) use ($domain) {
+        $url = $request->url();
 
-            if (str_contains($url, 'cloudflare-dns.com') || str_contains($url, 'dns.google')) {
-                if (str_contains($url, 'type=A')) {
-                    return Http::response(['Answer' => [['data' => '203.0.113.10']]], 200);
-                }
-
-                return Http::response(['Answer' => []], 200);
+        if (str_contains($url, 'cloudflare-dns.com') || str_contains($url, 'dns.google')) {
+            if (str_contains($url, 'type=A')) {
+                return Http::response(['Answer' => [['data' => '203.0.113.10']]], 200);
             }
 
-            $challengeId = basename(parse_url($url, PHP_URL_PATH));
-            $key = app(EnsureSiteVerificationKey::class)->ensure($this->site->refresh());
-            $expected = hash_hmac('sha256', implode("\n", [
-                (string) $this->site->server_id,
-                (string) $this->site->id,
-                $domain->domain,
-                $challengeId,
-            ]), (string) config('app.key'));
+            return Http::response(['Answer' => []], 200);
+        }
 
-            return Http::response($expected, 200);
-        });
+        $challengeId = basename(parse_url($url, PHP_URL_PATH));
+        $key = app(EnsureSiteVerificationKey::class)->ensure($this->site->refresh());
+        $expected = hash_hmac('sha256', implode("\n", [
+            (string) $this->site->server_id,
+            (string) $this->site->id,
+            $domain->domain,
+            $challengeId,
+        ]), (string) config('app.key'));
 
-        $result = app(VerifyHostedDomain::class)->verify($domain);
+        return Http::response($expected, 200);
+    });
 
-        $this->assertTrue($result->verified);
-    }
+    $result = app(VerifyHostedDomain::class)->verify($domain);
 
-    public function test_fails_when_response_body_does_not_match_hmac(): void
-    {
-        SSH::fake();
+    expect($result->verified)->toBeTrue();
+});
 
-        $domain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'mismatched.example.com',
-            'status' => HostedDomainStatus::PENDING,
-        ]);
+test('fails when response body does not match hmac', function () {
+    SSH::fake();
 
-        Http::fake(function (Request $request) {
-            $url = $request->url();
+    $domain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'mismatched.example.com',
+        'status' => HostedDomainStatus::PENDING,
+    ]);
 
-            if (str_contains($url, 'cloudflare-dns.com') || str_contains($url, 'dns.google')) {
-                return Http::response(['Answer' => str_contains($url, 'type=A') ? [['data' => '198.51.100.1']] : []], 200);
-            }
+    Http::fake(function (Request $request) {
+        $url = $request->url();
 
-            return Http::response('not the expected hmac', 200);
-        });
+        if (str_contains($url, 'cloudflare-dns.com') || str_contains($url, 'dns.google')) {
+            return Http::response(['Answer' => str_contains($url, 'type=A') ? [['data' => '198.51.100.1']] : []], 200);
+        }
 
-        $result = app(VerifyHostedDomain::class)->verify($domain);
+        return Http::response('not the expected hmac', 200);
+    });
 
-        $this->assertFalse($result->verified);
-    }
+    $result = app(VerifyHostedDomain::class)->verify($domain);
 
-    public function test_cross_install_secret_rejects_captured_response(): void
-    {
-        SSH::fake();
+    expect($result->verified)->toBeFalse();
+});
 
-        $domain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'cross-install.example.com',
-            'status' => HostedDomainStatus::PENDING,
-        ]);
+test('cross install secret rejects captured response', function () {
+    SSH::fake();
 
-        Http::fake(function (Request $request) use ($domain) {
-            $url = $request->url();
+    $domain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'cross-install.example.com',
+        'status' => HostedDomainStatus::PENDING,
+    ]);
 
-            if (str_contains($url, 'cloudflare-dns.com') || str_contains($url, 'dns.google')) {
-                return Http::response(['Answer' => str_contains($url, 'type=A') ? [['data' => '203.0.113.10']] : []], 200);
-            }
+    Http::fake(function (Request $request) use ($domain) {
+        $url = $request->url();
 
-            $challengeId = basename(parse_url($url, PHP_URL_PATH));
-            $impostor = hash_hmac('sha256', implode("\n", [
-                (string) $this->site->server_id,
-                (string) $this->site->id,
-                $domain->domain,
-                $challengeId,
-            ]), 'a-different-install-secret');
+        if (str_contains($url, 'cloudflare-dns.com') || str_contains($url, 'dns.google')) {
+            return Http::response(['Answer' => str_contains($url, 'type=A') ? [['data' => '203.0.113.10']] : []], 200);
+        }
 
-            return Http::response($impostor, 200);
-        });
+        $challengeId = basename(parse_url($url, PHP_URL_PATH));
+        $impostor = hash_hmac('sha256', implode("\n", [
+            (string) $this->site->server_id,
+            (string) $this->site->id,
+            $domain->domain,
+            $challengeId,
+        ]), 'a-different-install-secret');
 
-        $result = app(VerifyHostedDomain::class)->verify($domain);
+        return Http::response($impostor, 200);
+    });
 
-        $this->assertFalse($result->verified);
-    }
+    $result = app(VerifyHostedDomain::class)->verify($domain);
 
-    public function test_generates_a_fresh_challenge_id_per_attempt(): void
-    {
-        SSH::fake();
+    expect($result->verified)->toBeFalse();
+});
 
-        $domain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'fresh.example.com',
-            'status' => HostedDomainStatus::PENDING,
-        ]);
+test('generates a fresh challenge id per attempt', function () {
+    SSH::fake();
 
-        $challengeIds = [];
+    $domain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'fresh.example.com',
+        'status' => HostedDomainStatus::PENDING,
+    ]);
 
-        Http::fake(function (Request $request) use (&$challengeIds) {
-            $url = $request->url();
+    $challengeIds = [];
 
-            if (str_contains($url, 'cloudflare-dns.com') || str_contains($url, 'dns.google')) {
-                return Http::response(['Answer' => str_contains($url, 'type=A') ? [['data' => '203.0.113.10']] : []], 200);
-            }
+    Http::fake(function (Request $request) use (&$challengeIds) {
+        $url = $request->url();
 
-            $path = parse_url($url, PHP_URL_PATH);
-            if (preg_match('#/\.well-known/vito/[^/]+/([a-f0-9]{32})$#', $path, $m)) {
-                $challengeIds[] = $m[1];
-            }
+        if (str_contains($url, 'cloudflare-dns.com') || str_contains($url, 'dns.google')) {
+            return Http::response(['Answer' => str_contains($url, 'type=A') ? [['data' => '203.0.113.10']] : []], 200);
+        }
 
-            return Http::response('mismatch', 200);
-        });
+        $path = parse_url($url, PHP_URL_PATH);
+        if (preg_match('#/\.well-known/vito/[^/]+/([a-f0-9]{32})$#', $path, $m)) {
+            $challengeIds[] = $m[1];
+        }
 
-        app(VerifyHostedDomain::class)->verify($domain);
-        app(VerifyHostedDomain::class)->verify($domain);
+        return Http::response('mismatch', 200);
+    });
 
-        $this->assertCount(2, $challengeIds, 'expected exactly one verification fetch per verify()');
-        $this->assertNotSame($challengeIds[0], $challengeIds[1]);
-    }
+    app(VerifyHostedDomain::class)->verify($domain);
+    app(VerifyHostedDomain::class)->verify($domain);
 
-    public function test_fails_when_no_ips_resolve(): void
-    {
-        SSH::fake();
+    expect($challengeIds)->toHaveCount(2, 'expected exactly one verification fetch per verify()');
+    $this->assertNotSame($challengeIds[0], $challengeIds[1]);
+});
 
-        $domain = HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'noip.example.com',
-            'status' => HostedDomainStatus::PENDING,
-        ]);
+test('fails when no ips resolve', function () {
+    SSH::fake();
 
-        Http::fake([
-            'cloudflare-dns.com/*' => Http::response(['Answer' => []], 200),
-            'dns.google/*' => Http::response(['Answer' => []], 200),
-        ]);
+    $domain = HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'noip.example.com',
+        'status' => HostedDomainStatus::PENDING,
+    ]);
 
-        $result = app(VerifyHostedDomain::class)->verify($domain);
+    Http::fake([
+        'cloudflare-dns.com/*' => Http::response(['Answer' => []], 200),
+        'dns.google/*' => Http::response(['Answer' => []], 200),
+    ]);
 
-        $this->assertFalse($result->verified);
-        $this->assertStringContainsString('HTTP', $result->failureReason);
-    }
-}
+    $result = app(VerifyHostedDomain::class)->verify($domain);
+
+    expect($result->verified)->toBeFalse();
+    $this->assertStringContainsString('HTTP', $result->failureReason);
+});

--- a/tests/Unit/Actions/SSL/AssignSslToDomainsTest.php
+++ b/tests/Unit/Actions/SSL/AssignSslToDomainsTest.php
@@ -1,153 +1,134 @@
 <?php
 
-namespace Tests\Unit\Actions\SSL;
-
 use App\Actions\SSL\AssignSslToDomains;
 use App\Enums\HostedDomainType;
 use App\Enums\SslStatus;
 use App\Models\HostedDomain;
 use App\Models\Ssl;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class AssignSslToDomainsTest extends TestCase
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->action = new AssignSslToDomains;
+});
+
+test('exact match assigns correctly', function () {
+    $ssl = vitoPestUnitActionsSSLAssignSslToDomainsTestCreateServerSsl(['domains' => ['app.example.com']]);
+    $domain = vitoPestUnitActionsSSLAssignSslToDomainsTestCreateHostedDomain('app.example.com');
+
+    $changed = $this->action->assign($this->site);
+
+    expect($changed)->toHaveCount(1);
+    expect($domain->fresh()->ssl_id)->toEqual($ssl->id);
+});
+
+test('wildcard match assigns correctly', function () {
+    $ssl = vitoPestUnitActionsSSLAssignSslToDomainsTestCreateServerSsl(['domains' => ['*.example.com']]);
+    $domain = vitoPestUnitActionsSSLAssignSslToDomainsTestCreateHostedDomain('sub.example.com');
+
+    $changed = $this->action->assign($this->site);
+
+    expect($changed)->toHaveCount(1);
+    expect($domain->fresh()->ssl_id)->toEqual($ssl->id);
+});
+
+test('wildcard does not match bare domain', function () {
+    vitoPestUnitActionsSSLAssignSslToDomainsTestCreateServerSsl(['domains' => ['*.example.com']]);
+    $domain = vitoPestUnitActionsSSLAssignSslToDomainsTestCreateHostedDomain('example.com');
+
+    $changed = $this->action->assign($this->site);
+
+    expect($changed)->toHaveCount(0);
+    expect($domain->fresh()->ssl_id)->toBeNull();
+});
+
+test('wildcard does not match nested subdomain', function () {
+    vitoPestUnitActionsSSLAssignSslToDomainsTestCreateServerSsl(['domains' => ['*.example.com']]);
+    $domain = vitoPestUnitActionsSSLAssignSslToDomainsTestCreateHostedDomain('a.b.example.com');
+
+    $changed = $this->action->assign($this->site);
+
+    expect($changed)->toHaveCount(0);
+    expect($domain->fresh()->ssl_id)->toBeNull();
+});
+
+test('exact takes priority over wildcard', function () {
+    $wildcardSsl = vitoPestUnitActionsSSLAssignSslToDomainsTestCreateServerSsl(['domains' => ['*.example.com']]);
+    $exactSsl = vitoPestUnitActionsSSLAssignSslToDomainsTestCreateServerSsl(['domains' => ['app.example.com']]);
+    $domain = vitoPestUnitActionsSSLAssignSslToDomainsTestCreateHostedDomain('app.example.com');
+
+    $changed = $this->action->assign($this->site);
+
+    expect($changed)->toHaveCount(1);
+    expect($domain->fresh()->ssl_id)->toEqual($exactSsl->id);
+});
+
+test('no match leaves ssl id null', function () {
+    vitoPestUnitActionsSSLAssignSslToDomainsTestCreateServerSsl(['domains' => ['other.com']]);
+    $domain = vitoPestUnitActionsSSLAssignSslToDomainsTestCreateHostedDomain('app.example.com');
+
+    $changed = $this->action->assign($this->site);
+
+    expect($changed)->toHaveCount(0);
+    expect($domain->fresh()->ssl_id)->toBeNull();
+});
+
+test('only server level ssls considered', function () {
+    Ssl::factory()->create([
+        'site_id' => $this->site->id,
+        'domains' => ['app.example.com'],
+        'status' => SslStatus::CREATED,
+    ]);
+    $domain = vitoPestUnitActionsSSLAssignSslToDomainsTestCreateHostedDomain('app.example.com');
+
+    $changed = $this->action->assign($this->site);
+
+    expect($changed)->toHaveCount(0);
+    expect($domain->fresh()->ssl_id)->toBeNull();
+});
+
+test('non created status ssls not considered', function () {
+    vitoPestUnitActionsSSLAssignSslToDomainsTestCreateServerSsl([
+        'domains' => ['app.example.com'],
+        'status' => SslStatus::CREATING,
+    ]);
+    $domain = vitoPestUnitActionsSSLAssignSslToDomainsTestCreateHostedDomain('app.example.com');
+
+    $changed = $this->action->assign($this->site);
+
+    expect($changed)->toHaveCount(0);
+    expect($domain->fresh()->ssl_id)->toBeNull();
+});
+
+test('returns only changed domains', function () {
+    $ssl = vitoPestUnitActionsSSLAssignSslToDomainsTestCreateServerSsl(['domains' => ['app.example.com']]);
+
+    $alreadyAssigned = vitoPestUnitActionsSSLAssignSslToDomainsTestCreateHostedDomain('app.example.com');
+    $alreadyAssigned->update(['ssl_id' => $ssl->id]);
+
+    vitoPestUnitActionsSSLAssignSslToDomainsTestCreateHostedDomain('other.com');
+
+    $changed = $this->action->assign($this->site);
+
+    expect($changed)->toHaveCount(0);
+});
+
+function vitoPestUnitActionsSSLAssignSslToDomainsTestCreateServerSsl(array $attributes = []): Ssl
 {
-    use RefreshDatabase;
+    return Ssl::factory()->create(array_merge([
+        'site_id' => null,
+        'server_id' => test()->server->id,
+        'status' => SslStatus::CREATED,
+        'domains' => ['example.com'],
+    ], $attributes));
+}
 
-    private AssignSslToDomains $action;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->action = new AssignSslToDomains;
-    }
-
-    public function test_exact_match_assigns_correctly(): void
-    {
-        $ssl = $this->createServerSsl(['domains' => ['app.example.com']]);
-        $domain = $this->createHostedDomain('app.example.com');
-
-        $changed = $this->action->assign($this->site);
-
-        $this->assertCount(1, $changed);
-        $this->assertEquals($ssl->id, $domain->fresh()->ssl_id);
-    }
-
-    public function test_wildcard_match_assigns_correctly(): void
-    {
-        $ssl = $this->createServerSsl(['domains' => ['*.example.com']]);
-        $domain = $this->createHostedDomain('sub.example.com');
-
-        $changed = $this->action->assign($this->site);
-
-        $this->assertCount(1, $changed);
-        $this->assertEquals($ssl->id, $domain->fresh()->ssl_id);
-    }
-
-    public function test_wildcard_does_not_match_bare_domain(): void
-    {
-        $this->createServerSsl(['domains' => ['*.example.com']]);
-        $domain = $this->createHostedDomain('example.com');
-
-        $changed = $this->action->assign($this->site);
-
-        $this->assertCount(0, $changed);
-        $this->assertNull($domain->fresh()->ssl_id);
-    }
-
-    public function test_wildcard_does_not_match_nested_subdomain(): void
-    {
-        $this->createServerSsl(['domains' => ['*.example.com']]);
-        $domain = $this->createHostedDomain('a.b.example.com');
-
-        $changed = $this->action->assign($this->site);
-
-        $this->assertCount(0, $changed);
-        $this->assertNull($domain->fresh()->ssl_id);
-    }
-
-    public function test_exact_takes_priority_over_wildcard(): void
-    {
-        $wildcardSsl = $this->createServerSsl(['domains' => ['*.example.com']]);
-        $exactSsl = $this->createServerSsl(['domains' => ['app.example.com']]);
-        $domain = $this->createHostedDomain('app.example.com');
-
-        $changed = $this->action->assign($this->site);
-
-        $this->assertCount(1, $changed);
-        $this->assertEquals($exactSsl->id, $domain->fresh()->ssl_id);
-    }
-
-    public function test_no_match_leaves_ssl_id_null(): void
-    {
-        $this->createServerSsl(['domains' => ['other.com']]);
-        $domain = $this->createHostedDomain('app.example.com');
-
-        $changed = $this->action->assign($this->site);
-
-        $this->assertCount(0, $changed);
-        $this->assertNull($domain->fresh()->ssl_id);
-    }
-
-    public function test_only_server_level_ssls_considered(): void
-    {
-        Ssl::factory()->create([
-            'site_id' => $this->site->id,
-            'domains' => ['app.example.com'],
-            'status' => SslStatus::CREATED,
-        ]);
-        $domain = $this->createHostedDomain('app.example.com');
-
-        $changed = $this->action->assign($this->site);
-
-        $this->assertCount(0, $changed);
-        $this->assertNull($domain->fresh()->ssl_id);
-    }
-
-    public function test_non_created_status_ssls_not_considered(): void
-    {
-        $this->createServerSsl([
-            'domains' => ['app.example.com'],
-            'status' => SslStatus::CREATING,
-        ]);
-        $domain = $this->createHostedDomain('app.example.com');
-
-        $changed = $this->action->assign($this->site);
-
-        $this->assertCount(0, $changed);
-        $this->assertNull($domain->fresh()->ssl_id);
-    }
-
-    public function test_returns_only_changed_domains(): void
-    {
-        $ssl = $this->createServerSsl(['domains' => ['app.example.com']]);
-
-        $alreadyAssigned = $this->createHostedDomain('app.example.com');
-        $alreadyAssigned->update(['ssl_id' => $ssl->id]);
-
-        $this->createHostedDomain('other.com');
-
-        $changed = $this->action->assign($this->site);
-
-        $this->assertCount(0, $changed);
-    }
-
-    private function createServerSsl(array $attributes = []): Ssl
-    {
-        return Ssl::factory()->create(array_merge([
-            'site_id' => null,
-            'server_id' => $this->server->id,
-            'status' => SslStatus::CREATED,
-            'domains' => ['example.com'],
-        ], $attributes));
-    }
-
-    private function createHostedDomain(string $domain, HostedDomainType $type = HostedDomainType::ALIAS): HostedDomain
-    {
-        return HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => $domain,
-            'type' => $type,
-        ]);
-    }
+function vitoPestUnitActionsSSLAssignSslToDomainsTestCreateHostedDomain(string $domain, HostedDomainType $type = HostedDomainType::ALIAS): HostedDomain
+{
+    return HostedDomain::factory()->create([
+        'site_id' => test()->site->id,
+        'domain' => $domain,
+        'type' => $type,
+    ]);
 }

--- a/tests/Unit/Actions/SSL/CertificateParserTest.php
+++ b/tests/Unit/Actions/SSL/CertificateParserTest.php
@@ -1,100 +1,87 @@
 <?php
 
-namespace Tests\Unit\Actions\SSL;
-
 use App\Actions\SSL\CertificateParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Validation\ValidationException;
-use Tests\TestCase;
 
-class CertificateParserTest extends TestCase
+uses(RefreshDatabase::class);
+
+test('parses certificate with san', function () {
+    $cert = vitoPestUnitActionsSSLCertificateParserTestGenerateCertWithSan(['DNS:example.com', 'DNS:www.example.com']);
+
+    $result = CertificateParser::parse($cert);
+
+    expect($result)->toHaveKey('expires_at');
+    expect($result)->toHaveKey('domains');
+    expect($result['domains'])->toContain('example.com');
+    expect($result['domains'])->toContain('www.example.com');
+});
+
+test('parses certificate with wildcard san', function () {
+    $cert = vitoPestUnitActionsSSLCertificateParserTestGenerateCertWithSan(['DNS:*.example.com', 'DNS:example.com']);
+
+    $result = CertificateParser::parse($cert);
+
+    expect($result['domains'])->toContain('*.example.com');
+    expect($result['domains'])->toContain('example.com');
+});
+
+test('falls back to cn when no san', function () {
+    $cert = vitoPestUnitActionsSSLCertificateParserTestGenerateCertWithoutSan('fallback.example.com');
+
+    $result = CertificateParser::parse($cert);
+
+    expect($result['domains'])->toContain('fallback.example.com');
+});
+
+test('extracts expiry date', function () {
+    $cert = vitoPestUnitActionsSSLCertificateParserTestGenerateCertWithSan(['DNS:example.com'], 365);
+
+    $result = CertificateParser::parse($cert);
+
+    expect($result['expires_at']->isFuture())->toBeTrue();
+    expect($result['expires_at']->isAfter(now()->addDays(360)))->toBeTrue();
+    expect($result['expires_at']->isBefore(now()->addDays(370)))->toBeTrue();
+});
+
+test('throws on invalid certificate', function () {
+    $this->expectException(ValidationException::class);
+
+    CertificateParser::parse('not a valid certificate');
+});
+
+test('throws on empty string', function () {
+    $this->expectException(ValidationException::class);
+
+    CertificateParser::parse('');
+});
+
+test('deduplicates domains', function () {
+    $cert = vitoPestUnitActionsSSLCertificateParserTestGenerateCertWithSan(['DNS:example.com', 'DNS:example.com']);
+
+    $result = CertificateParser::parse($cert);
+
+    expect($result['domains'])->toHaveCount(1);
+});
+
+test('lowercases domains', function () {
+    $cert = vitoPestUnitActionsSSLCertificateParserTestGenerateCertWithSan(['DNS:EXAMPLE.COM']);
+
+    $result = CertificateParser::parse($cert);
+
+    expect($result['domains'])->toContain('example.com');
+});
+
+/**
+ * @param  array<int, string>  $sans
+ */
+function vitoPestUnitActionsSSLCertificateParserTestGenerateCertWithSan(array $sans, int $days = 365): string
 {
-    use RefreshDatabase;
+    $key = openssl_pkey_new(['private_key_bits' => 2048]);
 
-    public function test_parses_certificate_with_san(): void
-    {
-        $cert = $this->generateCertWithSan(['DNS:example.com', 'DNS:www.example.com']);
-
-        $result = CertificateParser::parse($cert);
-
-        $this->assertArrayHasKey('expires_at', $result);
-        $this->assertArrayHasKey('domains', $result);
-        $this->assertContains('example.com', $result['domains']);
-        $this->assertContains('www.example.com', $result['domains']);
-    }
-
-    public function test_parses_certificate_with_wildcard_san(): void
-    {
-        $cert = $this->generateCertWithSan(['DNS:*.example.com', 'DNS:example.com']);
-
-        $result = CertificateParser::parse($cert);
-
-        $this->assertContains('*.example.com', $result['domains']);
-        $this->assertContains('example.com', $result['domains']);
-    }
-
-    public function test_falls_back_to_cn_when_no_san(): void
-    {
-        $cert = $this->generateCertWithoutSan('fallback.example.com');
-
-        $result = CertificateParser::parse($cert);
-
-        $this->assertContains('fallback.example.com', $result['domains']);
-    }
-
-    public function test_extracts_expiry_date(): void
-    {
-        $cert = $this->generateCertWithSan(['DNS:example.com'], 365);
-
-        $result = CertificateParser::parse($cert);
-
-        $this->assertTrue($result['expires_at']->isFuture());
-        $this->assertTrue($result['expires_at']->isAfter(now()->addDays(360)));
-        $this->assertTrue($result['expires_at']->isBefore(now()->addDays(370)));
-    }
-
-    public function test_throws_on_invalid_certificate(): void
-    {
-        $this->expectException(ValidationException::class);
-
-        CertificateParser::parse('not a valid certificate');
-    }
-
-    public function test_throws_on_empty_string(): void
-    {
-        $this->expectException(ValidationException::class);
-
-        CertificateParser::parse('');
-    }
-
-    public function test_deduplicates_domains(): void
-    {
-        $cert = $this->generateCertWithSan(['DNS:example.com', 'DNS:example.com']);
-
-        $result = CertificateParser::parse($cert);
-
-        $this->assertCount(1, $result['domains']);
-    }
-
-    public function test_lowercases_domains(): void
-    {
-        $cert = $this->generateCertWithSan(['DNS:EXAMPLE.COM']);
-
-        $result = CertificateParser::parse($cert);
-
-        $this->assertContains('example.com', $result['domains']);
-    }
-
-    /**
-     * @param  array<int, string>  $sans
-     */
-    private function generateCertWithSan(array $sans, int $days = 365): string
-    {
-        $key = openssl_pkey_new(['private_key_bits' => 2048]);
-
-        $config = tempnam(sys_get_temp_dir(), 'openssl');
-        $sanString = implode(',', $sans);
-        file_put_contents($config, "
+    $config = tempnam(sys_get_temp_dir(), 'openssl');
+    $sanString = implode(',', $sans);
+    file_put_contents($config, "
 [req]
 distinguished_name = req_dn
 req_extensions = v3_req
@@ -104,34 +91,33 @@ CN = example.com
 subjectAltName = {$sanString}
 ");
 
-        $csr = openssl_csr_new(
-            ['commonName' => 'example.com'],
-            $key,
-            ['config' => $config, 'req_extensions' => 'v3_req']
-        );
+    $csr = openssl_csr_new(
+        ['commonName' => 'example.com'],
+        $key,
+        ['config' => $config, 'req_extensions' => 'v3_req']
+    );
 
-        $cert = openssl_csr_sign(
-            $csr,
-            null,
-            $key,
-            $days,
-            ['config' => $config, 'x509_extensions' => 'v3_req']
-        );
+    $cert = openssl_csr_sign(
+        $csr,
+        null,
+        $key,
+        $days,
+        ['config' => $config, 'x509_extensions' => 'v3_req']
+    );
 
-        openssl_x509_export($cert, $certPem);
-        unlink($config);
+    openssl_x509_export($cert, $certPem);
+    unlink($config);
 
-        return $certPem;
-    }
+    return $certPem;
+}
 
-    private function generateCertWithoutSan(string $cn): string
-    {
-        $key = openssl_pkey_new(['private_key_bits' => 2048]);
-        $csr = openssl_csr_new(['commonName' => $cn], $key);
-        $cert = openssl_csr_sign($csr, null, $key, 365);
+function vitoPestUnitActionsSSLCertificateParserTestGenerateCertWithoutSan(string $cn): string
+{
+    $key = openssl_pkey_new(['private_key_bits' => 2048]);
+    $csr = openssl_csr_new(['commonName' => $cn], $key);
+    $cert = openssl_csr_sign($csr, null, $key, 365);
 
-        openssl_x509_export($cert, $certPem);
+    openssl_x509_export($cert, $certPem);
 
-        return $certPem;
-    }
+    return $certPem;
 }

--- a/tests/Unit/Actions/SSL/DeleteSslTest.php
+++ b/tests/Unit/Actions/SSL/DeleteSslTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Unit\Actions\SSL;
-
 use App\Actions\SSL\DeleteSsl;
 use App\Enums\HostedDomainStatus;
 use App\Enums\SslStatus;
@@ -12,111 +10,98 @@ use App\Models\Ssl;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Validation\ValidationException;
-use Tests\TestCase;
 
-class DeleteSslTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    private DeleteSsl $action;
+beforeEach(function () {
+    $this->action = new DeleteSsl;
+});
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->action = new DeleteSsl;
-    }
+test('deletes server level ssl', function () {
+    SSH::fake('SSL DELETED SUCCESSFULLY');
 
-    public function test_deletes_server_level_ssl(): void
-    {
-        SSH::fake('SSL DELETED SUCCESSFULLY');
+    $ssl = Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'status' => SslStatus::CREATED,
+    ]);
 
-        $ssl = Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'status' => SslStatus::CREATED,
-        ]);
+    $this->action->delete($ssl);
 
-        $this->action->delete($ssl);
+    $this->assertDatabaseMissing('ssls', ['id' => $ssl->id]);
+});
 
-        $this->assertDatabaseMissing('ssls', ['id' => $ssl->id]);
-    }
+test('deletes site level ssl', function () {
+    SSH::fake();
 
-    public function test_deletes_site_level_ssl(): void
-    {
-        SSH::fake();
+    $ssl = Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => SslStatus::CREATED,
+    ]);
 
-        $ssl = Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => SslStatus::CREATED,
-        ]);
+    $this->action->delete($ssl);
 
-        $this->action->delete($ssl);
+    $this->assertDatabaseMissing('ssls', ['id' => $ssl->id]);
+});
 
-        $this->assertDatabaseMissing('ssls', ['id' => $ssl->id]);
-    }
+test('prevents deletion when in use by hosted domain', function () {
+    $ssl = Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'status' => SslStatus::CREATED,
+        'domains' => ['*.example.com'],
+    ]);
 
-    public function test_prevents_deletion_when_in_use_by_hosted_domain(): void
-    {
-        $ssl = Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'status' => SslStatus::CREATED,
-            'domains' => ['*.example.com'],
-        ]);
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'app.example.com',
+        'ssl_id' => $ssl->id,
+        'status' => HostedDomainStatus::ACTIVE,
+    ]);
 
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'app.example.com',
-            'ssl_id' => $ssl->id,
-            'status' => HostedDomainStatus::ACTIVE,
-        ]);
+    $this->expectException(ValidationException::class);
 
-        $this->expectException(ValidationException::class);
+    $this->action->delete($ssl);
+});
 
-        $this->action->delete($ssl);
-    }
+test('allows deletion when no hosted domains reference ssl', function () {
+    SSH::fake('SSL DELETED SUCCESSFULLY');
 
-    public function test_allows_deletion_when_no_hosted_domains_reference_ssl(): void
-    {
-        SSH::fake('SSL DELETED SUCCESSFULLY');
+    $ssl = Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'status' => SslStatus::CREATED,
+        'domains' => ['*.example.com'],
+    ]);
 
-        $ssl = Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'status' => SslStatus::CREATED,
-            'domains' => ['*.example.com'],
-        ]);
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'app.example.com',
+        'ssl_id' => null,
+        'status' => HostedDomainStatus::ACTIVE,
+    ]);
 
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'app.example.com',
-            'ssl_id' => null,
-            'status' => HostedDomainStatus::ACTIVE,
-        ]);
+    $this->action->delete($ssl);
 
-        $this->action->delete($ssl);
+    $this->assertDatabaseMissing('ssls', ['id' => $ssl->id]);
+});
 
-        $this->assertDatabaseMissing('ssls', ['id' => $ssl->id]);
-    }
+test('deletion dispatches job for server level', function () {
+    Bus::fake();
 
-    public function test_deletion_dispatches_job_for_server_level(): void
-    {
-        Bus::fake();
+    $ssl = Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'status' => SslStatus::CREATED,
+    ]);
 
-        $ssl = Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'status' => SslStatus::CREATED,
-        ]);
+    $this->action->delete($ssl);
 
-        $this->action->delete($ssl);
+    $this->assertDatabaseHas('ssls', [
+        'id' => $ssl->id,
+        'status' => SslStatus::DELETING,
+    ]);
 
-        $this->assertDatabaseHas('ssls', [
-            'id' => $ssl->id,
-            'status' => SslStatus::DELETING,
-        ]);
-
-        Bus::assertDispatched(DeleteServerSslJob::class);
-    }
-}
+    Bus::assertDispatched(DeleteServerSslJob::class);
+});

--- a/tests/Unit/Actions/SSL/GetMatchingSslCertificatesTest.php
+++ b/tests/Unit/Actions/SSL/GetMatchingSslCertificatesTest.php
@@ -1,170 +1,152 @@
 <?php
 
-namespace Tests\Unit\Actions\SSL;
-
 use App\Actions\SSL\GetMatchingSslCertificates;
 use App\Enums\SslStatus;
 use App\Models\HostedDomain;
 use App\Models\Ssl;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class GetMatchingSslCertificatesTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    private GetMatchingSslCertificates $action;
+beforeEach(function () {
+    $this->action = new GetMatchingSslCertificates;
+});
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->action = new GetMatchingSslCertificates;
-    }
+test('matches exact domain', function () {
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'status' => SslStatus::CREATED,
+        'domains' => ['app.example.com'],
+    ]);
 
-    public function test_matches_exact_domain(): void
-    {
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'status' => SslStatus::CREATED,
-            'domains' => ['app.example.com'],
-        ]);
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'app.example.com',
+    ]);
 
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'app.example.com',
-        ]);
+    $result = $this->action->get($this->site);
 
-        $result = $this->action->get($this->site);
+    expect($result)->toHaveCount(1);
+});
 
-        $this->assertCount(1, $result);
-    }
+test('matches wildcard domain', function () {
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'status' => SslStatus::CREATED,
+        'domains' => ['*.example.com'],
+    ]);
 
-    public function test_matches_wildcard_domain(): void
-    {
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'status' => SslStatus::CREATED,
-            'domains' => ['*.example.com'],
-        ]);
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'sub.example.com',
+    ]);
 
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'sub.example.com',
-        ]);
+    $result = $this->action->get($this->site);
 
-        $result = $this->action->get($this->site);
+    expect($result)->toHaveCount(1);
+});
 
-        $this->assertCount(1, $result);
-    }
+test('does not match unrelated domain', function () {
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'status' => SslStatus::CREATED,
+        'domains' => ['other.com'],
+    ]);
 
-    public function test_does_not_match_unrelated_domain(): void
-    {
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'status' => SslStatus::CREATED,
-            'domains' => ['other.com'],
-        ]);
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'app.example.com',
+    ]);
 
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'app.example.com',
-        ]);
+    $result = $this->action->get($this->site);
 
-        $result = $this->action->get($this->site);
+    expect($result)->toHaveCount(0);
+});
 
-        $this->assertCount(0, $result);
-    }
+test('excludes non created ssls', function () {
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'status' => SslStatus::CREATING,
+        'domains' => ['app.example.com'],
+    ]);
 
-    public function test_excludes_non_created_ssls(): void
-    {
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'status' => SslStatus::CREATING,
-            'domains' => ['app.example.com'],
-        ]);
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'app.example.com',
+    ]);
 
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'app.example.com',
-        ]);
+    $result = $this->action->get($this->site);
 
-        $result = $this->action->get($this->site);
+    expect($result)->toHaveCount(0);
+});
 
-        $this->assertCount(0, $result);
-    }
+test('excludes site level ssls', function () {
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+        'status' => SslStatus::CREATED,
+        'domains' => ['app.example.com'],
+    ]);
 
-    public function test_excludes_site_level_ssls(): void
-    {
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-            'status' => SslStatus::CREATED,
-            'domains' => ['app.example.com'],
-        ]);
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'app.example.com',
+    ]);
 
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'app.example.com',
-        ]);
+    $result = $this->action->get($this->site);
 
-        $result = $this->action->get($this->site);
+    expect($result)->toHaveCount(0);
+});
 
-        $this->assertCount(0, $result);
-    }
+test('for domain matches specific domain', function () {
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'status' => SslStatus::CREATED,
+        'domains' => ['*.example.com'],
+    ]);
 
-    public function test_for_domain_matches_specific_domain(): void
-    {
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'status' => SslStatus::CREATED,
-            'domains' => ['*.example.com'],
-        ]);
+    $result = $this->action->forDomain($this->site, 'sub.example.com');
 
-        $result = $this->action->forDomain($this->site, 'sub.example.com');
+    expect($result)->toHaveCount(1);
+});
 
-        $this->assertCount(1, $result);
-    }
+test('for domain does not match unrelated', function () {
+    Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'status' => SslStatus::CREATED,
+        'domains' => ['*.other.com'],
+    ]);
 
-    public function test_for_domain_does_not_match_unrelated(): void
-    {
-        Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'status' => SslStatus::CREATED,
-            'domains' => ['*.other.com'],
-        ]);
+    $result = $this->action->forDomain($this->site, 'sub.example.com');
 
-        $result = $this->action->forDomain($this->site, 'sub.example.com');
+    expect($result)->toHaveCount(0);
+});
 
-        $this->assertCount(0, $result);
-    }
+test('returns formatted result', function () {
+    $ssl = Ssl::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => null,
+        'status' => SslStatus::CREATED,
+        'type' => 'letsencrypt',
+        'domains' => ['*.example.com', 'example.com'],
+    ]);
 
-    public function test_returns_formatted_result(): void
-    {
-        $ssl = Ssl::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => null,
-            'status' => SslStatus::CREATED,
-            'type' => 'letsencrypt',
-            'domains' => ['*.example.com', 'example.com'],
-        ]);
+    HostedDomain::factory()->create([
+        'site_id' => $this->site->id,
+        'domain' => 'app.example.com',
+    ]);
 
-        HostedDomain::factory()->create([
-            'site_id' => $this->site->id,
-            'domain' => 'app.example.com',
-        ]);
+    $result = $this->action->get($this->site);
 
-        $result = $this->action->get($this->site);
-
-        $this->assertCount(1, $result);
-        $item = $result->first();
-        $this->assertEquals($ssl->id, $item['id']);
-        $this->assertArrayHasKey('label', $item);
-        $this->assertEquals(['*.example.com', 'example.com'], $item['domains']);
-    }
-}
+    expect($result)->toHaveCount(1);
+    $item = $result->first();
+    expect($item['id'])->toEqual($ssl->id);
+    expect($item)->toHaveKey('label');
+    expect($item['domains'])->toEqual(['*.example.com', 'example.com']);
+});

--- a/tests/Unit/Actions/Service/CheckServiceStatusesTest.php
+++ b/tests/Unit/Actions/Service/CheckServiceStatusesTest.php
@@ -11,11 +11,14 @@ use Illuminate\Support\Facades\Event;
 
 uses(RefreshDatabase::class);
 
+beforeEach(function () {
+    $this->server->services()->delete();
+});
+
 test('updates changed statuses and dispatches events', function () {
     SSH::fake("active\ninactive\nfailed");
     Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
 
-    $this->server->services()->delete();
     $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::READY);
     $mysql = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('database', 'mysql', ServiceStatus::READY);
     $redis = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('memory_database', 'redis', ServiceStatus::STOPPED);
@@ -41,7 +44,6 @@ test('disabled service reported inactive stays disabled', function () {
     SSH::fake('inactive');
     Event::fake([ServiceStatusChanged::class]);
 
-    $this->server->services()->delete();
     $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::DISABLED);
 
     app(CheckServiceStatuses::class)->check($this->server);
@@ -54,7 +56,6 @@ test('disabled service reported active becomes ready', function () {
     SSH::fake('active');
     Event::fake([ServiceStatusChanged::class]);
 
-    $this->server->services()->delete();
     $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::DISABLED);
 
     app(CheckServiceStatuses::class)->check($this->server);
@@ -69,7 +70,6 @@ test('transitional and unitless services are not checked', function () {
     SSH::fake('active');
     Event::fake([ServiceStatusChanged::class]);
 
-    $this->server->services()->delete();
     vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::INSTALLING);
     vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('nodejs', 'nodejs', ServiceStatus::READY);
     vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('log_analysis', 'goaccess', ServiceStatus::READY);
@@ -90,7 +90,6 @@ test('skips ssh when no pollable services', function () {
     SSH::fake('active');
     Event::fake([ServiceStatusChanged::class]);
 
-    $this->server->services()->delete();
     vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('nodejs', 'nodejs', ServiceStatus::READY);
 
     app(CheckServiceStatuses::class)->check($this->server);
@@ -103,7 +102,6 @@ test('mismatched output updates nothing', function () {
     SSH::fake('active');
     Event::fake([ServiceStatusChanged::class]);
 
-    $this->server->services()->delete();
     $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::STOPPED);
     $mysql = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('database', 'mysql', ServiceStatus::STOPPED);
 
@@ -118,7 +116,6 @@ test('single inactive reading does not change status', function () {
     SSH::fake('inactive');
     Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
 
-    $this->server->services()->delete();
     $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::READY);
 
     app(CheckServiceStatuses::class)->check($this->server);
@@ -131,7 +128,6 @@ test('single inactive reading does not change status', function () {
 test('restart flap does not change status', function () {
     Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
 
-    $this->server->services()->delete();
     $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::READY);
 
     SSH::fake('inactive');
@@ -151,7 +147,6 @@ test('two consecutive inactive readings change status', function () {
     SSH::fake('inactive');
     Event::fake([ServiceStatusChanged::class]);
 
-    $this->server->services()->delete();
     $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::READY);
 
     app(CheckServiceStatuses::class)->check($this->server);
@@ -165,7 +160,6 @@ test('recovery to active applies immediately', function () {
     SSH::fake('active');
     Event::fake([ServiceStatusChanged::class]);
 
-    $this->server->services()->delete();
     $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::STOPPED);
 
     app(CheckServiceStatuses::class)->check($this->server);

--- a/tests/Unit/Actions/Service/CheckServiceStatusesTest.php
+++ b/tests/Unit/Actions/Service/CheckServiceStatusesTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Unit\Actions\Service;
-
 use App\Actions\Service\CheckServiceStatuses;
 use App\Enums\ServiceStatus;
 use App\Events\ServiceStatusChanged;
@@ -10,195 +8,181 @@ use App\Facades\SSH;
 use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
-use Tests\TestCase;
 
-class CheckServiceStatusesTest extends TestCase
+uses(RefreshDatabase::class);
+
+test('updates changed statuses and dispatches events', function () {
+    SSH::fake("active\ninactive\nfailed");
+    Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
+
+    $this->server->services()->delete();
+    $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::READY);
+    $mysql = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('database', 'mysql', ServiceStatus::READY);
+    $redis = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('memory_database', 'redis', ServiceStatus::STOPPED);
+
+    app(CheckServiceStatuses::class)->check($this->server);
+    app(CheckServiceStatuses::class)->check($this->server);
+
+    $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+    $this->assertDatabaseHas('services', ['id' => $mysql->id, 'status' => ServiceStatus::STOPPED]);
+    $this->assertDatabaseHas('services', ['id' => $redis->id, 'status' => ServiceStatus::FAILED]);
+
+    Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $mysql->id
+        && $event->previousStatus === ServiceStatus::READY
+        && $event->newStatus === ServiceStatus::STOPPED);
+    Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $redis->id
+        && $event->previousStatus === ServiceStatus::STOPPED
+        && $event->newStatus === ServiceStatus::FAILED);
+    Event::assertNotDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $nginx->id);
+    Event::assertDispatchedTimes(SocketEvent::class, 2);
+});
+
+test('disabled service reported inactive stays disabled', function () {
+    SSH::fake('inactive');
+    Event::fake([ServiceStatusChanged::class]);
+
+    $this->server->services()->delete();
+    $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::DISABLED);
+
+    app(CheckServiceStatuses::class)->check($this->server);
+
+    $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::DISABLED]);
+    Event::assertNotDispatched(ServiceStatusChanged::class);
+});
+
+test('disabled service reported active becomes ready', function () {
+    SSH::fake('active');
+    Event::fake([ServiceStatusChanged::class]);
+
+    $this->server->services()->delete();
+    $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::DISABLED);
+
+    app(CheckServiceStatuses::class)->check($this->server);
+
+    $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+    Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $nginx->id
+        && $event->previousStatus === ServiceStatus::DISABLED
+        && $event->newStatus === ServiceStatus::READY);
+});
+
+test('transitional and unitless services are not checked', function () {
+    SSH::fake('active');
+    Event::fake([ServiceStatusChanged::class]);
+
+    $this->server->services()->delete();
+    vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::INSTALLING);
+    vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('nodejs', 'nodejs', ServiceStatus::READY);
+    vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('log_analysis', 'goaccess', ServiceStatus::READY);
+    $mysql = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('database', 'mysql', ServiceStatus::STOPPED);
+
+    app(CheckServiceStatuses::class)->check($this->server);
+
+    SSH::assertExecutedContains('mysql');
+    SSH::assertNotExecutedContains('nginx');
+    SSH::assertNotExecutedContains('nodejs');
+    SSH::assertNotExecutedContains('goaccess');
+    SSH::assertNotExecutedContains("''");
+    $this->assertDatabaseHas('services', ['id' => $mysql->id, 'status' => ServiceStatus::READY]);
+    Event::assertDispatchedTimes(ServiceStatusChanged::class, 1);
+});
+
+test('skips ssh when no pollable services', function () {
+    SSH::fake('active');
+    Event::fake([ServiceStatusChanged::class]);
+
+    $this->server->services()->delete();
+    vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('nodejs', 'nodejs', ServiceStatus::READY);
+
+    app(CheckServiceStatuses::class)->check($this->server);
+
+    SSH::assertNotExecutedContains('is-active');
+    Event::assertNotDispatched(ServiceStatusChanged::class);
+});
+
+test('mismatched output updates nothing', function () {
+    SSH::fake('active');
+    Event::fake([ServiceStatusChanged::class]);
+
+    $this->server->services()->delete();
+    $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::STOPPED);
+    $mysql = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('database', 'mysql', ServiceStatus::STOPPED);
+
+    app(CheckServiceStatuses::class)->check($this->server);
+
+    $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::STOPPED]);
+    $this->assertDatabaseHas('services', ['id' => $mysql->id, 'status' => ServiceStatus::STOPPED]);
+    Event::assertNotDispatched(ServiceStatusChanged::class);
+});
+
+test('single inactive reading does not change status', function () {
+    SSH::fake('inactive');
+    Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
+
+    $this->server->services()->delete();
+    $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::READY);
+
+    app(CheckServiceStatuses::class)->check($this->server);
+
+    $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+    Event::assertNotDispatched(ServiceStatusChanged::class);
+    Event::assertNotDispatched(SocketEvent::class);
+});
+
+test('restart flap does not change status', function () {
+    Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
+
+    $this->server->services()->delete();
+    $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::READY);
+
+    SSH::fake('inactive');
+    app(CheckServiceStatuses::class)->check($this->server);
+
+    SSH::fake('active');
+    app(CheckServiceStatuses::class)->check($this->server);
+
+    SSH::fake('inactive');
+    app(CheckServiceStatuses::class)->check($this->server);
+
+    $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+    Event::assertNotDispatched(ServiceStatusChanged::class);
+});
+
+test('two consecutive inactive readings change status', function () {
+    SSH::fake('inactive');
+    Event::fake([ServiceStatusChanged::class]);
+
+    $this->server->services()->delete();
+    $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::READY);
+
+    app(CheckServiceStatuses::class)->check($this->server);
+    app(CheckServiceStatuses::class)->check($this->server);
+
+    $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::STOPPED]);
+    Event::assertDispatchedTimes(ServiceStatusChanged::class, 1);
+});
+
+test('recovery to active applies immediately', function () {
+    SSH::fake('active');
+    Event::fake([ServiceStatusChanged::class]);
+
+    $this->server->services()->delete();
+    $nginx = vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService('webserver', 'nginx', ServiceStatus::STOPPED);
+
+    app(CheckServiceStatuses::class)->check($this->server);
+
+    $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+    Event::assertDispatchedTimes(ServiceStatusChanged::class, 1);
+});
+
+function vitoPestUnitActionsServiceCheckServiceStatusesTestCreateService(string $type, string $name, ServiceStatus $status): Service
 {
-    use RefreshDatabase;
+    /** @var Service $service */
+    $service = test()->server->services()->create([
+        'type' => $type,
+        'name' => $name,
+        'version' => 'latest',
+        'status' => $status,
+    ]);
 
-    public function test_updates_changed_statuses_and_dispatches_events(): void
-    {
-        SSH::fake("active\ninactive\nfailed");
-        Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
-
-        $this->server->services()->delete();
-        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::READY);
-        $mysql = $this->createService('database', 'mysql', ServiceStatus::READY);
-        $redis = $this->createService('memory_database', 'redis', ServiceStatus::STOPPED);
-
-        app(CheckServiceStatuses::class)->check($this->server);
-        app(CheckServiceStatuses::class)->check($this->server);
-
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
-        $this->assertDatabaseHas('services', ['id' => $mysql->id, 'status' => ServiceStatus::STOPPED]);
-        $this->assertDatabaseHas('services', ['id' => $redis->id, 'status' => ServiceStatus::FAILED]);
-
-        Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $mysql->id
-            && $event->previousStatus === ServiceStatus::READY
-            && $event->newStatus === ServiceStatus::STOPPED);
-        Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $redis->id
-            && $event->previousStatus === ServiceStatus::STOPPED
-            && $event->newStatus === ServiceStatus::FAILED);
-        Event::assertNotDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $nginx->id);
-        Event::assertDispatchedTimes(SocketEvent::class, 2);
-    }
-
-    public function test_disabled_service_reported_inactive_stays_disabled(): void
-    {
-        SSH::fake('inactive');
-        Event::fake([ServiceStatusChanged::class]);
-
-        $this->server->services()->delete();
-        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::DISABLED);
-
-        app(CheckServiceStatuses::class)->check($this->server);
-
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::DISABLED]);
-        Event::assertNotDispatched(ServiceStatusChanged::class);
-    }
-
-    public function test_disabled_service_reported_active_becomes_ready(): void
-    {
-        SSH::fake('active');
-        Event::fake([ServiceStatusChanged::class]);
-
-        $this->server->services()->delete();
-        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::DISABLED);
-
-        app(CheckServiceStatuses::class)->check($this->server);
-
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
-        Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $nginx->id
-            && $event->previousStatus === ServiceStatus::DISABLED
-            && $event->newStatus === ServiceStatus::READY);
-    }
-
-    public function test_transitional_and_unitless_services_are_not_checked(): void
-    {
-        SSH::fake('active');
-        Event::fake([ServiceStatusChanged::class]);
-
-        $this->server->services()->delete();
-        $this->createService('webserver', 'nginx', ServiceStatus::INSTALLING);
-        $this->createService('nodejs', 'nodejs', ServiceStatus::READY);
-        $this->createService('log_analysis', 'goaccess', ServiceStatus::READY);
-        $mysql = $this->createService('database', 'mysql', ServiceStatus::STOPPED);
-
-        app(CheckServiceStatuses::class)->check($this->server);
-
-        SSH::assertExecutedContains('mysql');
-        SSH::assertNotExecutedContains('nginx');
-        SSH::assertNotExecutedContains('nodejs');
-        SSH::assertNotExecutedContains('goaccess');
-        SSH::assertNotExecutedContains("''");
-        $this->assertDatabaseHas('services', ['id' => $mysql->id, 'status' => ServiceStatus::READY]);
-        Event::assertDispatchedTimes(ServiceStatusChanged::class, 1);
-    }
-
-    public function test_skips_ssh_when_no_pollable_services(): void
-    {
-        SSH::fake('active');
-        Event::fake([ServiceStatusChanged::class]);
-
-        $this->server->services()->delete();
-        $this->createService('nodejs', 'nodejs', ServiceStatus::READY);
-
-        app(CheckServiceStatuses::class)->check($this->server);
-
-        SSH::assertNotExecutedContains('is-active');
-        Event::assertNotDispatched(ServiceStatusChanged::class);
-    }
-
-    public function test_mismatched_output_updates_nothing(): void
-    {
-        SSH::fake('active');
-        Event::fake([ServiceStatusChanged::class]);
-
-        $this->server->services()->delete();
-        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::STOPPED);
-        $mysql = $this->createService('database', 'mysql', ServiceStatus::STOPPED);
-
-        app(CheckServiceStatuses::class)->check($this->server);
-
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::STOPPED]);
-        $this->assertDatabaseHas('services', ['id' => $mysql->id, 'status' => ServiceStatus::STOPPED]);
-        Event::assertNotDispatched(ServiceStatusChanged::class);
-    }
-
-    public function test_single_inactive_reading_does_not_change_status(): void
-    {
-        SSH::fake('inactive');
-        Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
-
-        $this->server->services()->delete();
-        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::READY);
-
-        app(CheckServiceStatuses::class)->check($this->server);
-
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
-        Event::assertNotDispatched(ServiceStatusChanged::class);
-        Event::assertNotDispatched(SocketEvent::class);
-    }
-
-    public function test_restart_flap_does_not_change_status(): void
-    {
-        Event::fake([ServiceStatusChanged::class, SocketEvent::class]);
-
-        $this->server->services()->delete();
-        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::READY);
-
-        SSH::fake('inactive');
-        app(CheckServiceStatuses::class)->check($this->server);
-
-        SSH::fake('active');
-        app(CheckServiceStatuses::class)->check($this->server);
-
-        SSH::fake('inactive');
-        app(CheckServiceStatuses::class)->check($this->server);
-
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
-        Event::assertNotDispatched(ServiceStatusChanged::class);
-    }
-
-    public function test_two_consecutive_inactive_readings_change_status(): void
-    {
-        SSH::fake('inactive');
-        Event::fake([ServiceStatusChanged::class]);
-
-        $this->server->services()->delete();
-        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::READY);
-
-        app(CheckServiceStatuses::class)->check($this->server);
-        app(CheckServiceStatuses::class)->check($this->server);
-
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::STOPPED]);
-        Event::assertDispatchedTimes(ServiceStatusChanged::class, 1);
-    }
-
-    public function test_recovery_to_active_applies_immediately(): void
-    {
-        SSH::fake('active');
-        Event::fake([ServiceStatusChanged::class]);
-
-        $this->server->services()->delete();
-        $nginx = $this->createService('webserver', 'nginx', ServiceStatus::STOPPED);
-
-        app(CheckServiceStatuses::class)->check($this->server);
-
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
-        Event::assertDispatchedTimes(ServiceStatusChanged::class, 1);
-    }
-
-    private function createService(string $type, string $name, ServiceStatus $status): Service
-    {
-        /** @var Service $service */
-        $service = $this->server->services()->create([
-            'type' => $type,
-            'name' => $name,
-            'version' => 'latest',
-            'status' => $status,
-        ]);
-
-        return $service;
-    }
+    return $service;
 }

--- a/tests/Unit/Actions/Service/InstallTest.php
+++ b/tests/Unit/Actions/Service/InstallTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Unit\Actions\Service;
-
 use App\Actions\Service\Install;
 use App\Enums\ServiceStatus;
 use App\Facades\SSH;
@@ -11,280 +9,263 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Validation\ValidationException;
-use Tests\TestCase;
 
-class InstallTest extends TestCase
+uses(RefreshDatabase::class);
+
+test('install vito agent', function () {
+    SSH::fake('Active: active');
+    Http::fake([
+        'https://api.github.com/repos/vitodeploy/agent/tags' => Http::response([['name' => '0.1.0']]),
+    ]);
+
+    $this->server->monitoring()?->delete();
+
+    app(Install::class)->install($this->server, [
+        'type' => 'monitoring',
+        'name' => 'vito-agent',
+        'version' => 'latest',
+    ]);
+
+    $this->assertDatabaseHas('services', [
+        'server_id' => $this->server->id,
+        'name' => 'vito-agent',
+        'type' => 'monitoring',
+        'version' => '0.1.0',
+        'status' => ServiceStatus::READY,
+    ]);
+});
+
+test('install vito agent failed', function () {
+    $this->server->monitoring()?->delete();
+    SSH::fake('Active: inactive');
+    Http::fake([
+        'https://api.github.com/repos/vitodeploy/agent/tags' => Http::response([]),
+    ]);
+
+    $service = app(Install::class)->install($this->server, [
+        'type' => 'monitoring',
+        'name' => 'vito-agent',
+        'version' => 'latest',
+    ]);
+
+    // Wait for the job to complete and check the service status
+    $service->refresh();
+    expect($service->status)->toEqual(ServiceStatus::INSTALLATION_FAILED);
+});
+
+test('install nginx', function () {
+    $this->server->webserver()->delete();
+
+    SSH::fake('Active: active');
+
+    app(Install::class)->install($this->server, [
+        'type' => 'webserver',
+        'name' => 'nginx',
+        'version' => 'latest',
+    ]);
+
+    $this->assertDatabaseHas('services', [
+        'server_id' => $this->server->id,
+        'name' => 'nginx',
+        'type' => 'webserver',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+});
+
+test('install caddy', function () {
+    $this->server->webserver()->delete();
+
+    SSH::fake('Active: active');
+
+    app(Install::class)->install($this->server, [
+        'type' => 'webserver',
+        'name' => 'caddy',
+        'version' => 'latest',
+    ]);
+
+    $this->assertDatabaseHas('services', [
+        'server_id' => $this->server->id,
+        'name' => 'caddy',
+        'type' => 'webserver',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+});
+
+test('install mysql', function () {
+    $this->server->database()->delete();
+
+    SSH::fake('Active: active');
+
+    app(Install::class)->install($this->server, [
+        'type' => 'database',
+        'name' => 'mysql',
+        'version' => '8.4',
+    ]);
+
+    $this->assertDatabaseHas('services', [
+        'server_id' => $this->server->id,
+        'name' => 'mysql',
+        'type' => 'database',
+        'version' => '8.4',
+        'status' => ServiceStatus::READY,
+    ]);
+});
+
+test('install mysql failed', function () {
+    $this->expectException(ValidationException::class);
+    app(Install::class)->install($this->server, [
+        'type' => 'database',
+        'name' => 'mysql',
+        'version' => '8.4',
+    ]);
+});
+
+test('install supervisor', function () {
+    $this->server->processManager()->delete();
+
+    SSH::fake('Active: active');
+
+    app(Install::class)->install($this->server, [
+        'type' => 'process_manager',
+        'name' => 'supervisor',
+        'version' => 'latest',
+    ]);
+
+    $this->assertDatabaseHas('services', [
+        'server_id' => $this->server->id,
+        'name' => 'supervisor',
+        'type' => 'process_manager',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+});
+
+test('install redis', function () {
+    $this->server->memoryDatabase()->delete();
+
+    SSH::fake('Active: active');
+
+    app(Install::class)->install($this->server, [
+        'type' => 'memory_database',
+        'name' => 'redis',
+        'version' => 'latest',
+    ]);
+
+    $this->assertDatabaseHas('services', [
+        'server_id' => $this->server->id,
+        'name' => 'redis',
+        'type' => 'memory_database',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+});
+
+test('installing service dispatches agent config update', function () {
+    SSH::fake('Active: active');
+    Bus::fake([UpdateVitoAgentConfigJob::class]);
+
+    vitoPestUnitActionsServiceInstallTestCreateVitoAgent();
+    $this->server->memoryDatabase()->delete();
+
+    app(Install::class)->install($this->server, [
+        'type' => 'memory_database',
+        'name' => 'redis',
+        'version' => 'latest',
+    ]);
+
+    Bus::assertDispatched(UpdateVitoAgentConfigJob::class);
+});
+
+test('installing service without unit does not dispatch agent config update', function () {
+    SSH::fake('Active: active');
+    Bus::fake([UpdateVitoAgentConfigJob::class]);
+
+    vitoPestUnitActionsServiceInstallTestCreateVitoAgent();
+    $this->server->services()->where('name', 'nodejs')->delete();
+
+    app(Install::class)->install($this->server, [
+        'type' => 'nodejs',
+        'name' => 'nodejs',
+        'version' => '20',
+    ]);
+
+    Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
+});
+
+test('failed install does not dispatch agent config update', function () {
+    SSH::fake('inactive');
+    Bus::fake([UpdateVitoAgentConfigJob::class]);
+
+    vitoPestUnitActionsServiceInstallTestCreateVitoAgent();
+    $this->server->memoryDatabase()->delete();
+
+    app(Install::class)->install($this->server, [
+        'type' => 'memory_database',
+        'name' => 'redis',
+        'version' => 'latest',
+    ]);
+
+    $this->assertDatabaseHas('services', [
+        'server_id' => $this->server->id,
+        'name' => 'redis',
+        'status' => ServiceStatus::INSTALLATION_FAILED,
+    ]);
+    Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
+});
+
+test('installing service without vito agent does not dispatch agent config update', function () {
+    SSH::fake('Active: active');
+    Bus::fake([UpdateVitoAgentConfigJob::class]);
+
+    $this->server->memoryDatabase()->delete();
+
+    app(Install::class)->install($this->server, [
+        'type' => 'memory_database',
+        'name' => 'redis',
+        'version' => 'latest',
+    ]);
+
+    Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
+});
+
+test('installing vito agent writes config with services', function () {
+    SSH::fake('Active: active');
+    Bus::fake([UpdateVitoAgentConfigJob::class]);
+    Http::fake([
+        'https://api.github.com/repos/vitodeploy/agent/tags' => Http::response([['name' => '0.1.0']]),
+    ]);
+
+    $this->server->monitoring()?->delete();
+
+    app(Install::class)->install($this->server, [
+        'type' => 'monitoring',
+        'name' => 'vito-agent',
+        'version' => 'latest',
+    ]);
+
+    $config = json_decode(SSH::getUploadedContent(), true);
+    expect($config['url'])->not->toBeEmpty();
+    expect($config['secret'])->not->toBeEmpty();
+    $this->assertArrayNotHasKey('data_retention', $config);
+    expect(array_column($config['services'], 'unit'))->toContain('nginx');
+
+    Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
+});
+
+function vitoPestUnitActionsServiceInstallTestCreateVitoAgent(): void
 {
-    use RefreshDatabase;
-
-    public function test_install_vito_agent(): void
-    {
-        SSH::fake('Active: active');
-        Http::fake([
-            'https://api.github.com/repos/vitodeploy/agent/tags' => Http::response([['name' => '0.1.0']]),
-        ]);
-
-        $this->server->monitoring()?->delete();
-
-        app(Install::class)->install($this->server, [
-            'type' => 'monitoring',
-            'name' => 'vito-agent',
-            'version' => 'latest',
-        ]);
-
-        $this->assertDatabaseHas('services', [
-            'server_id' => $this->server->id,
-            'name' => 'vito-agent',
-            'type' => 'monitoring',
-            'version' => '0.1.0',
-            'status' => ServiceStatus::READY,
-        ]);
-    }
-
-    public function test_install_vito_agent_failed(): void
-    {
-        $this->server->monitoring()?->delete();
-        SSH::fake('Active: inactive');
-        Http::fake([
-            'https://api.github.com/repos/vitodeploy/agent/tags' => Http::response([]),
-        ]);
-
-        $service = app(Install::class)->install($this->server, [
-            'type' => 'monitoring',
-            'name' => 'vito-agent',
-            'version' => 'latest',
-        ]);
-
-        // Wait for the job to complete and check the service status
-        $service->refresh();
-        $this->assertEquals(ServiceStatus::INSTALLATION_FAILED, $service->status);
-    }
-
-    public function test_install_nginx(): void
-    {
-        $this->server->webserver()->delete();
-
-        SSH::fake('Active: active');
-
-        app(Install::class)->install($this->server, [
-            'type' => 'webserver',
-            'name' => 'nginx',
-            'version' => 'latest',
-        ]);
-
-        $this->assertDatabaseHas('services', [
-            'server_id' => $this->server->id,
-            'name' => 'nginx',
-            'type' => 'webserver',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-    }
-
-    public function test_install_caddy(): void
-    {
-        $this->server->webserver()->delete();
-
-        SSH::fake('Active: active');
-
-        app(Install::class)->install($this->server, [
-            'type' => 'webserver',
-            'name' => 'caddy',
-            'version' => 'latest',
-        ]);
-
-        $this->assertDatabaseHas('services', [
-            'server_id' => $this->server->id,
-            'name' => 'caddy',
-            'type' => 'webserver',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-    }
-
-    public function test_install_mysql(): void
-    {
-        $this->server->database()->delete();
-
-        SSH::fake('Active: active');
-
-        app(Install::class)->install($this->server, [
-            'type' => 'database',
-            'name' => 'mysql',
-            'version' => '8.4',
-        ]);
-
-        $this->assertDatabaseHas('services', [
-            'server_id' => $this->server->id,
-            'name' => 'mysql',
-            'type' => 'database',
-            'version' => '8.4',
-            'status' => ServiceStatus::READY,
-        ]);
-    }
-
-    public function test_install_mysql_failed(): void
-    {
-        $this->expectException(ValidationException::class);
-        app(Install::class)->install($this->server, [
-            'type' => 'database',
-            'name' => 'mysql',
-            'version' => '8.4',
-        ]);
-    }
-
-    public function test_install_supervisor(): void
-    {
-        $this->server->processManager()->delete();
-
-        SSH::fake('Active: active');
-
-        app(Install::class)->install($this->server, [
-            'type' => 'process_manager',
-            'name' => 'supervisor',
-            'version' => 'latest',
-        ]);
-
-        $this->assertDatabaseHas('services', [
-            'server_id' => $this->server->id,
-            'name' => 'supervisor',
-            'type' => 'process_manager',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-    }
-
-    public function test_install_redis(): void
-    {
-        $this->server->memoryDatabase()->delete();
-
-        SSH::fake('Active: active');
-
-        app(Install::class)->install($this->server, [
-            'type' => 'memory_database',
-            'name' => 'redis',
-            'version' => 'latest',
-        ]);
-
-        $this->assertDatabaseHas('services', [
-            'server_id' => $this->server->id,
-            'name' => 'redis',
-            'type' => 'memory_database',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-    }
-
-    public function test_installing_service_dispatches_agent_config_update(): void
-    {
-        SSH::fake('Active: active');
-        Bus::fake([UpdateVitoAgentConfigJob::class]);
-
-        $this->createVitoAgent();
-        $this->server->memoryDatabase()->delete();
-
-        app(Install::class)->install($this->server, [
-            'type' => 'memory_database',
-            'name' => 'redis',
-            'version' => 'latest',
-        ]);
-
-        Bus::assertDispatched(UpdateVitoAgentConfigJob::class);
-    }
-
-    public function test_installing_service_without_unit_does_not_dispatch_agent_config_update(): void
-    {
-        SSH::fake('Active: active');
-        Bus::fake([UpdateVitoAgentConfigJob::class]);
-
-        $this->createVitoAgent();
-        $this->server->services()->where('name', 'nodejs')->delete();
-
-        app(Install::class)->install($this->server, [
-            'type' => 'nodejs',
-            'name' => 'nodejs',
-            'version' => '20',
-        ]);
-
-        Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
-    }
-
-    public function test_failed_install_does_not_dispatch_agent_config_update(): void
-    {
-        SSH::fake('inactive');
-        Bus::fake([UpdateVitoAgentConfigJob::class]);
-
-        $this->createVitoAgent();
-        $this->server->memoryDatabase()->delete();
-
-        app(Install::class)->install($this->server, [
-            'type' => 'memory_database',
-            'name' => 'redis',
-            'version' => 'latest',
-        ]);
-
-        $this->assertDatabaseHas('services', [
-            'server_id' => $this->server->id,
-            'name' => 'redis',
-            'status' => ServiceStatus::INSTALLATION_FAILED,
-        ]);
-        Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
-    }
-
-    public function test_installing_service_without_vito_agent_does_not_dispatch_agent_config_update(): void
-    {
-        SSH::fake('Active: active');
-        Bus::fake([UpdateVitoAgentConfigJob::class]);
-
-        $this->server->memoryDatabase()->delete();
-
-        app(Install::class)->install($this->server, [
-            'type' => 'memory_database',
-            'name' => 'redis',
-            'version' => 'latest',
-        ]);
-
-        Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
-    }
-
-    public function test_installing_vito_agent_writes_config_with_services(): void
-    {
-        SSH::fake('Active: active');
-        Bus::fake([UpdateVitoAgentConfigJob::class]);
-        Http::fake([
-            'https://api.github.com/repos/vitodeploy/agent/tags' => Http::response([['name' => '0.1.0']]),
-        ]);
-
-        $this->server->monitoring()?->delete();
-
-        app(Install::class)->install($this->server, [
-            'type' => 'monitoring',
-            'name' => 'vito-agent',
-            'version' => 'latest',
-        ]);
-
-        $config = json_decode(SSH::getUploadedContent(), true);
-        $this->assertNotEmpty($config['url']);
-        $this->assertNotEmpty($config['secret']);
-        $this->assertArrayNotHasKey('data_retention', $config);
-        $this->assertContains('nginx', array_column($config['services'], 'unit'));
-
-        Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
-    }
-
-    private function createVitoAgent(): void
-    {
-        Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'vito-agent',
-            'type' => 'monitoring',
-            'type_data' => [
-                'url' => 'https://vito.test/agent-endpoint',
-                'secret' => 'agent-secret',
-                'data_retention' => 7,
-            ],
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-    }
+    Service::factory()->create([
+        'server_id' => test()->server->id,
+        'name' => 'vito-agent',
+        'type' => 'monitoring',
+        'type_data' => [
+            'url' => 'https://vito.test/agent-endpoint',
+            'secret' => 'agent-secret',
+            'data_retention' => 7,
+        ],
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
 }

--- a/tests/Unit/Actions/Service/InstallTest.php
+++ b/tests/Unit/Actions/Service/InstallTest.php
@@ -48,7 +48,6 @@ test('install vito agent failed', function () {
         'version' => 'latest',
     ]);
 
-    // Wait for the job to complete and check the service status
     $service->refresh();
     expect($service->status)->toEqual(ServiceStatus::INSTALLATION_FAILED);
 });
@@ -166,7 +165,7 @@ test('installing service dispatches agent config update', function () {
     SSH::fake('Active: active');
     Bus::fake([UpdateVitoAgentConfigJob::class]);
 
-    vitoPestUnitActionsServiceInstallTestCreateVitoAgent();
+    Service::factory()->vitoAgent()->create(['server_id' => $this->server->id]);
     $this->server->memoryDatabase()->delete();
 
     app(Install::class)->install($this->server, [
@@ -182,7 +181,7 @@ test('installing service without unit does not dispatch agent config update', fu
     SSH::fake('Active: active');
     Bus::fake([UpdateVitoAgentConfigJob::class]);
 
-    vitoPestUnitActionsServiceInstallTestCreateVitoAgent();
+    Service::factory()->vitoAgent()->create(['server_id' => $this->server->id]);
     $this->server->services()->where('name', 'nodejs')->delete();
 
     app(Install::class)->install($this->server, [
@@ -198,7 +197,7 @@ test('failed install does not dispatch agent config update', function () {
     SSH::fake('inactive');
     Bus::fake([UpdateVitoAgentConfigJob::class]);
 
-    vitoPestUnitActionsServiceInstallTestCreateVitoAgent();
+    Service::factory()->vitoAgent()->create(['server_id' => $this->server->id]);
     $this->server->memoryDatabase()->delete();
 
     app(Install::class)->install($this->server, [
@@ -253,19 +252,3 @@ test('installing vito agent writes config with services', function () {
 
     Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
 });
-
-function vitoPestUnitActionsServiceInstallTestCreateVitoAgent(): void
-{
-    Service::factory()->create([
-        'server_id' => test()->server->id,
-        'name' => 'vito-agent',
-        'type' => 'monitoring',
-        'type_data' => [
-            'url' => 'https://vito.test/agent-endpoint',
-            'secret' => 'agent-secret',
-            'data_retention' => 7,
-        ],
-        'version' => 'latest',
-        'status' => ServiceStatus::READY,
-    ]);
-}

--- a/tests/Unit/Actions/Service/UninstallTest.php
+++ b/tests/Unit/Actions/Service/UninstallTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Unit\Actions\Service;
-
 use App\Actions\Network\CreateNetwork;
 use App\Actions\Service\Uninstall;
 use App\Enums\ServerStatus;
@@ -14,166 +12,141 @@ use App\Models\Worker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Validation\ValidationException;
-use Tests\TestCase;
 
-class UninstallTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_uninstall_vito_agent(): void
-    {
-        SSH::fake();
+test('uninstall vito agent', function () {
+    SSH::fake();
 
-        $this->server->monitoring()?->delete();
+    $this->server->monitoring()?->delete();
 
-        $service = Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'vito-agent',
-            'type' => 'monitoring',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
+    $service = Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'vito-agent',
+        'type' => 'monitoring',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
 
-        app(Uninstall::class)->uninstall($this->server->monitoring());
+    app(Uninstall::class)->uninstall($this->server->monitoring());
 
-        $this->assertDatabaseMissing('services', [
-            'id' => $service->id,
-        ]);
-    }
+    $this->assertDatabaseMissing('services', [
+        'id' => $service->id,
+    ]);
+});
 
-    public function test_uninstalling_service_dispatches_agent_config_update(): void
-    {
-        SSH::fake();
-        Bus::fake([UpdateVitoAgentConfigJob::class]);
+test('uninstalling service dispatches agent config update', function () {
+    SSH::fake();
+    Bus::fake([UpdateVitoAgentConfigJob::class]);
 
-        Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'vito-agent',
-            'type' => 'monitoring',
-            'type_data' => [
-                'url' => 'https://vito.test/agent-endpoint',
-                'secret' => 'agent-secret',
-                'data_retention' => 7,
-            ],
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
+    Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'vito-agent',
+        'type' => 'monitoring',
+        'type_data' => [
+            'url' => 'https://vito.test/agent-endpoint',
+            'secret' => 'agent-secret',
+            'data_retention' => 7,
+        ],
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
 
-        $redis = $this->server->services()->where('name', 'redis')->firstOrFail();
+    $redis = $this->server->services()->where('name', 'redis')->firstOrFail();
 
-        app(Uninstall::class)->uninstall($redis);
+    app(Uninstall::class)->uninstall($redis);
 
-        $this->assertDatabaseMissing('services', ['id' => $redis->id]);
-        Bus::assertDispatched(UpdateVitoAgentConfigJob::class);
-    }
+    $this->assertDatabaseMissing('services', ['id' => $redis->id]);
+    Bus::assertDispatched(UpdateVitoAgentConfigJob::class);
+});
 
-    public function test_uninstalling_vito_agent_does_not_dispatch_agent_config_update(): void
-    {
-        SSH::fake();
-        Bus::fake([UpdateVitoAgentConfigJob::class]);
+test('uninstalling vito agent does not dispatch agent config update', function () {
+    SSH::fake();
+    Bus::fake([UpdateVitoAgentConfigJob::class]);
 
-        $this->server->monitoring()?->delete();
+    $this->server->monitoring()?->delete();
 
-        Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'vito-agent',
-            'type' => 'monitoring',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
+    Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'vito-agent',
+        'type' => 'monitoring',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
 
-        app(Uninstall::class)->uninstall($this->server->monitoring());
+    app(Uninstall::class)->uninstall($this->server->monitoring());
 
-        Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
-    }
+    Bus::assertNotDispatched(UpdateVitoAgentConfigJob::class);
+});
 
-    /**
-     * Cannot uninstall nginx because some sites using it
-     */
-    public function test_cannot_uninstall_nginx(): void
-    {
-        SSH::fake();
+test('cannot uninstall nginx', function () {
+    SSH::fake();
 
-        $this->expectException(ValidationException::class);
+    $this->expectException(ValidationException::class);
 
-        app(Uninstall::class)->uninstall($this->server->webserver());
-    }
+    app(Uninstall::class)->uninstall($this->server->webserver());
+});
 
-    /**
-     * Cannot uninstall caddy because some sites using it
-     */
-    public function test_cannot_uninstall_caddy(): void
-    {
-        SSH::fake();
+test('cannot uninstall caddy', function () {
+    SSH::fake();
 
-        $this->expectException(ValidationException::class);
+    $this->expectException(ValidationException::class);
 
-        app(Uninstall::class)->uninstall($this->server->webserver());
-    }
+    app(Uninstall::class)->uninstall($this->server->webserver());
+});
 
-    /**
-     * Cannot uninstall mysql because some databases exist
-     */
-    public function test_cannot_uninstall_mysql(): void
-    {
-        SSH::fake();
+test('cannot uninstall mysql', function () {
+    SSH::fake();
 
-        Database::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+    Database::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
 
-        $this->expectException(ValidationException::class);
+    $this->expectException(ValidationException::class);
 
-        app(Uninstall::class)->uninstall($this->server->database());
-    }
+    app(Uninstall::class)->uninstall($this->server->database());
+});
 
-    public function test_cannot_uninstall_wireguard_when_server_is_network_member(): void
-    {
-        SSH::fake();
-        $this->server->update(['status' => ServerStatus::READY]);
+test('cannot uninstall wireguard when server is network member', function () {
+    SSH::fake();
+    $this->server->update(['status' => ServerStatus::READY]);
 
-        app(CreateNetwork::class)->create($this->server->project, [
-            'name' => 'wg-net',
-            'type' => 'wireguard',
-            'servers' => [$this->server->id],
-        ]);
+    app(CreateNetwork::class)->create($this->server->project, [
+        'name' => 'wg-net',
+        'type' => 'wireguard',
+        'servers' => [$this->server->id],
+    ]);
 
-        $this->expectException(ValidationException::class);
+    $this->expectException(ValidationException::class);
 
-        app(Uninstall::class)->uninstall($this->server->service('vpn'));
-    }
+    app(Uninstall::class)->uninstall($this->server->service('vpn'));
+});
 
-    public function test_can_uninstall_wireguard_when_server_is_not_a_network_member(): void
-    {
-        SSH::fake();
+test('can uninstall wireguard when server is not a network member', function () {
+    SSH::fake();
 
-        $service = Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'wireguard',
-            'type' => 'vpn',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
+    $service = Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'wireguard',
+        'type' => 'vpn',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
 
-        app(Uninstall::class)->uninstall($service);
+    app(Uninstall::class)->uninstall($service);
 
-        $this->assertDatabaseMissing('services', ['id' => $service->id]);
-    }
+    $this->assertDatabaseMissing('services', ['id' => $service->id]);
+});
 
-    /**
-     * Cannot uninstall supervisor because some queues exist
-     */
-    public function test_cannot_uninstall_supervisor(): void
-    {
-        SSH::fake();
+test('cannot uninstall supervisor', function () {
+    SSH::fake();
 
-        Worker::factory()->create([
-            'server_id' => $this->server->id,
-            'site_id' => $this->site->id,
-        ]);
+    Worker::factory()->create([
+        'server_id' => $this->server->id,
+        'site_id' => $this->site->id,
+    ]);
 
-        $this->expectException(ValidationException::class);
+    $this->expectException(ValidationException::class);
 
-        app(Uninstall::class)->uninstall($this->server->processManager());
-    }
-}
+    app(Uninstall::class)->uninstall($this->server->processManager());
+});

--- a/tests/Unit/Actions/Service/UninstallTest.php
+++ b/tests/Unit/Actions/Service/UninstallTest.php
@@ -9,6 +9,7 @@ use App\Jobs\Service\UpdateVitoAgentConfigJob;
 use App\Models\Database;
 use App\Models\Service;
 use App\Models\Worker;
+use App\Services\Webserver\Caddy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Validation\ValidationException;
@@ -39,18 +40,7 @@ test('uninstalling service dispatches agent config update', function () {
     SSH::fake();
     Bus::fake([UpdateVitoAgentConfigJob::class]);
 
-    Service::factory()->create([
-        'server_id' => $this->server->id,
-        'name' => 'vito-agent',
-        'type' => 'monitoring',
-        'type_data' => [
-            'url' => 'https://vito.test/agent-endpoint',
-            'secret' => 'agent-secret',
-            'data_retention' => 7,
-        ],
-        'version' => 'latest',
-        'status' => ServiceStatus::READY,
-    ]);
+    Service::factory()->vitoAgent()->create(['server_id' => $this->server->id]);
 
     $redis = $this->server->services()->where('name', 'redis')->firstOrFail();
 
@@ -90,9 +80,12 @@ test('cannot uninstall nginx', function () {
 test('cannot uninstall caddy', function () {
     SSH::fake();
 
+    $caddy = $this->server->webserver();
+    $caddy->update(['name' => Caddy::id()]);
+
     $this->expectException(ValidationException::class);
 
-    app(Uninstall::class)->uninstall($this->server->webserver());
+    app(Uninstall::class)->uninstall($caddy);
 });
 
 test('cannot uninstall mysql', function () {

--- a/tests/Unit/BunSiteTest.php
+++ b/tests/Unit/BunSiteTest.php
@@ -1,163 +1,130 @@
 <?php
 
-namespace Tests\Unit;
-
 use App\Models\Site;
 use App\SiteTypes\BunSite;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class BunSiteTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    protected Site $bunSite;
-
-    protected BunSite $siteType;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->bunSite = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'testuser',
-            'path' => '/home/testuser/example.com',
-            'type' => BunSite::id(),
-            'type_data' => [
-                'bun_version' => '1.2',
-                'build_command' => 'bun run build',
-                'start_command' => 'bun run start',
-            ],
-        ]);
-        $this->siteType = new BunSite($this->bunSite);
-    }
-
-    public function test_id(): void
-    {
-        $this->assertEquals('bun', BunSite::id());
-    }
-
-    public function test_language(): void
-    {
-        $this->assertEquals('bun', $this->siteType->language());
-    }
-
-    public function test_required_services(): void
-    {
-        $this->assertEquals(['webserver', 'process_manager'], $this->siteType->requiredServices());
-    }
-
-    public function test_create_time_tools_returns_bun(): void
-    {
-        $this->assertSame(['bun'], BunSite::createTimeTools());
-    }
-
-    public function test_deploy_commands(): void
-    {
-        $reflection = new \ReflectionMethod($this->siteType, 'deployCommands');
-
-        $this->assertSame(
-            ['bun install --frozen-lockfile', 'bun run build'],
-            $reflection->invoke($this->siteType),
-        );
-    }
-
-    public function test_start_command_returns_default(): void
-    {
-        $reflection = new \ReflectionMethod($this->siteType, 'startCommand');
-
-        $this->assertEquals('bun run start', $reflection->invoke($this->siteType));
-    }
-
-    public function test_start_command_from_type_data(): void
-    {
-        $reflection = new \ReflectionMethod($this->siteType, 'startCommand');
-
-        $this->assertEquals('bun run start', $reflection->invoke($this->siteType));
-    }
-
-    public function test_start_command_defaults(): void
-    {
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'testuser',
-            'path' => '/home/testuser/example.com',
-            'type' => BunSite::id(),
-            'type_data' => [],
-        ]);
-        $siteType = new BunSite($site);
-        $reflection = new \ReflectionMethod($siteType, 'startCommand');
-
-        $this->assertEquals('bun run start', $reflection->invoke($siteType));
-    }
-
-    public function test_data_with_defaults(): void
-    {
-        $data = $this->siteType->data([]);
-
-        $this->assertEquals([
+beforeEach(function () {
+    $this->bunSite = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'testuser',
+        'path' => '/home/testuser/example.com',
+        'type' => BunSite::id(),
+        'type_data' => [
             'bun_version' => '1.2',
+            'build_command' => 'bun run build',
             'start_command' => 'bun run start',
-        ], $data);
-    }
+        ],
+    ]);
+    $this->siteType = new BunSite($this->bunSite);
+});
 
-    public function test_data_with_custom_commands(): void
-    {
-        $data = $this->siteType->data([
-            'bun_version' => '1.1',
-            'start_command' => 'bun run start:prod',
-        ]);
+test('id', function () {
+    expect(BunSite::id())->toEqual('bun');
+});
 
-        $this->assertEquals([
-            'bun_version' => '1.1',
-            'start_command' => 'bun run start:prod',
-        ], $data);
-    }
+test('language', function () {
+    expect($this->siteType->language())->toEqual('bun');
+});
 
-    public function test_create_fields(): void
-    {
-        $fields = $this->siteType->createFields([
-            'source_control' => '1',
-            'repository' => 'org/repo',
-            'branch' => 'main',
-            'port' => '3000',
-        ]);
+test('required services', function () {
+    expect($this->siteType->requiredServices())->toEqual(['webserver', 'process_manager']);
+});
 
-        $this->assertEquals([
-            'source_control_id' => '1',
-            'repository' => 'org/repo',
-            'branch' => 'main',
-            'port' => '3000',
-        ], $fields);
-    }
+test('create time tools returns bun', function () {
+    expect(BunSite::createTimeTools())->toBe(['bun']);
+});
 
-    public function test_create_rules_contain_bun_version(): void
-    {
-        $rules = $this->siteType->createRules([]);
+test('deploy commands', function () {
+    $reflection = new ReflectionMethod($this->siteType, 'deployCommands');
 
-        $this->assertArrayHasKey('bun_version', $rules);
-        $this->assertArrayHasKey('source_control', $rules);
-        $this->assertArrayHasKey('repository', $rules);
-        $this->assertArrayHasKey('branch', $rules);
-        $this->assertArrayHasKey('port', $rules);
-        $this->assertArrayNotHasKey('build_command', $rules);
-        $this->assertArrayHasKey('start_command', $rules);
-        $this->assertArrayNotHasKey('package_manager', $rules);
-    }
+    expect($reflection->invoke($this->siteType))->toBe(['bun install --frozen-lockfile', 'bun run build']);
+});
 
-    public function test_base_commands_returns_empty_array(): void
-    {
-        $this->assertEquals([], $this->siteType->baseCommands());
-    }
+test('start command returns default', function () {
+    $reflection = new ReflectionMethod($this->siteType, 'startCommand');
 
-    public function test_default_deployment_script_contains_git_pull_then_deploy_commands(): void
-    {
-        $script = $this->siteType->defaultDeploymentScript();
+    expect($reflection->invoke($this->siteType))->toEqual('bun run start');
+});
 
-        $this->assertSame(
-            "git pull origin \$BRANCH\n\nbun install --frozen-lockfile\n\nbun run build\n",
-            $script,
-        );
-    }
-}
+test('start command from type data', function () {
+    $reflection = new ReflectionMethod($this->siteType, 'startCommand');
+
+    expect($reflection->invoke($this->siteType))->toEqual('bun run start');
+});
+
+test('start command defaults', function () {
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'testuser',
+        'path' => '/home/testuser/example.com',
+        'type' => BunSite::id(),
+        'type_data' => [],
+    ]);
+    $siteType = new BunSite($site);
+    $reflection = new ReflectionMethod($siteType, 'startCommand');
+
+    expect($reflection->invoke($siteType))->toEqual('bun run start');
+});
+
+test('data with defaults', function () {
+    $data = $this->siteType->data([]);
+
+    expect($data)->toEqual([
+        'bun_version' => '1.2',
+        'start_command' => 'bun run start',
+    ]);
+});
+
+test('data with custom commands', function () {
+    $data = $this->siteType->data([
+        'bun_version' => '1.1',
+        'start_command' => 'bun run start:prod',
+    ]);
+
+    expect($data)->toEqual([
+        'bun_version' => '1.1',
+        'start_command' => 'bun run start:prod',
+    ]);
+});
+
+test('create fields', function () {
+    $fields = $this->siteType->createFields([
+        'source_control' => '1',
+        'repository' => 'org/repo',
+        'branch' => 'main',
+        'port' => '3000',
+    ]);
+
+    expect($fields)->toEqual([
+        'source_control_id' => '1',
+        'repository' => 'org/repo',
+        'branch' => 'main',
+        'port' => '3000',
+    ]);
+});
+
+test('create rules contain bun version', function () {
+    $rules = $this->siteType->createRules([]);
+
+    expect($rules)->toHaveKey('bun_version');
+    expect($rules)->toHaveKey('source_control');
+    expect($rules)->toHaveKey('repository');
+    expect($rules)->toHaveKey('branch');
+    expect($rules)->toHaveKey('port');
+    $this->assertArrayNotHasKey('build_command', $rules);
+    expect($rules)->toHaveKey('start_command');
+    $this->assertArrayNotHasKey('package_manager', $rules);
+});
+
+test('base commands returns empty array', function () {
+    expect($this->siteType->baseCommands())->toEqual([]);
+});
+
+test('default deployment script contains git pull then deploy commands', function () {
+    $script = $this->siteType->defaultDeploymentScript();
+
+    expect($script)->toBe("git pull origin \$BRANCH\n\nbun install --frozen-lockfile\n\nbun run build\n");
+});

--- a/tests/Unit/BunSiteTest.php
+++ b/tests/Unit/BunSiteTest.php
@@ -50,9 +50,15 @@ test('start command returns default', function () {
 });
 
 test('start command from type data', function () {
-    $reflection = new ReflectionMethod($this->siteType, 'startCommand');
+    $this->bunSite->update([
+        'type_data' => array_merge($this->bunSite->type_data, [
+            'start_command' => 'bun run start:prod',
+        ]),
+    ]);
+    $siteType = new BunSite($this->bunSite->refresh());
+    $reflection = new ReflectionMethod($siteType, 'startCommand');
 
-    expect($reflection->invoke($this->siteType))->toEqual('bun run start');
+    expect($reflection->invoke($siteType))->toEqual('bun run start:prod');
 });
 
 test('start command defaults', function () {

--- a/tests/Unit/Commands/CreateUserCommandTest.php
+++ b/tests/Unit/Commands/CreateUserCommandTest.php
@@ -1,72 +1,63 @@
 <?php
 
-namespace Tests\Unit\Commands;
-
 use App\Models\Project;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class CreateUserCommandTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_user(): void
-    {
-        $this->artisan('user:create', [
-            'name' => 'John Doe',
-            'email' => 'john@doe.com',
-            'password' => 'password',
-        ])->expectsOutput('User created!');
+test('create user', function () {
+    $this->artisan('user:create', [
+        'name' => 'John Doe',
+        'email' => 'john@doe.com',
+        'password' => 'password',
+    ])->expectsOutput('User created!');
 
-        $this->assertDatabaseHas('users', [
-            'name' => 'John Doe',
-            'email' => 'john@doe.com',
-        ]);
+    $this->assertDatabaseHas('users', [
+        'name' => 'John Doe',
+        'email' => 'john@doe.com',
+    ]);
 
-        /** @var User $user */
-        $user = User::query()->where('email', 'john@doe.com')->first();
+    /** @var User $user */
+    $user = User::query()->where('email', 'john@doe.com')->first();
 
-        $this->assertDatabaseHas('projects', [
-            'name' => 'default',
-        ]);
-    }
+    $this->assertDatabaseHas('projects', [
+        'name' => 'default',
+    ]);
+});
 
-    public function test_create_user_and_project(): void
-    {
-        Project::query()->delete();
-        User::query()->delete();
+test('create user and project', function () {
+    Project::query()->delete();
+    User::query()->delete();
 
-        $this->artisan('user:create', [
-            'name' => 'John Doe',
-            'email' => 'john@doe.com',
-            'password' => 'password',
-        ])->expectsOutput('User created!');
+    $this->artisan('user:create', [
+        'name' => 'John Doe',
+        'email' => 'john@doe.com',
+        'password' => 'password',
+    ])->expectsOutput('User created!');
 
-        $this->assertDatabaseHas('users', [
-            'name' => 'John Doe',
-            'email' => 'john@doe.com',
-        ]);
+    $this->assertDatabaseHas('users', [
+        'name' => 'John Doe',
+        'email' => 'john@doe.com',
+    ]);
 
-        /** @var User $user */
-        $user = User::query()->where('email', 'john@doe.com')->first();
+    /** @var User $user */
+    $user = User::query()->where('email', 'john@doe.com')->first();
 
-        $this->assertDatabaseHas('projects', [
-            'name' => 'default',
-        ]);
+    $this->assertDatabaseHas('projects', [
+        'name' => 'default',
+    ]);
 
-        $this->assertDatabaseHas('user_project', [
-            'user_id' => $user->id,
-            'project_id' => $user->refresh()->current_project_id,
-        ]);
-    }
+    $this->assertDatabaseHas('user_project', [
+        'user_id' => $user->id,
+        'project_id' => $user->refresh()->current_project_id,
+    ]);
+});
 
-    public function test_skip_existing_user(): void
-    {
-        $this->artisan('user:create', [
-            'name' => 'John Doe',
-            'email' => $this->user->email,
-            'password' => 'password',
-        ])->expectsOutput('User already exists. Skipping...');
-    }
-}
+test('skip existing user', function () {
+    $this->artisan('user:create', [
+        'name' => 'John Doe',
+        'email' => $this->user->email,
+        'password' => 'password',
+    ])->expectsOutput('User already exists. Skipping...');
+});

--- a/tests/Unit/Commands/CreateUserCommandTest.php
+++ b/tests/Unit/Commands/CreateUserCommandTest.php
@@ -18,11 +18,15 @@ test('create user', function () {
         'email' => 'john@doe.com',
     ]);
 
-    /** @var User $user */
-    $user = User::query()->where('email', 'john@doe.com')->first();
+    $user = User::query()->where('email', 'john@doe.com')->firstOrFail();
 
     $this->assertDatabaseHas('projects', [
         'name' => 'default',
+    ]);
+
+    $this->assertDatabaseHas('user_project', [
+        'user_id' => $user->id,
+        'project_id' => $user->refresh()->current_project_id,
     ]);
 });
 
@@ -41,8 +45,7 @@ test('create user and project', function () {
         'email' => 'john@doe.com',
     ]);
 
-    /** @var User $user */
-    $user = User::query()->where('email', 'john@doe.com')->first();
+    $user = User::query()->where('email', 'john@doe.com')->firstOrFail();
 
     $this->assertDatabaseHas('projects', [
         'name' => 'default',

--- a/tests/Unit/Commands/DeleteOlderMetricsCommandTest.php
+++ b/tests/Unit/Commands/DeleteOlderMetricsCommandTest.php
@@ -1,49 +1,42 @@
 <?php
 
-namespace Tests\Unit\Commands;
-
 use App\Enums\ServiceStatus;
 use App\Models\Metric;
 use App\Models\Service;
 use Carbon\Carbon;
 use Carbon\CarbonPeriod;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class DeleteOlderMetricsCommandTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_delete_older_metrics(): void
-    {
-        $monitoring = Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'vito-agent',
-            'type' => 'monitoring',
-            'type_data' => [
-                'data_retention' => 1,
-            ],
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
+test('delete older metrics', function () {
+    $monitoring = Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'vito-agent',
+        'type' => 'monitoring',
+        'type_data' => [
+            'data_retention' => 1,
+        ],
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
 
-        $range = CarbonPeriod::create(Carbon::now()->subDays(10), '1 hour', Carbon::now()->subDays(8));
-        foreach ($range as $date) {
-            Metric::factory()->create([
-                'server_id' => $monitoring->server_id,
-                'created_at' => $date,
-            ]);
-        }
-
-        $this->assertDatabaseHas('metrics', [
-            'server_id' => $this->server->id,
-        ]);
-
-        $this->artisan('metrics:delete-older-metrics')
-            ->expectsOutput('Metrics deleted');
-
-        $this->assertDatabaseMissing('metrics', [
-            'server_id' => $this->server->id,
+    $range = CarbonPeriod::create(Carbon::now()->subDays(10), '1 hour', Carbon::now()->subDays(8));
+    foreach ($range as $date) {
+        Metric::factory()->create([
+            'server_id' => $monitoring->server_id,
+            'created_at' => $date,
         ]);
     }
-}
+
+    $this->assertDatabaseHas('metrics', [
+        'server_id' => $this->server->id,
+    ]);
+
+    $this->artisan('metrics:delete-older-metrics')
+        ->expectsOutput('Metrics deleted');
+
+    $this->assertDatabaseMissing('metrics', [
+        'server_id' => $this->server->id,
+    ]);
+});

--- a/tests/Unit/Commands/GetMetricsCommandTest.php
+++ b/tests/Unit/Commands/GetMetricsCommandTest.php
@@ -1,22 +1,16 @@
 <?php
 
-namespace Tests\Unit\Commands;
-
 use App\Enums\ServiceStatus;
 use App\Events\ServiceStatusChanged;
 use App\Facades\SSH;
 use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
-use Tests\TestCase;
 
-class GetMetricsCommandTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_get_metrics(): void
-    {
-        SSH::fake(<<<'EOF'
+test('get metrics', function () {
+    SSH::fake(<<<'EOF'
             load:1
             memory_total:1
             memory_used:1
@@ -36,79 +30,77 @@ class GetMetricsCommandTest extends TestCase
             cpu_usage_and_steal:1.23|0.45
         EOF);
 
-        Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'remote-monitor',
-            'type' => 'monitoring',
-            'type_data' => [
-                'data_retention' => 7,
-            ],
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
+    Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'remote-monitor',
+        'type' => 'monitoring',
+        'type_data' => [
+            'data_retention' => 7,
+        ],
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
 
-        $this->artisan('metrics:get')
-            ->expectsOutput('Checked 1 metrics');
+    $this->artisan('metrics:get')
+        ->expectsOutput('Checked 1 metrics');
 
-        $this->assertDatabaseHas('metrics', [
-            'server_id' => $this->server->id,
-            'load' => 1,
-            'memory_total' => 1,
-            'memory_used' => 1,
-            'memory_free' => 1,
-            'disk_total' => 1,
-            'disk_used' => 1,
-            'disk_free' => 1,
-            'cpu_cores' => 4,
-            'cpu_physical_cores' => 2,
-            'cpu_usage_percent' => 1.23,
-            'cpu_steal_percent' => 0.45,
-            'swap_total' => 1024,
-            'swap_used' => 256,
-            'swap_free' => 768,
-            'swap_used_percent' => 25.00,
-            'uptime_seconds' => 12345.67,
-            'reboot_required' => true,
-            'oom_kill_count' => 3,
-            'cpu_per_core_usage_percent' => null,
-        ]);
-    }
+    $this->assertDatabaseHas('metrics', [
+        'server_id' => $this->server->id,
+        'load' => 1,
+        'memory_total' => 1,
+        'memory_used' => 1,
+        'memory_free' => 1,
+        'disk_total' => 1,
+        'disk_used' => 1,
+        'disk_free' => 1,
+        'cpu_cores' => 4,
+        'cpu_physical_cores' => 2,
+        'cpu_usage_percent' => 1.23,
+        'cpu_steal_percent' => 0.45,
+        'swap_total' => 1024,
+        'swap_used' => 256,
+        'swap_free' => 768,
+        'swap_used_percent' => 25.00,
+        'uptime_seconds' => 12345.67,
+        'reboot_required' => true,
+        'oom_kill_count' => 3,
+        'cpu_per_core_usage_percent' => null,
+    ]);
+});
 
-    public function test_checks_service_statuses(): void
-    {
-        SSH::fake('active');
-        Event::fake([ServiceStatusChanged::class]);
+test('checks service statuses', function () {
+    SSH::fake('active');
+    Event::fake([ServiceStatusChanged::class]);
 
-        $this->server->services()->delete();
-        Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'remote-monitor',
-            'type' => 'monitoring',
-            'type_data' => [
-                'data_retention' => 7,
-            ],
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-        $nginx = $this->server->services()->create([
-            'type' => 'webserver',
-            'name' => 'nginx',
-            'version' => 'latest',
-            'status' => ServiceStatus::STOPPED,
-        ]);
+    $this->server->services()->delete();
+    Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'remote-monitor',
+        'type' => 'monitoring',
+        'type_data' => [
+            'data_retention' => 7,
+        ],
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+    $nginx = $this->server->services()->create([
+        'type' => 'webserver',
+        'name' => 'nginx',
+        'version' => 'latest',
+        'status' => ServiceStatus::STOPPED,
+    ]);
 
-        $this->artisan('metrics:get')->assertSuccessful();
+    $this->artisan('metrics:get')->assertSuccessful();
 
-        SSH::assertExecutedContains('is-active');
-        $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
-        Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $nginx->id
-            && $event->previousStatus === ServiceStatus::STOPPED
-            && $event->newStatus === ServiceStatus::READY);
-    }
+    SSH::assertExecutedContains('is-active');
+    $this->assertDatabaseHas('services', ['id' => $nginx->id, 'status' => ServiceStatus::READY]);
+    Event::assertDispatched(fn (ServiceStatusChanged $event): bool => $event->service->id === $nginx->id
+        && $event->previousStatus === ServiceStatus::STOPPED
+        && $event->newStatus === ServiceStatus::READY);
+});
 
-    public function test_get_metrics_with_missing_extended_fields(): void
-    {
-        SSH::fake(<<<'EOF'
+test('get metrics with missing extended fields', function () {
+    SSH::fake(<<<'EOF'
             load:1
             memory_total:1
             memory_used:1
@@ -118,30 +110,29 @@ class GetMetricsCommandTest extends TestCase
             disk_free:1
         EOF);
 
-        Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'remote-monitor',
-            'type' => 'monitoring',
-            'type_data' => [
-                'data_retention' => 7,
-            ],
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
+    Service::factory()->create([
+        'server_id' => $this->server->id,
+        'name' => 'remote-monitor',
+        'type' => 'monitoring',
+        'type_data' => [
+            'data_retention' => 7,
+        ],
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
 
-        $this->artisan('metrics:get')
-            ->expectsOutput('Checked 1 metrics');
+    $this->artisan('metrics:get')
+        ->expectsOutput('Checked 1 metrics');
 
-        $this->assertDatabaseHas('metrics', [
-            'server_id' => $this->server->id,
-            'load' => 1,
-            'cpu_cores' => null,
-            'cpu_usage_percent' => null,
-            'cpu_steal_percent' => null,
-            'swap_total' => null,
-            'uptime_seconds' => null,
-            'oom_kill_count' => null,
-            'reboot_required' => false,
-        ]);
-    }
-}
+    $this->assertDatabaseHas('metrics', [
+        'server_id' => $this->server->id,
+        'load' => 1,
+        'cpu_cores' => null,
+        'cpu_usage_percent' => null,
+        'cpu_steal_percent' => null,
+        'swap_total' => null,
+        'uptime_seconds' => null,
+        'oom_kill_count' => null,
+        'reboot_required' => false,
+    ]);
+});

--- a/tests/Unit/Commands/RunBackupCommandTest.php
+++ b/tests/Unit/Commands/RunBackupCommandTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Unit\Commands;
-
 use App\Enums\BackupFileStatus;
 use App\Enums\BackupStatus;
 use App\Facades\SSH;
@@ -13,128 +11,116 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;
-use Tests\TestCase;
 
-class RunBackupCommandTest extends TestCase
+uses(RefreshDatabase::class);
+
+function vitoPestUnitCommandsRunBackupCommandTestFakeStorageHttp(): void
 {
-    use RefreshDatabase;
-
-    private function fakeStorageHttp(): void
-    {
-        Http::fake([
-            '*oauth2/token' => Http::response([
-                'access_token' => 'fresh-access',
-                'expires_in' => 14400,
-            ]),
-            '*' => Http::response([], 200),
-        ]);
-    }
-
-    private function createBackup(array $attributes): Backup
-    {
-        $database = Database::factory()->create(['server_id' => $this->server]);
-        $storage = StorageProvider::factory()->dropbox()->create(['user_id' => $this->user->id]);
-
-        return Backup::factory()->create(array_merge([
-            'server_id' => $this->server->id,
-            'database_id' => $database->id,
-            'storage_id' => $storage->id,
-            'keep_backups' => 10,
-        ], $attributes));
-    }
-
-    public function test_run_without_any_backups(): void
-    {
-        $this->artisan('backups:run')
-            ->expectsOutput('0 backups started');
-    }
-
-    public function test_runs_backups_that_are_due(): void
-    {
-        SSH::fake();
-        $this->fakeStorageHttp();
-        Carbon::setTestNow('2026-06-19 10:00:00');
-
-        $this->createBackup(['interval' => '0 * * * *']);
-
-        $this->artisan('backups:run')
-            ->expectsOutput('1 backups started');
-    }
-
-    public function test_does_not_run_backups_that_are_not_due(): void
-    {
-        SSH::fake();
-        Carbon::setTestNow('2026-06-19 10:00:00');
-
-        $this->createBackup(['interval' => '30 * * * *']);
-
-        $this->artisan('backups:run')
-            ->expectsOutput('0 backups started');
-    }
-
-    public function test_runs_custom_interval_backups_when_due(): void
-    {
-        SSH::fake();
-        $this->fakeStorageHttp();
-        Carbon::setTestNow('2026-06-19 10:05:00');
-
-        $this->createBackup(['interval' => '5 10 * * *']);
-
-        $this->artisan('backups:run')
-            ->expectsOutput('1 backups started');
-    }
-
-    public function test_does_not_run_disabled_backups(): void
-    {
-        SSH::fake();
-        Carbon::setTestNow('2026-06-19 10:00:00');
-
-        $this->createBackup(['interval' => '* * * * *', 'enabled' => false]);
-
-        $this->artisan('backups:run')
-            ->expectsOutput('0 backups started');
-    }
-
-    public function test_does_not_run_backups_being_deleted(): void
-    {
-        SSH::fake();
-        Carbon::setTestNow('2026-06-19 10:00:00');
-
-        $this->createBackup(['interval' => '* * * * *', 'status' => BackupStatus::DELETING]);
-
-        $this->artisan('backups:run')
-            ->expectsOutput('0 backups started');
-    }
-
-    public function test_runs_enabled_backup_even_after_a_failed_run(): void
-    {
-        SSH::fake();
-        $this->fakeStorageHttp();
-        Carbon::setTestNow('2026-06-19 10:00:00');
-
-        $backup = $this->createBackup(['interval' => '0 * * * *', 'status' => null, 'enabled' => true]);
-
-        BackupFile::factory()->create([
-            'backup_id' => $backup->id,
-            'status' => BackupFileStatus::FAILED,
-        ]);
-
-        $this->artisan('backups:run')
-            ->expectsOutput('1 backups started');
-    }
-
-    public function test_does_not_run_backups_whose_server_is_missing(): void
-    {
-        SSH::fake();
-        Bus::fake();
-        Carbon::setTestNow('2026-06-19 10:00:00');
-
-        $backup = $this->createBackup(['interval' => '0 * * * *', 'server_id' => 999999]);
-
-        $this->artisan('backups:run')
-            ->expectsOutput('0 backups started');
-
-        $this->assertDatabaseHas('backups', ['id' => $backup->id, 'server_id' => 999999]);
-        Bus::assertNothingDispatched();
-    }
+    Http::fake([
+        '*oauth2/token' => Http::response([
+            'access_token' => 'fresh-access',
+            'expires_in' => 14400,
+        ]),
+        '*' => Http::response([], 200),
+    ]);
 }
+
+function vitoPestUnitCommandsRunBackupCommandTestCreateBackup(array $attributes): Backup
+{
+    $database = Database::factory()->create(['server_id' => test()->server]);
+    $storage = StorageProvider::factory()->dropbox()->create(['user_id' => test()->user->id]);
+
+    return Backup::factory()->create(array_merge([
+        'server_id' => test()->server->id,
+        'database_id' => $database->id,
+        'storage_id' => $storage->id,
+        'keep_backups' => 10,
+    ], $attributes));
+}
+
+test('run without any backups', function () {
+    $this->artisan('backups:run')
+        ->expectsOutput('0 backups started');
+});
+
+test('runs backups that are due', function () {
+    SSH::fake();
+    vitoPestUnitCommandsRunBackupCommandTestFakeStorageHttp();
+    Carbon::setTestNow('2026-06-19 10:00:00');
+
+    vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '0 * * * *']);
+
+    $this->artisan('backups:run')
+        ->expectsOutput('1 backups started');
+});
+
+test('does not run backups that are not due', function () {
+    SSH::fake();
+    Carbon::setTestNow('2026-06-19 10:00:00');
+
+    vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '30 * * * *']);
+
+    $this->artisan('backups:run')
+        ->expectsOutput('0 backups started');
+});
+
+test('runs custom interval backups when due', function () {
+    SSH::fake();
+    vitoPestUnitCommandsRunBackupCommandTestFakeStorageHttp();
+    Carbon::setTestNow('2026-06-19 10:05:00');
+
+    vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '5 10 * * *']);
+
+    $this->artisan('backups:run')
+        ->expectsOutput('1 backups started');
+});
+
+test('does not run disabled backups', function () {
+    SSH::fake();
+    Carbon::setTestNow('2026-06-19 10:00:00');
+
+    vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '* * * * *', 'enabled' => false]);
+
+    $this->artisan('backups:run')
+        ->expectsOutput('0 backups started');
+});
+
+test('does not run backups being deleted', function () {
+    SSH::fake();
+    Carbon::setTestNow('2026-06-19 10:00:00');
+
+    vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '* * * * *', 'status' => BackupStatus::DELETING]);
+
+    $this->artisan('backups:run')
+        ->expectsOutput('0 backups started');
+});
+
+test('runs enabled backup even after a failed run', function () {
+    SSH::fake();
+    vitoPestUnitCommandsRunBackupCommandTestFakeStorageHttp();
+    Carbon::setTestNow('2026-06-19 10:00:00');
+
+    $backup = vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '0 * * * *', 'status' => null, 'enabled' => true]);
+
+    BackupFile::factory()->create([
+        'backup_id' => $backup->id,
+        'status' => BackupFileStatus::FAILED,
+    ]);
+
+    $this->artisan('backups:run')
+        ->expectsOutput('1 backups started');
+});
+
+test('does not run backups whose server is missing', function () {
+    SSH::fake();
+    Bus::fake();
+    Carbon::setTestNow('2026-06-19 10:00:00');
+
+    $backup = vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '0 * * * *', 'server_id' => 999999]);
+
+    $this->artisan('backups:run')
+        ->expectsOutput('0 backups started');
+
+    $this->assertDatabaseHas('backups', ['id' => $backup->id, 'server_id' => 999999]);
+    Bus::assertNothingDispatched();
+});

--- a/tests/Unit/Commands/RunBackupCommandTest.php
+++ b/tests/Unit/Commands/RunBackupCommandTest.php
@@ -25,9 +25,12 @@ function vitoPestUnitCommandsRunBackupCommandTestFakeStorageHttp(): void
     ]);
 }
 
+/**
+ * @param  array{interval: string, enabled?: bool, status?: BackupStatus|null, server_id?: int}  $attributes
+ */
 function vitoPestUnitCommandsRunBackupCommandTestCreateBackup(array $attributes): Backup
 {
-    $database = Database::factory()->create(['server_id' => test()->server]);
+    $database = Database::factory()->create(['server_id' => test()->server->id]);
     $storage = StorageProvider::factory()->dropbox()->create(['user_id' => test()->user->id]);
 
     return Backup::factory()->create(array_merge([

--- a/tests/Unit/Commands/VacuumDatabaseCommandTest.php
+++ b/tests/Unit/Commands/VacuumDatabaseCommandTest.php
@@ -1,61 +1,51 @@
 <?php
 
-namespace Tests\Unit\Commands;
-
 use Illuminate\Database\Connection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
-use Mockery;
-use Tests\TestCase;
 
-class VacuumDatabaseCommandTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_skips_when_connection_is_not_sqlite(): void
-    {
-        $connection = Mockery::mock(Connection::class);
-        $connection->shouldReceive('getDriverName')->andReturn('mysql');
-        $connection->shouldNotReceive('statement');
+test('skips when connection is not sqlite', function () {
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('getDriverName')->andReturn('mysql');
+    $connection->shouldNotReceive('statement');
 
-        DB::shouldReceive('connection')->andReturn($connection);
+    DB::shouldReceive('connection')->andReturn($connection);
 
-        $this->artisan('db:vacuum')
-            ->expectsOutput('VACUUM is only supported on SQLite connections. Skipping.')
-            ->assertSuccessful();
-    }
+    $this->artisan('db:vacuum')
+        ->expectsOutput('VACUUM is only supported on SQLite connections. Skipping.')
+        ->assertSuccessful();
+});
 
-    public function test_skips_when_database_file_is_missing(): void
-    {
-        $connection = Mockery::mock(Connection::class);
-        $connection->shouldReceive('getDriverName')->andReturn('sqlite');
-        $connection->shouldReceive('getDatabaseName')->andReturn('/path/that/does/not/exist.sqlite');
-        $connection->shouldNotReceive('statement');
+test('skips when database file is missing', function () {
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('getDriverName')->andReturn('sqlite');
+    $connection->shouldReceive('getDatabaseName')->andReturn('/path/that/does/not/exist.sqlite');
+    $connection->shouldNotReceive('statement');
 
-        DB::shouldReceive('connection')->andReturn($connection);
+    DB::shouldReceive('connection')->andReturn($connection);
 
-        $this->artisan('db:vacuum')
-            ->expectsOutput('Could not locate the SQLite database file. Skipping.')
-            ->assertSuccessful();
-    }
+    $this->artisan('db:vacuum')
+        ->expectsOutput('Could not locate the SQLite database file. Skipping.')
+        ->assertSuccessful();
+});
 
-    public function test_vacuums_when_disk_space_is_sufficient(): void
-    {
-        $database = tempnam(sys_get_temp_dir(), 'vito-vacuum-test-');
-        file_put_contents($database, 'x');
+test('vacuums when disk space is sufficient', function () {
+    $database = tempnam(sys_get_temp_dir(), 'vito-vacuum-test-');
+    file_put_contents($database, 'x');
 
-        $connection = Mockery::mock(Connection::class);
-        $connection->shouldReceive('getDriverName')->andReturn('sqlite');
-        $connection->shouldReceive('getDatabaseName')->andReturn($database);
-        $connection->shouldReceive('statement')->once()->with('VACUUM');
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('getDriverName')->andReturn('sqlite');
+    $connection->shouldReceive('getDatabaseName')->andReturn($database);
+    $connection->shouldReceive('statement')->once()->with('VACUUM');
 
-        DB::shouldReceive('connection')->andReturn($connection);
+    DB::shouldReceive('connection')->andReturn($connection);
 
-        $this->artisan('db:vacuum')
-            ->expectsOutput('Vacuuming the database...')
-            ->expectsOutput('Database vacuumed!')
-            ->assertSuccessful();
+    $this->artisan('db:vacuum')
+        ->expectsOutput('Vacuuming the database...')
+        ->expectsOutput('Database vacuumed!')
+        ->assertSuccessful();
 
-        unlink($database);
-    }
-}
+    unlink($database);
+});

--- a/tests/Unit/Commands/VacuumDatabaseCommandTest.php
+++ b/tests/Unit/Commands/VacuumDatabaseCommandTest.php
@@ -35,17 +35,19 @@ test('vacuums when disk space is sufficient', function () {
     $database = tempnam(sys_get_temp_dir(), 'vito-vacuum-test-');
     file_put_contents($database, 'x');
 
-    $connection = Mockery::mock(Connection::class);
-    $connection->shouldReceive('getDriverName')->andReturn('sqlite');
-    $connection->shouldReceive('getDatabaseName')->andReturn($database);
-    $connection->shouldReceive('statement')->once()->with('VACUUM');
+    try {
+        $connection = Mockery::mock(Connection::class);
+        $connection->shouldReceive('getDriverName')->andReturn('sqlite');
+        $connection->shouldReceive('getDatabaseName')->andReturn($database);
+        $connection->shouldReceive('statement')->once()->with('VACUUM');
 
-    DB::shouldReceive('connection')->andReturn($connection);
+        DB::shouldReceive('connection')->andReturn($connection);
 
-    $this->artisan('db:vacuum')
-        ->expectsOutput('Vacuuming the database...')
-        ->expectsOutput('Database vacuumed!')
-        ->assertSuccessful();
-
-    unlink($database);
+        $this->artisan('db:vacuum')
+            ->expectsOutput('Vacuuming the database...')
+            ->expectsOutput('Database vacuumed!')
+            ->assertSuccessful();
+    } finally {
+        unlink($database);
+    }
 });

--- a/tests/Unit/DNSProviders/CloudflareTest.php
+++ b/tests/Unit/DNSProviders/CloudflareTest.php
@@ -1,782 +1,737 @@
 <?php
 
-namespace Tests\Unit\DNSProviders;
-
 use App\DNSProviders\Cloudflare;
 use App\Models\DNSProvider as DNSProviderModel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Validation\ValidationException;
-use Tests\TestCase;
 
-class CloudflareTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    private DNSProviderModel $dnsProvider;
+beforeEach(function () {
+    $this->dnsProvider = DNSProviderModel::factory()->create([
+        'provider' => 'cloudflare',
+        'credentials' => [
+            'token' => 'test-token-123',
+        ],
+    ]);
 
-    private Cloudflare $cloudflare;
+    $this->cloudflare = new Cloudflare($this->dnsProvider);
+});
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+test('id returns cloudflare', function () {
+    expect(Cloudflare::id())->toBe('cloudflare');
+});
 
-        $this->dnsProvider = DNSProviderModel::factory()->create([
-            'provider' => 'cloudflare',
-            'credentials' => [
-                'token' => 'test-token-123',
+test('validation rules', function () {
+    $rules = $this->cloudflare->validationRules([]);
+
+    expect($rules)->toBe([
+        'token' => 'required|string',
+    ]);
+});
+
+test('credential data', function () {
+    $input = [
+        'token' => 'test-token-456',
+    ];
+
+    $credentialData = $this->cloudflare->credentialData($input);
+
+    expect($credentialData)->toBe([
+        'token' => 'test-token-456',
+    ]);
+});
+
+test('connect success', function () {
+    Http::fake([
+        'api.cloudflare.com/client/v4/zones*' => Http::response([
+            'success' => true,
+            'result' => [],
+        ], 200),
+    ]);
+
+    $credentials = ['token' => 'test-token-123'];
+
+    $result = $this->cloudflare->connect($credentials);
+
+    expect($result)->toBeTrue();
+
+    Http::assertSent(function (Request $request) {
+        return str_contains($request->url(), 'api.cloudflare.com/client/v4/zones')
+            && str_contains($request->url(), 'per_page=1')
+            && $request->header('Authorization')[0] === 'Bearer test-token-123'
+            && $request->header('Content-Type')[0] === 'application/json';
+    });
+});
+
+test('connect failure invalid response', function () {
+    Http::fake([
+        'api.cloudflare.com/client/v4/zones*' => Http::response([
+            'success' => false,
+            'errors' => [
+                ['message' => 'Invalid token'],
             ],
-        ]);
+        ], 200),
+    ]);
 
-        $this->cloudflare = new Cloudflare($this->dnsProvider);
-    }
+    $credentials = ['token' => 'invalid-token'];
 
-    public function test_id_returns_cloudflare(): void
-    {
-        $this->assertSame('cloudflare', Cloudflare::id());
-    }
+    $result = $this->cloudflare->connect($credentials);
 
-    public function test_validation_rules(): void
-    {
-        $rules = $this->cloudflare->validationRules([]);
+    expect($result)->toBeFalse();
+});
 
-        $this->assertSame([
-            'token' => 'required|string',
-        ], $rules);
-    }
+test('connect failure http error', function () {
+    Http::fake([
+        'api.cloudflare.com/client/v4/zones*' => Http::response([], 401),
+    ]);
 
-    public function test_credential_data(): void
-    {
-        $input = [
-            'token' => 'test-token-456',
-        ];
+    $credentials = ['token' => 'invalid-token'];
 
-        $credentialData = $this->cloudflare->credentialData($input);
+    $result = $this->cloudflare->connect($credentials);
 
-        $this->assertSame([
-            'token' => 'test-token-456',
-        ], $credentialData);
-    }
+    expect($result)->toBeFalse();
+});
 
-    public function test_connect_success(): void
-    {
-        Http::fake([
-            'api.cloudflare.com/client/v4/zones*' => Http::response([
-                'success' => true,
-                'result' => [],
-            ], 200),
-        ]);
+test('connect exception', function () {
+    Http::fake(function () {
+        throw new Exception('Network error');
+    });
 
-        $credentials = ['token' => 'test-token-123'];
+    $credentials = ['token' => 'test-token'];
 
-        $result = $this->cloudflare->connect($credentials);
+    $result = $this->cloudflare->connect($credentials);
 
-        $this->assertTrue($result);
+    expect($result)->toBeFalse();
+});
 
-        Http::assertSent(function (Request $request) {
-            return str_contains($request->url(), 'api.cloudflare.com/client/v4/zones')
-                && str_contains($request->url(), 'per_page=1')
-                && $request->header('Authorization')[0] === 'Bearer test-token-123'
-                && $request->header('Content-Type')[0] === 'application/json';
-        });
-    }
-
-    public function test_connect_failure_invalid_response(): void
-    {
-        Http::fake([
-            'api.cloudflare.com/client/v4/zones*' => Http::response([
-                'success' => false,
-                'errors' => [
-                    ['message' => 'Invalid token'],
-                ],
-            ], 200),
-        ]);
-
-        $credentials = ['token' => 'invalid-token'];
-
-        $result = $this->cloudflare->connect($credentials);
-
-        $this->assertFalse($result);
-    }
-
-    public function test_connect_failure_http_error(): void
-    {
-        Http::fake([
-            'api.cloudflare.com/client/v4/zones*' => Http::response([], 401),
-        ]);
-
-        $credentials = ['token' => 'invalid-token'];
-
-        $result = $this->cloudflare->connect($credentials);
-
-        $this->assertFalse($result);
-    }
-
-    public function test_connect_exception(): void
-    {
-        Http::fake(function () {
-            throw new \Exception('Network error');
-        });
-
-        $credentials = ['token' => 'test-token'];
-
-        $result = $this->cloudflare->connect($credentials);
-
-        $this->assertFalse($result);
-    }
-
-    public function test_get_domains_success(): void
-    {
-        Http::fake([
-            'api.cloudflare.com/client/v4/zones*' => Http::response([
-                'success' => true,
-                'result' => [
-                    [
-                        'id' => 'zone-1',
-                        'name' => 'example.com',
-                        'status' => 'active',
-                        'created_on' => '2023-01-01T00:00:00Z',
-                        'modified_on' => '2023-01-02T00:00:00Z',
-                    ],
-                    [
-                        'id' => 'zone-2',
-                        'name' => 'test.com',
-                        'status' => 'pending',
-                        'created_on' => '2023-01-03T00:00:00Z',
-                        'modified_on' => '2023-01-04T00:00:00Z',
-                    ],
-                ],
-            ], 200),
-        ]);
-
-        $domains = $this->cloudflare->getDomains();
-
-        $expected = [
-            [
-                'id' => 'zone-1',
-                'name' => 'example.com',
-                'status' => 'active',
-                'created_on' => '2023-01-01T00:00:00Z',
-                'modified_on' => '2023-01-02T00:00:00Z',
-            ],
-            [
-                'id' => 'zone-2',
-                'name' => 'test.com',
-                'status' => 'pending',
-                'created_on' => '2023-01-03T00:00:00Z',
-                'modified_on' => '2023-01-04T00:00:00Z',
-            ],
-        ];
-
-        $this->assertSame($expected, $domains);
-
-        Http::assertSent(function (Request $request) {
-            return str_contains($request->url(), 'api.cloudflare.com/client/v4/zones')
-                && $request->data()['per_page'] === 100;
-        });
-    }
-
-    public function test_get_domains_failure(): void
-    {
-        Http::fake([
-            'api.cloudflare.com/client/v4/zones*' => Http::response([], 401),
-        ]);
-
-        $domains = $this->cloudflare->getDomains();
-
-        $this->assertSame([], $domains);
-    }
-
-    public function test_get_domains_exception(): void
-    {
-        Http::fake(function () {
-            throw new \Exception('Network error');
-        });
-
-        $domains = $this->cloudflare->getDomains();
-
-        $this->assertSame([], $domains);
-    }
-
-    public function test_get_domain_success(): void
-    {
-        $domainId = 'zone-123';
-
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}" => Http::response([
-                'success' => true,
-                'result' => [
-                    'id' => 'zone-123',
+test('get domains success', function () {
+    Http::fake([
+        'api.cloudflare.com/client/v4/zones*' => Http::response([
+            'success' => true,
+            'result' => [
+                [
+                    'id' => 'zone-1',
                     'name' => 'example.com',
                     'status' => 'active',
                     'created_on' => '2023-01-01T00:00:00Z',
                     'modified_on' => '2023-01-02T00:00:00Z',
                 ],
-            ], 200),
-        ]);
+                [
+                    'id' => 'zone-2',
+                    'name' => 'test.com',
+                    'status' => 'pending',
+                    'created_on' => '2023-01-03T00:00:00Z',
+                    'modified_on' => '2023-01-04T00:00:00Z',
+                ],
+            ],
+        ], 200),
+    ]);
 
-        $domain = $this->cloudflare->getDomain($domainId);
+    $domains = $this->cloudflare->getDomains();
 
-        $expected = [
-            'id' => 'zone-123',
+    $expected = [
+        [
+            'id' => 'zone-1',
             'name' => 'example.com',
             'status' => 'active',
             'created_on' => '2023-01-01T00:00:00Z',
             'modified_on' => '2023-01-02T00:00:00Z',
-        ];
+        ],
+        [
+            'id' => 'zone-2',
+            'name' => 'test.com',
+            'status' => 'pending',
+            'created_on' => '2023-01-03T00:00:00Z',
+            'modified_on' => '2023-01-04T00:00:00Z',
+        ],
+    ];
 
-        $this->assertSame($expected, $domain);
-    }
+    expect($domains)->toBe($expected);
 
-    public function test_get_domain_failure(): void
-    {
-        $domainId = 'invalid-zone';
+    Http::assertSent(function (Request $request) {
+        return str_contains($request->url(), 'api.cloudflare.com/client/v4/zones')
+            && $request->data()['per_page'] === 100;
+    });
+});
 
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}" => Http::response([], 404),
-        ]);
+test('get domains failure', function () {
+    Http::fake([
+        'api.cloudflare.com/client/v4/zones*' => Http::response([], 401),
+    ]);
 
-        $domain = $this->cloudflare->getDomain($domainId);
+    $domains = $this->cloudflare->getDomains();
 
-        $this->assertSame([], $domain);
-    }
+    expect($domains)->toBe([]);
+});
 
-    public function test_get_domain_exception(): void
-    {
-        $domainId = 'zone-123';
+test('get domains exception', function () {
+    Http::fake(function () {
+        throw new Exception('Network error');
+    });
 
-        Http::fake(function () {
-            throw new \Exception('Network error');
-        });
+    $domains = $this->cloudflare->getDomains();
 
-        $domain = $this->cloudflare->getDomain($domainId);
+    expect($domains)->toBe([]);
+});
 
-        $this->assertSame([], $domain);
-    }
+test('get domain success', function () {
+    $domainId = 'zone-123';
 
-    public function test_get_records_success(): void
-    {
-        $domainId = 'zone-123';
-
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records*" => Http::response([
-                'success' => true,
-                'result' => [
-                    [
-                        'id' => 'record-1',
-                        'type' => 'A',
-                        'name' => 'example.com',
-                        'content' => '192.168.1.1',
-                        'ttl' => 300,
-                        'proxied' => false,
-                        'created_on' => '2023-01-01T00:00:00Z',
-                        'modified_on' => '2023-01-02T00:00:00Z',
-                    ],
-                    [
-                        'id' => 'record-2',
-                        'type' => 'CNAME',
-                        'name' => 'www.example.com',
-                        'content' => 'example.com',
-                        'ttl' => 1,
-                        'proxied' => true,
-                        'created_on' => '2023-01-03T00:00:00Z',
-                        'modified_on' => '2023-01-04T00:00:00Z',
-                    ],
-                ],
-            ], 200),
-        ]);
-
-        $records = $this->cloudflare->getRecords($domainId);
-
-        $expected = [
-            [
-                'id' => 'record-1',
-                'type' => 'A',
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}" => Http::response([
+            'success' => true,
+            'result' => [
+                'id' => 'zone-123',
                 'name' => 'example.com',
-                'content' => '192.168.1.1',
-                'ttl' => 300,
-                'proxied' => false,
-                'priority' => null,
+                'status' => 'active',
                 'created_on' => '2023-01-01T00:00:00Z',
                 'modified_on' => '2023-01-02T00:00:00Z',
             ],
-            [
-                'id' => 'record-2',
-                'type' => 'CNAME',
-                'name' => 'www.example.com',
-                'content' => 'example.com',
-                'ttl' => 1,
-                'proxied' => true,
-                'priority' => null,
-                'created_on' => '2023-01-03T00:00:00Z',
-                'modified_on' => '2023-01-04T00:00:00Z',
-            ],
-        ];
+        ], 200),
+    ]);
 
-        $this->assertSame($expected, $records);
-    }
+    $domain = $this->cloudflare->getDomain($domainId);
 
-    public function test_get_records_mx_priority_is_parsed(): void
-    {
-        $domainId = 'zone-123';
+    $expected = [
+        'id' => 'zone-123',
+        'name' => 'example.com',
+        'status' => 'active',
+        'created_on' => '2023-01-01T00:00:00Z',
+        'modified_on' => '2023-01-02T00:00:00Z',
+    ];
 
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records*" => Http::response([
-                'success' => true,
-                'result' => [
-                    [
-                        'id' => 'record-mx',
-                        'type' => 'MX',
-                        'name' => 'example.com',
-                        'content' => 'mail.example.com',
-                        'ttl' => 3600,
-                        'proxied' => false,
-                        'priority' => 10,
-                        'created_on' => '2023-01-01T00:00:00Z',
-                        'modified_on' => '2023-01-02T00:00:00Z',
-                    ],
-                ],
-            ], 200),
-        ]);
+    expect($domain)->toBe($expected);
+});
 
-        $records = $this->cloudflare->getRecords($domainId);
+test('get domain failure', function () {
+    $domainId = 'invalid-zone';
 
-        $this->assertCount(1, $records);
-        $this->assertSame('MX', $records[0]['type']);
-        $this->assertSame(10, $records[0]['priority']);
-    }
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}" => Http::response([], 404),
+    ]);
 
-    public function test_get_records_mx_priority_zero_is_preserved(): void
-    {
-        $domainId = 'zone-123';
+    $domain = $this->cloudflare->getDomain($domainId);
 
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records*" => Http::response([
-                'success' => true,
-                'result' => [
-                    [
-                        'id' => 'record-mx',
-                        'type' => 'MX',
-                        'name' => 'example.com',
-                        'content' => 'mail.example.com',
-                        'ttl' => 3600,
-                        'proxied' => false,
-                        'priority' => 0,
-                        'created_on' => '2023-01-01T00:00:00Z',
-                        'modified_on' => '2023-01-02T00:00:00Z',
-                    ],
-                ],
-            ], 200),
-        ]);
+    expect($domain)->toBe([]);
+});
 
-        $records = $this->cloudflare->getRecords($domainId);
+test('get domain exception', function () {
+    $domainId = 'zone-123';
 
-        $this->assertCount(1, $records);
-        $this->assertSame('MX', $records[0]['type']);
-        $this->assertSame(0, $records[0]['priority']);
-    }
+    Http::fake(function () {
+        throw new Exception('Network error');
+    });
 
-    public function test_get_records_non_mx_priority_is_always_null(): void
-    {
-        $domainId = 'zone-123';
+    $domain = $this->cloudflare->getDomain($domainId);
 
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records*" => Http::response([
-                'success' => true,
-                'result' => [
-                    [
-                        'id' => 'record-a',
-                        'type' => 'A',
-                        'name' => 'example.com',
-                        'content' => '192.168.1.1',
-                        'ttl' => 300,
-                        'proxied' => false,
-                        'priority' => 5,
-                        'created_on' => '2023-01-01T00:00:00Z',
-                        'modified_on' => '2023-01-02T00:00:00Z',
-                    ],
-                    [
-                        'id' => 'record-cname',
-                        'type' => 'CNAME',
-                        'name' => 'www.example.com',
-                        'content' => 'example.com',
-                        'ttl' => 1,
-                        'proxied' => true,
-                        'priority' => 10,
-                        'created_on' => '2023-01-03T00:00:00Z',
-                        'modified_on' => '2023-01-04T00:00:00Z',
-                    ],
-                    [
-                        'id' => 'record-txt',
-                        'type' => 'TXT',
-                        'name' => 'example.com',
-                        'content' => 'v=spf1 include:example.com ~all',
-                        'ttl' => 600,
-                        'proxied' => false,
-                        'priority' => 0,
-                        'created_on' => '2023-01-05T00:00:00Z',
-                        'modified_on' => '2023-01-06T00:00:00Z',
-                    ],
-                ],
-            ], 200),
-        ]);
+    expect($domain)->toBe([]);
+});
 
-        $records = $this->cloudflare->getRecords($domainId);
+test('get records success', function () {
+    $domainId = 'zone-123';
 
-        $this->assertCount(3, $records);
-
-        foreach ($records as $record) {
-            $this->assertNull($record['priority'], "Expected null priority for {$record['type']} record, got {$record['priority']}");
-        }
-    }
-
-    public function test_get_records_mx_without_priority_returns_null(): void
-    {
-        $domainId = 'zone-123';
-
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records*" => Http::response([
-                'success' => true,
-                'result' => [
-                    [
-                        'id' => 'record-mx',
-                        'type' => 'MX',
-                        'name' => 'example.com',
-                        'content' => 'mail.example.com',
-                        'ttl' => 3600,
-                        'proxied' => false,
-                        'created_on' => '2023-01-01T00:00:00Z',
-                        'modified_on' => '2023-01-02T00:00:00Z',
-                    ],
-                ],
-            ], 200),
-        ]);
-
-        $records = $this->cloudflare->getRecords($domainId);
-
-        $this->assertCount(1, $records);
-        $this->assertSame('MX', $records[0]['type']);
-        $this->assertNull($records[0]['priority']);
-    }
-
-    public function test_get_records_failure(): void
-    {
-        $domainId = 'invalid-zone';
-
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records*" => Http::response([
-                'success' => false,
-                'errors' => [
-                    ['message' => 'Zone not found'],
-                ],
-            ], 404),
-        ]);
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Failed to fetch DNS records: Zone not found');
-
-        $this->cloudflare->getRecords($domainId);
-    }
-
-    public function test_get_records_exception(): void
-    {
-        $domainId = 'zone-123';
-
-        Http::fake(function () {
-            throw new \Exception('Network error');
-        });
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Network error');
-
-        $this->cloudflare->getRecords($domainId);
-    }
-
-    public function test_create_record_success(): void
-    {
-        $domainId = 'zone-123';
-        $input = [
-            'type' => 'A',
-            'name' => 'test.example.com',
-            'content' => '192.168.1.100',
-            'ttl' => 300,
-            'proxied' => false,
-        ];
-
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records" => Http::response([
-                'success' => true,
-                'result' => [
-                    'id' => 'new-record-123',
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records*" => Http::response([
+            'success' => true,
+            'result' => [
+                [
+                    'id' => 'record-1',
                     'type' => 'A',
-                    'name' => 'test.example.com',
-                    'content' => '192.168.1.100',
+                    'name' => 'example.com',
+                    'content' => '192.168.1.1',
                     'ttl' => 300,
                     'proxied' => false,
+                    'created_on' => '2023-01-01T00:00:00Z',
+                    'modified_on' => '2023-01-02T00:00:00Z',
                 ],
-            ], 200),
-        ]);
+                [
+                    'id' => 'record-2',
+                    'type' => 'CNAME',
+                    'name' => 'www.example.com',
+                    'content' => 'example.com',
+                    'ttl' => 1,
+                    'proxied' => true,
+                    'created_on' => '2023-01-03T00:00:00Z',
+                    'modified_on' => '2023-01-04T00:00:00Z',
+                ],
+            ],
+        ], 200),
+    ]);
 
-        $result = $this->cloudflare->createRecord($domainId, $input);
+    $records = $this->cloudflare->getRecords($domainId);
 
-        $expected = [
-            'id' => 'new-record-123',
+    $expected = [
+        [
+            'id' => 'record-1',
             'type' => 'A',
-            'name' => 'test.example.com',
-            'content' => '192.168.1.100',
+            'name' => 'example.com',
+            'content' => '192.168.1.1',
             'ttl' => 300,
             'proxied' => false,
-        ];
-
-        $this->assertSame($expected, $result);
-    }
-
-    public function test_create_record_with_defaults(): void
-    {
-        $domainId = 'zone-123';
-        $input = [
-            'type' => 'A',
-            'name' => 'test.example.com',
-            'content' => '192.168.1.100',
-        ];
-
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records" => Http::response([
-                'success' => true,
-                'result' => [],
-            ], 200),
-        ]);
-
-        $this->cloudflare->createRecord($domainId, $input);
-
-        Http::assertSent(function (Request $request) use ($domainId) {
-            return $request->url() === "https://api.cloudflare.com/client/v4/zones/{$domainId}/dns_records"
-                && $request->data()['ttl'] === 1
-                && $request->data()['proxied'] === false;
-        });
-    }
-
-    public function test_create_record_failure(): void
-    {
-        $domainId = 'zone-123';
-        $input = [
-            'type' => 'A',
-            'name' => 'test.example.com',
-            'content' => '192.168.1.100',
-        ];
-
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records" => Http::response([
-                'success' => false,
-                'errors' => [
-                    ['message' => 'Invalid record data'],
-                ],
-            ], 400),
-        ]);
-
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Failed to create DNS record: Invalid record data');
-
-        $this->cloudflare->createRecord($domainId, $input);
-    }
-
-    public function test_create_record_failure_unknown_error(): void
-    {
-        $domainId = 'zone-123';
-        $input = [
-            'type' => 'A',
-            'name' => 'test.example.com',
-            'content' => '192.168.1.100',
-        ];
-
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records" => Http::response([
-                'success' => false,
-                'errors' => [],
-            ], 400),
-        ]);
-
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Failed to create DNS record: Unknown error');
-
-        $this->cloudflare->createRecord($domainId, $input);
-    }
-
-    public function test_create_record_exception(): void
-    {
-        $domainId = 'zone-123';
-        $input = [
-            'type' => 'A',
-            'name' => 'test.example.com',
-            'content' => '192.168.1.100',
-        ];
-
-        Http::fake(function () {
-            throw new \Exception('Network error');
-        });
-
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Failed to create DNS record: Network error');
-
-        $this->cloudflare->createRecord($domainId, $input);
-    }
-
-    public function test_update_record_success(): void
-    {
-        $domainId = 'zone-123';
-        $recordId = 'record-456';
-        $input = [
-            'type' => 'A',
-            'name' => 'updated.example.com',
-            'content' => '192.168.1.200',
-            'ttl' => 600,
+            'priority' => null,
+            'created_on' => '2023-01-01T00:00:00Z',
+            'modified_on' => '2023-01-02T00:00:00Z',
+        ],
+        [
+            'id' => 'record-2',
+            'type' => 'CNAME',
+            'name' => 'www.example.com',
+            'content' => 'example.com',
+            'ttl' => 1,
             'proxied' => true,
-        ];
+            'priority' => null,
+            'created_on' => '2023-01-03T00:00:00Z',
+            'modified_on' => '2023-01-04T00:00:00Z',
+        ],
+    ];
 
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records/{$recordId}" => Http::response([
-                'success' => true,
-                'result' => [
-                    'id' => 'record-456',
+    expect($records)->toBe($expected);
+});
+
+test('get records mx priority is parsed', function () {
+    $domainId = 'zone-123';
+
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records*" => Http::response([
+            'success' => true,
+            'result' => [
+                [
+                    'id' => 'record-mx',
+                    'type' => 'MX',
+                    'name' => 'example.com',
+                    'content' => 'mail.example.com',
+                    'ttl' => 3600,
+                    'proxied' => false,
+                    'priority' => 10,
+                    'created_on' => '2023-01-01T00:00:00Z',
+                    'modified_on' => '2023-01-02T00:00:00Z',
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $records = $this->cloudflare->getRecords($domainId);
+
+    expect($records)->toHaveCount(1);
+    expect($records[0]['type'])->toBe('MX');
+    expect($records[0]['priority'])->toBe(10);
+});
+
+test('get records mx priority zero is preserved', function () {
+    $domainId = 'zone-123';
+
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records*" => Http::response([
+            'success' => true,
+            'result' => [
+                [
+                    'id' => 'record-mx',
+                    'type' => 'MX',
+                    'name' => 'example.com',
+                    'content' => 'mail.example.com',
+                    'ttl' => 3600,
+                    'proxied' => false,
+                    'priority' => 0,
+                    'created_on' => '2023-01-01T00:00:00Z',
+                    'modified_on' => '2023-01-02T00:00:00Z',
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $records = $this->cloudflare->getRecords($domainId);
+
+    expect($records)->toHaveCount(1);
+    expect($records[0]['type'])->toBe('MX');
+    expect($records[0]['priority'])->toBe(0);
+});
+
+test('get records non mx priority is always null', function () {
+    $domainId = 'zone-123';
+
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records*" => Http::response([
+            'success' => true,
+            'result' => [
+                [
+                    'id' => 'record-a',
                     'type' => 'A',
-                    'name' => 'updated.example.com',
-                    'content' => '192.168.1.200',
-                    'ttl' => 600,
+                    'name' => 'example.com',
+                    'content' => '192.168.1.1',
+                    'ttl' => 300,
+                    'proxied' => false,
+                    'priority' => 5,
+                    'created_on' => '2023-01-01T00:00:00Z',
+                    'modified_on' => '2023-01-02T00:00:00Z',
+                ],
+                [
+                    'id' => 'record-cname',
+                    'type' => 'CNAME',
+                    'name' => 'www.example.com',
+                    'content' => 'example.com',
+                    'ttl' => 1,
                     'proxied' => true,
+                    'priority' => 10,
+                    'created_on' => '2023-01-03T00:00:00Z',
+                    'modified_on' => '2023-01-04T00:00:00Z',
                 ],
-            ], 200),
-        ]);
-
-        $result = $this->cloudflare->updateRecord($domainId, $recordId, $input);
-
-        $expected = [
-            'id' => 'record-456',
-            'type' => 'A',
-            'name' => 'updated.example.com',
-            'content' => '192.168.1.200',
-            'ttl' => 600,
-            'proxied' => true,
-        ];
-
-        $this->assertSame($expected, $result);
-    }
-
-    public function test_update_record_with_defaults(): void
-    {
-        $domainId = 'zone-123';
-        $recordId = 'record-456';
-        $input = [
-            'type' => 'A',
-            'name' => 'updated.example.com',
-            'content' => '192.168.1.200',
-        ];
-
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records/{$recordId}" => Http::response([
-                'success' => true,
-                'result' => [],
-            ], 200),
-        ]);
-
-        $this->cloudflare->updateRecord($domainId, $recordId, $input);
-
-        Http::assertSent(function (Request $request) use ($domainId, $recordId) {
-            return $request->url() === "https://api.cloudflare.com/client/v4/zones/{$domainId}/dns_records/{$recordId}"
-                && $request->data()['ttl'] === 1
-                && $request->data()['proxied'] === false;
-        });
-    }
-
-    public function test_update_record_failure(): void
-    {
-        $domainId = 'zone-123';
-        $recordId = 'record-456';
-        $input = [
-            'type' => 'A',
-            'name' => 'updated.example.com',
-            'content' => '192.168.1.200',
-        ];
-
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records/{$recordId}" => Http::response([
-                'success' => false,
-                'errors' => [
-                    ['message' => 'Record not found'],
+                [
+                    'id' => 'record-txt',
+                    'type' => 'TXT',
+                    'name' => 'example.com',
+                    'content' => 'v=spf1 include:example.com ~all',
+                    'ttl' => 600,
+                    'proxied' => false,
+                    'priority' => 0,
+                    'created_on' => '2023-01-05T00:00:00Z',
+                    'modified_on' => '2023-01-06T00:00:00Z',
                 ],
-            ], 404),
-        ]);
+            ],
+        ], 200),
+    ]);
 
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Failed to update DNS record: Record not found');
+    $records = $this->cloudflare->getRecords($domainId);
 
-        $this->cloudflare->updateRecord($domainId, $recordId, $input);
+    expect($records)->toHaveCount(3);
+
+    foreach ($records as $record) {
+        expect($record['priority'])->toBeNull("Expected null priority for {$record['type']} record, got {$record['priority']}");
     }
+});
 
-    public function test_update_record_exception(): void
-    {
-        $domainId = 'zone-123';
-        $recordId = 'record-456';
-        $input = [
-            'type' => 'A',
-            'name' => 'updated.example.com',
-            'content' => '192.168.1.200',
-        ];
+test('get records mx without priority returns null', function () {
+    $domainId = 'zone-123';
 
-        Http::fake(function () {
-            throw new \Exception('Network error');
-        });
-
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Failed to update DNS record: Network error');
-
-        $this->cloudflare->updateRecord($domainId, $recordId, $input);
-    }
-
-    public function test_delete_record_success(): void
-    {
-        $domainId = 'zone-123';
-        $recordId = 'record-456';
-
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records/{$recordId}" => Http::response([
-                'success' => true,
-                'result' => [
-                    'id' => 'record-456',
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records*" => Http::response([
+            'success' => true,
+            'result' => [
+                [
+                    'id' => 'record-mx',
+                    'type' => 'MX',
+                    'name' => 'example.com',
+                    'content' => 'mail.example.com',
+                    'ttl' => 3600,
+                    'proxied' => false,
+                    'created_on' => '2023-01-01T00:00:00Z',
+                    'modified_on' => '2023-01-02T00:00:00Z',
                 ],
-            ], 200),
-        ]);
+            ],
+        ], 200),
+    ]);
 
-        $result = $this->cloudflare->deleteRecord($domainId, $recordId);
+    $records = $this->cloudflare->getRecords($domainId);
 
-        $this->assertTrue($result);
-    }
+    expect($records)->toHaveCount(1);
+    expect($records[0]['type'])->toBe('MX');
+    expect($records[0]['priority'])->toBeNull();
+});
 
-    public function test_delete_record_failure(): void
-    {
-        $domainId = 'zone-123';
-        $recordId = 'invalid-record';
+test('get records failure', function () {
+    $domainId = 'invalid-zone';
 
-        Http::fake([
-            "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records/{$recordId}" => Http::response([], 404),
-        ]);
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records*" => Http::response([
+            'success' => false,
+            'errors' => [
+                ['message' => 'Zone not found'],
+            ],
+        ], 404),
+    ]);
 
-        $result = $this->cloudflare->deleteRecord($domainId, $recordId);
+    $this->expectException(RuntimeException::class);
+    $this->expectExceptionMessage('Failed to fetch DNS records: Zone not found');
 
-        $this->assertFalse($result);
-    }
+    $this->cloudflare->getRecords($domainId);
+});
 
-    public function test_delete_record_exception(): void
-    {
-        $domainId = 'zone-123';
-        $recordId = 'record-456';
+test('get records exception', function () {
+    $domainId = 'zone-123';
 
-        Http::fake(function () {
-            throw new \Exception('Network error');
-        });
+    Http::fake(function () {
+        throw new Exception('Network error');
+    });
 
-        $result = $this->cloudflare->deleteRecord($domainId, $recordId);
+    $this->expectException(Exception::class);
+    $this->expectExceptionMessage('Network error');
 
-        $this->assertFalse($result);
-    }
-}
+    $this->cloudflare->getRecords($domainId);
+});
+
+test('create record success', function () {
+    $domainId = 'zone-123';
+    $input = [
+        'type' => 'A',
+        'name' => 'test.example.com',
+        'content' => '192.168.1.100',
+        'ttl' => 300,
+        'proxied' => false,
+    ];
+
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records" => Http::response([
+            'success' => true,
+            'result' => [
+                'id' => 'new-record-123',
+                'type' => 'A',
+                'name' => 'test.example.com',
+                'content' => '192.168.1.100',
+                'ttl' => 300,
+                'proxied' => false,
+            ],
+        ], 200),
+    ]);
+
+    $result = $this->cloudflare->createRecord($domainId, $input);
+
+    $expected = [
+        'id' => 'new-record-123',
+        'type' => 'A',
+        'name' => 'test.example.com',
+        'content' => '192.168.1.100',
+        'ttl' => 300,
+        'proxied' => false,
+    ];
+
+    expect($result)->toBe($expected);
+});
+
+test('create record with defaults', function () {
+    $domainId = 'zone-123';
+    $input = [
+        'type' => 'A',
+        'name' => 'test.example.com',
+        'content' => '192.168.1.100',
+    ];
+
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records" => Http::response([
+            'success' => true,
+            'result' => [],
+        ], 200),
+    ]);
+
+    $this->cloudflare->createRecord($domainId, $input);
+
+    Http::assertSent(function (Request $request) use ($domainId) {
+        return $request->url() === "https://api.cloudflare.com/client/v4/zones/{$domainId}/dns_records"
+            && $request->data()['ttl'] === 1
+            && $request->data()['proxied'] === false;
+    });
+});
+
+test('create record failure', function () {
+    $domainId = 'zone-123';
+    $input = [
+        'type' => 'A',
+        'name' => 'test.example.com',
+        'content' => '192.168.1.100',
+    ];
+
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records" => Http::response([
+            'success' => false,
+            'errors' => [
+                ['message' => 'Invalid record data'],
+            ],
+        ], 400),
+    ]);
+
+    $this->expectException(ValidationException::class);
+    $this->expectExceptionMessage('Failed to create DNS record: Invalid record data');
+
+    $this->cloudflare->createRecord($domainId, $input);
+});
+
+test('create record failure unknown error', function () {
+    $domainId = 'zone-123';
+    $input = [
+        'type' => 'A',
+        'name' => 'test.example.com',
+        'content' => '192.168.1.100',
+    ];
+
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records" => Http::response([
+            'success' => false,
+            'errors' => [],
+        ], 400),
+    ]);
+
+    $this->expectException(ValidationException::class);
+    $this->expectExceptionMessage('Failed to create DNS record: Unknown error');
+
+    $this->cloudflare->createRecord($domainId, $input);
+});
+
+test('create record exception', function () {
+    $domainId = 'zone-123';
+    $input = [
+        'type' => 'A',
+        'name' => 'test.example.com',
+        'content' => '192.168.1.100',
+    ];
+
+    Http::fake(function () {
+        throw new Exception('Network error');
+    });
+
+    $this->expectException(ValidationException::class);
+    $this->expectExceptionMessage('Failed to create DNS record: Network error');
+
+    $this->cloudflare->createRecord($domainId, $input);
+});
+
+test('update record success', function () {
+    $domainId = 'zone-123';
+    $recordId = 'record-456';
+    $input = [
+        'type' => 'A',
+        'name' => 'updated.example.com',
+        'content' => '192.168.1.200',
+        'ttl' => 600,
+        'proxied' => true,
+    ];
+
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records/{$recordId}" => Http::response([
+            'success' => true,
+            'result' => [
+                'id' => 'record-456',
+                'type' => 'A',
+                'name' => 'updated.example.com',
+                'content' => '192.168.1.200',
+                'ttl' => 600,
+                'proxied' => true,
+            ],
+        ], 200),
+    ]);
+
+    $result = $this->cloudflare->updateRecord($domainId, $recordId, $input);
+
+    $expected = [
+        'id' => 'record-456',
+        'type' => 'A',
+        'name' => 'updated.example.com',
+        'content' => '192.168.1.200',
+        'ttl' => 600,
+        'proxied' => true,
+    ];
+
+    expect($result)->toBe($expected);
+});
+
+test('update record with defaults', function () {
+    $domainId = 'zone-123';
+    $recordId = 'record-456';
+    $input = [
+        'type' => 'A',
+        'name' => 'updated.example.com',
+        'content' => '192.168.1.200',
+    ];
+
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records/{$recordId}" => Http::response([
+            'success' => true,
+            'result' => [],
+        ], 200),
+    ]);
+
+    $this->cloudflare->updateRecord($domainId, $recordId, $input);
+
+    Http::assertSent(function (Request $request) use ($domainId, $recordId) {
+        return $request->url() === "https://api.cloudflare.com/client/v4/zones/{$domainId}/dns_records/{$recordId}"
+            && $request->data()['ttl'] === 1
+            && $request->data()['proxied'] === false;
+    });
+});
+
+test('update record failure', function () {
+    $domainId = 'zone-123';
+    $recordId = 'record-456';
+    $input = [
+        'type' => 'A',
+        'name' => 'updated.example.com',
+        'content' => '192.168.1.200',
+    ];
+
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records/{$recordId}" => Http::response([
+            'success' => false,
+            'errors' => [
+                ['message' => 'Record not found'],
+            ],
+        ], 404),
+    ]);
+
+    $this->expectException(ValidationException::class);
+    $this->expectExceptionMessage('Failed to update DNS record: Record not found');
+
+    $this->cloudflare->updateRecord($domainId, $recordId, $input);
+});
+
+test('update record exception', function () {
+    $domainId = 'zone-123';
+    $recordId = 'record-456';
+    $input = [
+        'type' => 'A',
+        'name' => 'updated.example.com',
+        'content' => '192.168.1.200',
+    ];
+
+    Http::fake(function () {
+        throw new Exception('Network error');
+    });
+
+    $this->expectException(ValidationException::class);
+    $this->expectExceptionMessage('Failed to update DNS record: Network error');
+
+    $this->cloudflare->updateRecord($domainId, $recordId, $input);
+});
+
+test('delete record success', function () {
+    $domainId = 'zone-123';
+    $recordId = 'record-456';
+
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records/{$recordId}" => Http::response([
+            'success' => true,
+            'result' => [
+                'id' => 'record-456',
+            ],
+        ], 200),
+    ]);
+
+    $result = $this->cloudflare->deleteRecord($domainId, $recordId);
+
+    expect($result)->toBeTrue();
+});
+
+test('delete record failure', function () {
+    $domainId = 'zone-123';
+    $recordId = 'invalid-record';
+
+    Http::fake([
+        "api.cloudflare.com/client/v4/zones/{$domainId}/dns_records/{$recordId}" => Http::response([], 404),
+    ]);
+
+    $result = $this->cloudflare->deleteRecord($domainId, $recordId);
+
+    expect($result)->toBeFalse();
+});
+
+test('delete record exception', function () {
+    $domainId = 'zone-123';
+    $recordId = 'record-456';
+
+    Http::fake(function () {
+        throw new Exception('Network error');
+    });
+
+    $result = $this->cloudflare->deleteRecord($domainId, $recordId);
+
+    expect($result)->toBeFalse();
+});

--- a/tests/Unit/EnvParserTest.php
+++ b/tests/Unit/EnvParserTest.php
@@ -1,407 +1,361 @@
 <?php
 
-namespace Tests\Unit;
-
 use App\Helpers\EnvParser;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class EnvParserTest extends TestCase
-{
-    public function test_parse_simple_env(): void
-    {
-        $raw = "APP_NAME=Laravel\nAPP_ENV=production";
-        $result = EnvParser::parse($raw);
+test('parse simple env', function () {
+    $raw = "APP_NAME=Laravel\nAPP_ENV=production";
+    $result = EnvParser::parse($raw);
 
-        $this->assertCount(2, $result);
-        $this->assertEquals('APP_NAME', $result[0]['key']);
-        $this->assertEquals('Laravel', $result[0]['value']);
-        $this->assertFalse($result[0]['is_secret']);
-        $this->assertEquals('APP_ENV', $result[1]['key']);
-        $this->assertEquals('production', $result[1]['value']);
+    expect($result)->toHaveCount(2);
+    expect($result[0]['key'])->toEqual('APP_NAME');
+    expect($result[0]['value'])->toEqual('Laravel');
+    expect($result[0]['is_secret'])->toBeFalse();
+    expect($result[1]['key'])->toEqual('APP_ENV');
+    expect($result[1]['value'])->toEqual('production');
+});
+
+test('parse quoted values', function () {
+    $raw = 'APP_NAME="My Laravel App"';
+    $result = EnvParser::parse($raw);
+
+    expect($result)->toHaveCount(1);
+    expect($result[0]['value'])->toEqual('My Laravel App');
+});
+
+test('parse single quoted values', function () {
+    $raw = "APP_NAME='My Laravel App'";
+    $result = EnvParser::parse($raw);
+
+    expect($result)->toHaveCount(1);
+    expect($result[0]['value'])->toEqual('My Laravel App');
+});
+
+test('parse skips comments', function () {
+    $raw = "# This is a comment\nAPP_NAME=Laravel\n# Another comment";
+    $result = EnvParser::parse($raw);
+
+    expect($result)->toHaveCount(1);
+    expect($result[0]['key'])->toEqual('APP_NAME');
+});
+
+test('parse skips empty lines', function () {
+    $raw = "APP_NAME=Laravel\n\n\nAPP_ENV=production";
+    $result = EnvParser::parse($raw);
+
+    expect($result)->toHaveCount(2);
+});
+
+test('parse handles value with equals', function () {
+    $raw = 'APP_KEY=base64:abc=123=def=';
+    $result = EnvParser::parse($raw);
+
+    expect($result)->toHaveCount(1);
+    expect($result[0]['value'])->toEqual('base64:abc=123=def=');
+});
+
+test('is secret key detects password', function () {
+    $raw = 'DB_PASSWORD=secret123';
+    $result = EnvParser::parse($raw);
+
+    expect($result[0]['is_secret'])->toBeTrue();
+});
+
+test('is secret key detects secret', function () {
+    $raw = 'APP_SECRET=abc123';
+    $result = EnvParser::parse($raw);
+
+    expect($result[0]['is_secret'])->toBeTrue();
+});
+
+test('is secret key detects token', function () {
+    $raw = 'API_TOKEN=xyz789';
+    $result = EnvParser::parse($raw);
+
+    expect($result[0]['is_secret'])->toBeTrue();
+});
+
+test('is secret key detects key', function () {
+    $raw = 'APP_KEY=base64:abc123';
+    $result = EnvParser::parse($raw);
+
+    expect($result[0]['is_secret'])->toBeTrue();
+});
+
+test('is secret key detects private', function () {
+    $raw = 'PRIVATE_KEY=-----BEGIN RSA-----';
+    $result = EnvParser::parse($raw);
+
+    expect($result[0]['is_secret'])->toBeTrue();
+});
+
+test('stringify simple variables', function () {
+    $variables = [
+        ['key' => 'APP_NAME', 'value' => 'Laravel'],
+        ['key' => 'APP_ENV', 'value' => 'production'],
+    ];
+    $result = EnvParser::stringify($variables);
+
+    expect($result)->toEqual("APP_NAME=Laravel\nAPP_ENV=production");
+});
+
+test('stringify quotes values with spaces', function () {
+    $variables = [
+        ['key' => 'APP_NAME', 'value' => 'My Laravel App'],
+    ];
+    $result = EnvParser::stringify($variables);
+
+    expect($result)->toEqual('APP_NAME="My Laravel App"');
+});
+
+test('stringify quotes values with newlines', function () {
+    $variables = [
+        ['key' => 'MULTILINE', 'value' => "line1\nline2"],
+    ];
+    $result = EnvParser::stringify($variables);
+
+    expect($result)->toEqual('MULTILINE="line1\nline2"');
+});
+
+test('stringify skips empty keys', function () {
+    $variables = [
+        ['key' => '', 'value' => 'empty'],
+        ['key' => 'APP_NAME', 'value' => 'Laravel'],
+    ];
+    $result = EnvParser::stringify($variables);
+
+    expect($result)->toEqual('APP_NAME=Laravel');
+});
+
+test('roundtrip preserves data', function () {
+    $original = "APP_NAME=Laravel\nDB_PASSWORD=secret123\nAPP_KEY=base64:abc=123=";
+    $parsed = EnvParser::parse($original);
+    $stringified = EnvParser::stringify($parsed);
+    $reParsed = EnvParser::parse($stringified);
+
+    expect($reParsed)->toHaveCount(count($parsed));
+    foreach ($parsed as $i => $var) {
+        expect($reParsed[$i]['key'])->toEqual($var['key']);
+        expect($reParsed[$i]['value'])->toEqual($var['value']);
     }
+});
+
+/**
+ * @return array<string, array<int, string>>
+ */
+dataset('roundtripValueProvider', function () {
+    return [
+        'double quote' => ['he said "hi"'],
+        'literal backslash n unquoted' => ['C:\name'],
+        'literal backslash n quoted' => ['%h \n %t'],
+        'hash' => ['#fff'],
+        'spaces' => ['My Laravel App'],
+        'trailing backslash inside quotes' => ['abc def\\'],
+        'trailing backslash unquoted' => ['trail\\'],
+        'multi line' => ["line1\nline2"],
+        'empty' => [''],
+        'base64 padding' => ['base64:abc=123='],
+        'backslash and quote' => ['C:\dir "x"'],
+    ];
+});
+
+test('roundtrip preserves every value shape', function (string $value) {
+    $stringified = EnvParser::stringify([['key' => 'K', 'value' => $value]]);
+    $reParsed = EnvParser::parse($stringified);
+
+    expect($reParsed)->toHaveCount(1);
+    expect($reParsed[0]['key'])->toEqual('K');
+    expect($reParsed[0]['value'])->toEqual($value);
+})->with('roundtripValueProvider');
+
+/**
+ * @return array<string, array<int, string>>
+ */
+dataset('representableContentProvider', function () {
+    return [
+        'comments and blank lines' => ["# Application\n\nAPP_NAME=TestApp"],
+        'crlf line endings' => ["APP_NAME=TestApp\r\nAPP_ENV=production"],
+        'single quoted value' => ["A='single quoted'"],
+        'duplicate keys' => ["A=1\nA=2"],
+        'whitespace around equals' => [' A = 1 '],
+        'dashed key' => ['MY-KEY=1'],
+        'dotted key' => ['MY.KEY=1'],
+        'leading digit key' => ['2FA_ENABLED=1'],
+        'empty value' => ['DB_PASSWORD='],
+        'escaped quotes' => ['K="he said \\"hi\\""'],
+    ];
+});
+
+test('is representable accepts content the form can hold', function (string $content) {
+    expect(EnvParser::isRepresentable($content, EnvParser::parse($content)))->toBeTrue();
+})->with('representableContentProvider');
+
+/**
+ * @return array<string, array<int, string>>
+ */
+dataset('unrepresentableContentProvider', function () {
+    return [
+        'pem block' => ["KEY=\"-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA\n-----END RSA PRIVATE KEY-----\""],
+        'continuation line containing equals' => ["EXTRA_CONFIG=\"foo=1\nbar=2\""],
+        'single quoted multi line' => ["A='foo=1\nbar=2'"],
+        'escaped closing quote' => ["A=\"foo\\\"\nb=2\""],
+        'export prefix' => ['export FOO=bar'],
+    ];
+});
+
+test('is representable rejects content the form would mangle', function (string $content) {
+    expect(EnvParser::isRepresentable($content, EnvParser::parse($content)))->toBeFalse();
+})->with('unrepresentableContentProvider');
+
+test('mask secrets hides secret values', function () {
+    $variables = [
+        ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
+        ['key' => 'DB_PASSWORD', 'value' => 'supersecret', 'is_secret' => true],
+        ['key' => 'API_TOKEN', 'value' => 'token123', 'is_secret' => true],
+    ];
+
+    $masked = EnvParser::maskSecrets($variables);
+
+    expect($masked[0]['value'])->toEqual('Laravel');
+    expect($masked[1]['value'])->toEqual('');
+    expect($masked[2]['value'])->toEqual('');
+});
+
+test('merge with live preserves empty secret values', function () {
+    $live = [
+        ['key' => 'DB_PASSWORD', 'value' => 'original_secret', 'is_secret' => true],
+        ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
+    ];
+
+    $incoming = [
+        ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
+        ['key' => 'APP_NAME', 'value' => 'NewName', 'is_secret' => false],
+    ];
+
+    $merged = EnvParser::mergeWithLive($incoming, $live);
+
+    expect($merged[0]['value'])->toEqual('original_secret');
+    expect($merged[1]['value'])->toEqual('NewName');
+});
+
+test('merge with live allows updating secret values', function () {
+    $live = [
+        ['key' => 'DB_PASSWORD', 'value' => 'original_secret', 'is_secret' => true],
+    ];
 
-    public function test_parse_quoted_values(): void
-    {
-        $raw = 'APP_NAME="My Laravel App"';
-        $result = EnvParser::parse($raw);
-
-        $this->assertCount(1, $result);
-        $this->assertEquals('My Laravel App', $result[0]['value']);
-    }
-
-    public function test_parse_single_quoted_values(): void
-    {
-        $raw = "APP_NAME='My Laravel App'";
-        $result = EnvParser::parse($raw);
-
-        $this->assertCount(1, $result);
-        $this->assertEquals('My Laravel App', $result[0]['value']);
-    }
-
-    public function test_parse_skips_comments(): void
-    {
-        $raw = "# This is a comment\nAPP_NAME=Laravel\n# Another comment";
-        $result = EnvParser::parse($raw);
-
-        $this->assertCount(1, $result);
-        $this->assertEquals('APP_NAME', $result[0]['key']);
-    }
-
-    public function test_parse_skips_empty_lines(): void
-    {
-        $raw = "APP_NAME=Laravel\n\n\nAPP_ENV=production";
-        $result = EnvParser::parse($raw);
-
-        $this->assertCount(2, $result);
-    }
-
-    public function test_parse_handles_value_with_equals(): void
-    {
-        $raw = 'APP_KEY=base64:abc=123=def=';
-        $result = EnvParser::parse($raw);
-
-        $this->assertCount(1, $result);
-        $this->assertEquals('base64:abc=123=def=', $result[0]['value']);
-    }
-
-    public function test_is_secret_key_detects_password(): void
-    {
-        $raw = 'DB_PASSWORD=secret123';
-        $result = EnvParser::parse($raw);
-
-        $this->assertTrue($result[0]['is_secret']);
-    }
-
-    public function test_is_secret_key_detects_secret(): void
-    {
-        $raw = 'APP_SECRET=abc123';
-        $result = EnvParser::parse($raw);
-
-        $this->assertTrue($result[0]['is_secret']);
-    }
-
-    public function test_is_secret_key_detects_token(): void
-    {
-        $raw = 'API_TOKEN=xyz789';
-        $result = EnvParser::parse($raw);
-
-        $this->assertTrue($result[0]['is_secret']);
-    }
-
-    public function test_is_secret_key_detects_key(): void
-    {
-        $raw = 'APP_KEY=base64:abc123';
-        $result = EnvParser::parse($raw);
-
-        $this->assertTrue($result[0]['is_secret']);
-    }
-
-    public function test_is_secret_key_detects_private(): void
-    {
-        $raw = 'PRIVATE_KEY=-----BEGIN RSA-----';
-        $result = EnvParser::parse($raw);
-
-        $this->assertTrue($result[0]['is_secret']);
-    }
-
-    public function test_stringify_simple_variables(): void
-    {
-        $variables = [
-            ['key' => 'APP_NAME', 'value' => 'Laravel'],
-            ['key' => 'APP_ENV', 'value' => 'production'],
-        ];
-        $result = EnvParser::stringify($variables);
-
-        $this->assertEquals("APP_NAME=Laravel\nAPP_ENV=production", $result);
-    }
-
-    public function test_stringify_quotes_values_with_spaces(): void
-    {
-        $variables = [
-            ['key' => 'APP_NAME', 'value' => 'My Laravel App'],
-        ];
-        $result = EnvParser::stringify($variables);
-
-        $this->assertEquals('APP_NAME="My Laravel App"', $result);
-    }
-
-    public function test_stringify_quotes_values_with_newlines(): void
-    {
-        $variables = [
-            ['key' => 'MULTILINE', 'value' => "line1\nline2"],
-        ];
-        $result = EnvParser::stringify($variables);
-
-        $this->assertEquals('MULTILINE="line1\nline2"', $result);
-    }
-
-    public function test_stringify_skips_empty_keys(): void
-    {
-        $variables = [
-            ['key' => '', 'value' => 'empty'],
-            ['key' => 'APP_NAME', 'value' => 'Laravel'],
-        ];
-        $result = EnvParser::stringify($variables);
-
-        $this->assertEquals('APP_NAME=Laravel', $result);
-    }
-
-    public function test_roundtrip_preserves_data(): void
-    {
-        $original = "APP_NAME=Laravel\nDB_PASSWORD=secret123\nAPP_KEY=base64:abc=123=";
-        $parsed = EnvParser::parse($original);
-        $stringified = EnvParser::stringify($parsed);
-        $reParsed = EnvParser::parse($stringified);
-
-        $this->assertCount(count($parsed), $reParsed);
-        foreach ($parsed as $i => $var) {
-            $this->assertEquals($var['key'], $reParsed[$i]['key']);
-            $this->assertEquals($var['value'], $reParsed[$i]['value']);
-        }
-    }
-
-    /**
-     * @return array<string, array<int, string>>
-     */
-    public static function roundtripValueProvider(): array
-    {
-        return [
-            'double quote' => ['he said "hi"'],
-            'literal backslash n unquoted' => ['C:\name'],
-            'literal backslash n quoted' => ['%h \n %t'],
-            'hash' => ['#fff'],
-            'spaces' => ['My Laravel App'],
-            'trailing backslash inside quotes' => ['abc def\\'],
-            'trailing backslash unquoted' => ['trail\\'],
-            'multi line' => ["line1\nline2"],
-            'empty' => [''],
-            'base64 padding' => ['base64:abc=123='],
-            'backslash and quote' => ['C:\dir "x"'],
-        ];
-    }
-
-    #[DataProvider('roundtripValueProvider')]
-    public function test_roundtrip_preserves_every_value_shape(string $value): void
-    {
-        $stringified = EnvParser::stringify([['key' => 'K', 'value' => $value]]);
-        $reParsed = EnvParser::parse($stringified);
-
-        $this->assertCount(1, $reParsed);
-        $this->assertEquals('K', $reParsed[0]['key']);
-        $this->assertEquals($value, $reParsed[0]['value']);
-    }
-
-    /**
-     * @return array<string, array<int, string>>
-     */
-    public static function representableContentProvider(): array
-    {
-        return [
-            'comments and blank lines' => ["# Application\n\nAPP_NAME=TestApp"],
-            'crlf line endings' => ["APP_NAME=TestApp\r\nAPP_ENV=production"],
-            'single quoted value' => ["A='single quoted'"],
-            'duplicate keys' => ["A=1\nA=2"],
-            'whitespace around equals' => [' A = 1 '],
-            'dashed key' => ['MY-KEY=1'],
-            'dotted key' => ['MY.KEY=1'],
-            'leading digit key' => ['2FA_ENABLED=1'],
-            'empty value' => ['DB_PASSWORD='],
-            'escaped quotes' => ['K="he said \\"hi\\""'],
-        ];
-    }
-
-    #[DataProvider('representableContentProvider')]
-    public function test_is_representable_accepts_content_the_form_can_hold(string $content): void
-    {
-        $this->assertTrue(EnvParser::isRepresentable($content, EnvParser::parse($content)));
-    }
-
-    /**
-     * @return array<string, array<int, string>>
-     */
-    public static function unrepresentableContentProvider(): array
-    {
-        return [
-            'pem block' => ["KEY=\"-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA\n-----END RSA PRIVATE KEY-----\""],
-            'continuation line containing equals' => ["EXTRA_CONFIG=\"foo=1\nbar=2\""],
-            'single quoted multi line' => ["A='foo=1\nbar=2'"],
-            'escaped closing quote' => ["A=\"foo\\\"\nb=2\""],
-            'export prefix' => ['export FOO=bar'],
-        ];
-    }
-
-    #[DataProvider('unrepresentableContentProvider')]
-    public function test_is_representable_rejects_content_the_form_would_mangle(string $content): void
-    {
-        $this->assertFalse(EnvParser::isRepresentable($content, EnvParser::parse($content)));
-    }
-
-    public function test_mask_secrets_hides_secret_values(): void
-    {
-        $variables = [
-            ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
-            ['key' => 'DB_PASSWORD', 'value' => 'supersecret', 'is_secret' => true],
-            ['key' => 'API_TOKEN', 'value' => 'token123', 'is_secret' => true],
-        ];
-
-        $masked = EnvParser::maskSecrets($variables);
-
-        $this->assertEquals('Laravel', $masked[0]['value']);
-        $this->assertEquals('', $masked[1]['value']);
-        $this->assertEquals('', $masked[2]['value']);
-    }
-
-    public function test_merge_with_live_preserves_empty_secret_values(): void
-    {
-        $live = [
-            ['key' => 'DB_PASSWORD', 'value' => 'original_secret', 'is_secret' => true],
-            ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
-        ];
-
-        $incoming = [
-            ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
-            ['key' => 'APP_NAME', 'value' => 'NewName', 'is_secret' => false],
-        ];
-
-        $merged = EnvParser::mergeWithLive($incoming, $live);
-
-        $this->assertEquals('original_secret', $merged[0]['value']);
-        $this->assertEquals('NewName', $merged[1]['value']);
-    }
-
-    public function test_merge_with_live_allows_updating_secret_values(): void
-    {
-        $live = [
-            ['key' => 'DB_PASSWORD', 'value' => 'original_secret', 'is_secret' => true],
-        ];
-
-        $incoming = [
-            ['key' => 'DB_PASSWORD', 'value' => 'new_secret', 'is_secret' => true],
-        ];
-
-        $merged = EnvParser::mergeWithLive($incoming, $live);
-
-        $this->assertEquals('new_secret', $merged[0]['value']);
-    }
-
-    public function test_merge_with_empty_live_returns_incoming(): void
-    {
-        $incoming = [
-            ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
-        ];
-
-        $this->assertEquals($incoming, EnvParser::mergeWithLive($incoming, []));
-    }
-
-    public function test_merge_restores_secret_from_live_file_value(): void
-    {
-        $live = [
-            ['key' => 'DB_PASSWORD', 'value' => 'rotated_secret', 'is_secret' => true],
-        ];
-
-        $incoming = [
-            ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
-        ];
-
-        $merged = EnvParser::mergeWithLive($incoming, $live);
-
-        $this->assertEquals('rotated_secret', $merged[0]['value']);
-    }
-
-    public function test_merge_does_not_restore_non_secret_empty_values(): void
-    {
-        $live = [
-            ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
-        ];
-
-        $incoming = [
-            ['key' => 'APP_NAME', 'value' => '', 'is_secret' => false],
-        ];
-
-        $merged = EnvParser::mergeWithLive($incoming, $live);
-
-        $this->assertEquals('', $merged[0]['value']);
-    }
-
-    public function test_secret_keys_from_flat_list(): void
-    {
-        $this->assertEquals(['APP_KEY', 'JWT_SECRET'], EnvParser::secretKeys(['APP_KEY', 'JWT_SECRET']));
-    }
-
-    public function test_secret_keys_from_legacy_variable_array(): void
-    {
-        $legacy = [
-            ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
-            ['key' => 'DB_PASSWORD', 'value' => 'secret', 'is_secret' => true],
-            ['key' => 'APP_KEY', 'value' => 'base64:abc', 'is_secret' => true],
-        ];
-
-        $this->assertEquals(['DB_PASSWORD', 'APP_KEY'], EnvParser::secretKeys($legacy));
-    }
-
-    public function test_secret_keys_deduplicates(): void
-    {
-        $this->assertEquals(['APP_KEY'], EnvParser::secretKeys(['APP_KEY', 'APP_KEY']));
-    }
-
-    public function test_secret_keys_from_null_returns_empty(): void
-    {
-        $this->assertEquals([], EnvParser::secretKeys(null));
-    }
-
-    public function test_classify_marks_only_stored_secret_keys(): void
-    {
-        $parsed = [
-            ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
-            ['key' => 'DB_PASSWORD', 'value' => 'plain', 'is_secret' => true],
-        ];
-
-        $classified = EnvParser::classify($parsed, ['APP_NAME']);
-
-        $this->assertTrue($classified[0]['is_secret']);
-        $this->assertFalse($classified[1]['is_secret']);
-    }
-
-    public function test_classify_reads_legacy_stored_shape(): void
-    {
-        $parsed = [
-            ['key' => 'DB_PASSWORD', 'value' => 'plain', 'is_secret' => false],
-            ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
-        ];
-
-        $legacy = [
-            ['key' => 'DB_PASSWORD', 'value' => 'old', 'is_secret' => true],
-            ['key' => 'APP_NAME', 'value' => 'old', 'is_secret' => false],
-        ];
-
-        $classified = EnvParser::classify($parsed, $legacy);
-
-        $this->assertTrue($classified[0]['is_secret']);
-        $this->assertFalse($classified[1]['is_secret']);
-    }
-
-    public function test_classify_with_null_stored_falls_back_to_auto_detection(): void
-    {
-        $parsed = [
-            ['key' => 'DB_PASSWORD', 'value' => 'plain', 'is_secret' => true],
-            ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
-        ];
-
-        $classified = EnvParser::classify($parsed, null);
-
-        $this->assertTrue($classified[0]['is_secret']);
-        $this->assertFalse($classified[1]['is_secret']);
-    }
-
-    public function test_classify_with_empty_stored_list_is_authoritative(): void
-    {
-        $parsed = [
-            ['key' => 'DB_PASSWORD', 'value' => 'plain', 'is_secret' => true],
-        ];
-
-        $classified = EnvParser::classify($parsed, []);
-
-        $this->assertFalse($classified[0]['is_secret']);
-    }
-}
+    $incoming = [
+        ['key' => 'DB_PASSWORD', 'value' => 'new_secret', 'is_secret' => true],
+    ];
+
+    $merged = EnvParser::mergeWithLive($incoming, $live);
+
+    expect($merged[0]['value'])->toEqual('new_secret');
+});
+
+test('merge with empty live returns incoming', function () {
+    $incoming = [
+        ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
+    ];
+
+    expect(EnvParser::mergeWithLive($incoming, []))->toEqual($incoming);
+});
+
+test('merge restores secret from live file value', function () {
+    $live = [
+        ['key' => 'DB_PASSWORD', 'value' => 'rotated_secret', 'is_secret' => true],
+    ];
+
+    $incoming = [
+        ['key' => 'DB_PASSWORD', 'value' => '', 'is_secret' => true],
+    ];
+
+    $merged = EnvParser::mergeWithLive($incoming, $live);
+
+    expect($merged[0]['value'])->toEqual('rotated_secret');
+});
+
+test('merge does not restore non secret empty values', function () {
+    $live = [
+        ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
+    ];
+
+    $incoming = [
+        ['key' => 'APP_NAME', 'value' => '', 'is_secret' => false],
+    ];
+
+    $merged = EnvParser::mergeWithLive($incoming, $live);
+
+    expect($merged[0]['value'])->toEqual('');
+});
+
+test('secret keys from flat list', function () {
+    expect(EnvParser::secretKeys(['APP_KEY', 'JWT_SECRET']))->toEqual(['APP_KEY', 'JWT_SECRET']);
+});
+
+test('secret keys from legacy variable array', function () {
+    $legacy = [
+        ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
+        ['key' => 'DB_PASSWORD', 'value' => 'secret', 'is_secret' => true],
+        ['key' => 'APP_KEY', 'value' => 'base64:abc', 'is_secret' => true],
+    ];
+
+    expect(EnvParser::secretKeys($legacy))->toEqual(['DB_PASSWORD', 'APP_KEY']);
+});
+
+test('secret keys deduplicates', function () {
+    expect(EnvParser::secretKeys(['APP_KEY', 'APP_KEY']))->toEqual(['APP_KEY']);
+});
+
+test('secret keys from null returns empty', function () {
+    expect(EnvParser::secretKeys(null))->toEqual([]);
+});
+
+test('classify marks only stored secret keys', function () {
+    $parsed = [
+        ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
+        ['key' => 'DB_PASSWORD', 'value' => 'plain', 'is_secret' => true],
+    ];
+
+    $classified = EnvParser::classify($parsed, ['APP_NAME']);
+
+    expect($classified[0]['is_secret'])->toBeTrue();
+    expect($classified[1]['is_secret'])->toBeFalse();
+});
+
+test('classify reads legacy stored shape', function () {
+    $parsed = [
+        ['key' => 'DB_PASSWORD', 'value' => 'plain', 'is_secret' => false],
+        ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
+    ];
+
+    $legacy = [
+        ['key' => 'DB_PASSWORD', 'value' => 'old', 'is_secret' => true],
+        ['key' => 'APP_NAME', 'value' => 'old', 'is_secret' => false],
+    ];
+
+    $classified = EnvParser::classify($parsed, $legacy);
+
+    expect($classified[0]['is_secret'])->toBeTrue();
+    expect($classified[1]['is_secret'])->toBeFalse();
+});
+
+test('classify with null stored falls back to auto detection', function () {
+    $parsed = [
+        ['key' => 'DB_PASSWORD', 'value' => 'plain', 'is_secret' => true],
+        ['key' => 'APP_NAME', 'value' => 'Laravel', 'is_secret' => false],
+    ];
+
+    $classified = EnvParser::classify($parsed, null);
+
+    expect($classified[0]['is_secret'])->toBeTrue();
+    expect($classified[1]['is_secret'])->toBeFalse();
+});
+
+test('classify with empty stored list is authoritative', function () {
+    $parsed = [
+        ['key' => 'DB_PASSWORD', 'value' => 'plain', 'is_secret' => true],
+    ];
+
+    $classified = EnvParser::classify($parsed, []);
+
+    expect($classified[0]['is_secret'])->toBeFalse();
+});

--- a/tests/Unit/EnvParserTest.php
+++ b/tests/Unit/EnvParserTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use App\Helpers\EnvParser;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
 
 test('parse simple env', function () {
     $raw = "APP_NAME=Laravel\nAPP_ENV=production";

--- a/tests/Unit/EnvParserTest.php
+++ b/tests/Unit/EnvParserTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use App\Helpers\EnvParser;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-
-uses(RefreshDatabase::class);
 
 test('parse simple env', function () {
     $raw = "APP_NAME=Laravel\nAPP_ENV=production";

--- a/tests/Unit/Helpers/AgentTest.php
+++ b/tests/Unit/Helpers/AgentTest.php
@@ -1,19 +1,12 @@
 <?php
 
-namespace Tests\Unit\Helpers;
-
 use App\Helpers\Agent;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class AgentTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    /**
-     * @var array<string, string>
-     */
-    private array $operatingSystems = [
+beforeEach(function () {
+    $this->operatingSystems = [
         'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' => 'Windows',
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2' => 'OS X',
         'Mozilla/5.0 (iPad; CPU OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko ) Version/5.1 Mobile/9B176 Safari/7534.48.3' => 'iOS',
@@ -23,11 +16,7 @@ class AgentTest extends TestCase
         'Mozilla/5.0 (X11; CrOS x86_64 6680.78.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.102 Safari/537.36' => 'ChromeOS',
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36' => 'Windows',
     ];
-
-    /**
-     * @var array<string, string>
-     */
-    private array $browsers = [
+    $this->browsers = [
         'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' => 'IE',
         'Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25' => 'Safari',
         'Mozilla/5.0 (Windows; U; Win 9x 4.90; SG; rv:1.9.2.4) Gecko/20101104 Netscape/9.1.0285' => 'Netscape',
@@ -44,11 +33,7 @@ class AgentTest extends TestCase
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.29 Safari/537.36 Edg/79.0.309.18' => 'Edge',
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/86.0.180 Chrome/80.0.3987.180 Safari/537.36' => 'Coc Coc',
     ];
-
-    /**
-     * @var array<string>
-     */
-    private array $mobileDevices = [
+    $this->mobileDevices = [
         'Mozilla/5.0 (iPhone; U; ru; CPU iPhone OS 4_2_1 like Mac OS X; ru) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5',
         'Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25',
         'Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; HTC Desire Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
@@ -56,11 +41,7 @@ class AgentTest extends TestCase
         'Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
         'Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; ASUS Transformer Pad TF300T Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30',
     ];
-
-    /**
-     * @var array<string>
-     */
-    private array $desktops = [
+    $this->desktops = [
         'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko',
         'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:24.0) Gecko/20100101 Firefox/24.0',
         'Mozilla/5.0 (Windows; U; Win 9x 4.90; SG; rv:1.9.2.4) Gecko/20101104 Netscape/9.1.0285',
@@ -70,44 +51,40 @@ class AgentTest extends TestCase
         'Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14',
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2',
     ];
+});
 
-    public function test_operating_systems(): void
-    {
-        $agent = new Agent;
+test('operating systems', function () {
+    $agent = new Agent;
 
-        foreach ($this->operatingSystems as $ua => $platform) {
-            $agent->setUserAgent($ua);
-            $this->assertEquals($platform, $agent->platform(), $ua);
-        }
+    foreach ($this->operatingSystems as $ua => $platform) {
+        $agent->setUserAgent($ua);
+        expect($agent->platform())->toEqual($platform);
     }
+});
 
-    public function test_browsers(): void
-    {
-        $agent = new Agent;
+test('browsers', function () {
+    $agent = new Agent;
 
-        foreach ($this->browsers as $ua => $browser) {
-            $agent->setUserAgent($ua);
-            $this->assertEquals($browser, $agent->browser(), $ua);
-        }
+    foreach ($this->browsers as $ua => $browser) {
+        $agent->setUserAgent($ua);
+        expect($agent->browser())->toEqual($browser);
     }
+});
 
-    public function test_desktop_devices(): void
-    {
-        $agent = new Agent;
+test('desktop devices', function () {
+    $agent = new Agent;
 
-        foreach ($this->desktops as $ua) {
-            $agent->setUserAgent($ua);
-            $this->assertTrue($agent->isDesktop(), $ua);
-        }
+    foreach ($this->desktops as $ua) {
+        $agent->setUserAgent($ua);
+        expect($agent->isDesktop())->toBeTrue($ua);
     }
+});
 
-    public function test_mobile_devices(): void
-    {
-        $agent = new Agent;
+test('mobile devices', function () {
+    $agent = new Agent;
 
-        foreach ($this->mobileDevices as $ua) {
-            $agent->setUserAgent($ua);
-            $this->assertTrue($agent->isMobile(), $ua);
-        }
+    foreach ($this->mobileDevices as $ua) {
+        $agent->setUserAgent($ua);
+        expect($agent->isMobile())->toBeTrue($ua);
     }
-}
+});

--- a/tests/Unit/Helpers/AgentTest.php
+++ b/tests/Unit/Helpers/AgentTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use App\Helpers\Agent;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-
-uses(RefreshDatabase::class);
 
 beforeEach(function () {
     $this->operatingSystems = [

--- a/tests/Unit/Helpers/AgentTest.php
+++ b/tests/Unit/Helpers/AgentTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use App\Helpers\Agent;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
 
 beforeEach(function () {
     $this->operatingSystems = [

--- a/tests/Unit/Helpers/Apr1HasherTest.php
+++ b/tests/Unit/Helpers/Apr1HasherTest.php
@@ -1,21 +1,12 @@
 <?php
 
-namespace Tests\Unit\Helpers;
-
 use App\Helpers\Apr1Hasher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class Apr1HasherTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    /**
-     * Known-good vectors verified against Apache's htpasswd -vb.
-     *
-     * @var array<string, array{password: string, salt: string, expected: string}>
-     */
-    private array $knownVectors = [
+beforeEach(function () {
+    $this->knownVectors = [
         'simple' => [
             'password' => 'password',
             'salt' => 'salt1234',
@@ -42,84 +33,65 @@ class Apr1HasherTest extends TestCase
             'expected' => '$apr1$salt1234$5H34QiH40LY95k4Ru.Rsw0',
         ],
     ];
+});
 
-    public function test_hash_produces_apr1_format(): void
-    {
-        $hash = Apr1Hasher::hash('password');
+test('hash produces apr1 format', function () {
+    $hash = Apr1Hasher::hash('password');
 
-        $this->assertMatchesRegularExpression(
-            '/^\$apr1\$[A-Za-z0-9.\/]{8}\$[A-Za-z0-9.\/]{22}$/',
-            $hash
-        );
+    expect($hash)->toMatch('/^\$apr1\$[A-Za-z0-9.\/]{8}\$[A-Za-z0-9.\/]{22}$/');
+});
+
+test('hash is deterministic for same salt', function () {
+    $hash1 = Apr1Hasher::hash('password', 'salt1234');
+    $hash2 = Apr1Hasher::hash('password', 'salt1234');
+
+    expect($hash2)->toBe($hash1);
+});
+
+test('hash differs with different salts', function () {
+    $hash1 = Apr1Hasher::hash('password', 'salt1234');
+    $hash2 = Apr1Hasher::hash('password', 'differen');
+
+    $this->assertNotSame($hash1, $hash2);
+});
+
+test('hash differs with different passwords', function () {
+    $hash1 = Apr1Hasher::hash('password1', 'salt1234');
+    $hash2 = Apr1Hasher::hash('password2', 'salt1234');
+
+    $this->assertNotSame($hash1, $hash2);
+});
+
+test('random salt is used when not provided', function () {
+    $hash1 = Apr1Hasher::hash('password');
+    $hash2 = Apr1Hasher::hash('password');
+
+    $this->assertNotSame($hash1, $hash2);
+});
+
+test('hash against known vectors', function () {
+    foreach ($this->knownVectors as $name => $vector) {
+        expect(Apr1Hasher::hash($vector['password'], $vector['salt']))->toBe($vector['expected'], "Vector '{$name}' failed");
     }
+});
 
-    public function test_hash_is_deterministic_for_same_salt(): void
-    {
-        $hash1 = Apr1Hasher::hash('password', 'salt1234');
-        $hash2 = Apr1Hasher::hash('password', 'salt1234');
+test('salt is sanitised when containing invalid characters', function () {
+    $hash = Apr1Hasher::hash('password', 'bad!@#$%');
 
-        $this->assertSame($hash1, $hash2);
-    }
+    expect($hash)->toMatch('/^\$apr1\$[A-Za-z0-9.\/]{8}\$[A-Za-z0-9.\/]{22}$/');
+});
 
-    public function test_hash_differs_with_different_salts(): void
-    {
-        $hash1 = Apr1Hasher::hash('password', 'salt1234');
-        $hash2 = Apr1Hasher::hash('password', 'differen');
+test('short salt is padded', function () {
+    $hash = Apr1Hasher::hash('password', 'ab');
 
-        $this->assertNotSame($hash1, $hash2);
-    }
+    preg_match('/^\$apr1\$([^$]+)\$/', $hash, $matches);
+    expect(strlen($matches[1]))->toBe(8);
+});
 
-    public function test_hash_differs_with_different_passwords(): void
-    {
-        $hash1 = Apr1Hasher::hash('password1', 'salt1234');
-        $hash2 = Apr1Hasher::hash('password2', 'salt1234');
+test('long salt is truncated', function () {
+    $hash = Apr1Hasher::hash('password', 'abcdefghijklmnop');
 
-        $this->assertNotSame($hash1, $hash2);
-    }
-
-    public function test_random_salt_is_used_when_not_provided(): void
-    {
-        $hash1 = Apr1Hasher::hash('password');
-        $hash2 = Apr1Hasher::hash('password');
-
-        $this->assertNotSame($hash1, $hash2);
-    }
-
-    public function test_hash_against_known_vectors(): void
-    {
-        foreach ($this->knownVectors as $name => $vector) {
-            $this->assertSame(
-                $vector['expected'],
-                Apr1Hasher::hash($vector['password'], $vector['salt']),
-                "Vector '{$name}' failed"
-            );
-        }
-    }
-
-    public function test_salt_is_sanitised_when_containing_invalid_characters(): void
-    {
-        $hash = Apr1Hasher::hash('password', 'bad!@#$%');
-
-        $this->assertMatchesRegularExpression(
-            '/^\$apr1\$[A-Za-z0-9.\/]{8}\$[A-Za-z0-9.\/]{22}$/',
-            $hash
-        );
-    }
-
-    public function test_short_salt_is_padded(): void
-    {
-        $hash = Apr1Hasher::hash('password', 'ab');
-
-        preg_match('/^\$apr1\$([^$]+)\$/', $hash, $matches);
-        $this->assertSame(8, strlen($matches[1]));
-    }
-
-    public function test_long_salt_is_truncated(): void
-    {
-        $hash = Apr1Hasher::hash('password', 'abcdefghijklmnop');
-
-        preg_match('/^\$apr1\$([^$]+)\$/', $hash, $matches);
-        $this->assertSame(8, strlen($matches[1]));
-        $this->assertSame('abcdefgh', $matches[1]);
-    }
-}
+    preg_match('/^\$apr1\$([^$]+)\$/', $hash, $matches);
+    expect(strlen($matches[1]))->toBe(8);
+    expect($matches[1])->toBe('abcdefgh');
+});

--- a/tests/Unit/Helpers/Apr1HasherTest.php
+++ b/tests/Unit/Helpers/Apr1HasherTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use App\Helpers\Apr1Hasher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
 
 beforeEach(function () {
     $this->knownVectors = [

--- a/tests/Unit/Helpers/Apr1HasherTest.php
+++ b/tests/Unit/Helpers/Apr1HasherTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use App\Helpers\Apr1Hasher;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-
-uses(RefreshDatabase::class);
 
 beforeEach(function () {
     $this->knownVectors = [

--- a/tests/Unit/Helpers/SSHTest.php
+++ b/tests/Unit/Helpers/SSHTest.php
@@ -13,12 +13,8 @@ test('write propagates the failure and cleans up the local temporary file', func
     $ssh = SSH::fake();
     $ssh->execWillFail();
 
-    try {
-        $this->server->ssh()->write('/home/vito/example.com/.env', 'APP_NAME=TestApp', 'vito');
-        $this->fail('Expected the write to throw when the remote command fails.');
-    } catch (SSHCommandError) {
-        // expected
-    }
+    expect(fn () => $this->server->ssh()->write('/home/vito/example.com/.env', 'APP_NAME=TestApp', 'vito'))
+        ->toThrow(SSHCommandError::class);
 
     expect(Storage::disk('local')->files())->toBeEmpty();
 });

--- a/tests/Unit/Helpers/SSHTest.php
+++ b/tests/Unit/Helpers/SSHTest.php
@@ -1,62 +1,52 @@
 <?php
 
-namespace Tests\Unit\Helpers;
-
 use App\Exceptions\SSHCommandError;
 use App\Facades\SSH;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
-use Tests\TestCase;
 
-class SSHTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_write_propagates_the_failure_and_cleans_up_the_local_temporary_file(): void
-    {
-        Storage::fake('local');
+test('write propagates the failure and cleans up the local temporary file', function () {
+    Storage::fake('local');
 
-        $ssh = SSH::fake();
-        $ssh->execWillFail();
+    $ssh = SSH::fake();
+    $ssh->execWillFail();
 
-        try {
-            $this->server->ssh()->write('/home/vito/example.com/.env', 'APP_NAME=TestApp', 'vito');
-            $this->fail('Expected the write to throw when the remote command fails.');
-        } catch (SSHCommandError) {
-            // expected
-        }
-
-        $this->assertEmpty(Storage::disk('local')->files());
-    }
-
-    public function test_write_cleans_up_the_local_temporary_file_on_success(): void
-    {
-        Storage::fake('local');
-
-        SSH::fake();
-
+    try {
         $this->server->ssh()->write('/home/vito/example.com/.env', 'APP_NAME=TestApp', 'vito');
-
-        $this->assertEmpty(Storage::disk('local')->files());
+        $this->fail('Expected the write to throw when the remote command fails.');
+    } catch (SSHCommandError) {
+        // expected
     }
 
-    public function test_write_removes_the_remote_temporary_file_on_both_branches(): void
-    {
-        SSH::fake();
+    expect(Storage::disk('local')->files())->toBeEmpty();
+});
 
-        $this->server->ssh()->write('/home/vito/example.com/.env', 'APP_NAME=TestApp', 'vito');
+test('write cleans up the local temporary file on success', function () {
+    Storage::fake('local');
 
-        SSH::assertExecutedContains("> '/home/vito/example.com/.env'; then");
-        SSH::assertExecutedContains("else\n    rm -f ");
-        SSH::assertExecutedContains('exit 1');
-    }
+    SSH::fake();
 
-    public function test_write_quotes_the_destination_path(): void
-    {
-        SSH::fake();
+    $this->server->ssh()->write('/home/vito/example.com/.env', 'APP_NAME=TestApp', 'vito');
 
-        $this->server->ssh()->write('/home/vito/legacy path/.env', 'APP_NAME=TestApp', 'vito');
+    expect(Storage::disk('local')->files())->toBeEmpty();
+});
 
-        SSH::assertExecutedContains("> '/home/vito/legacy path/.env'");
-    }
-}
+test('write removes the remote temporary file on both branches', function () {
+    SSH::fake();
+
+    $this->server->ssh()->write('/home/vito/example.com/.env', 'APP_NAME=TestApp', 'vito');
+
+    SSH::assertExecutedContains("> '/home/vito/example.com/.env'; then");
+    SSH::assertExecutedContains("else\n    rm -f ");
+    SSH::assertExecutedContains('exit 1');
+});
+
+test('write quotes the destination path', function () {
+    SSH::fake();
+
+    $this->server->ssh()->write('/home/vito/legacy path/.env', 'APP_NAME=TestApp', 'vito');
+
+    SSH::assertExecutedContains("> '/home/vito/legacy path/.env'");
+});

--- a/tests/Unit/IsolatedUserModelTest.php
+++ b/tests/Unit/IsolatedUserModelTest.php
@@ -75,7 +75,6 @@ test('lock uses legacy key shape for cross deploy compat', function () {
     $lock = $iuser->lock();
     expect($lock->get())->toBeTrue('iuser lock should be acquirable initially');
 
-    // Same logical lock as the legacy `Server::isolatedUserLock($username)`.
     $legacyClash = Cache::lock("isolate:{$this->server->id}:alpha", 60);
     expect($legacyClash->get())->toBeFalse('legacy-shaped lock should clash with the iuser lock');
 

--- a/tests/Unit/IsolatedUserModelTest.php
+++ b/tests/Unit/IsolatedUserModelTest.php
@@ -1,94 +1,83 @@
 <?php
 
-namespace Tests\Unit;
-
 use App\Models\IsolatedUser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
-use Tests\TestCase;
 
-class IsolatedUserModelTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_tooling_version_round_trips_via_set_and_get(): void
-    {
-        $iuser = IsolatedUser::factory()->create([
-            'server_id' => $this->server->id,
-            'username' => 'alpha',
-        ]);
+test('tooling version round trips via set and get', function () {
+    $iuser = IsolatedUser::factory()->create([
+        'server_id' => $this->server->id,
+        'username' => 'alpha',
+    ]);
 
-        $this->assertNull($iuser->toolingVersion('node'));
+    expect($iuser->toolingVersion('node'))->toBeNull();
 
-        $iuser->setToolingVersion('node', '22');
+    $iuser->setToolingVersion('node', '22');
 
-        $this->assertSame('22', $iuser->toolingVersion('node'));
-        $this->assertSame('22', $iuser->fresh()->toolingVersion('node'));
-    }
+    expect($iuser->toolingVersion('node'))->toBe('22');
+    expect($iuser->fresh()->toolingVersion('node'))->toBe('22');
+});
 
-    public function test_tooling_status_round_trips(): void
-    {
-        $iuser = IsolatedUser::factory()->create([
-            'server_id' => $this->server->id,
-            'username' => 'alpha',
-        ]);
+test('tooling status round trips', function () {
+    $iuser = IsolatedUser::factory()->create([
+        'server_id' => $this->server->id,
+        'username' => 'alpha',
+    ]);
 
-        $iuser->setToolingStatus('bun', 'installing');
-        $this->assertSame('installing', $iuser->fresh()->toolingStatus('bun'));
+    $iuser->setToolingStatus('bun', 'installing');
+    expect($iuser->fresh()->toolingStatus('bun'))->toBe('installing');
 
-        $iuser->setToolingStatus('bun', null);
-        $this->assertNull($iuser->fresh()->toolingStatus('bun'));
-    }
+    $iuser->setToolingStatus('bun', null);
+    expect($iuser->fresh()->toolingStatus('bun'))->toBeNull();
+});
 
-    public function test_set_version_and_status_for_different_tools_does_not_clobber_each_other(): void
-    {
-        $iuser = IsolatedUser::factory()->create([
-            'server_id' => $this->server->id,
-            'username' => 'alpha',
-        ]);
+test('set version and status for different tools does not clobber each other', function () {
+    $iuser = IsolatedUser::factory()->create([
+        'server_id' => $this->server->id,
+        'username' => 'alpha',
+    ]);
 
-        $iuser->setToolingVersion('node', '22');
-        $iuser->setToolingVersion('bun', '1.2');
-        $iuser->setToolingStatus('node', 'installing');
+    $iuser->setToolingVersion('node', '22');
+    $iuser->setToolingVersion('bun', '1.2');
+    $iuser->setToolingStatus('node', 'installing');
 
-        $fresh = $iuser->fresh();
-        $this->assertSame('22', $fresh->toolingVersion('node'));
-        $this->assertSame('installing', $fresh->toolingStatus('node'));
-        $this->assertSame('1.2', $fresh->toolingVersion('bun'));
-        $this->assertNull($fresh->toolingStatus('bun'));
-    }
+    $fresh = $iuser->fresh();
+    expect($fresh->toolingVersion('node'))->toBe('22');
+    expect($fresh->toolingStatus('node'))->toBe('installing');
+    expect($fresh->toolingVersion('bun'))->toBe('1.2');
+    expect($fresh->toolingStatus('bun'))->toBeNull();
+});
 
-    public function test_clear_tooling_removes_only_the_named_tool(): void
-    {
-        $iuser = IsolatedUser::factory()->create([
-            'server_id' => $this->server->id,
-            'username' => 'alpha',
-        ]);
+test('clear tooling removes only the named tool', function () {
+    $iuser = IsolatedUser::factory()->create([
+        'server_id' => $this->server->id,
+        'username' => 'alpha',
+    ]);
 
-        $iuser->setToolingVersion('node', '22');
-        $iuser->setToolingVersion('bun', '1.2');
+    $iuser->setToolingVersion('node', '22');
+    $iuser->setToolingVersion('bun', '1.2');
 
-        $iuser->clearTooling('node');
+    $iuser->clearTooling('node');
 
-        $fresh = $iuser->fresh();
-        $this->assertNull($fresh->toolingVersion('node'));
-        $this->assertSame('1.2', $fresh->toolingVersion('bun'));
-    }
+    $fresh = $iuser->fresh();
+    expect($fresh->toolingVersion('node'))->toBeNull();
+    expect($fresh->toolingVersion('bun'))->toBe('1.2');
+});
 
-    public function test_lock_uses_legacy_key_shape_for_cross_deploy_compat(): void
-    {
-        $iuser = IsolatedUser::factory()->create([
-            'server_id' => $this->server->id,
-            'username' => 'alpha',
-        ]);
+test('lock uses legacy key shape for cross deploy compat', function () {
+    $iuser = IsolatedUser::factory()->create([
+        'server_id' => $this->server->id,
+        'username' => 'alpha',
+    ]);
 
-        $lock = $iuser->lock();
-        $this->assertTrue($lock->get(), 'iuser lock should be acquirable initially');
+    $lock = $iuser->lock();
+    expect($lock->get())->toBeTrue('iuser lock should be acquirable initially');
 
-        // Same logical lock as the legacy `Server::isolatedUserLock($username)`.
-        $legacyClash = Cache::lock("isolate:{$this->server->id}:alpha", 60);
-        $this->assertFalse($legacyClash->get(), 'legacy-shaped lock should clash with the iuser lock');
+    // Same logical lock as the legacy `Server::isolatedUserLock($username)`.
+    $legacyClash = Cache::lock("isolate:{$this->server->id}:alpha", 60);
+    expect($legacyClash->get())->toBeFalse('legacy-shaped lock should clash with the iuser lock');
 
-        $lock->release();
-    }
-}
+    $lock->release();
+});

--- a/tests/Unit/Jobs/UpdateVitoAgentConfigJobTest.php
+++ b/tests/Unit/Jobs/UpdateVitoAgentConfigJobTest.php
@@ -1,115 +1,105 @@
 <?php
 
-namespace Tests\Unit\Jobs;
-
 use App\Enums\ServiceStatus;
 use App\Facades\SSH;
 use App\Jobs\Service\UpdateVitoAgentConfigJob;
 use App\Models\Service;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
-use Tests\TestCase;
 
-class UpdateVitoAgentConfigJobTest extends TestCase
+uses(RefreshDatabase::class);
+
+test('updates config and restarts agent', function () {
+    SSH::fake();
+
+    $agent = vitoPestUnitJobsUpdateVitoAgentConfigJobTestCreateAgent(ServiceStatus::READY);
+    $this->server->services()->create([
+        'type' => 'log_analysis',
+        'name' => 'goaccess',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+
+    dispatch(new UpdateVitoAgentConfigJob($this->server));
+
+    SSH::assertExecutedContains('/etc/vito-agent/config.json');
+    SSH::assertExecutedContains("rm -f '/tmp/");
+    SSH::assertExecutedContains('chmod 600 /etc/vito-agent/config.json');
+    SSH::assertExecutedContains('Monitoring services: ');
+    SSH::assertNotExecutedContains('agent-secret');
+    SSH::assertExecutedContains('restart vito-agent');
+
+    $config = json_decode(SSH::getUploadedContent(), true);
+    expect($config['url'])->toBe('https://vito.test/agent-endpoint');
+    expect($config['secret'])->toBe('agent-secret');
+    $this->assertArrayNotHasKey('data_retention', $config);
+
+    $units = array_column($config['services'], 'unit', 'id');
+    expect($units)->toHaveCount(6);
+    expect($units)->toContain('nginx');
+    expect($units)->toContain('mysql');
+    expect($units)->toContain('php8.2-fpm');
+    expect($units)->toContain('ufw');
+    expect($units)->toContain('supervisor');
+    expect($units)->toContain('redis-server');
+    expect($units)->not->toContain('');
+    $this->assertArrayNotHasKey($agent->id, $units);
+});
+
+test('does nothing without vito agent', function () {
+    SSH::fake();
+
+    dispatch(new UpdateVitoAgentConfigJob($this->server));
+
+    SSH::assertNotExecutedContains('vito-agent');
+    expect(SSH::getUploadedContent())->toBe('');
+});
+
+test('does nothing when agent is not ready', function () {
+    SSH::fake();
+
+    vitoPestUnitJobsUpdateVitoAgentConfigJobTestCreateAgent(ServiceStatus::STOPPED);
+
+    dispatch(new UpdateVitoAgentConfigJob($this->server));
+
+    SSH::assertNotExecutedContains('restart vito-agent');
+    expect(SSH::getUploadedContent())->toBe('');
+});
+
+test('dispatch for never throws into the calling job', function () {
+    Queue::fake();
+
+    vitoPestUnitJobsUpdateVitoAgentConfigJobTestCreateAgent(ServiceStatus::READY);
+    config()->set('service.services.broken.handler', 'App\Services\DoesNotExist');
+
+    /** @var Service $broken */
+    $broken = $this->server->services()->create([
+        'type' => 'broken',
+        'name' => 'broken',
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
+
+    UpdateVitoAgentConfigJob::dispatchFor($broken);
+
+    Queue::assertNotPushed(UpdateVitoAgentConfigJob::class);
+});
+
+function vitoPestUnitJobsUpdateVitoAgentConfigJobTestCreateAgent(ServiceStatus $status): Service
 {
-    use RefreshDatabase;
+    /** @var Service $service */
+    $service = Service::factory()->create([
+        'server_id' => test()->server->id,
+        'name' => 'vito-agent',
+        'type' => 'monitoring',
+        'type_data' => [
+            'url' => 'https://vito.test/agent-endpoint',
+            'secret' => 'agent-secret',
+            'data_retention' => 7,
+        ],
+        'version' => 'latest',
+        'status' => $status,
+    ]);
 
-    public function test_updates_config_and_restarts_agent(): void
-    {
-        SSH::fake();
-
-        $agent = $this->createAgent(ServiceStatus::READY);
-        $this->server->services()->create([
-            'type' => 'log_analysis',
-            'name' => 'goaccess',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-
-        dispatch(new UpdateVitoAgentConfigJob($this->server));
-
-        SSH::assertExecutedContains('/etc/vito-agent/config.json');
-        SSH::assertExecutedContains("rm -f '/tmp/");
-        SSH::assertExecutedContains('chmod 600 /etc/vito-agent/config.json');
-        SSH::assertExecutedContains('Monitoring services: ');
-        SSH::assertNotExecutedContains('agent-secret');
-        SSH::assertExecutedContains('restart vito-agent');
-
-        $config = json_decode(SSH::getUploadedContent(), true);
-        $this->assertSame('https://vito.test/agent-endpoint', $config['url']);
-        $this->assertSame('agent-secret', $config['secret']);
-        $this->assertArrayNotHasKey('data_retention', $config);
-
-        $units = array_column($config['services'], 'unit', 'id');
-        $this->assertCount(6, $units);
-        $this->assertContains('nginx', $units);
-        $this->assertContains('mysql', $units);
-        $this->assertContains('php8.2-fpm', $units);
-        $this->assertContains('ufw', $units);
-        $this->assertContains('supervisor', $units);
-        $this->assertContains('redis-server', $units);
-        $this->assertNotContains('', $units);
-        $this->assertArrayNotHasKey($agent->id, $units);
-    }
-
-    public function test_does_nothing_without_vito_agent(): void
-    {
-        SSH::fake();
-
-        dispatch(new UpdateVitoAgentConfigJob($this->server));
-
-        SSH::assertNotExecutedContains('vito-agent');
-        $this->assertSame('', SSH::getUploadedContent());
-    }
-
-    public function test_does_nothing_when_agent_is_not_ready(): void
-    {
-        SSH::fake();
-
-        $this->createAgent(ServiceStatus::STOPPED);
-
-        dispatch(new UpdateVitoAgentConfigJob($this->server));
-
-        SSH::assertNotExecutedContains('restart vito-agent');
-        $this->assertSame('', SSH::getUploadedContent());
-    }
-
-    public function test_dispatch_for_never_throws_into_the_calling_job(): void
-    {
-        Queue::fake();
-
-        $this->createAgent(ServiceStatus::READY);
-        config()->set('service.services.broken.handler', 'App\Services\DoesNotExist');
-
-        /** @var Service $broken */
-        $broken = $this->server->services()->create([
-            'type' => 'broken',
-            'name' => 'broken',
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
-
-        UpdateVitoAgentConfigJob::dispatchFor($broken);
-
-        Queue::assertNotPushed(UpdateVitoAgentConfigJob::class);
-    }
-
-    private function createAgent(ServiceStatus $status): Service
-    {
-        /** @var Service $service */
-        $service = Service::factory()->create([
-            'server_id' => $this->server->id,
-            'name' => 'vito-agent',
-            'type' => 'monitoring',
-            'type_data' => [
-                'url' => 'https://vito.test/agent-endpoint',
-                'secret' => 'agent-secret',
-                'data_retention' => 7,
-            ],
-            'version' => 'latest',
-            'status' => $status,
-        ]);
-
-        return $service;
-    }
+    return $service;
 }

--- a/tests/Unit/Jobs/UpdateVitoAgentConfigJobTest.php
+++ b/tests/Unit/Jobs/UpdateVitoAgentConfigJobTest.php
@@ -32,7 +32,7 @@ test('updates config and restarts agent', function () {
     $config = json_decode(SSH::getUploadedContent(), true);
     expect($config['url'])->toBe('https://vito.test/agent-endpoint');
     expect($config['secret'])->toBe('agent-secret');
-    $this->assertArrayNotHasKey('data_retention', $config);
+    expect($config)->not->toHaveKey('data_retention');
 
     $units = array_column($config['services'], 'unit', 'id');
     expect($units)->toHaveCount(6);
@@ -43,7 +43,7 @@ test('updates config and restarts agent', function () {
     expect($units)->toContain('supervisor');
     expect($units)->toContain('redis-server');
     expect($units)->not->toContain('');
-    $this->assertArrayNotHasKey($agent->id, $units);
+    expect($units)->not->toHaveKey($agent->id);
 });
 
 test('does nothing without vito agent', function () {
@@ -88,16 +88,8 @@ test('dispatch for never throws into the calling job', function () {
 function vitoPestUnitJobsUpdateVitoAgentConfigJobTestCreateAgent(ServiceStatus $status): Service
 {
     /** @var Service $service */
-    $service = Service::factory()->create([
+    $service = Service::factory()->vitoAgent()->create([
         'server_id' => test()->server->id,
-        'name' => 'vito-agent',
-        'type' => 'monitoring',
-        'type_data' => [
-            'url' => 'https://vito.test/agent-endpoint',
-            'secret' => 'agent-secret',
-            'data_retention' => 7,
-        ],
-        'version' => 'latest',
         'status' => $status,
     ]);
 

--- a/tests/Unit/Models/ServerModelTest.php
+++ b/tests/Unit/Models/ServerModelTest.php
@@ -1,103 +1,92 @@
 <?php
 
-namespace Tests\Unit\Models;
-
 use App\Enums\ServerStatus;
 use App\Facades\SSH;
 use App\Helpers\SSH as SSHHelper;
-use Closure;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use phpseclib3\Net\SSH2;
-use ReflectionProperty;
-use Tests\TestCase;
 
-class ServerModelTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_should_have_default_service(): void
-    {
-        $php = $this->server->defaultService('php');
-        $php->update(['is_default' => false]);
-        $this->assertNotNull($this->server->defaultService('php'));
-        $php->refresh();
-        $this->assertTrue($php->is_default);
-    }
+test('should have default service', function () {
+    $php = $this->server->defaultService('php');
+    $php->update(['is_default' => false]);
+    expect($this->server->defaultService('php'))->not->toBeNull();
+    $php->refresh();
+    expect($php->is_default)->toBeTrue();
+});
 
-    public function test_check_connection_is_ready(): void
-    {
-        SSH::fake();
+test('check connection is ready', function () {
+    SSH::fake();
 
-        $this->server->update(['status' => ServerStatus::DISCONNECTED]);
+    $this->server->update(['status' => ServerStatus::DISCONNECTED]);
 
-        $this->server->checkConnection();
+    $this->server->checkConnection();
 
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-            'status' => ServerStatus::READY,
-        ]);
-    }
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'status' => ServerStatus::READY,
+    ]);
+});
 
-    public function test_connection_failed(): void
-    {
-        SSH::fake()->connectionWillFail();
+test('connection failed', function () {
+    SSH::fake()->connectionWillFail();
 
-        $this->server->update(['status' => ServerStatus::READY]);
+    $this->server->update(['status' => ServerStatus::READY]);
 
-        $this->server->checkConnection();
+    $this->server->checkConnection();
 
-        $this->assertDatabaseHas('servers', [
-            'id' => $this->server->id,
-            'status' => ServerStatus::DISCONNECTED,
-        ]);
-    }
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'status' => ServerStatus::DISCONNECTED,
+    ]);
+});
 
-    public function test_exec_wraps_command_when_using_custom_user(): void
-    {
-        $ssh = (new SSHHelper)->init($this->server, 'deploy');
+test('exec wraps command when using custom user', function () {
+    $ssh = (new SSHHelper)->init($this->server, 'deploy');
 
-        $connection = $this->getMockBuilder(SSH2::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['setTimeout', 'exec', 'getExitStatus', 'disconnect'])
-            ->getMock();
+    $connection = $this->getMockBuilder(SSH2::class)
+        ->disableOriginalConstructor()
+        ->onlyMethods(['setTimeout', 'exec', 'getExitStatus', 'disconnect'])
+        ->getMock();
 
-        $executedCommand = null;
+    $executedCommand = null;
 
-        $connection->expects($this->once())
-            ->method('setTimeout')
-            ->with(0);
+    $connection->expects($this->once())
+        ->method('setTimeout')
+        ->with(0);
 
-        $connection->expects($this->once())
-            ->method('exec')
-            ->with(
-                $this->isString(),
-                $this->isInstanceOf(Closure::class)
-            )
-            ->willReturnCallback(function ($command, $callback) use (&$executedCommand) {
-                $executedCommand = $command;
-                $callback('');
+    $connection->expects($this->once())
+        ->method('exec')
+        ->with(
+            $this->isString(),
+            $this->isInstanceOf(Closure::class)
+        )
+        ->willReturnCallback(function ($command, $callback) use (&$executedCommand) {
+            $executedCommand = $command;
+            $callback('');
 
-                return '';
-            });
+            return '';
+        });
 
-        $connection->expects($this->once())
-            ->method('getExitStatus')
-            ->willReturn(0);
+    $connection->expects($this->once())
+        ->method('getExitStatus')
+        ->willReturn(0);
 
-        $connection->method('disconnect');
+    $connection->method('disconnect');
 
-        $reflection = new ReflectionProperty(SSHHelper::class, 'connection');
-        $reflection->setValue($ssh, $connection);
+    $reflection = new ReflectionProperty(SSHHelper::class, 'connection');
+    $reflection->setValue($ssh, $connection);
 
-        $command = <<<'BASH'
+    $command = <<<'BASH'
 pwd
 ls -la
 BASH;
 
-        $output = $ssh->exec($command);
-        $ssh->disconnect();
+    $output = $ssh->exec($command);
+    $ssh->disconnect();
 
-        $expected = <<<'BASH'
+    $expected = <<<'BASH'
 sudo -u deploy bash <<'EOF'
 cd ~ || { echo 'VITO_SSH_ERROR: failed to cd to home directory' >&2; exit 1; }
 set -e; pwd
@@ -105,7 +94,6 @@ ls -la
 EOF
 BASH;
 
-        $this->assertSame('', $output);
-        $this->assertSame($expected, $executedCommand);
-    }
-}
+    expect($output)->toBe('');
+    expect($executedCommand)->toBe($expected);
+});

--- a/tests/Unit/Models/ServerModelTest.php
+++ b/tests/Unit/Models/ServerModelTest.php
@@ -10,6 +10,7 @@ uses(RefreshDatabase::class);
 
 test('should have default service', function () {
     $php = $this->server->defaultService('php');
+    $this->assertNotNull($php);
     $php->update(['is_default' => false]);
     expect($this->server->defaultService('php'))->not->toBeNull();
     $php->refresh();

--- a/tests/Unit/Models/SiteTypeResolutionTest.php
+++ b/tests/Unit/Models/SiteTypeResolutionTest.php
@@ -1,52 +1,42 @@
 <?php
 
-namespace Tests\Unit\Models;
-
 use App\Models\Site;
 use App\SiteTypes\BunSite;
 use App\SiteTypes\NodeJS;
 use App\SiteTypes\NodeSite;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use RuntimeException;
-use Tests\TestCase;
 
-class SiteTypeResolutionTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_legacy_mise_bun_rows_resolve_to_bun_site(): void
-    {
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'type' => 'mise_bun',
-        ]);
+test('legacy mise bun rows resolve to bun site', function () {
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'type' => 'mise_bun',
+    ]);
 
-        $this->assertInstanceOf(BunSite::class, $site->type());
-    }
+    expect($site->type())->toBeInstanceOf(BunSite::class);
+});
 
-    public function test_legacy_mise_nodejs_rows_resolve_to_node_site(): void
-    {
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'type' => 'mise_nodejs',
-        ]);
+test('legacy mise nodejs rows resolve to node site', function () {
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'type' => 'mise_nodejs',
+    ]);
 
-        $this->assertInstanceOf(NodeSite::class, $site->type());
-    }
+    expect($site->type())->toBeInstanceOf(NodeSite::class);
+});
 
-    public function test_deprecated_nodejs_install_throws(): void
-    {
-        /** @var Site $site */
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'type' => NodeJS::id(),
-        ]);
+test('deprecated nodejs install throws', function () {
+    /** @var Site $site */
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'type' => NodeJS::id(),
+    ]);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageMatches('/deprecated/i');
+    $this->expectException(RuntimeException::class);
+    $this->expectExceptionMessageMatches('/deprecated/i');
 
-        $site->type()->install();
-    }
-}
+    $site->type()->install();
+});

--- a/tests/Unit/Models/WorkflowTest.php
+++ b/tests/Unit/Models/WorkflowTest.php
@@ -1,279 +1,31 @@
 <?php
 
-namespace Tests\Unit\Models;
-
 use App\DTOs\WorkflowActionDTO;
 use App\Models\Workflow;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class WorkflowTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_get_execution_tree_returns_null_when_no_nodes(): void
-    {
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'payload' => [
-                'nodes' => [],
-                'edges' => [],
-            ],
-        ]);
+test('get execution tree returns null when no nodes', function () {
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'payload' => [
+            'nodes' => [],
+            'edges' => [],
+        ],
+    ]);
 
-        $result = $workflow->getExecutionTree();
+    $result = $workflow->getExecutionTree();
 
-        $this->assertNull($result);
-    }
+    expect($result)->toBeNull();
+});
 
-    public function test_get_execution_tree_returns_null_when_no_starting_node(): void
-    {
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'payload' => [
-                'nodes' => [
-                    [
-                        'id' => 'node-1',
-                        'data' => [
-                            'action' => [
-                                'label' => 'Test Action',
-                                'handler' => 'TestHandler',
-                                'outputs' => [],
-                                'inputs' => [],
-                                'starting' => false,
-                            ],
-                        ],
-                    ],
-                ],
-                'edges' => [],
-            ],
-        ]);
-
-        $result = $workflow->getExecutionTree();
-
-        $this->assertNull($result);
-    }
-
-    public function test_get_execution_tree_returns_single_node_dto(): void
-    {
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'payload' => [
-                'nodes' => [
-                    [
-                        'id' => 'node-1',
-                        'data' => [
-                            'action' => [
-                                'label' => 'Create Server',
-                                'handler' => 'App\\WorkflowActions\\Server\\CreateServer',
-                                'outputs' => [
-                                    'server_id' => 'The ID of the created server',
-                                    'server_ip' => 'The IP address of the created server',
-                                ],
-                                'inputs' => [
-                                    'name' => 'test-server',
-                                    'provider' => 'digitalocean',
-                                ],
-                                'starting' => true,
-                            ],
-                        ],
-                    ],
-                ],
-                'edges' => [],
-            ],
-        ]);
-
-        $result = $workflow->getExecutionTree();
-
-        $this->assertInstanceOf(WorkflowActionDTO::class, $result);
-        $this->assertEquals('Create Server', $result->label);
-        $this->assertEquals('App\\WorkflowActions\\Server\\CreateServer', $result->handler);
-        $this->assertEquals(['server_id', 'server_ip'], $result->outputs);
-        $this->assertEquals(['name' => 'test-server', 'provider' => 'digitalocean'], $result->inputs);
-        $this->assertEquals('node-1', $result->id);
-        $this->assertNull($result->success);
-        $this->assertNull($result->failure);
-    }
-
-    public function test_get_execution_tree_handles_success_and_failure_branches(): void
-    {
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'payload' => [
-                'nodes' => [
-                    [
-                        'id' => 'node-1',
-                        'data' => [
-                            'action' => [
-                                'label' => 'Create Server',
-                                'handler' => 'App\\WorkflowActions\\Server\\CreateServer',
-                                'outputs' => ['server_id'],
-                                'inputs' => [],
-                                'starting' => true,
-                            ],
-                        ],
-                    ],
-                    [
-                        'id' => 'node-2',
-                        'data' => [
-                            'action' => [
-                                'label' => 'Install Service',
-                                'handler' => 'App\\WorkflowActions\\Service\\InstallService',
-                                'outputs' => ['service_id'],
-                                'inputs' => [],
-                                'starting' => false,
-                            ],
-                        ],
-                    ],
-                    [
-                        'id' => 'node-3',
-                        'data' => [
-                            'action' => [
-                                'label' => 'Create Site',
-                                'handler' => 'App\\WorkflowActions\\Site\\CreateSite',
-                                'outputs' => ['site_id'],
-                                'inputs' => [],
-                                'starting' => false,
-                            ],
-                        ],
-                    ],
-                ],
-                'edges' => [
-                    [
-                        'source' => 'node-1',
-                        'target' => 'node-2',
-                        'data' => ['status' => 'success'],
-                    ],
-                    [
-                        'source' => 'node-1',
-                        'target' => 'node-3',
-                        'data' => ['status' => 'failure'],
-                    ],
-                ],
-            ],
-        ]);
-
-        $result = $workflow->getExecutionTree();
-
-        $this->assertInstanceOf(WorkflowActionDTO::class, $result);
-        $this->assertEquals('Create Server', $result->label);
-        $this->assertEquals('node-1', $result->id);
-
-        // Check success branch
-        $this->assertInstanceOf(WorkflowActionDTO::class, $result->success);
-        $this->assertEquals('Install Service', $result->success->label);
-        $this->assertEquals('node-2', $result->success->id);
-        $this->assertNull($result->success->success);
-        $this->assertNull($result->success->failure);
-
-        // Check failure branch
-        $this->assertInstanceOf(WorkflowActionDTO::class, $result->failure);
-        $this->assertEquals('Create Site', $result->failure->label);
-        $this->assertEquals('node-3', $result->failure->id);
-        $this->assertNull($result->failure->success);
-        $this->assertNull($result->failure->failure);
-    }
-
-    public function test_get_execution_tree_handles_deep_nested_workflows(): void
-    {
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'payload' => [
-                'nodes' => [
-                    [
-                        'id' => 'node-1',
-                        'data' => [
-                            'action' => [
-                                'label' => 'Start',
-                                'handler' => 'StartHandler',
-                                'outputs' => ['start_id'],
-                                'inputs' => [],
-                                'starting' => true,
-                            ],
-                        ],
-                    ],
-                    [
-                        'id' => 'node-2',
-                        'data' => [
-                            'action' => [
-                                'label' => 'Step 1',
-                                'handler' => 'Step1Handler',
-                                'outputs' => ['step1_id'],
-                                'inputs' => [],
-                                'starting' => false,
-                            ],
-                        ],
-                    ],
-                    [
-                        'id' => 'node-3',
-                        'data' => [
-                            'action' => [
-                                'label' => 'Step 2',
-                                'handler' => 'Step2Handler',
-                                'outputs' => ['step2_id'],
-                                'inputs' => [],
-                                'starting' => false,
-                            ],
-                        ],
-                    ],
-                    [
-                        'id' => 'node-4',
-                        'data' => [
-                            'action' => [
-                                'label' => 'Final',
-                                'handler' => 'FinalHandler',
-                                'outputs' => ['final_id'],
-                                'inputs' => [],
-                                'starting' => false,
-                            ],
-                        ],
-                    ],
-                ],
-                'edges' => [
-                    [
-                        'source' => 'node-1',
-                        'target' => 'node-2',
-                        'data' => ['status' => 'success'],
-                    ],
-                    [
-                        'source' => 'node-2',
-                        'target' => 'node-3',
-                        'data' => ['status' => 'success'],
-                    ],
-                    [
-                        'source' => 'node-3',
-                        'target' => 'node-4',
-                        'data' => ['status' => 'success'],
-                    ],
-                ],
-            ],
-        ]);
-
-        $result = $workflow->getExecutionTree();
-
-        $this->assertInstanceOf(WorkflowActionDTO::class, $result);
-        $this->assertEquals('Start', $result->label);
-
-        // Check nested success chain
-        $this->assertInstanceOf(WorkflowActionDTO::class, $result->success);
-        $this->assertEquals('Step 1', $result->success->label);
-
-        $this->assertInstanceOf(WorkflowActionDTO::class, $result->success->success);
-        $this->assertEquals('Step 2', $result->success->success->label);
-
-        $this->assertInstanceOf(WorkflowActionDTO::class, $result->success->success->success);
-        $this->assertEquals('Final', $result->success->success->success->label);
-        $this->assertNull($result->success->success->success->success);
-    }
-
-    public function test_get_execution_tree_handles_string_payload(): void
-    {
-        $payload = [
+test('get execution tree returns null when no starting node', function () {
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'payload' => [
             'nodes' => [
                 [
                     'id' => 'node-1',
@@ -281,173 +33,407 @@ class WorkflowTest extends TestCase
                         'action' => [
                             'label' => 'Test Action',
                             'handler' => 'TestHandler',
-                            'outputs' => ['test_id'],
+                            'outputs' => [],
                             'inputs' => [],
+                            'starting' => false,
+                        ],
+                    ],
+                ],
+            ],
+            'edges' => [],
+        ],
+    ]);
+
+    $result = $workflow->getExecutionTree();
+
+    expect($result)->toBeNull();
+});
+
+test('get execution tree returns single node dto', function () {
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'payload' => [
+            'nodes' => [
+                [
+                    'id' => 'node-1',
+                    'data' => [
+                        'action' => [
+                            'label' => 'Create Server',
+                            'handler' => 'App\\WorkflowActions\\Server\\CreateServer',
+                            'outputs' => [
+                                'server_id' => 'The ID of the created server',
+                                'server_ip' => 'The IP address of the created server',
+                            ],
+                            'inputs' => [
+                                'name' => 'test-server',
+                                'provider' => 'digitalocean',
+                            ],
                             'starting' => true,
                         ],
                     ],
                 ],
             ],
             'edges' => [],
-        ];
+        ],
+    ]);
 
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'payload' => $payload,
-        ]);
+    $result = $workflow->getExecutionTree();
 
-        $result = $workflow->getExecutionTree();
+    expect($result)->toBeInstanceOf(WorkflowActionDTO::class);
+    expect($result->label)->toEqual('Create Server');
+    expect($result->handler)->toEqual('App\\WorkflowActions\\Server\\CreateServer');
+    expect($result->outputs)->toEqual(['server_id', 'server_ip']);
+    expect($result->inputs)->toEqual(['name' => 'test-server', 'provider' => 'digitalocean']);
+    expect($result->id)->toEqual('node-1');
+    expect($result->success)->toBeNull();
+    expect($result->failure)->toBeNull();
+});
 
-        $this->assertInstanceOf(WorkflowActionDTO::class, $result);
-        $this->assertEquals('Test Action', $result->label);
-        $this->assertEquals('node-1', $result->id);
-    }
-
-    public function test_get_execution_tree_handles_missing_action_data(): void
-    {
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'payload' => [
-                'nodes' => [
-                    [
-                        'id' => 'node-1',
-                        'data' => [
-                            'action' => [
-                                'starting' => true,
-                            ],
+test('get execution tree handles success and failure branches', function () {
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'payload' => [
+            'nodes' => [
+                [
+                    'id' => 'node-1',
+                    'data' => [
+                        'action' => [
+                            'label' => 'Create Server',
+                            'handler' => 'App\\WorkflowActions\\Server\\CreateServer',
+                            'outputs' => ['server_id'],
+                            'inputs' => [],
+                            'starting' => true,
                         ],
                     ],
                 ],
-                'edges' => [],
-            ],
-        ]);
-
-        $result = $workflow->getExecutionTree();
-
-        $this->assertInstanceOf(WorkflowActionDTO::class, $result);
-        $this->assertEquals('', $result->label);
-        $this->assertEquals('', $result->handler);
-        $this->assertEquals([], $result->outputs);
-        $this->assertEquals([], $result->inputs);
-        $this->assertEquals('node-1', $result->id);
-    }
-
-    public function test_get_execution_tree_handles_missing_edge_status(): void
-    {
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'payload' => [
-                'nodes' => [
-                    [
-                        'id' => 'node-1',
-                        'data' => [
-                            'action' => [
-                                'label' => 'Start',
-                                'handler' => 'StartHandler',
-                                'outputs' => [],
-                                'inputs' => [],
-                                'starting' => true,
-                            ],
-                        ],
-                    ],
-                    [
-                        'id' => 'node-2',
-                        'data' => [
-                            'action' => [
-                                'label' => 'Next',
-                                'handler' => 'NextHandler',
-                                'outputs' => [],
-                                'inputs' => [],
-                                'starting' => false,
-                            ],
+                [
+                    'id' => 'node-2',
+                    'data' => [
+                        'action' => [
+                            'label' => 'Install Service',
+                            'handler' => 'App\\WorkflowActions\\Service\\InstallService',
+                            'outputs' => ['service_id'],
+                            'inputs' => [],
+                            'starting' => false,
                         ],
                     ],
                 ],
-                'edges' => [
-                    [
-                        'source' => 'node-1',
-                        'target' => 'node-2',
-                        'data' => [], // Missing status
+                [
+                    'id' => 'node-3',
+                    'data' => [
+                        'action' => [
+                            'label' => 'Create Site',
+                            'handler' => 'App\\WorkflowActions\\Site\\CreateSite',
+                            'outputs' => ['site_id'],
+                            'inputs' => [],
+                            'starting' => false,
+                        ],
                     ],
                 ],
             ],
-        ]);
+            'edges' => [
+                [
+                    'source' => 'node-1',
+                    'target' => 'node-2',
+                    'data' => ['status' => 'success'],
+                ],
+                [
+                    'source' => 'node-1',
+                    'target' => 'node-3',
+                    'data' => ['status' => 'failure'],
+                ],
+            ],
+        ],
+    ]);
 
-        $result = $workflow->getExecutionTree();
+    $result = $workflow->getExecutionTree();
 
-        $this->assertInstanceOf(WorkflowActionDTO::class, $result);
-        $this->assertEquals('Start', $result->label);
-        // Should default to success when status is missing
-        $this->assertInstanceOf(WorkflowActionDTO::class, $result->success);
-        $this->assertEquals('Next', $result->success->label);
-    }
+    expect($result)->toBeInstanceOf(WorkflowActionDTO::class);
+    expect($result->label)->toEqual('Create Server');
+    expect($result->id)->toEqual('node-1');
 
-    public function test_get_execution_tree_to_array_method(): void
-    {
-        $workflow = Workflow::factory()->create([
-            'user_id' => $this->user->id,
-            'project_id' => $this->user->current_project_id,
-            'payload' => [
-                'nodes' => [
-                    [
-                        'id' => 'node-1',
-                        'data' => [
-                            'action' => [
-                                'label' => 'Create Server',
-                                'handler' => 'App\\WorkflowActions\\Server\\CreateServer',
-                                'outputs' => [
-                                    'server_id' => 'The ID of the created server',
-                                    'server_ip' => 'The IP address of the created server',
-                                ],
-                                'inputs' => [
-                                    'name' => 'test-server',
-                                ],
-                                'starting' => true,
-                            ],
-                        ],
-                    ],
-                    [
-                        'id' => 'node-2',
-                        'data' => [
-                            'action' => [
-                                'label' => 'Install Service',
-                                'handler' => 'App\\WorkflowActions\\Service\\InstallService',
-                                'outputs' => ['service_id'],
-                                'inputs' => [],
-                                'starting' => false,
-                            ],
+    // Check success branch
+    expect($result->success)->toBeInstanceOf(WorkflowActionDTO::class);
+    expect($result->success->label)->toEqual('Install Service');
+    expect($result->success->id)->toEqual('node-2');
+    expect($result->success->success)->toBeNull();
+    expect($result->success->failure)->toBeNull();
+
+    // Check failure branch
+    expect($result->failure)->toBeInstanceOf(WorkflowActionDTO::class);
+    expect($result->failure->label)->toEqual('Create Site');
+    expect($result->failure->id)->toEqual('node-3');
+    expect($result->failure->success)->toBeNull();
+    expect($result->failure->failure)->toBeNull();
+});
+
+test('get execution tree handles deep nested workflows', function () {
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'payload' => [
+            'nodes' => [
+                [
+                    'id' => 'node-1',
+                    'data' => [
+                        'action' => [
+                            'label' => 'Start',
+                            'handler' => 'StartHandler',
+                            'outputs' => ['start_id'],
+                            'inputs' => [],
+                            'starting' => true,
                         ],
                     ],
                 ],
-                'edges' => [
-                    [
-                        'source' => 'node-1',
-                        'target' => 'node-2',
-                        'data' => ['status' => 'success'],
+                [
+                    'id' => 'node-2',
+                    'data' => [
+                        'action' => [
+                            'label' => 'Step 1',
+                            'handler' => 'Step1Handler',
+                            'outputs' => ['step1_id'],
+                            'inputs' => [],
+                            'starting' => false,
+                        ],
+                    ],
+                ],
+                [
+                    'id' => 'node-3',
+                    'data' => [
+                        'action' => [
+                            'label' => 'Step 2',
+                            'handler' => 'Step2Handler',
+                            'outputs' => ['step2_id'],
+                            'inputs' => [],
+                            'starting' => false,
+                        ],
+                    ],
+                ],
+                [
+                    'id' => 'node-4',
+                    'data' => [
+                        'action' => [
+                            'label' => 'Final',
+                            'handler' => 'FinalHandler',
+                            'outputs' => ['final_id'],
+                            'inputs' => [],
+                            'starting' => false,
+                        ],
                     ],
                 ],
             ],
-        ]);
+            'edges' => [
+                [
+                    'source' => 'node-1',
+                    'target' => 'node-2',
+                    'data' => ['status' => 'success'],
+                ],
+                [
+                    'source' => 'node-2',
+                    'target' => 'node-3',
+                    'data' => ['status' => 'success'],
+                ],
+                [
+                    'source' => 'node-3',
+                    'target' => 'node-4',
+                    'data' => ['status' => 'success'],
+                ],
+            ],
+        ],
+    ]);
 
-        $result = $workflow->getExecutionTree();
-        $array = $result->toArray();
+    $result = $workflow->getExecutionTree();
 
-        $this->assertIsArray($array);
-        $this->assertArrayHasKey('run', $array);
-        $this->assertArrayHasKey('success', $array);
-        $this->assertArrayHasKey('failure', $array);
+    expect($result)->toBeInstanceOf(WorkflowActionDTO::class);
+    expect($result->label)->toEqual('Start');
 
-        $this->assertEquals('Create Server', $array['run']['label']);
-        $this->assertEquals('App\\WorkflowActions\\Server\\CreateServer', $array['run']['handler']);
-        $this->assertEquals(['name' => 'test-server'], $array['run']['inputs']);
-        $this->assertEquals(['server_id', 'server_ip'], $array['run']['outputs']);
-        $this->assertEquals('node-1', $array['run']['id']);
+    // Check nested success chain
+    expect($result->success)->toBeInstanceOf(WorkflowActionDTO::class);
+    expect($result->success->label)->toEqual('Step 1');
 
-        $this->assertIsArray($array['success']);
-        $this->assertEquals('Install Service', $array['success']['run']['label']);
-        $this->assertNull($array['failure']);
-    }
-}
+    expect($result->success->success)->toBeInstanceOf(WorkflowActionDTO::class);
+    expect($result->success->success->label)->toEqual('Step 2');
+
+    expect($result->success->success->success)->toBeInstanceOf(WorkflowActionDTO::class);
+    expect($result->success->success->success->label)->toEqual('Final');
+    expect($result->success->success->success->success)->toBeNull();
+});
+
+test('get execution tree handles string payload', function () {
+    $payload = [
+        'nodes' => [
+            [
+                'id' => 'node-1',
+                'data' => [
+                    'action' => [
+                        'label' => 'Test Action',
+                        'handler' => 'TestHandler',
+                        'outputs' => ['test_id'],
+                        'inputs' => [],
+                        'starting' => true,
+                    ],
+                ],
+            ],
+        ],
+        'edges' => [],
+    ];
+
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'payload' => $payload,
+    ]);
+
+    $result = $workflow->getExecutionTree();
+
+    expect($result)->toBeInstanceOf(WorkflowActionDTO::class);
+    expect($result->label)->toEqual('Test Action');
+    expect($result->id)->toEqual('node-1');
+});
+
+test('get execution tree handles missing action data', function () {
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'payload' => [
+            'nodes' => [
+                [
+                    'id' => 'node-1',
+                    'data' => [
+                        'action' => [
+                            'starting' => true,
+                        ],
+                    ],
+                ],
+            ],
+            'edges' => [],
+        ],
+    ]);
+
+    $result = $workflow->getExecutionTree();
+
+    expect($result)->toBeInstanceOf(WorkflowActionDTO::class);
+    expect($result->label)->toEqual('');
+    expect($result->handler)->toEqual('');
+    expect($result->outputs)->toEqual([]);
+    expect($result->inputs)->toEqual([]);
+    expect($result->id)->toEqual('node-1');
+});
+
+test('get execution tree handles missing edge status', function () {
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'payload' => [
+            'nodes' => [
+                [
+                    'id' => 'node-1',
+                    'data' => [
+                        'action' => [
+                            'label' => 'Start',
+                            'handler' => 'StartHandler',
+                            'outputs' => [],
+                            'inputs' => [],
+                            'starting' => true,
+                        ],
+                    ],
+                ],
+                [
+                    'id' => 'node-2',
+                    'data' => [
+                        'action' => [
+                            'label' => 'Next',
+                            'handler' => 'NextHandler',
+                            'outputs' => [],
+                            'inputs' => [],
+                            'starting' => false,
+                        ],
+                    ],
+                ],
+            ],
+            'edges' => [
+                [
+                    'source' => 'node-1',
+                    'target' => 'node-2',
+                    'data' => [], // Missing status
+                ],
+            ],
+        ],
+    ]);
+
+    $result = $workflow->getExecutionTree();
+
+    expect($result)->toBeInstanceOf(WorkflowActionDTO::class);
+    expect($result->label)->toEqual('Start');
+
+    // Should default to success when status is missing
+    expect($result->success)->toBeInstanceOf(WorkflowActionDTO::class);
+    expect($result->success->label)->toEqual('Next');
+});
+
+test('get execution tree to array method', function () {
+    $workflow = Workflow::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
+        'payload' => [
+            'nodes' => [
+                [
+                    'id' => 'node-1',
+                    'data' => [
+                        'action' => [
+                            'label' => 'Create Server',
+                            'handler' => 'App\\WorkflowActions\\Server\\CreateServer',
+                            'outputs' => [
+                                'server_id' => 'The ID of the created server',
+                                'server_ip' => 'The IP address of the created server',
+                            ],
+                            'inputs' => [
+                                'name' => 'test-server',
+                            ],
+                            'starting' => true,
+                        ],
+                    ],
+                ],
+                [
+                    'id' => 'node-2',
+                    'data' => [
+                        'action' => [
+                            'label' => 'Install Service',
+                            'handler' => 'App\\WorkflowActions\\Service\\InstallService',
+                            'outputs' => ['service_id'],
+                            'inputs' => [],
+                            'starting' => false,
+                        ],
+                    ],
+                ],
+            ],
+            'edges' => [
+                [
+                    'source' => 'node-1',
+                    'target' => 'node-2',
+                    'data' => ['status' => 'success'],
+                ],
+            ],
+        ],
+    ]);
+
+    $result = $workflow->getExecutionTree();
+    $array = $result->toArray();
+
+    expect($array)->toBeArray();
+    expect($array)->toHaveKey('run');
+    expect($array)->toHaveKey('success');
+    expect($array)->toHaveKey('failure');
+
+    expect($array['run']['label'])->toEqual('Create Server');
+    expect($array['run']['handler'])->toEqual('App\\WorkflowActions\\Server\\CreateServer');
+    expect($array['run']['inputs'])->toEqual(['name' => 'test-server']);
+    expect($array['run']['outputs'])->toEqual(['server_id', 'server_ip']);
+    expect($array['run']['id'])->toEqual('node-1');
+
+    expect($array['success'])->toBeArray();
+    expect($array['success']['run']['label'])->toEqual('Install Service');
+    expect($array['failure'])->toBeNull();
+});

--- a/tests/Unit/NodeSiteTest.php
+++ b/tests/Unit/NodeSiteTest.php
@@ -1,78 +1,55 @@
 <?php
 
-namespace Tests\Unit;
-
 use App\Models\Site;
 use App\SiteTypes\NodeSite;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class NodeSiteTest extends TestCase
+uses(RefreshDatabase::class);
+
+function vitoPestUnitNodeSiteTestSiteType(string $packageManager): NodeSite
 {
-    use RefreshDatabase;
+    $site = Site::factory()->create([
+        'server_id' => test()->server->id,
+        'user' => 'testuser',
+        'path' => '/home/testuser/example.com',
+        'type' => NodeSite::id(),
+        'type_data' => [
+            'node_version' => '22',
+            'package_manager' => $packageManager,
+        ],
+    ]);
 
-    private function siteType(string $packageManager): NodeSite
-    {
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'testuser',
-            'path' => '/home/testuser/example.com',
-            'type' => NodeSite::id(),
-            'type_data' => [
-                'node_version' => '22',
-                'package_manager' => $packageManager,
-            ],
-        ]);
-
-        return new NodeSite($site);
-    }
-
-    public function test_id_and_language(): void
-    {
-        $this->assertSame('node', NodeSite::id());
-        $this->assertSame('nodejs', $this->siteType('npm')->language());
-    }
-
-    public function test_deploy_commands_for_npm(): void
-    {
-        $siteType = $this->siteType('npm');
-        $reflection = new \ReflectionMethod($siteType, 'deployCommands');
-
-        $this->assertSame(
-            ['npm ci', 'npm run build'],
-            $reflection->invoke($siteType),
-        );
-    }
-
-    public function test_deploy_commands_for_pnpm(): void
-    {
-        $siteType = $this->siteType('pnpm');
-        $reflection = new \ReflectionMethod($siteType, 'deployCommands');
-
-        $this->assertSame(
-            ['pnpm install --frozen-lockfile', 'pnpm run build'],
-            $reflection->invoke($siteType),
-        );
-    }
-
-    public function test_deploy_commands_for_yarn(): void
-    {
-        $siteType = $this->siteType('yarn');
-        $reflection = new \ReflectionMethod($siteType, 'deployCommands');
-
-        $this->assertSame(
-            ['yarn install --frozen-lockfile', 'yarn build'],
-            $reflection->invoke($siteType),
-        );
-    }
-
-    public function test_default_deployment_script_for_pnpm(): void
-    {
-        $script = $this->siteType('pnpm')->defaultDeploymentScript();
-
-        $this->assertSame(
-            "git pull origin \$BRANCH\n\npnpm install --frozen-lockfile\n\npnpm run build\n",
-            $script,
-        );
-    }
+    return new NodeSite($site);
 }
+
+test('id and language', function () {
+    expect(NodeSite::id())->toBe('node');
+    expect(vitoPestUnitNodeSiteTestSiteType('npm')->language())->toBe('nodejs');
+});
+
+test('deploy commands for npm', function () {
+    $siteType = vitoPestUnitNodeSiteTestSiteType('npm');
+    $reflection = new ReflectionMethod($siteType, 'deployCommands');
+
+    expect($reflection->invoke($siteType))->toBe(['npm ci', 'npm run build']);
+});
+
+test('deploy commands for pnpm', function () {
+    $siteType = vitoPestUnitNodeSiteTestSiteType('pnpm');
+    $reflection = new ReflectionMethod($siteType, 'deployCommands');
+
+    expect($reflection->invoke($siteType))->toBe(['pnpm install --frozen-lockfile', 'pnpm run build']);
+});
+
+test('deploy commands for yarn', function () {
+    $siteType = vitoPestUnitNodeSiteTestSiteType('yarn');
+    $reflection = new ReflectionMethod($siteType, 'deployCommands');
+
+    expect($reflection->invoke($siteType))->toBe(['yarn install --frozen-lockfile', 'yarn build']);
+});
+
+test('default deployment script for pnpm', function () {
+    $script = vitoPestUnitNodeSiteTestSiteType('pnpm')->defaultDeploymentScript();
+
+    expect($script)->toBe("git pull origin \$BRANCH\n\npnpm install --frozen-lockfile\n\npnpm run build\n");
+});

--- a/tests/Unit/NotificationChannels/DiscordTest.php
+++ b/tests/Unit/NotificationChannels/DiscordTest.php
@@ -1,93 +1,83 @@
 <?php
 
-namespace Tests\Unit\NotificationChannels;
-
 use App\Models\NotificationChannel;
 use App\NotificationChannels\Discord;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use Tests\TestCase;
+use Tests\Unit\NotificationChannels\TestNotification;
 
-class DiscordTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_rules(): void
-    {
-        $provider = new Discord(NotificationChannel::factory()->create([
-            'provider' => 'discord',
-        ]));
+test('create rules', function () {
+    $provider = new Discord(NotificationChannel::factory()->create([
+        'provider' => 'discord',
+    ]));
 
-        $this->assertSame([
-            'webhook_url' => [
-                'required',
-                'url',
-            ],
-        ], $provider->createRules([]));
-    }
+    expect($provider->createRules([]))->toBe([
+        'webhook_url' => [
+            'required',
+            'url',
+        ],
+    ]);
+});
 
-    public function test_create_data(): void
-    {
-        $provider = new Discord(NotificationChannel::factory()->create([
-            'provider' => 'discord',
-        ]));
+test('create data', function () {
+    $provider = new Discord(NotificationChannel::factory()->create([
+        'provider' => 'discord',
+    ]));
 
-        $this->assertSame([
+    expect($provider->createData([
+        'webhook_url' => 'https://discord.com/xxxxx',
+    ]))->toBe([
+        'webhook_url' => 'https://discord.com/xxxxx',
+    ]);
+});
+
+test('data', function () {
+    $provider = new Discord(NotificationChannel::factory()->create([
+        'provider' => 'discord',
+        'data' => [
             'webhook_url' => 'https://discord.com/xxxxx',
-        ], $provider->createData([
+        ],
+    ]));
+
+    expect($provider->data())->toBe([
+        'webhook_url' => 'https://discord.com/xxxxx',
+    ]);
+});
+
+test('connect', function () {
+    $provider = new Discord(NotificationChannel::factory()->create([
+        'provider' => 'discord',
+        'data' => [
             'webhook_url' => 'https://discord.com/xxxxx',
-        ]));
-    }
+        ],
+    ]));
 
-    public function test_data(): void
-    {
-        $provider = new Discord(NotificationChannel::factory()->create([
-            'provider' => 'discord',
-            'data' => [
-                'webhook_url' => 'https://discord.com/xxxxx',
-            ],
-        ]));
+    Http::fake();
 
-        $this->assertSame([
+    expect($provider->connect())->toBeTrue();
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://discord.com/xxxxx';
+    });
+});
+
+test('send', function () {
+    $channel = NotificationChannel::factory()->create([
+        'provider' => 'discord',
+        'data' => [
             'webhook_url' => 'https://discord.com/xxxxx',
-        ], $provider->data());
-    }
+        ],
+    ]);
+    $provider = new Discord($channel);
 
-    public function test_connect(): void
-    {
-        $provider = new Discord(NotificationChannel::factory()->create([
-            'provider' => 'discord',
-            'data' => [
-                'webhook_url' => 'https://discord.com/xxxxx',
-            ],
-        ]));
+    Http::fake();
 
-        Http::fake();
+    $provider->send($channel, new TestNotification);
 
-        $this->assertTrue($provider->connect());
-
-        Http::assertSent(function ($request) {
-            return $request->url() === 'https://discord.com/xxxxx';
-        });
-    }
-
-    public function test_send(): void
-    {
-        $channel = NotificationChannel::factory()->create([
-            'provider' => 'discord',
-            'data' => [
-                'webhook_url' => 'https://discord.com/xxxxx',
-            ],
-        ]);
-        $provider = new Discord($channel);
-
-        Http::fake();
-
-        $provider->send($channel, new TestNotification);
-
-        Http::assertSent(function (Request $request) {
-            return $request->body() === '{"content":"Hello"}';
-        });
-    }
-}
+    Http::assertSent(function (Request $request) {
+        return $request->body() === '{"content":"Hello"}';
+    });
+});

--- a/tests/Unit/NotificationChannels/EmailTest.php
+++ b/tests/Unit/NotificationChannels/EmailTest.php
@@ -1,89 +1,79 @@
 <?php
 
-namespace Tests\Unit\NotificationChannels;
-
 use App\Models\NotificationChannel;
 use App\NotificationChannels\Email;
 use App\NotificationChannels\Email\NotificationMail;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
-use Tests\TestCase;
+use Tests\Unit\NotificationChannels\TestNotification;
 
-class EmailTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_rules(): void
-    {
-        $provider = new Email(NotificationChannel::factory()->create([
-            'provider' => 'email',
-        ]));
+test('create rules', function () {
+    $provider = new Email(NotificationChannel::factory()->create([
+        'provider' => 'email',
+    ]));
 
-        $this->assertSame([
-            'email' => [
-                'required',
-                'email',
-            ],
-        ], $provider->createRules([]));
-    }
+    expect($provider->createRules([]))->toBe([
+        'email' => [
+            'required',
+            'email',
+        ],
+    ]);
+});
 
-    public function test_create_data(): void
-    {
-        $provider = new Email(NotificationChannel::factory()->create([
-            'provider' => 'email',
-        ]));
+test('create data', function () {
+    $provider = new Email(NotificationChannel::factory()->create([
+        'provider' => 'email',
+    ]));
 
-        $this->assertSame([
+    expect($provider->createData([
+        'email' => 'user@example.com',
+    ]))->toBe([
+        'email' => 'user@example.com',
+    ]);
+});
+
+test('data', function () {
+    $provider = new Email(NotificationChannel::factory()->create([
+        'provider' => 'email',
+        'data' => [
             'email' => 'user@example.com',
-        ], $provider->createData([
+        ],
+    ]));
+
+    expect($provider->data())->toBe([
+        'email' => 'user@example.com',
+    ]);
+});
+
+test('connect', function () {
+    $provider = new Email(NotificationChannel::factory()->create([
+        'provider' => 'email',
+        'data' => [
             'email' => 'user@example.com',
-        ]));
-    }
+        ],
+    ]));
 
-    public function test_data(): void
-    {
-        $provider = new Email(NotificationChannel::factory()->create([
-            'provider' => 'email',
-            'data' => [
-                'email' => 'user@example.com',
-            ],
-        ]));
+    Mail::fake();
 
-        $this->assertSame([
+    expect($provider->connect())->toBeTrue();
+
+    Mail::assertSent(NotificationMail::class);
+});
+
+test('send', function () {
+    $channel = NotificationChannel::factory()->create([
+        'provider' => 'email',
+        'data' => [
             'email' => 'user@example.com',
-        ], $provider->data());
-    }
+        ],
+    ]);
+    $provider = new Email($channel);
 
-    public function test_connect(): void
-    {
-        $provider = new Email(NotificationChannel::factory()->create([
-            'provider' => 'email',
-            'data' => [
-                'email' => 'user@example.com',
-            ],
-        ]));
+    Mail::fake();
 
-        Mail::fake();
+    $provider->send($channel, new TestNotification);
 
-        $this->assertTrue($provider->connect());
-
-        Mail::assertSent(NotificationMail::class);
-    }
-
-    public function test_send(): void
-    {
-        $channel = NotificationChannel::factory()->create([
-            'provider' => 'email',
-            'data' => [
-                'email' => 'user@example.com',
-            ],
-        ]);
-        $provider = new Email($channel);
-
-        Mail::fake();
-
-        $provider->send($channel, new TestNotification);
-
-        Mail::assertSent(NotificationMail::class);
-    }
-}
+    Mail::assertSent(NotificationMail::class);
+});

--- a/tests/Unit/NotificationChannels/SlackTest.php
+++ b/tests/Unit/NotificationChannels/SlackTest.php
@@ -1,93 +1,83 @@
 <?php
 
-namespace Tests\Unit\NotificationChannels;
-
 use App\Models\NotificationChannel;
 use App\NotificationChannels\Slack;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use Tests\TestCase;
+use Tests\Unit\NotificationChannels\TestNotification;
 
-class SlackTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_rules(): void
-    {
-        $provider = new Slack(NotificationChannel::factory()->create([
-            'provider' => 'slack',
-        ]));
+test('create rules', function () {
+    $provider = new Slack(NotificationChannel::factory()->create([
+        'provider' => 'slack',
+    ]));
 
-        $this->assertSame([
-            'webhook_url' => [
-                'required',
-                'url',
-            ],
-        ], $provider->createRules([]));
-    }
+    expect($provider->createRules([]))->toBe([
+        'webhook_url' => [
+            'required',
+            'url',
+        ],
+    ]);
+});
 
-    public function test_create_data(): void
-    {
-        $provider = new Slack(NotificationChannel::factory()->create([
-            'provider' => 'slack',
-        ]));
+test('create data', function () {
+    $provider = new Slack(NotificationChannel::factory()->create([
+        'provider' => 'slack',
+    ]));
 
-        $this->assertSame([
+    expect($provider->createData([
+        'webhook_url' => 'https://slack.com/xxxxx',
+    ]))->toBe([
+        'webhook_url' => 'https://slack.com/xxxxx',
+    ]);
+});
+
+test('data', function () {
+    $provider = new Slack(NotificationChannel::factory()->create([
+        'provider' => 'slack',
+        'data' => [
             'webhook_url' => 'https://slack.com/xxxxx',
-        ], $provider->createData([
+        ],
+    ]));
+
+    expect($provider->data())->toBe([
+        'webhook_url' => 'https://slack.com/xxxxx',
+    ]);
+});
+
+test('connect', function () {
+    $provider = new Slack(NotificationChannel::factory()->create([
+        'provider' => 'slack',
+        'data' => [
             'webhook_url' => 'https://slack.com/xxxxx',
-        ]));
-    }
+        ],
+    ]));
 
-    public function test_data(): void
-    {
-        $provider = new Slack(NotificationChannel::factory()->create([
-            'provider' => 'slack',
-            'data' => [
-                'webhook_url' => 'https://slack.com/xxxxx',
-            ],
-        ]));
+    Http::fake();
 
-        $this->assertSame([
+    expect($provider->connect())->toBeTrue();
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://slack.com/xxxxx';
+    });
+});
+
+test('send', function () {
+    $channel = NotificationChannel::factory()->create([
+        'provider' => 'slack',
+        'data' => [
             'webhook_url' => 'https://slack.com/xxxxx',
-        ], $provider->data());
-    }
+        ],
+    ]);
+    $provider = new Slack($channel);
 
-    public function test_connect(): void
-    {
-        $provider = new Slack(NotificationChannel::factory()->create([
-            'provider' => 'slack',
-            'data' => [
-                'webhook_url' => 'https://slack.com/xxxxx',
-            ],
-        ]));
+    Http::fake();
 
-        Http::fake();
+    $provider->send($channel, new TestNotification);
 
-        $this->assertTrue($provider->connect());
-
-        Http::assertSent(function ($request) {
-            return $request->url() === 'https://slack.com/xxxxx';
-        });
-    }
-
-    public function test_send(): void
-    {
-        $channel = NotificationChannel::factory()->create([
-            'provider' => 'slack',
-            'data' => [
-                'webhook_url' => 'https://slack.com/xxxxx',
-            ],
-        ]);
-        $provider = new Slack($channel);
-
-        Http::fake();
-
-        $provider->send($channel, new TestNotification);
-
-        Http::assertSent(function (Request $request) {
-            return $request->body() === '{"text":"Hello"}';
-        });
-    }
-}
+    Http::assertSent(function (Request $request) {
+        return $request->body() === '{"text":"Hello"}';
+    });
+});

--- a/tests/Unit/NotificationChannels/TelegramTest.php
+++ b/tests/Unit/NotificationChannels/TelegramTest.php
@@ -1,115 +1,105 @@
 <?php
 
-namespace Tests\Unit\NotificationChannels;
-
 use App\Models\NotificationChannel;
 use App\NotificationChannels\Telegram;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use Tests\TestCase;
+use Tests\Unit\NotificationChannels\TestNotification;
 
-class TelegramTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_create_rules(): void
-    {
-        $provider = new Telegram(NotificationChannel::factory()->create([
-            'provider' => 'telegram',
-        ]));
+test('create rules', function () {
+    $provider = new Telegram(NotificationChannel::factory()->create([
+        'provider' => 'telegram',
+    ]));
 
-        $this->assertSame([
-            'bot_token' => [
-                'required',
-            ],
-            'chat_id' => [
-                'required',
-            ],
-        ], $provider->createRules([]));
-    }
+    expect($provider->createRules([]))->toBe([
+        'bot_token' => [
+            'required',
+        ],
+        'chat_id' => [
+            'required',
+        ],
+    ]);
+});
 
-    public function test_create_data(): void
-    {
-        $provider = new Telegram(NotificationChannel::factory()->create([
-            'provider' => 'telegram',
-        ]));
+test('create data', function () {
+    $provider = new Telegram(NotificationChannel::factory()->create([
+        'provider' => 'telegram',
+    ]));
 
-        $this->assertSame([
+    expect($provider->createData([
+        'bot_token' => 'xxxxx',
+        'chat_id' => '12345',
+    ]))->toBe([
+        'bot_token' => 'xxxxx',
+        'chat_id' => '12345',
+    ]);
+});
+
+test('data', function () {
+    $provider = new Telegram(NotificationChannel::factory()->create([
+        'provider' => 'telegram',
+        'data' => [
             'bot_token' => 'xxxxx',
             'chat_id' => '12345',
-        ], $provider->createData([
+        ],
+    ]));
+
+    expect($provider->data())->toBe([
+        'bot_token' => 'xxxxx',
+        'chat_id' => '12345',
+    ]);
+});
+
+test('connect', function () {
+    $provider = new Telegram(NotificationChannel::factory()->create([
+        'provider' => 'telegram',
+        'data' => [
             'bot_token' => 'xxxxx',
             'chat_id' => '12345',
-        ]));
-    }
+        ],
+    ]));
 
-    public function test_data(): void
-    {
-        $provider = new Telegram(NotificationChannel::factory()->create([
-            'provider' => 'telegram',
-            'data' => [
-                'bot_token' => 'xxxxx',
+    Http::fake();
+
+    expect($provider->connect())->toBeTrue();
+
+    Http::assertSent(function ($request) {
+        if ($request->url() === 'https://api.telegram.org/botxxxxx/sendMessage') {
+            return $request->data() === [
                 'chat_id' => '12345',
-            ],
-        ]));
+                'text' => 'Connected!',
+                'parse_mode' => 'HTML',
+                'disable_web_page_preview' => true,
+            ];
+        }
+    });
+});
 
-        $this->assertSame([
+test('send', function () {
+    $channel = NotificationChannel::factory()->create([
+        'provider' => 'telegram',
+        'data' => [
             'bot_token' => 'xxxxx',
             'chat_id' => '12345',
-        ], $provider->data());
-    }
+        ],
+    ]);
+    $provider = new Telegram($channel);
 
-    public function test_connect(): void
-    {
-        $provider = new Telegram(NotificationChannel::factory()->create([
-            'provider' => 'telegram',
-            'data' => [
-                'bot_token' => 'xxxxx',
+    Http::fake();
+
+    $provider->send($channel, new TestNotification);
+
+    Http::assertSent(function (Request $request) {
+        if ($request->url() === 'https://api.telegram.org/botxxxxx/sendMessage') {
+            return $request->data() === [
                 'chat_id' => '12345',
-            ],
-        ]));
-
-        Http::fake();
-
-        $this->assertTrue($provider->connect());
-
-        Http::assertSent(function ($request) {
-            if ($request->url() === 'https://api.telegram.org/botxxxxx/sendMessage') {
-                return $request->data() === [
-                    'chat_id' => '12345',
-                    'text' => 'Connected!',
-                    'parse_mode' => 'HTML',
-                    'disable_web_page_preview' => true,
-                ];
-            }
-        });
-    }
-
-    public function test_send(): void
-    {
-        $channel = NotificationChannel::factory()->create([
-            'provider' => 'telegram',
-            'data' => [
-                'bot_token' => 'xxxxx',
-                'chat_id' => '12345',
-            ],
-        ]);
-        $provider = new Telegram($channel);
-
-        Http::fake();
-
-        $provider->send($channel, new TestNotification);
-
-        Http::assertSent(function (Request $request) {
-            if ($request->url() === 'https://api.telegram.org/botxxxxx/sendMessage') {
-                return $request->data() === [
-                    'chat_id' => '12345',
-                    'text' => 'Hello',
-                    'parse_mode' => 'HTML',
-                    'disable_web_page_preview' => true,
-                ];
-            }
-        });
-    }
-}
+                'text' => 'Hello',
+                'parse_mode' => 'HTML',
+                'disable_web_page_preview' => true,
+            ];
+        }
+    });
+});

--- a/tests/Unit/Notifications/NotificationMailTest.php
+++ b/tests/Unit/Notifications/NotificationMailTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Unit\Notifications;
-
 use App\Enums\DeploymentStatus;
 use App\Mail\ProjectInvitation;
 use App\Models\Backup;
@@ -16,99 +14,84 @@ use App\Notifications\ServerInstallationSucceed;
 use App\Notifications\SiteInstallationFailed;
 use App\Notifications\WebhookDeploymentFailed;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class NotificationMailTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_server_installation_succeed_links_to_server_with_success_level(): void
-    {
-        $message = (new ServerInstallationSucceed($this->server))->toEmail($this->notificationChannel);
+test('server installation succeed links to server with success level', function () {
+    $message = (new ServerInstallationSucceed($this->server))->toEmail($this->notificationChannel);
 
-        $this->assertSame('success', $message->level);
-        $this->assertSame(url('/servers/'.$this->server->id), $message->actionUrl);
-        $this->assertStringNotContainsString('/login', (string) $message->actionUrl);
-    }
+    expect($message->level)->toBe('success');
+    expect($message->actionUrl)->toBe(url('/servers/'.$this->server->id));
+    $this->assertStringNotContainsString('/login', (string) $message->actionUrl);
+});
 
-    public function test_failure_notification_uses_error_level(): void
-    {
-        $message = (new ServerInstallationFailed($this->server))->toEmail($this->notificationChannel);
+test('failure notification uses error level', function () {
+    $message = (new ServerInstallationFailed($this->server))->toEmail($this->notificationChannel);
 
-        $this->assertSame('error', $message->level);
-    }
+    expect($message->level)->toBe('error');
+});
 
-    public function test_rendered_email_contains_vito_branding(): void
-    {
-        $html = (new ServerInstallationSucceed($this->server))->toEmail($this->notificationChannel)->render();
+test('rendered email contains vito branding', function () {
+    $html = (new ServerInstallationSucceed($this->server))->toEmail($this->notificationChannel)->render();
 
-        $this->assertStringContainsString('email/logo.png', $html);
-        $this->assertStringContainsString('Sent by', $html);
-    }
+    $this->assertStringContainsString('email/logo.png', $html);
+    $this->assertStringContainsString('Sent by', $html);
+});
 
-    public function test_site_installation_failed_links_to_site_with_retry_message(): void
-    {
-        $message = (new SiteInstallationFailed($this->site))->toEmail($this->notificationChannel);
+test('site installation failed links to site with retry message', function () {
+    $message = (new SiteInstallationFailed($this->site))->toEmail($this->notificationChannel);
 
-        $this->assertSame('error', $message->level);
-        $this->assertSame(
-            url('/servers/'.$this->site->server_id.'/sites/'.$this->site->id),
-            $message->actionUrl
-        );
-        $this->assertStringContainsString('retry the installation', $message->render());
-    }
+    expect($message->level)->toBe('error');
+    expect($message->actionUrl)->toBe(url('/servers/'.$this->site->server_id.'/sites/'.$this->site->id));
+    $this->assertStringContainsString('retry the installation', $message->render());
+});
 
-    public function test_deployment_completed_includes_commit_summary_and_author(): void
-    {
-        $deployment = Deployment::factory()->create([
-            'site_id' => $this->site->id,
-            'status' => DeploymentStatus::FINISHED,
-            'commit_id' => 'abcdef1234567890',
-            'commit_data' => [
-                'name' => 'Jane Dev',
-                'message' => "Fix login redirect bug\n\nlong body",
-            ],
-        ]);
+test('deployment completed includes commit summary and author', function () {
+    $deployment = Deployment::factory()->create([
+        'site_id' => $this->site->id,
+        'status' => DeploymentStatus::FINISHED,
+        'commit_id' => 'abcdef1234567890',
+        'commit_data' => [
+            'name' => 'Jane Dev',
+            'message' => "Fix login redirect bug\n\nlong body",
+        ],
+    ]);
 
-        $html = (new DeploymentCompleted($deployment, $this->site))->toEmail($this->notificationChannel)->render();
+    $html = (new DeploymentCompleted($deployment, $this->site))->toEmail($this->notificationChannel)->render();
 
-        $this->assertStringContainsString('Fix login redirect bug', $html);
-        $this->assertStringContainsString('abcdef1', $html);
-        $this->assertStringContainsString('Jane Dev', $html);
-    }
+    $this->assertStringContainsString('Fix login redirect bug', $html);
+    $this->assertStringContainsString('abcdef1', $html);
+    $this->assertStringContainsString('Jane Dev', $html);
+});
 
-    public function test_backup_failed_links_to_backup_with_error_level(): void
-    {
-        $backup = Backup::factory()->create([
-            'server_id' => $this->server->id,
-            'storage_id' => StorageProvider::factory()->create()->id,
-            'database_id' => Database::factory()->create(['server_id' => $this->server->id])->id,
-        ]);
+test('backup failed links to backup with error level', function () {
+    $backup = Backup::factory()->create([
+        'server_id' => $this->server->id,
+        'storage_id' => StorageProvider::factory()->create()->id,
+        'database_id' => Database::factory()->create(['server_id' => $this->server->id])->id,
+    ]);
 
-        $message = (new BackupFailed($backup))->toEmail($this->notificationChannel);
+    $message = (new BackupFailed($backup))->toEmail($this->notificationChannel);
 
-        $this->assertSame('error', $message->level);
-        $this->assertSame(url('/servers/'.$this->server->id.'/backups/'.$backup->id), $message->actionUrl);
-    }
+    expect($message->level)->toBe('error');
+    expect($message->actionUrl)->toBe(url('/servers/'.$this->server->id.'/backups/'.$backup->id));
+});
 
-    public function test_webhook_deployment_failed_links_to_logs_with_error_level(): void
-    {
-        $message = (new WebhookDeploymentFailed($this->site))->toEmail($this->notificationChannel);
+test('webhook deployment failed links to logs with error level', function () {
+    $message = (new WebhookDeploymentFailed($this->site))->toEmail($this->notificationChannel);
 
-        $this->assertSame('error', $message->level);
-        $this->assertSame(url('/servers/'.$this->site->server_id.'/logs'), $message->actionUrl);
-    }
+    expect($message->level)->toBe('error');
+    expect($message->actionUrl)->toBe(url('/servers/'.$this->site->server_id.'/logs'));
+});
 
-    public function test_project_invitation_renders_accept_url(): void
-    {
-        $project = Project::factory()->create();
+test('project invitation renders accept url', function () {
+    $project = Project::factory()->create();
 
-        $html = (new ProjectInvitation($project))->render();
+    $html = (new ProjectInvitation($project))->render();
 
-        $this->assertStringContainsString(
-            route('projects.invitations.accept', ['project' => $project]),
-            $html
-        );
-        $this->assertStringContainsString('email/logo.png', $html);
-    }
-}
+    $this->assertStringContainsString(
+        route('projects.invitations.accept', ['project' => $project]),
+        $html
+    );
+    $this->assertStringContainsString('email/logo.png', $html);
+});

--- a/tests/Unit/Plugins/LegacyPluginsTest.php
+++ b/tests/Unit/Plugins/LegacyPluginsTest.php
@@ -1,395 +1,361 @@
 <?php
 
-namespace Tests\Unit\Plugins;
-
 use App\Plugins\LegacyPlugins;
-use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
-use Tests\TestCase;
 
-class LegacyPluginsTest extends TestCase
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->plugins = new LegacyPlugins;
+    $this->pluginsBackupPath = storage_path('legacy_plugins_backup_'.time());
+
+    vitoPestUnitPluginsLegacyPluginsTestMoveExistingPlugins();
+    vitoPestUnitPluginsLegacyPluginsTestCleanupTestPlugins();
+});
+
+afterEach(function () {
+    vitoPestUnitPluginsLegacyPluginsTestCleanupTestPlugins();
+    vitoPestUnitPluginsLegacyPluginsTestRestoreExistingPlugins();
+
+});
+
+function vitoPestUnitPluginsLegacyPluginsTestMoveExistingPlugins(): void
 {
-    use RefreshDatabase;
+    $pluginsPath = storage_path('plugins');
 
-    private LegacyPlugins $plugins;
-
-    private string $pluginsBackupPath;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->plugins = new LegacyPlugins;
-        $this->pluginsBackupPath = storage_path('legacy_plugins_backup_'.time());
-
-        $this->moveExistingPlugins();
-        $this->cleanupTestPlugins();
+    if (File::exists($pluginsPath)) {
+        File::moveDirectory($pluginsPath, test()->pluginsBackupPath);
     }
 
-    protected function tearDown(): void
-    {
-        $this->cleanupTestPlugins();
-        $this->restoreExistingPlugins();
+    File::makeDirectory($pluginsPath, 0755, true);
+}
 
-        parent::tearDown();
+function vitoPestUnitPluginsLegacyPluginsTestRestoreExistingPlugins(): void
+{
+    $pluginsPath = storage_path('plugins');
+
+    if (File::exists($pluginsPath)) {
+        File::deleteDirectory($pluginsPath);
     }
 
-    private function moveExistingPlugins(): void
-    {
-        $pluginsPath = storage_path('plugins');
+    if (File::exists(test()->pluginsBackupPath)) {
+        File::moveDirectory(test()->pluginsBackupPath, $pluginsPath);
+    }
+}
 
-        if (File::exists($pluginsPath)) {
-            File::moveDirectory($pluginsPath, $this->pluginsBackupPath);
-        }
-
-        File::makeDirectory($pluginsPath, 0755, true);
+function vitoPestUnitPluginsLegacyPluginsTestCleanupTestPlugins(): void
+{
+    $pluginsPath = storage_path('plugins');
+    if (! File::exists($pluginsPath)) {
+        return;
     }
 
-    private function restoreExistingPlugins(): void
-    {
-        $pluginsPath = storage_path('plugins');
-
-        if (File::exists($pluginsPath)) {
-            File::deleteDirectory($pluginsPath);
-        }
-
-        if (File::exists($this->pluginsBackupPath)) {
-            File::moveDirectory($this->pluginsBackupPath, $pluginsPath);
+    $directories = File::directories($pluginsPath);
+    foreach ($directories as $directory) {
+        $dirName = basename($directory);
+        if (str_starts_with($dirName, 'test-')) {
+            File::deleteDirectory($directory);
         }
     }
 
-    private function cleanupTestPlugins(): void
-    {
-        $pluginsPath = storage_path('plugins');
-        if (! File::exists($pluginsPath)) {
-            return;
-        }
-
-        $directories = File::directories($pluginsPath);
-        foreach ($directories as $directory) {
+    $installedPath = $pluginsPath.'/.installed';
+    if (File::exists($installedPath)) {
+        $installedDirectories = File::directories($installedPath);
+        foreach ($installedDirectories as $directory) {
             $dirName = basename($directory);
             if (str_starts_with($dirName, 'test-')) {
                 File::deleteDirectory($directory);
             }
         }
-
-        $installedPath = $pluginsPath.'/.installed';
-        if (File::exists($installedPath)) {
-            $installedDirectories = File::directories($installedPath);
-            foreach ($installedDirectories as $directory) {
-                $dirName = basename($directory);
-                if (str_starts_with($dirName, 'test-')) {
-                    File::deleteDirectory($directory);
-                }
-            }
-        }
-    }
-
-    public function test_all_returns_empty_array_when_no_plugins(): void
-    {
-        $result = $this->plugins->all();
-
-        $this->assertIsArray($result);
-        $this->assertEmpty($result);
-    }
-
-    public function test_all_returns_plugins_with_valid_composer_json(): void
-    {
-        $pluginsPath = storage_path('plugins');
-        $vendorPath = $pluginsPath.'/test-vendor';
-        $pluginPath = $vendorPath.'/test-plugin';
-        File::makeDirectory($pluginPath, 0755, true);
-
-        $composerData = [
-            'name' => 'test-vendor/test-plugin',
-            'version' => '1.0.0',
-        ];
-        File::put($pluginPath.'/composer.json', json_encode($composerData));
-
-        $result = $this->plugins->all();
-
-        $this->assertCount(1, $result);
-        $this->assertEquals('test-vendor/test-plugin', $result[0]['name']);
-        $this->assertEquals('1.0.0', $result[0]['version']);
-    }
-
-    public function test_all_handles_missing_name_and_version(): void
-    {
-        $pluginsPath = storage_path('plugins');
-        $vendorPath = $pluginsPath.'/test-vendor';
-        $pluginPath = $vendorPath.'/test-plugin';
-        File::makeDirectory($pluginPath, 0755, true);
-
-        File::put($pluginPath.'/composer.json', json_encode([]));
-
-        $result = $this->plugins->all();
-
-        $this->assertCount(1, $result);
-        $this->assertEquals('Unknown', $result[0]['name']);
-        $this->assertEquals('Unknown', $result[0]['version']);
-    }
-
-    public function test_all_skips_directories_without_composer_json(): void
-    {
-        $pluginsPath = storage_path('plugins');
-        $vendorPath = $pluginsPath.'/test-vendor';
-        $pluginPath = $vendorPath.'/test-plugin';
-        File::makeDirectory($pluginPath, 0755, true);
-
-        $result = $this->plugins->all();
-
-        $this->assertEmpty($result);
-    }
-
-    public function test_install_creates_plugin_directory(): void
-    {
-        Process::fake([
-            'git clone*' => Process::result(output: 'Cloning into plugin...'),
-            'composer require*' => Process::result(output: 'Package installed successfully'),
-        ]);
-
-        $url = 'https://github.com/test-vendor/test-plugin.git';
-
-        $result = $this->plugins->install($url);
-
-        $this->assertIsString($result);
-        $this->assertStringContainsString('Cloning into plugin...', $result);
-    }
-
-    public function test_install_with_branch(): void
-    {
-        Process::fake([
-            'git clone https://github.com/test-vendor/test-plugin.git * --branch main*' => Process::result(output: 'Cloning...'),
-            'composer require*' => Process::result(output: 'Package installed'),
-        ]);
-
-        $url = 'https://github.com/test-vendor/test-plugin.git';
-
-        $result = $this->plugins->install($url, 'main');
-
-        $this->assertStringContainsString('Cloning...', $result);
-    }
-
-    public function test_install_with_tag(): void
-    {
-        Process::fake([
-            'git clone https://github.com/test-vendor/test-plugin.git * --tag v1.0.0*' => Process::result(output: 'Cloning...'),
-            'composer require*' => Process::result(output: 'Package installed'),
-        ]);
-
-        $url = 'https://github.com/test-vendor/test-plugin.git';
-
-        $result = $this->plugins->install($url, null, 'v1.0.0');
-
-        $this->assertStringContainsString('Cloning...', $result);
-    }
-
-    public function test_install_throws_exception_on_git_failure(): void
-    {
-        Process::fake([
-            'git clone*' => Process::result(exitCode: 1, errorOutput: 'Git clone failed'),
-        ]);
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Git clone failed');
-
-        $url = 'https://github.com/test-vendor/test-plugin.git';
-        $this->plugins->install($url);
-    }
-
-    public function test_load_processes_plugins_with_composer_json(): void
-    {
-        Process::fake([
-            'composer require test-vendor/test-plugin' => Process::result(output: 'Package installed'),
-        ]);
-
-        $vendorPath = storage_path('plugins/test-vendor');
-        $pluginPath = $vendorPath.'/test-plugin';
-        File::makeDirectory($pluginPath, 0755, true);
-
-        $composerData = [
-            'name' => 'test-vendor/test-plugin',
-            'version' => '1.0.0',
-        ];
-        File::put($pluginPath.'/composer.json', json_encode($composerData));
-
-        $result = $this->plugins->load();
-
-        $this->assertStringContainsString('Package installed', $result);
-    }
-
-    public function test_load_skips_plugins_with_invalid_names(): void
-    {
-        $vendorPath = storage_path('plugins/test-vendor');
-        $pluginPath = $vendorPath.'/test-plugin';
-        File::makeDirectory($pluginPath, 0755, true);
-
-        $composerData = [
-            'name' => 'invalid-name-without-vendor',
-            'version' => '1.0.0',
-        ];
-        File::put($pluginPath.'/composer.json', json_encode($composerData));
-
-        $result = $this->plugins->load();
-
-        $this->assertEmpty($result);
-    }
-
-    public function test_load_throws_exception_on_composer_failure(): void
-    {
-        Process::fake([
-            'composer require test-vendor/test-plugin' => Process::result(exitCode: 1, errorOutput: 'Composer failed'),
-        ]);
-
-        $vendorPath = storage_path('plugins/test-vendor');
-        $pluginPath = $vendorPath.'/test-plugin';
-        File::makeDirectory($pluginPath, 0755, true);
-
-        $composerData = [
-            'name' => 'test-vendor/test-plugin',
-            'version' => '1.0.0',
-        ];
-        File::put($pluginPath.'/composer.json', json_encode($composerData));
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Composer failed');
-
-        $this->plugins->load();
-    }
-
-    public function test_uninstall_removes_plugin_and_runs_composer_remove(): void
-    {
-        Process::fake([
-            'echo "Uninstalling..."' => Process::result(output: 'Uninstalling...'),
-            'composer remove test-vendor/test-plugin' => Process::result(output: 'Package removed'),
-        ]);
-
-        $pluginPath = storage_path('plugins/test-vendor/test-plugin');
-        File::makeDirectory($pluginPath, 0755, true);
-
-        $composerData = [
-            'name' => 'test-vendor/test-plugin',
-            'scripts' => [
-                'pre-package-uninstall' => ['echo "Uninstalling..."'],
-            ],
-        ];
-        File::put($pluginPath.'/composer.json', json_encode($composerData));
-
-        $flagFile = storage_path('plugins/.installed/test-vendor/test-plugin');
-        File::makeDirectory(dirname($flagFile), 0755, true);
-        File::put($flagFile, now()->toISOString());
-
-        $result = $this->plugins->uninstall('test-vendor/test-plugin');
-
-        $this->assertStringContainsString('Package removed', $result);
-        $this->assertFalse(File::exists($pluginPath));
-        $this->assertFalse(File::exists($flagFile));
-    }
-
-    public function test_uninstall_throws_exception_for_nonexistent_plugin(): void
-    {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Plugin not found: nonexistent/plugin');
-
-        $this->plugins->uninstall('nonexistent/plugin');
-    }
-
-    public function test_uninstall_throws_exception_on_composer_failure(): void
-    {
-        Process::fake([
-            'composer remove test-vendor/test-plugin' => Process::result(exitCode: 1, output: 'Composer remove failed'),
-        ]);
-
-        $pluginPath = storage_path('plugins/test-vendor/test-plugin');
-        File::makeDirectory($pluginPath, 0755, true);
-        File::put($pluginPath.'/composer.json', json_encode(['name' => 'test-vendor/test-plugin']));
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Composer remove failed');
-
-        $this->plugins->uninstall('test-vendor/test-plugin');
-    }
-
-    public function test_cleanup_handles_missing_backup_files(): void
-    {
-        $composerJsonBackup = base_path('composer.json.bak');
-        $composerLockBackup = base_path('composer.lock.bak');
-
-        if (File::exists($composerJsonBackup)) {
-            File::delete($composerJsonBackup);
-        }
-        if (File::exists($composerLockBackup)) {
-            File::delete($composerLockBackup);
-        }
-
-        $this->plugins->cleanup();
-
-        $this->assertTrue(true);
-    }
-
-    public function test_execute_install_plugin_scripts_runs_post_install_scripts(): void
-    {
-        Process::fake([
-            'echo "Post install script"' => Process::result(output: 'Script executed'),
-        ]);
-
-        $composerJson = [
-            'name' => 'test-vendor/test-plugin',
-            'scripts' => [
-                'post-package-install' => ['echo "Post install script"'],
-            ],
-        ];
-
-        $reflection = new \ReflectionClass($this->plugins);
-        $method = $reflection->getMethod('executeInstallPluginScripts');
-
-        $result = $method->invoke($this->plugins, $composerJson);
-
-        $this->assertStringContainsString('Script executed', $result);
-    }
-
-    public function test_execute_install_plugin_scripts_skips_if_already_installed(): void
-    {
-        $flagFile = storage_path('plugins/.installed/test-vendor/test-plugin');
-        File::makeDirectory(dirname($flagFile), 0755, true);
-        File::put($flagFile, now()->toISOString());
-
-        $composerJson = [
-            'name' => 'test-vendor/test-plugin',
-            'scripts' => [
-                'post-package-install' => ['echo "Post install script"'],
-            ],
-        ];
-
-        $reflection = new \ReflectionClass($this->plugins);
-        $method = $reflection->getMethod('executeInstallPluginScripts');
-
-        $result = $method->invoke($this->plugins, $composerJson);
-
-        $this->assertEmpty($result);
-
-        File::delete($flagFile);
-    }
-
-    public function test_execute_composer_scripts_handles_script_failures(): void
-    {
-        Process::fake([
-            'failing-command' => Process::result(exitCode: 1, errorOutput: 'Script failed'),
-        ]);
-
-        $composerJson = [
-            'scripts' => [
-                'post-package-install' => ['failing-command'],
-            ],
-        ];
-
-        $reflection = new \ReflectionClass($this->plugins);
-        $method = $reflection->getMethod('executeComposerScripts');
-
-        $result = $method->invoke($this->plugins, $composerJson, 'post-package-install');
-
-        $this->assertStringContainsString('Warning: Plugin script failed: Script failed', $result);
     }
 }
+
+test('all returns empty array when no plugins', function () {
+    $result = $this->plugins->all();
+
+    expect($result)->toBeArray();
+    expect($result)->toBeEmpty();
+});
+
+test('all returns plugins with valid composer json', function () {
+    $pluginsPath = storage_path('plugins');
+    $vendorPath = $pluginsPath.'/test-vendor';
+    $pluginPath = $vendorPath.'/test-plugin';
+    File::makeDirectory($pluginPath, 0755, true);
+
+    $composerData = [
+        'name' => 'test-vendor/test-plugin',
+        'version' => '1.0.0',
+    ];
+    File::put($pluginPath.'/composer.json', json_encode($composerData));
+
+    $result = $this->plugins->all();
+
+    expect($result)->toHaveCount(1);
+    expect($result[0]['name'])->toEqual('test-vendor/test-plugin');
+    expect($result[0]['version'])->toEqual('1.0.0');
+});
+
+test('all handles missing name and version', function () {
+    $pluginsPath = storage_path('plugins');
+    $vendorPath = $pluginsPath.'/test-vendor';
+    $pluginPath = $vendorPath.'/test-plugin';
+    File::makeDirectory($pluginPath, 0755, true);
+
+    File::put($pluginPath.'/composer.json', json_encode([]));
+
+    $result = $this->plugins->all();
+
+    expect($result)->toHaveCount(1);
+    expect($result[0]['name'])->toEqual('Unknown');
+    expect($result[0]['version'])->toEqual('Unknown');
+});
+
+test('all skips directories without composer json', function () {
+    $pluginsPath = storage_path('plugins');
+    $vendorPath = $pluginsPath.'/test-vendor';
+    $pluginPath = $vendorPath.'/test-plugin';
+    File::makeDirectory($pluginPath, 0755, true);
+
+    $result = $this->plugins->all();
+
+    expect($result)->toBeEmpty();
+});
+
+test('install creates plugin directory', function () {
+    Process::fake([
+        'git clone*' => Process::result(output: 'Cloning into plugin...'),
+        'composer require*' => Process::result(output: 'Package installed successfully'),
+    ]);
+
+    $url = 'https://github.com/test-vendor/test-plugin.git';
+
+    $result = $this->plugins->install($url);
+
+    expect($result)->toBeString();
+    $this->assertStringContainsString('Cloning into plugin...', $result);
+});
+
+test('install with branch', function () {
+    Process::fake([
+        'git clone https://github.com/test-vendor/test-plugin.git * --branch main*' => Process::result(output: 'Cloning...'),
+        'composer require*' => Process::result(output: 'Package installed'),
+    ]);
+
+    $url = 'https://github.com/test-vendor/test-plugin.git';
+
+    $result = $this->plugins->install($url, 'main');
+
+    $this->assertStringContainsString('Cloning...', $result);
+});
+
+test('install with tag', function () {
+    Process::fake([
+        'git clone https://github.com/test-vendor/test-plugin.git * --tag v1.0.0*' => Process::result(output: 'Cloning...'),
+        'composer require*' => Process::result(output: 'Package installed'),
+    ]);
+
+    $url = 'https://github.com/test-vendor/test-plugin.git';
+
+    $result = $this->plugins->install($url, null, 'v1.0.0');
+
+    $this->assertStringContainsString('Cloning...', $result);
+});
+
+test('install throws exception on git failure', function () {
+    Process::fake([
+        'git clone*' => Process::result(exitCode: 1, errorOutput: 'Git clone failed'),
+    ]);
+
+    $this->expectException(Exception::class);
+    $this->expectExceptionMessage('Git clone failed');
+
+    $url = 'https://github.com/test-vendor/test-plugin.git';
+    $this->plugins->install($url);
+});
+
+test('load processes plugins with composer json', function () {
+    Process::fake([
+        'composer require test-vendor/test-plugin' => Process::result(output: 'Package installed'),
+    ]);
+
+    $vendorPath = storage_path('plugins/test-vendor');
+    $pluginPath = $vendorPath.'/test-plugin';
+    File::makeDirectory($pluginPath, 0755, true);
+
+    $composerData = [
+        'name' => 'test-vendor/test-plugin',
+        'version' => '1.0.0',
+    ];
+    File::put($pluginPath.'/composer.json', json_encode($composerData));
+
+    $result = $this->plugins->load();
+
+    $this->assertStringContainsString('Package installed', $result);
+});
+
+test('load skips plugins with invalid names', function () {
+    $vendorPath = storage_path('plugins/test-vendor');
+    $pluginPath = $vendorPath.'/test-plugin';
+    File::makeDirectory($pluginPath, 0755, true);
+
+    $composerData = [
+        'name' => 'invalid-name-without-vendor',
+        'version' => '1.0.0',
+    ];
+    File::put($pluginPath.'/composer.json', json_encode($composerData));
+
+    $result = $this->plugins->load();
+
+    expect($result)->toBeEmpty();
+});
+
+test('load throws exception on composer failure', function () {
+    Process::fake([
+        'composer require test-vendor/test-plugin' => Process::result(exitCode: 1, errorOutput: 'Composer failed'),
+    ]);
+
+    $vendorPath = storage_path('plugins/test-vendor');
+    $pluginPath = $vendorPath.'/test-plugin';
+    File::makeDirectory($pluginPath, 0755, true);
+
+    $composerData = [
+        'name' => 'test-vendor/test-plugin',
+        'version' => '1.0.0',
+    ];
+    File::put($pluginPath.'/composer.json', json_encode($composerData));
+
+    $this->expectException(Exception::class);
+    $this->expectExceptionMessage('Composer failed');
+
+    $this->plugins->load();
+});
+
+test('uninstall removes plugin and runs composer remove', function () {
+    Process::fake([
+        'echo "Uninstalling..."' => Process::result(output: 'Uninstalling...'),
+        'composer remove test-vendor/test-plugin' => Process::result(output: 'Package removed'),
+    ]);
+
+    $pluginPath = storage_path('plugins/test-vendor/test-plugin');
+    File::makeDirectory($pluginPath, 0755, true);
+
+    $composerData = [
+        'name' => 'test-vendor/test-plugin',
+        'scripts' => [
+            'pre-package-uninstall' => ['echo "Uninstalling..."'],
+        ],
+    ];
+    File::put($pluginPath.'/composer.json', json_encode($composerData));
+
+    $flagFile = storage_path('plugins/.installed/test-vendor/test-plugin');
+    File::makeDirectory(dirname($flagFile), 0755, true);
+    File::put($flagFile, now()->toISOString());
+
+    $result = $this->plugins->uninstall('test-vendor/test-plugin');
+
+    $this->assertStringContainsString('Package removed', $result);
+    expect(File::exists($pluginPath))->toBeFalse();
+    expect(File::exists($flagFile))->toBeFalse();
+});
+
+test('uninstall throws exception for nonexistent plugin', function () {
+    $this->expectException(Exception::class);
+    $this->expectExceptionMessage('Plugin not found: nonexistent/plugin');
+
+    $this->plugins->uninstall('nonexistent/plugin');
+});
+
+test('uninstall throws exception on composer failure', function () {
+    Process::fake([
+        'composer remove test-vendor/test-plugin' => Process::result(exitCode: 1, output: 'Composer remove failed'),
+    ]);
+
+    $pluginPath = storage_path('plugins/test-vendor/test-plugin');
+    File::makeDirectory($pluginPath, 0755, true);
+    File::put($pluginPath.'/composer.json', json_encode(['name' => 'test-vendor/test-plugin']));
+
+    $this->expectException(Exception::class);
+    $this->expectExceptionMessage('Composer remove failed');
+
+    $this->plugins->uninstall('test-vendor/test-plugin');
+});
+
+test('cleanup handles missing backup files', function () {
+    $composerJsonBackup = base_path('composer.json.bak');
+    $composerLockBackup = base_path('composer.lock.bak');
+
+    if (File::exists($composerJsonBackup)) {
+        File::delete($composerJsonBackup);
+    }
+    if (File::exists($composerLockBackup)) {
+        File::delete($composerLockBackup);
+    }
+
+    $this->plugins->cleanup();
+
+    expect(true)->toBeTrue();
+});
+
+test('execute install plugin scripts runs post install scripts', function () {
+    Process::fake([
+        'echo "Post install script"' => Process::result(output: 'Script executed'),
+    ]);
+
+    $composerJson = [
+        'name' => 'test-vendor/test-plugin',
+        'scripts' => [
+            'post-package-install' => ['echo "Post install script"'],
+        ],
+    ];
+
+    $reflection = new ReflectionClass($this->plugins);
+    $method = $reflection->getMethod('executeInstallPluginScripts');
+
+    $result = $method->invoke($this->plugins, $composerJson);
+
+    $this->assertStringContainsString('Script executed', $result);
+});
+
+test('execute install plugin scripts skips if already installed', function () {
+    $flagFile = storage_path('plugins/.installed/test-vendor/test-plugin');
+    File::makeDirectory(dirname($flagFile), 0755, true);
+    File::put($flagFile, now()->toISOString());
+
+    $composerJson = [
+        'name' => 'test-vendor/test-plugin',
+        'scripts' => [
+            'post-package-install' => ['echo "Post install script"'],
+        ],
+    ];
+
+    $reflection = new ReflectionClass($this->plugins);
+    $method = $reflection->getMethod('executeInstallPluginScripts');
+
+    $result = $method->invoke($this->plugins, $composerJson);
+
+    expect($result)->toBeEmpty();
+
+    File::delete($flagFile);
+});
+
+test('execute composer scripts handles script failures', function () {
+    Process::fake([
+        'failing-command' => Process::result(exitCode: 1, errorOutput: 'Script failed'),
+    ]);
+
+    $composerJson = [
+        'scripts' => [
+            'post-package-install' => ['failing-command'],
+        ],
+    ];
+
+    $reflection = new ReflectionClass($this->plugins);
+    $method = $reflection->getMethod('executeComposerScripts');
+
+    $result = $method->invoke($this->plugins, $composerJson, 'post-package-install');
+
+    $this->assertStringContainsString('Warning: Plugin script failed: Script failed', $result);
+});

--- a/tests/Unit/Plugins/PluginTest.php
+++ b/tests/Unit/Plugins/PluginTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Unit\Plugins;
-
 use App\Actions\Plugins\BootPlugins;
 use App\Actions\Plugins\DisablePlugin;
 use App\Actions\Plugins\DiscoverPlugins;
@@ -17,363 +15,332 @@ use App\DTOs\GitHub\ReleaseDto;
 use App\Models\Plugin;
 use App\Models\PluginError;
 use Carbon\Carbon;
-use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
-use Mockery;
-use Tests\TestCase;
 
-class PluginTest extends TestCase
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->repoUrl = 'https://github.com/RichardAnderson/VitoOctanePlugin';
+    $this->pluginPath = app_path('Vito/Plugins');
+    $this->backupPath = storage_path('plugins_backup_'.time());
+
+    vitoPestUnitPluginsPluginTestMovePlugins($this->pluginPath, $this->backupPath);
+    File::makeDirectory($this->pluginPath, 0755, true);
+
+    Plugin::truncate();
+    PluginError::truncate();
+
+    app(GetPluginInstance::class)->clear();
+});
+
+afterEach(function () {
+    vitoPestUnitPluginsPluginTestMovePlugins($this->backupPath, $this->pluginPath);
+});
+
+function vitoPestUnitPluginsPluginTestInstallExamplePlugin(): Plugin
 {
-    use RefreshDatabase;
+    $fromFile = implode(
+        DIRECTORY_SEPARATOR,
+        [__DIR__, 'Example', 'Repo', 'Plugin.php'],
+    );
 
-    private string $backupPath;
+    $toFile = implode(
+        DIRECTORY_SEPARATOR,
+        [test()->pluginPath, 'Example', 'Repo', 'Plugin.php']
+    );
 
-    private string $pluginPath;
-
-    private string $repoUrl = 'https://github.com/RichardAnderson/VitoOctanePlugin';
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->pluginPath = app_path('Vito/Plugins');
-        $this->backupPath = storage_path('plugins_backup_'.time());
-
-        $this->movePlugins($this->pluginPath, $this->backupPath);
-        File::makeDirectory($this->pluginPath, 0755, true);
-
-        Plugin::truncate();
-        PluginError::truncate();
-
-        app(GetPluginInstance::class)->clear();
+    File::ensureDirectoryExists(dirname($toFile));
+    if (! File::copy($fromFile, $toFile)) {
+        test()->fail("Failed to copy example plugin from '$fromFile' to '$toFile'");
     }
 
-    protected function tearDown(): void
-    {
-        $this->movePlugins($this->backupPath, $this->pluginPath);
-        parent::tearDown();
-    }
+    $folder = implode(DIRECTORY_SEPARATOR, ['Example', 'Repo']);
 
-    private function installExamplePlugin(): Plugin
-    {
-        $fromFile = implode(
-            DIRECTORY_SEPARATOR,
-            [__DIR__, 'Example', 'Repo', 'Plugin.php'],
-        );
+    $discovery = app(DiscoverPlugins::class);
+    $discovery->handle();
 
-        $toFile = implode(
-            DIRECTORY_SEPARATOR,
-            [$this->pluginPath, 'Example', 'Repo', 'Plugin.php']
-        );
-
-        File::ensureDirectoryExists(dirname($toFile));
-        if (! File::copy($fromFile, $toFile)) {
-            $this->fail("Failed to copy example plugin from '$fromFile' to '$toFile'");
-        }
-
-        $folder = implode(DIRECTORY_SEPARATOR, ['Example', 'Repo']);
-
-        $discovery = app(DiscoverPlugins::class);
-        $discovery->handle();
-
-        return Plugin::where('folder', $folder)->first();
-    }
-
-    private function movePlugins(string $from, string $to): void
-    {
-        File::deleteDirectory($to);
-        File::makeDirectory(path: $to, recursive: true, force: true);
-        File::moveDirectory($from, $to, true);
-    }
-
-    private function createTestReleaseDto(string $tagName = '1.0.2', string $repoName = 'repo'): ReleaseDto
-    {
-        return new ReleaseDto(
-            url: "https://api.github.com/repos/username/{$repoName}/releases/123456",
-            tagName: $tagName,
-            name: "Release {$tagName}",
-            draft: false,
-            preRelease: false,
-            createdAt: Carbon::now(),
-            updatedAt: Carbon::now(),
-            publishedAt: Carbon::now(),
-            author: new AuthorDto('username', 'https://api.github.com/username', 'individual'),
-            tarUrl: "https://api.github.com/repos/username/{$repoName}/tarball/{$tagName}",
-            zipUrl: "https://github.com/username/{$repoName}/archive/{$tagName}.zip",
-            body: "Release notes for version {$tagName}"
-        );
-    }
-
-    private function installDemoPlugin(): Plugin
-    {
-        $zip = implode(DIRECTORY_SEPARATOR, [__DIR__, 'Artifacts', 'VitoOctanePlugin-1.0.2.zip']);
-
-        $this->app->bind(DownloadRelease::class, function () use ($zip) {
-            $mock = Mockery::mock(DownloadRelease::class);
-            $mock->shouldReceive('handle')
-                ->andReturnUsing(function ($release, $location) use ($zip) {
-                    File::ensureDirectoryExists(dirname($location));
-                    if (! File::copy($zip, $location)) {
-                        throw new Exception("Unable to copy file from $zip to $location");
-                    }
-                });
-
-            return $mock;
-        });
-
-        $this->app->bind(GetReleaseInfo::class, function () {
-            $mock = Mockery::mock(GetReleaseInfo::class);
-            $mock->shouldReceive('handle')
-                ->andReturn($this->createTestReleaseDto());
-
-            return $mock;
-        });
-
-        $action = app(InstallGithubPlugin::class);
-
-        return $action->handle($this->repoUrl);
-    }
-
-    private function getPluginPath(Plugin $plugin): string
-    {
-        return implode(DIRECTORY_SEPARATOR, [$this->pluginPath, $plugin->folder]);
-    }
-
-    private function createFakePlugin(): Plugin
-    {
-        $folder = implode(DIRECTORY_SEPARATOR, ['ExampleUser', 'ExampleRepo']);
-        $path = implode(DIRECTORY_SEPARATOR, [$this->pluginPath, $folder]);
-        File::makeDirectory($path, 0755, true);
-
-        $discovery = app(DiscoverPlugins::class);
-        $discovery->handle();
-
-        return Plugin::where('folder', $folder)->first();
-    }
-
-    public function test_can_install_plugin(): void
-    {
-        $plugin = $this->installDemoPlugin();
-        $path = $this->getPluginPath($plugin);
-
-        $this->assertThat(File::isDirectory($path), $this->isTrue());
-        $this->assertThat(File::isEmptyDirectory($path), $this->isFalse());
-        $this->assertThat($plugin->is_installed, $this->isTrue());
-    }
-
-    public function test_can_enable_plugin(): void
-    {
-        $plugin = $this->installDemoPlugin();
-
-        $action = app(EnablePlugin::class);
-        $action->handle($plugin);
-
-        $plugin->refresh();
-        $this->assertThat($plugin->is_enabled, $this->isTrue());
-    }
-
-    public function test_can_disable_plugin(): void
-    {
-        $plugin = $this->installDemoPlugin();
-
-        $plugin->is_enabled = true;
-        $plugin->save();
-
-        $disable = app(DisablePlugin::class);
-        $disable->handle($plugin);
-
-        $plugin->refresh();
-        $this->assertThat($plugin->is_enabled, $this->isFalse());
-    }
-
-    public function test_can_discovery_plugins(): void
-    {
-        $plugin = $this->createFakePlugin();
-
-        $this->assertNotNull($plugin);
-        $this->assertThat($plugin->namespace, $this->equalTo('App\\Vito\\Plugins\\ExampleUser\\ExampleRepo\\Plugin'));
-        $this->assertThat($plugin->is_installed, $this->isFalse());
-        $this->assertThat($plugin->is_enabled, $this->isFalse());
-    }
-
-    public function test_install_invalid_plugin_raises_error(): void
-    {
-        $plugin = $this->createFakePlugin();
-
-        $install = app(InstallPlugin::class);
-        $this->assertThrows(fn () => $install->handle($plugin));
-
-        $plugin->refresh();
-        $errors = PluginError::where('plugin_id', $plugin->id)->get();
-
-        $this->assertThat($plugin->is_installed, $this->isFalse());
-        $this->assertCount(1, $errors);
-    }
-
-    public function test_can_remove_local_plugin(): void
-    {
-        $plugin = $this->createFakePlugin();
-        $folder = $plugin->folder;
-        $path = $this->getPluginPath($plugin);
-
-        $uninstall = app(UninstallPlugin::class);
-        $uninstall->handle($plugin);
-
-        $plugin = Plugin::where('folder', $folder)->first();
-        $this->assertThat($plugin, $this->isNull());
-        $this->assertThat(File::isDirectory($path), $this->IsFalse());
-    }
-
-    public function test_can_uninstall_plugin(): void
-    {
-        $plugin = $this->installDemoPlugin();
-        $path = $this->getPluginPath($plugin);
-
-        $plugin->is_enabled = false;
-        $plugin->save();
-
-        $folder = $plugin->folder;
-
-        $uninstall = app(UninstallPlugin::class);
-        $uninstall->handle($plugin);
-
-        $plugin = Plugin::where('folder', $folder)->first();
-        $this->assertThat($plugin, $this->isNull());
-        $this->assertThat(File::isDirectory($path), $this->IsFalse());
-    }
-
-    public function test_cannot_uninstall_enabled_plugin(): void
-    {
-        $plugin = $this->installDemoPlugin();
-        $path = $this->getPluginPath($plugin);
-
-        $plugin->is_enabled = true;
-        $plugin->save();
-
-        $uninstall = app(UninstallPlugin::class);
-
-        $this->assertThrows(fn () => $uninstall->handle($plugin));
-
-        $plugin->refresh();
-        $this->assertThat($plugin->is_enabled, $this->isTrue());
-        $this->assertThat($plugin->is_installed, $this->isTrue());
-        $this->assertThat(File::isDirectory($path), $this->isTrue());
-    }
-
-    public function test_cannot_enable_enabled_plugin(): void
-    {
-        $plugin = $this->installDemoPlugin();
-
-        $plugin->is_enabled = true;
-        $plugin->save();
-
-        $enable = app(EnablePlugin::class);
-
-        $this->assertThrows(fn () => $enable->handle($plugin));
-
-        $plugin->refresh();
-        $this->assertThat($plugin->is_enabled, $this->isTrue());
-        $this->assertThat($plugin->is_installed, $this->isTrue());
-    }
-
-    public function test_cannot_disable_disabled_plugin(): void
-    {
-        $plugin = $this->installDemoPlugin();
-
-        $plugin->is_enabled = false;
-        $plugin->save();
-
-        $disable = app(DisablePlugin::class);
-
-        $this->assertThrows(fn () => $disable->handle($plugin));
-
-        $plugin->refresh();
-        $this->assertThat($plugin->is_enabled, $this->isFalse());
-        $this->assertThat($plugin->is_installed, $this->isTrue());
-    }
-
-    public function test_install_method_called(): void
-    {
-        $plugin = $this->installExamplePlugin();
-
-        $installer = app(InstallPlugin::class);
-        $installer->handle($plugin);
-
-        $implementation = app(GetPluginInstance::class)->handle($plugin);
-        $methods = $implementation->getMethods();
-
-        $this->assertThat($methods, $this->arrayHasKey('install'));
-        $this->assertCount(1, $methods);
-        $this->assertThat($methods['install'], $this->equalTo(1));
-    }
-
-    public function test_enable_method_called(): void
-    {
-        $plugin = $this->installExamplePlugin();
-        $plugin->is_installed = true;
-        $plugin->save();
-
-        $action = app(EnablePlugin::class);
-        $action->handle($plugin);
-
-        $implementation = app(GetPluginInstance::class)->handle($plugin);
-        $methods = $implementation->getMethods();
-
-        $this->assertThat($methods, $this->arrayHasKey('enable'));
-        $this->assertCount(1, $methods);
-        $this->assertThat($methods['enable'], $this->equalTo(1));
-    }
-
-    public function test_disable_method_called(): void
-    {
-        $plugin = $this->installExamplePlugin();
-        $plugin->is_installed = true;
-        $plugin->is_enabled = true;
-        $plugin->save();
-
-        $action = app(DisablePlugin::class);
-        $action->handle($plugin);
-
-        $implementation = app(GetPluginInstance::class)->handle($plugin);
-        $methods = $implementation->getMethods();
-
-        $this->assertThat($methods, $this->arrayHasKey('disable'));
-        $this->assertCount(1, $methods);
-        $this->assertThat($methods['disable'], $this->equalTo(1));
-    }
-
-    public function test_boot_method_called_for_enabled_plugin(): void
-    {
-        $plugin = $this->installExamplePlugin();
-        $plugin->is_installed = true;
-        $plugin->is_enabled = true;
-        $plugin->save();
-
-        $action = app(BootPlugins::class);
-        $action->handle();
-
-        $implementation = app(GetPluginInstance::class)->handle($plugin);
-        $methods = $implementation->getMethods();
-
-        $this->assertThat($methods, $this->arrayHasKey('boot'));
-        $this->assertCount(1, $methods);
-        $this->assertThat($methods['boot'], $this->equalTo(1));
-    }
-
-    public function test_boot_method_not_called_for_disabled_plugin(): void
-    {
-        $plugin = $this->installExamplePlugin();
-        $plugin->is_installed = true;
-        $plugin->is_enabled = false;
-        $plugin->save();
-
-        $action = app(BootPlugins::class);
-        $action->handle();
-
-        $implementation = app(GetPluginInstance::class)->handle($plugin);
-        $methods = $implementation->getMethods();
-
-        $this->assertCount(0, $methods);
-    }
+    return Plugin::where('folder', $folder)->first();
 }
+
+function vitoPestUnitPluginsPluginTestMovePlugins(string $from, string $to): void
+{
+    File::deleteDirectory($to);
+    File::makeDirectory(path: $to, recursive: true, force: true);
+    File::moveDirectory($from, $to, true);
+}
+
+function vitoPestUnitPluginsPluginTestCreateTestReleaseDto(string $tagName = '1.0.2', string $repoName = 'repo'): ReleaseDto
+{
+    return new ReleaseDto(
+        url: "https://api.github.com/repos/username/{$repoName}/releases/123456",
+        tagName: $tagName,
+        name: "Release {$tagName}",
+        draft: false,
+        preRelease: false,
+        createdAt: Carbon::now(),
+        updatedAt: Carbon::now(),
+        publishedAt: Carbon::now(),
+        author: new AuthorDto('username', 'https://api.github.com/username', 'individual'),
+        tarUrl: "https://api.github.com/repos/username/{$repoName}/tarball/{$tagName}",
+        zipUrl: "https://github.com/username/{$repoName}/archive/{$tagName}.zip",
+        body: "Release notes for version {$tagName}"
+    );
+}
+
+function vitoPestUnitPluginsPluginTestInstallDemoPlugin(): Plugin
+{
+    $zip = implode(DIRECTORY_SEPARATOR, [__DIR__, 'Artifacts', 'VitoOctanePlugin-1.0.2.zip']);
+
+    app()->bind(DownloadRelease::class, function () use ($zip) {
+        $mock = Mockery::mock(DownloadRelease::class);
+        $mock->shouldReceive('handle')
+            ->andReturnUsing(function ($release, $location) use ($zip) {
+                File::ensureDirectoryExists(dirname($location));
+                if (! File::copy($zip, $location)) {
+                    throw new Exception("Unable to copy file from $zip to $location");
+                }
+            });
+
+        return $mock;
+    });
+
+    app()->bind(GetReleaseInfo::class, function () {
+        $mock = Mockery::mock(GetReleaseInfo::class);
+        $mock->shouldReceive('handle')
+            ->andReturn(vitoPestUnitPluginsPluginTestCreateTestReleaseDto());
+
+        return $mock;
+    });
+
+    $action = app(InstallGithubPlugin::class);
+
+    return $action->handle(test()->repoUrl);
+}
+
+function vitoPestUnitPluginsPluginTestGetPluginPath(Plugin $plugin): string
+{
+    return implode(DIRECTORY_SEPARATOR, [test()->pluginPath, $plugin->folder]);
+}
+
+function vitoPestUnitPluginsPluginTestCreateFakePlugin(): Plugin
+{
+    $folder = implode(DIRECTORY_SEPARATOR, ['ExampleUser', 'ExampleRepo']);
+    $path = implode(DIRECTORY_SEPARATOR, [test()->pluginPath, $folder]);
+    File::makeDirectory($path, 0755, true);
+
+    $discovery = app(DiscoverPlugins::class);
+    $discovery->handle();
+
+    return Plugin::where('folder', $folder)->first();
+}
+
+test('can install plugin', function () {
+    $plugin = vitoPestUnitPluginsPluginTestInstallDemoPlugin();
+    $path = vitoPestUnitPluginsPluginTestGetPluginPath($plugin);
+
+    expect(File::isDirectory($path))->toMatchConstraint($this->isTrue());
+    expect(File::isEmptyDirectory($path))->toMatchConstraint($this->isFalse());
+    expect($plugin->is_installed)->toMatchConstraint($this->isTrue());
+});
+
+test('can enable plugin', function () {
+    $plugin = vitoPestUnitPluginsPluginTestInstallDemoPlugin();
+
+    $action = app(EnablePlugin::class);
+    $action->handle($plugin);
+
+    $plugin->refresh();
+    expect($plugin->is_enabled)->toMatchConstraint($this->isTrue());
+});
+
+test('can disable plugin', function () {
+    $plugin = vitoPestUnitPluginsPluginTestInstallDemoPlugin();
+
+    $plugin->is_enabled = true;
+    $plugin->save();
+
+    $disable = app(DisablePlugin::class);
+    $disable->handle($plugin);
+
+    $plugin->refresh();
+    expect($plugin->is_enabled)->toMatchConstraint($this->isFalse());
+});
+
+test('can discovery plugins', function () {
+    $plugin = vitoPestUnitPluginsPluginTestCreateFakePlugin();
+
+    expect($plugin)->not->toBeNull();
+    expect($plugin->namespace)->toMatchConstraint($this->equalTo('App\\Vito\\Plugins\\ExampleUser\\ExampleRepo\\Plugin'));
+    expect($plugin->is_installed)->toMatchConstraint($this->isFalse());
+    expect($plugin->is_enabled)->toMatchConstraint($this->isFalse());
+});
+
+test('install invalid plugin raises error', function () {
+    $plugin = vitoPestUnitPluginsPluginTestCreateFakePlugin();
+
+    $install = app(InstallPlugin::class);
+    $this->assertThrows(fn () => $install->handle($plugin));
+
+    $plugin->refresh();
+    $errors = PluginError::where('plugin_id', $plugin->id)->get();
+
+    expect($plugin->is_installed)->toMatchConstraint($this->isFalse());
+    expect($errors)->toHaveCount(1);
+});
+
+test('can remove local plugin', function () {
+    $plugin = vitoPestUnitPluginsPluginTestCreateFakePlugin();
+    $folder = $plugin->folder;
+    $path = vitoPestUnitPluginsPluginTestGetPluginPath($plugin);
+
+    $uninstall = app(UninstallPlugin::class);
+    $uninstall->handle($plugin);
+
+    $plugin = Plugin::where('folder', $folder)->first();
+    expect($plugin)->toMatchConstraint($this->isNull());
+    expect(File::isDirectory($path))->toMatchConstraint($this->IsFalse());
+});
+
+test('can uninstall plugin', function () {
+    $plugin = vitoPestUnitPluginsPluginTestInstallDemoPlugin();
+    $path = vitoPestUnitPluginsPluginTestGetPluginPath($plugin);
+
+    $plugin->is_enabled = false;
+    $plugin->save();
+
+    $folder = $plugin->folder;
+
+    $uninstall = app(UninstallPlugin::class);
+    $uninstall->handle($plugin);
+
+    $plugin = Plugin::where('folder', $folder)->first();
+    expect($plugin)->toMatchConstraint($this->isNull());
+    expect(File::isDirectory($path))->toMatchConstraint($this->IsFalse());
+});
+
+test('cannot uninstall enabled plugin', function () {
+    $plugin = vitoPestUnitPluginsPluginTestInstallDemoPlugin();
+    $path = vitoPestUnitPluginsPluginTestGetPluginPath($plugin);
+
+    $plugin->is_enabled = true;
+    $plugin->save();
+
+    $uninstall = app(UninstallPlugin::class);
+
+    $this->assertThrows(fn () => $uninstall->handle($plugin));
+
+    $plugin->refresh();
+    expect($plugin->is_enabled)->toMatchConstraint($this->isTrue());
+    expect($plugin->is_installed)->toMatchConstraint($this->isTrue());
+    expect(File::isDirectory($path))->toMatchConstraint($this->isTrue());
+});
+
+test('cannot enable enabled plugin', function () {
+    $plugin = vitoPestUnitPluginsPluginTestInstallDemoPlugin();
+
+    $plugin->is_enabled = true;
+    $plugin->save();
+
+    $enable = app(EnablePlugin::class);
+
+    $this->assertThrows(fn () => $enable->handle($plugin));
+
+    $plugin->refresh();
+    expect($plugin->is_enabled)->toMatchConstraint($this->isTrue());
+    expect($plugin->is_installed)->toMatchConstraint($this->isTrue());
+});
+
+test('cannot disable disabled plugin', function () {
+    $plugin = vitoPestUnitPluginsPluginTestInstallDemoPlugin();
+
+    $plugin->is_enabled = false;
+    $plugin->save();
+
+    $disable = app(DisablePlugin::class);
+
+    $this->assertThrows(fn () => $disable->handle($plugin));
+
+    $plugin->refresh();
+    expect($plugin->is_enabled)->toMatchConstraint($this->isFalse());
+    expect($plugin->is_installed)->toMatchConstraint($this->isTrue());
+});
+
+test('install method called', function () {
+    $plugin = vitoPestUnitPluginsPluginTestInstallExamplePlugin();
+
+    $installer = app(InstallPlugin::class);
+    $installer->handle($plugin);
+
+    $implementation = app(GetPluginInstance::class)->handle($plugin);
+    $methods = $implementation->getMethods();
+
+    expect($methods)->toMatchConstraint($this->arrayHasKey('install'));
+    expect($methods)->toHaveCount(1);
+    expect($methods['install'])->toMatchConstraint($this->equalTo(1));
+});
+
+test('enable method called', function () {
+    $plugin = vitoPestUnitPluginsPluginTestInstallExamplePlugin();
+    $plugin->is_installed = true;
+    $plugin->save();
+
+    $action = app(EnablePlugin::class);
+    $action->handle($plugin);
+
+    $implementation = app(GetPluginInstance::class)->handle($plugin);
+    $methods = $implementation->getMethods();
+
+    expect($methods)->toMatchConstraint($this->arrayHasKey('enable'));
+    expect($methods)->toHaveCount(1);
+    expect($methods['enable'])->toMatchConstraint($this->equalTo(1));
+});
+
+test('disable method called', function () {
+    $plugin = vitoPestUnitPluginsPluginTestInstallExamplePlugin();
+    $plugin->is_installed = true;
+    $plugin->is_enabled = true;
+    $plugin->save();
+
+    $action = app(DisablePlugin::class);
+    $action->handle($plugin);
+
+    $implementation = app(GetPluginInstance::class)->handle($plugin);
+    $methods = $implementation->getMethods();
+
+    expect($methods)->toMatchConstraint($this->arrayHasKey('disable'));
+    expect($methods)->toHaveCount(1);
+    expect($methods['disable'])->toMatchConstraint($this->equalTo(1));
+});
+
+test('boot method called for enabled plugin', function () {
+    $plugin = vitoPestUnitPluginsPluginTestInstallExamplePlugin();
+    $plugin->is_installed = true;
+    $plugin->is_enabled = true;
+    $plugin->save();
+
+    $action = app(BootPlugins::class);
+    $action->handle();
+
+    $implementation = app(GetPluginInstance::class)->handle($plugin);
+    $methods = $implementation->getMethods();
+
+    expect($methods)->toMatchConstraint($this->arrayHasKey('boot'));
+    expect($methods)->toHaveCount(1);
+    expect($methods['boot'])->toMatchConstraint($this->equalTo(1));
+});
+
+test('boot method not called for disabled plugin', function () {
+    $plugin = vitoPestUnitPluginsPluginTestInstallExamplePlugin();
+    $plugin->is_installed = true;
+    $plugin->is_enabled = false;
+    $plugin->save();
+
+    $action = app(BootPlugins::class);
+    $action->handle();
+
+    $implementation = app(GetPluginInstance::class)->handle($plugin);
+    $methods = $implementation->getMethods();
+
+    expect($methods)->toHaveCount(0);
+});

--- a/tests/Unit/SSH/Services/Database/GetCharsetsTest.php
+++ b/tests/Unit/SSH/Services/Database/GetCharsetsTest.php
@@ -1,21 +1,14 @@
 <?php
 
-namespace Tests\Unit\SSH\Services\Database;
-
 use App\Facades\SSH;
 use App\Services\Database\Database;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class GetCharsetsTest extends TestCase
+uses(RefreshDatabase::class);
+
+function vitoPestUnitSSHServicesDatabaseGetCharsetsTestMysqlCharsets(): array
 {
-    use RefreshDatabase;
-
-    /**
-     * @var array<string, array<string, string|array<string>>>
-     */
-    protected static array $mysqlCharsets = [
+    return [
         'armscii8' => [
             'default' => 'armscii8_general_ci',
             'list' => [
@@ -38,37 +31,32 @@ class GetCharsetsTest extends TestCase
             ],
         ],
     ];
+}
 
-    /**
-     * @param  array<string, array{default: string|null, list: array<int, string>}>  $expected
-     */
-    #[DataProvider('data')]
-    public function test_update_charsets(string $name, string $version, string $output, array $expected): void
-    {
-        $database = $this->server->database();
-        $database->name = $name;
-        $database->version = $version;
-        $database->save();
+test('update charsets', function (string $name, string $version, string $output, array $expected) {
+    $database = $this->server->database();
+    $database->name = $name;
+    $database->version = $version;
+    $database->save();
 
-        SSH::fake($output);
+    SSH::fake($output);
 
-        /** @var Database $databaseHandler */
-        $databaseHandler = $database->handler();
-        $charsets = $databaseHandler->getCharsets();
+    /** @var Database $databaseHandler */
+    $databaseHandler = $database->handler();
+    $charsets = $databaseHandler->getCharsets();
 
-        $this->assertEquals($expected, $charsets['charsets']);
-    }
+    expect($charsets['charsets'])->toEqual($expected);
+})->with('data');
 
-    /**
-     * @return array<int, array<int, mixed>>
-     */
-    public static function data(): array
-    {
-        return [
-            [
-                'mysql',
-                '8.0',
-                <<<'EOD'
+/**
+ * @return array<int, array<int, mixed>>
+ */
+dataset('data', function () {
+    return [
+        [
+            'mysql',
+            '8.0',
+            <<<'EOD'
                 Collation	Charset	Id	Default	Compiled	Sortlen	Pad_attribute
                 armscii8_bin	armscii8	64		Yes	1	PAD SPACE
                 armscii8_general_ci	armscii8	32	Yes	Yes	1	PAD SPACE
@@ -77,12 +65,12 @@ class GetCharsetsTest extends TestCase
                 big5_bin	big5	84		Yes	1	PAD SPACE
                 big5_chinese_ci	big5	1	Yes	Yes	1	PAD SPACE
                 EOD,
-                static::$mysqlCharsets,
-            ],
-            [
-                'mysql',
-                '5.7',
-                <<<'EOD'
+            vitoPestUnitSSHServicesDatabaseGetCharsetsTestMysqlCharsets(),
+        ],
+        [
+            'mysql',
+            '5.7',
+            <<<'EOD'
                 Collation	Charset	Id	Default	Compiled	Sortlen	Pad_attribute
                 armscii8_bin	armscii8	64		Yes	1	PAD SPACE
                 armscii8_general_ci	armscii8	32	Yes	Yes	1	PAD SPACE
@@ -91,12 +79,12 @@ class GetCharsetsTest extends TestCase
                 big5_bin	big5	84		Yes	1	PAD SPACE
                 big5_chinese_ci	big5	1	Yes	Yes	1	PAD SPACE
                 EOD,
-                static::$mysqlCharsets,
-            ],
-            [
-                'mariadb',
-                '10.5',
-                <<<'EOD'
+            vitoPestUnitSSHServicesDatabaseGetCharsetsTestMysqlCharsets(),
+        ],
+        [
+            'mariadb',
+            '10.5',
+            <<<'EOD'
                 Collation	Charset	Id	Default	Compiled	Sortlen	Pad_attribute
                 armscii8_bin	armscii8	64		Yes	1	PAD SPACE
                 armscii8_general_ci	armscii8	32	Yes	Yes	1	PAD SPACE
@@ -105,12 +93,12 @@ class GetCharsetsTest extends TestCase
                 big5_bin	big5	84		Yes	1	PAD SPACE
                 big5_chinese_ci	big5	1	Yes	Yes	1	PAD SPACE
                 EOD,
-                static::$mysqlCharsets,
-            ],
-            [
-                'mariadb',
-                '11.4',
-                <<<'EOD'
+            vitoPestUnitSSHServicesDatabaseGetCharsetsTestMysqlCharsets(),
+        ],
+        [
+            'mariadb',
+            '11.4',
+            <<<'EOD'
                 Collation	Charset	Id	Default	Compiled	Sortlen
                 big5_chinese_ci	big5	1	Yes	Yes	1
                 big5_bin	big5	84		Yes	1
@@ -119,27 +107,27 @@ class GetCharsetsTest extends TestCase
                 uca1400_ai_ci	NULL	NULL	NULL	Yes	8
                 uca1400_ai_cs	NULL	NULL	NULL	Yes	8
                 EOD,
-                [
-                    'big5' => [
-                        'default' => 'big5_chinese_ci',
-                        'list' => [
-                            'big5_chinese_ci',
-                            'big5_bin',
-                        ],
+            [
+                'big5' => [
+                    'default' => 'big5_chinese_ci',
+                    'list' => [
+                        'big5_chinese_ci',
+                        'big5_bin',
                     ],
-                    'utf8mb4' => [
-                        'default' => null,
-                        'list' => [
-                            'utf8mb4_general_ci',
-                            'utf8mb4_bin',
-                        ],
+                ],
+                'utf8mb4' => [
+                    'default' => null,
+                    'list' => [
+                        'utf8mb4_general_ci',
+                        'utf8mb4_bin',
                     ],
                 ],
             ],
-            [
-                'postgresql',
-                '16',
-                <<<'EOD'
+        ],
+        [
+            'postgresql',
+            '16',
+            <<<'EOD'
                  collation  | charset | id | default | compiled | sortlen | pad_attribute
                 ------------+---------+----+---------+----------+---------+---------------
                  ucs_basic  | UTF8    |    |         | Yes      |         |
@@ -148,22 +136,22 @@ class GetCharsetsTest extends TestCase
                  en_US      | UTF8    |    |         | Yes      |         |
                 (4 rows)
                 EOD,
-                [
-                    'UTF8' => [
-                        'default' => null,
-                        'list' => [
-                            'ucs_basic',
-                            'C.utf8',
-                            'en_US.utf8',
-                            'en_US',
-                        ],
+            [
+                'UTF8' => [
+                    'default' => null,
+                    'list' => [
+                        'ucs_basic',
+                        'C.utf8',
+                        'en_US.utf8',
+                        'en_US',
                     ],
                 ],
             ],
-            [
-                'postgresql',
-                '18',
-                <<<'EOD'
+        ],
+        [
+            'postgresql',
+            '18',
+            <<<'EOD'
                  collation   | charset | id | default | compiled | sortlen | pad_attribute
                 -------------+---------+----+---------+----------+---------+---------------
                  C           | UTF8    |    |         | Yes      |         |
@@ -175,21 +163,20 @@ class GetCharsetsTest extends TestCase
                  en_US.utf8  | UTF8    |    |         | Yes      |         |
                 (7 rows)
                 EOD,
-                [
-                    'UTF8' => [
-                        'default' => null,
-                        'list' => [
-                            'C',
-                            'POSIX',
-                            'ucs_basic',
-                            'pg_c_utf8',
-                            'unicode',
-                            'en-US-x-icu',
-                            'en_US.utf8',
-                        ],
+            [
+                'UTF8' => [
+                    'default' => null,
+                    'list' => [
+                        'C',
+                        'POSIX',
+                        'ucs_basic',
+                        'pg_c_utf8',
+                        'unicode',
+                        'en-US-x-icu',
+                        'en_US.utf8',
                     ],
                 ],
             ],
-        ];
-    }
-}
+        ],
+    ];
+});

--- a/tests/Unit/SSH/Services/Database/GetDatabasesTest.php
+++ b/tests/Unit/SSH/Services/Database/GetDatabasesTest.php
@@ -1,44 +1,35 @@
 <?php
 
-namespace Tests\Unit\SSH\Services\Database;
-
 use App\Facades\SSH;
 use App\Services\Database\Database;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class GetDatabasesTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    #[DataProvider('data')]
-    public function test_get_databases(string $name, string $version, string $output): void
-    {
-        $database = $this->server->database();
-        $database->name = $name;
-        $database->version = $version;
-        $database->save();
+test('get databases', function (string $name, string $version, string $output) {
+    $database = $this->server->database();
+    $database->name = $name;
+    $database->version = $version;
+    $database->save();
 
-        SSH::fake($output);
+    SSH::fake($output);
 
-        /** @var Database $databaseHandler */
-        $databaseHandler = $database->handler();
-        $databases = $databaseHandler->getDatabases();
+    /** @var Database $databaseHandler */
+    $databaseHandler = $database->handler();
+    $databases = $databaseHandler->getDatabases();
 
-        $this->assertEquals('vito', $databases[0][0]);
-    }
+    expect($databases[0][0])->toEqual('vito');
+})->with('data');
 
-    /**
-     * @return array<int, array<int, mixed>>
-     */
-    public static function data(): array
-    {
-        return [
-            [
-                'mysql',
-                '8.0',
-                <<<'EOD'
+/**
+ * @return array<int, array<int, mixed>>
+ */
+dataset('data', function () {
+    return [
+        [
+            'mysql',
+            '8.0',
+            <<<'EOD'
                 database_name	charset	collation
                 mysql	utf8mb4	utf8mb4_0900_ai_ci
                 information_schema	utf8mb3	utf8mb3_general_ci
@@ -46,11 +37,11 @@ class GetDatabasesTest extends TestCase
                 sys	utf8mb4	utf8mb4_0900_ai_ci
                 vito	utf8mb3	utf8mb3_general_ci
                 EOD
-            ],
-            [
-                'mysql',
-                '5.7',
-                <<<'EOD'
+        ],
+        [
+            'mysql',
+            '5.7',
+            <<<'EOD'
                 database_name	charset	collation
                 mysql	utf8mb4	utf8mb4_0900_ai_ci
                 information_schema	utf8mb3	utf8mb3_general_ci
@@ -58,11 +49,11 @@ class GetDatabasesTest extends TestCase
                 sys	utf8mb4	utf8mb4_0900_ai_ci
                 vito	utf8mb3	utf8mb3_general_ci
                 EOD
-            ],
-            [
-                'mariadb',
-                '11.4',
-                <<<'EOD'
+        ],
+        [
+            'mariadb',
+            '11.4',
+            <<<'EOD'
                 database_name	charset	collation
                 information_schema	utf8mb3	utf8mb3_general_ci
                 mysql	utf8mb4	utf8mb4_uca1400_ai_ci
@@ -70,11 +61,11 @@ class GetDatabasesTest extends TestCase
                 sys	utf8mb3	utf8mb3_general_ci
                 vito	utf8mb3	utf8mb3_general_ci
                 EOD
-            ],
-            [
-                'postgresql',
-                '16',
-                <<<'EOD'
+        ],
+        [
+            'postgresql',
+            '16',
+            <<<'EOD'
                  database_name | charset |  collation
                 ---------------+---------+-------------
                  postgres      | UTF8    | en_US.UTF-8
@@ -83,7 +74,6 @@ class GetDatabasesTest extends TestCase
                  vito          | UTF8    | en_US.UTF-8
                 (3 rows)
                 EOD
-            ],
-        ];
-    }
-}
+        ],
+    ];
+});

--- a/tests/Unit/SSH/Services/Database/GetUsersTest.php
+++ b/tests/Unit/SSH/Services/Database/GetUsersTest.php
@@ -1,44 +1,35 @@
 <?php
 
-namespace Tests\Unit\SSH\Services\Database;
-
 use App\Facades\SSH;
 use App\Services\Database\Database;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class GetUsersTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    #[DataProvider('data')]
-    public function test_get_users(string $name, string $version, string $output): void
-    {
-        $database = $this->server->database();
-        $database->name = $name;
-        $database->version = $version;
-        $database->save();
+test('get users', function (string $name, string $version, string $output) {
+    $database = $this->server->database();
+    $database->name = $name;
+    $database->version = $version;
+    $database->save();
 
-        SSH::fake($output);
+    SSH::fake($output);
 
-        /** @var Database $databaseHandler */
-        $databaseHandler = $database->handler();
-        $users = $databaseHandler->getUsers();
+    /** @var Database $databaseHandler */
+    $databaseHandler = $database->handler();
+    $users = $databaseHandler->getUsers();
 
-        $this->assertEquals('vito', $users[0][0]);
-    }
+    expect($users[0][0])->toEqual('vito');
+})->with('data');
 
-    /**
-     * @return array<int, array<int, mixed>>
-     */
-    public static function data(): array
-    {
-        return [
-            [
-                'mysql',
-                '8.0',
-                <<<'EOD'
+/**
+ * @return array<int, array<int, mixed>>
+ */
+dataset('data', function () {
+    return [
+        [
+            'mysql',
+            '8.0',
+            <<<'EOD'
                 User	Host	Privileges
                 vito	localhost	mydb,testdb
                 mysql.infoschema	localhost	NULL
@@ -46,11 +37,11 @@ class GetUsersTest extends TestCase
                 mysql.sys	localhost	sys
                 root	localhost	NULL
                 EOD
-            ],
-            [
-                'mysql',
-                '5.7',
-                <<<'EOD'
+        ],
+        [
+            'mysql',
+            '5.7',
+            <<<'EOD'
                 User	Host	Privileges
                 vito	localhost	mydb,testdb
                 mysql.infoschema	localhost	NULL
@@ -58,29 +49,28 @@ class GetUsersTest extends TestCase
                 mysql.sys	localhost	sys
                 root	localhost	NULL
                 EOD
-            ],
-            [
-                'mariadb',
-                '11.4',
-                <<<'EOD'
+        ],
+        [
+            'mariadb',
+            '11.4',
+            <<<'EOD'
                 User	Host	Privileges
                 mariadb.sys	localhost	NULL
                 mysql	localhost	NULL
                 root	localhost	NULL
                 vito	localhost	NULL
                 EOD
-            ],
-            [
-                'postgresql',
-                '16',
-                <<<'EOD'
+        ],
+        [
+            'postgresql',
+            '16',
+            <<<'EOD'
                  username | host |                databases
                 ----------+------+------------------------------------------
                  postgres |      | template1,template0,postgres,test,vitodb
                  vito     |      | template1,template0,postgres,test,vitodb
                 (2 rows)
                 EOD
-            ],
-        ];
-    }
-}
+        ],
+    ];
+});

--- a/tests/Unit/SSH/Services/Firewall/UfwInstallTest.php
+++ b/tests/Unit/SSH/Services/Firewall/UfwInstallTest.php
@@ -1,87 +1,78 @@
 <?php
 
-namespace Tests\Unit\SSH\Services\Firewall;
-
 use App\Facades\SSH;
 use App\Services\Firewall\Ufw;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class UfwInstallTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_install_seeds_ssh_rule_with_custom_server_port(): void
-    {
-        SSH::fake();
+test('install seeds ssh rule with custom server port', function () {
+    SSH::fake();
 
-        $this->server->update(['port' => 22022]);
+    $this->server->update(['port' => 22022]);
 
-        /** @var Ufw $ufw */
-        $ufw = $this->server->services()
-            ->where('type', Ufw::type())
-            ->firstOrFail()
-            ->handler();
+    /** @var Ufw $ufw */
+    $ufw = $this->server->services()
+        ->where('type', Ufw::type())
+        ->firstOrFail()
+        ->handler();
 
-        $ufw->install();
+    $ufw->install();
 
-        $this->assertDatabaseHas('firewall_rules', [
-            'server_id' => $this->server->id,
-            'name' => 'SSH',
-            'port' => 22022,
-        ]);
+    $this->assertDatabaseHas('firewall_rules', [
+        'server_id' => $this->server->id,
+        'name' => 'SSH',
+        'port' => 22022,
+    ]);
 
-        $this->assertDatabaseMissing('firewall_rules', [
-            'server_id' => $this->server->id,
-            'name' => 'SSH',
-            'port' => 22,
-        ]);
-    }
+    $this->assertDatabaseMissing('firewall_rules', [
+        'server_id' => $this->server->id,
+        'name' => 'SSH',
+        'port' => 22,
+    ]);
+});
 
-    public function test_install_seeds_ssh_rule_with_default_port_when_unchanged(): void
-    {
-        SSH::fake();
+test('install seeds ssh rule with default port when unchanged', function () {
+    SSH::fake();
 
-        $this->server->update(['port' => 22]);
+    $this->server->update(['port' => 22]);
 
-        /** @var Ufw $ufw */
-        $ufw = $this->server->services()
-            ->where('type', Ufw::type())
-            ->firstOrFail()
-            ->handler();
+    /** @var Ufw $ufw */
+    $ufw = $this->server->services()
+        ->where('type', Ufw::type())
+        ->firstOrFail()
+        ->handler();
 
-        $ufw->install();
+    $ufw->install();
 
-        $this->assertDatabaseHas('firewall_rules', [
-            'server_id' => $this->server->id,
-            'name' => 'SSH',
-            'port' => 22,
-        ]);
-    }
+    $this->assertDatabaseHas('firewall_rules', [
+        'server_id' => $this->server->id,
+        'name' => 'SSH',
+        'port' => 22,
+    ]);
+});
 
-    public function test_install_seeds_http_and_https_rules_unchanged(): void
-    {
-        SSH::fake();
+test('install seeds http and https rules unchanged', function () {
+    SSH::fake();
 
-        $this->server->update(['port' => 22022]);
+    $this->server->update(['port' => 22022]);
 
-        /** @var Ufw $ufw */
-        $ufw = $this->server->services()
-            ->where('type', Ufw::type())
-            ->firstOrFail()
-            ->handler();
+    /** @var Ufw $ufw */
+    $ufw = $this->server->services()
+        ->where('type', Ufw::type())
+        ->firstOrFail()
+        ->handler();
 
-        $ufw->install();
+    $ufw->install();
 
-        $this->assertDatabaseHas('firewall_rules', [
-            'server_id' => $this->server->id,
-            'name' => 'HTTP',
-            'port' => 80,
-        ]);
-        $this->assertDatabaseHas('firewall_rules', [
-            'server_id' => $this->server->id,
-            'name' => 'HTTPS',
-            'port' => 443,
-        ]);
-    }
-}
+    $this->assertDatabaseHas('firewall_rules', [
+        'server_id' => $this->server->id,
+        'name' => 'HTTP',
+        'port' => 80,
+    ]);
+    $this->assertDatabaseHas('firewall_rules', [
+        'server_id' => $this->server->id,
+        'name' => 'HTTPS',
+        'port' => 443,
+    ]);
+});

--- a/tests/Unit/SSH/Services/Webserver/DeploySplashTest.php
+++ b/tests/Unit/SSH/Services/Webserver/DeploySplashTest.php
@@ -1,67 +1,59 @@
 <?php
 
-namespace Tests\Unit\SSH\Services\Webserver;
-
 use App\Enums\ServiceStatus;
 use App\Facades\SSH;
 use App\Services\Webserver\Caddy;
 use App\Services\Webserver\Nginx;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class DeploySplashTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_nginx_deploy_splash_runs_expected_commands_and_writes_default_vhost(): void
-    {
-        SSH::fake();
+test('nginx deploy splash runs expected commands and writes default vhost', function () {
+    SSH::fake();
 
-        /** @var Nginx $nginx */
-        $nginx = $this->server->webserver()->handler();
+    /** @var Nginx $nginx */
+    $nginx = $this->server->webserver()->handler();
 
-        $nginx->deploySplash();
+    $nginx->deploySplash();
 
-        SSH::assertExecutedContains('sudo rm -f /etc/nginx/sites-enabled/default');
-        SSH::assertExecutedContains('sudo mkdir -p /var/www/vito-splash');
-        SSH::assertExecutedContains("> '/var/www/vito-splash/index.html'");
-        SSH::assertExecutedContains("> '/etc/nginx/sites-available/000-default'");
-        SSH::assertExecutedContains('sudo ln -sf /etc/nginx/sites-available/000-default /etc/nginx/sites-enabled/000-default');
+    SSH::assertExecutedContains('sudo rm -f /etc/nginx/sites-enabled/default');
+    SSH::assertExecutedContains('sudo mkdir -p /var/www/vito-splash');
+    SSH::assertExecutedContains("> '/var/www/vito-splash/index.html'");
+    SSH::assertExecutedContains("> '/etc/nginx/sites-available/000-default'");
+    SSH::assertExecutedContains('sudo ln -sf /etc/nginx/sites-available/000-default /etc/nginx/sites-enabled/000-default');
 
-        SSH::assertNotExecutedContains(
-            'systemctl reload nginx',
-            'deploySplash() must not reload nginx — install() restarts it and the reload can fail on fresh installs.'
-        );
+    SSH::assertNotExecutedContains(
+        'systemctl reload nginx',
+        'deploySplash() must not reload nginx — install() restarts it and the reload can fail on fresh installs.'
+    );
 
-        $this->addToAssertionCount(6);
-    }
+    $this->addToAssertionCount(6);
+});
 
-    public function test_caddy_deploy_splash_runs_expected_commands_and_writes_default_vhost(): void
-    {
-        $this->server->webserver()->delete();
-        $this->server->services()->create([
-            'type' => Caddy::type(),
-            'name' => Caddy::id(),
-            'version' => 'latest',
-            'status' => ServiceStatus::READY,
-        ]);
+test('caddy deploy splash runs expected commands and writes default vhost', function () {
+    $this->server->webserver()->delete();
+    $this->server->services()->create([
+        'type' => Caddy::type(),
+        'name' => Caddy::id(),
+        'version' => 'latest',
+        'status' => ServiceStatus::READY,
+    ]);
 
-        SSH::fake();
+    SSH::fake();
 
-        /** @var Caddy $caddy */
-        $caddy = $this->server->refresh()->webserver()->handler();
+    /** @var Caddy $caddy */
+    $caddy = $this->server->refresh()->webserver()->handler();
 
-        $caddy->deploySplash();
+    $caddy->deploySplash();
 
-        SSH::assertExecutedContains('sudo mkdir -p /var/www/vito-splash');
-        SSH::assertExecutedContains("> '/var/www/vito-splash/index.html'");
-        SSH::assertExecutedContains("> '/etc/caddy/sites-enabled/000-default.caddy'");
+    SSH::assertExecutedContains('sudo mkdir -p /var/www/vito-splash');
+    SSH::assertExecutedContains("> '/var/www/vito-splash/index.html'");
+    SSH::assertExecutedContains("> '/etc/caddy/sites-enabled/000-default.caddy'");
 
-        SSH::assertNotExecutedContains(
-            'caddy reload',
-            'deploySplash() must not reload caddy — install() restarts it and the reload can fail on fresh installs.'
-        );
+    SSH::assertNotExecutedContains(
+        'caddy reload',
+        'deploySplash() must not reload caddy — install() restarts it and the reload can fail on fresh installs.'
+    );
 
-        $this->addToAssertionCount(4);
-    }
-}
+    $this->addToAssertionCount(4);
+});

--- a/tests/Unit/SiteEnvPathTest.php
+++ b/tests/Unit/SiteEnvPathTest.php
@@ -1,69 +1,53 @@
 <?php
 
-namespace Tests\Unit;
-
 use App\Models\Site;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Validation\ValidationException;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class SiteEnvPathTest extends TestCase
+uses(RefreshDatabase::class);
+
+function vitoPestUnitSiteEnvPathTestSite(?string $storedEnvPath = null): Site
 {
-    use RefreshDatabase;
-
-    private function site(?string $storedEnvPath = null): Site
-    {
-        return Site::factory()->make([
-            'path' => '/home/vito/example.com',
-            'type_data' => $storedEnvPath === null ? null : ['env_path' => $storedEnvPath],
-        ]);
-    }
-
-    /**
-     * @return array<string, array<int, string>>
-     */
-    public static function rejectedPathProvider(): array
-    {
-        return [
-            'outside the site directory' => ['/etc/passwd'],
-            'shell metacharacters' => ['/etc/passwd;id'],
-            'command substitution' => ['/home/vito/example.com/$(id)'],
-            'traversal' => ['/home/vito/example.com/../other/.env'],
-            'trailing newline' => ["/home/vito/example.com/.env\n"],
-            'empty string' => [''],
-            'sibling directory sharing a prefix' => ['/home/vito/example.com-evil/.env'],
-        ];
-    }
-
-    #[DataProvider('rejectedPathProvider')]
-    public function test_it_rejects_paths_outside_the_site(string $path): void
-    {
-        $this->expectException(ValidationException::class);
-
-        $this->site()->resolveEnvPath($path);
-    }
-
-    public function test_it_accepts_a_path_inside_the_site(): void
-    {
-        $this->assertEquals(
-            '/home/vito/example.com/nested/.env',
-            $this->site()->resolveEnvPath('/home/vito/example.com/nested/.env'),
-        );
-    }
-
-    public function test_it_defaults_to_the_site_env_file(): void
-    {
-        $this->assertEquals('/home/vito/example.com/.env', $this->site()->resolveEnvPath());
-    }
-
-    public function test_it_exempts_the_stored_path_and_stays_idempotent(): void
-    {
-        $site = $this->site('/home/vito/legacy path/.env');
-
-        $resolved = $site->resolveEnvPath();
-
-        $this->assertEquals('/home/vito/legacy path/.env', $resolved);
-        $this->assertEquals($resolved, $site->resolveEnvPath($resolved));
-    }
+    return Site::factory()->make([
+        'path' => '/home/vito/example.com',
+        'type_data' => $storedEnvPath === null ? null : ['env_path' => $storedEnvPath],
+    ]);
 }
+
+/**
+ * @return array<string, array<int, string>>
+ */
+dataset('rejectedPathProvider', function () {
+    return [
+        'outside the site directory' => ['/etc/passwd'],
+        'shell metacharacters' => ['/etc/passwd;id'],
+        'command substitution' => ['/home/vito/example.com/$(id)'],
+        'traversal' => ['/home/vito/example.com/../other/.env'],
+        'trailing newline' => ["/home/vito/example.com/.env\n"],
+        'empty string' => [''],
+        'sibling directory sharing a prefix' => ['/home/vito/example.com-evil/.env'],
+    ];
+});
+
+test('it rejects paths outside the site', function (string $path) {
+    $this->expectException(ValidationException::class);
+
+    vitoPestUnitSiteEnvPathTestSite()->resolveEnvPath($path);
+})->with('rejectedPathProvider');
+
+test('it accepts a path inside the site', function () {
+    expect(vitoPestUnitSiteEnvPathTestSite()->resolveEnvPath('/home/vito/example.com/nested/.env'))->toEqual('/home/vito/example.com/nested/.env');
+});
+
+test('it defaults to the site env file', function () {
+    expect(vitoPestUnitSiteEnvPathTestSite()->resolveEnvPath())->toEqual('/home/vito/example.com/.env');
+});
+
+test('it exempts the stored path and stays idempotent', function () {
+    $site = vitoPestUnitSiteEnvPathTestSite('/home/vito/legacy path/.env');
+
+    $resolved = $site->resolveEnvPath();
+
+    expect($resolved)->toEqual('/home/vito/legacy path/.env');
+    expect($site->resolveEnvPath($resolved))->toEqual($resolved);
+});

--- a/tests/Unit/SiteShellEnvironmentTest.php
+++ b/tests/Unit/SiteShellEnvironmentTest.php
@@ -1,97 +1,86 @@
 <?php
 
-namespace Tests\Unit;
-
 use App\Helpers\SiteShellEnvironment;
 use App\Models\Site;
 use App\SiteTypes\Laravel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class SiteShellEnvironmentTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_collect_returns_empty_when_no_tools_are_installed(): void
-    {
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'isolated-empty',
-            'path' => '/home/isolated-empty/site.test',
-            'type' => Laravel::id(),
-            'type_data' => [],
-        ]);
+test('collect returns empty when no tools are installed', function () {
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'isolated-empty',
+        'path' => '/home/isolated-empty/site.test',
+        'type' => Laravel::id(),
+        'type_data' => [],
+    ]);
 
-        $this->assertSame([], SiteShellEnvironment::collect($site));
-    }
+    expect(SiteShellEnvironment::collect($site))->toBe([]);
+});
 
-    public function test_collect_returns_mise_shims_on_path_when_a_tool_is_installed(): void
-    {
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'isolated-node',
-            'path' => '/home/isolated-node/site.test',
-            'type' => Laravel::id(),
-            'type_data' => [],
-        ]);
-        $site->isolatedUser->setToolingVersion('node', '22');
+test('collect returns mise shims on path when a tool is installed', function () {
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'isolated-node',
+        'path' => '/home/isolated-node/site.test',
+        'type' => Laravel::id(),
+        'type_data' => [],
+    ]);
+    $site->isolatedUser->setToolingVersion('node', '22');
 
-        $env = SiteShellEnvironment::collect($site->refresh());
+    $env = SiteShellEnvironment::collect($site->refresh());
 
-        $this->assertArrayHasKey('PATH', $env);
-        $this->assertStringStartsWith('/home/isolated-node/.local/share/mise/shims:', $env['PATH']);
-        $this->assertStringContainsString('/usr/local/bin', $env['PATH']);
-        $this->assertStringContainsString('/home/isolated-node/.local/bin', $env['PATH']);
-    }
+    expect($env)->toHaveKey('PATH');
+    expect($env['PATH'])->toStartWith('/home/isolated-node/.local/share/mise/shims:');
+    $this->assertStringContainsString('/usr/local/bin', $env['PATH']);
+    $this->assertStringContainsString('/home/isolated-node/.local/bin', $env['PATH']);
+});
 
-    public function test_collect_dedupes_path_entries_from_multiple_mise_tools(): void
-    {
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'isolated-multi',
-            'path' => '/home/isolated-multi/site.test',
-            'type' => Laravel::id(),
-            'type_data' => [],
-        ]);
-        $site->isolatedUser->setToolingVersion('node', '22');
-        $site->isolatedUser->setToolingVersion('bun', '1.2');
-        $site->isolatedUser->setToolingVersion('pnpm', '9');
+test('collect dedupes path entries from multiple mise tools', function () {
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'isolated-multi',
+        'path' => '/home/isolated-multi/site.test',
+        'type' => Laravel::id(),
+        'type_data' => [],
+    ]);
+    $site->isolatedUser->setToolingVersion('node', '22');
+    $site->isolatedUser->setToolingVersion('bun', '1.2');
+    $site->isolatedUser->setToolingVersion('pnpm', '9');
 
-        $env = SiteShellEnvironment::collect($site->refresh());
+    $env = SiteShellEnvironment::collect($site->refresh());
 
-        $this->assertArrayHasKey('PATH', $env);
-        $occurrences = substr_count($env['PATH'], '/home/isolated-multi/.local/share/mise/shims');
-        $this->assertSame(1, $occurrences, 'Mise shims path should appear exactly once.');
-    }
+    expect($env)->toHaveKey('PATH');
+    $occurrences = substr_count($env['PATH'], '/home/isolated-multi/.local/share/mise/shims');
+    expect($occurrences)->toBe(1, 'Mise shims path should appear exactly once.');
+});
 
-    public function test_collect_returns_empty_when_site_user_is_empty(): void
-    {
-        $site = new Site(['user' => '']);
+test('collect returns empty when site user is empty', function () {
+    $site = new Site(['user' => '']);
 
-        $this->assertSame([], SiteShellEnvironment::collect($site));
-    }
+    expect(SiteShellEnvironment::collect($site))->toBe([]);
+});
 
-    public function test_wrap_builds_bash_invocation_with_env_and_optional_cd(): void
-    {
-        $site = Site::factory()->create([
-            'server_id' => $this->server->id,
-            'user' => 'isolated-wrap',
-            'path' => '/home/isolated-wrap/site.test',
-            'type' => Laravel::id(),
-            'type_data' => [],
-        ]);
-        $site->isolatedUser->setToolingVersion('node', '22');
-        $site->refresh();
+test('wrap builds bash invocation with env and optional cd', function () {
+    $site = Site::factory()->create([
+        'server_id' => $this->server->id,
+        'user' => 'isolated-wrap',
+        'path' => '/home/isolated-wrap/site.test',
+        'type' => Laravel::id(),
+        'type_data' => [],
+    ]);
+    $site->isolatedUser->setToolingVersion('node', '22');
+    $site->refresh();
 
-        $withoutCd = SiteShellEnvironment::wrap($site, 'node -v');
-        $this->assertStringStartsWith("bash -c '", $withoutCd);
-        $this->assertStringContainsString('export PATH=', $withoutCd);
-        $this->assertStringContainsString('node -v', $withoutCd);
-        $this->assertStringNotContainsString('cd ', $withoutCd);
+    $withoutCd = SiteShellEnvironment::wrap($site, 'node -v');
+    expect($withoutCd)->toStartWith("bash -c '");
+    $this->assertStringContainsString('export PATH=', $withoutCd);
+    $this->assertStringContainsString('node -v', $withoutCd);
+    $this->assertStringNotContainsString('cd ', $withoutCd);
 
-        $withCd = SiteShellEnvironment::wrap($site, 'npm install', true);
-        $this->assertStringContainsString('cd ', $withCd);
-        $this->assertStringContainsString('isolated-wrap/site.test', $withCd);
-        $this->assertStringContainsString('npm install', $withCd);
-    }
-}
+    $withCd = SiteShellEnvironment::wrap($site, 'npm install', true);
+    $this->assertStringContainsString('cd ', $withCd);
+    $this->assertStringContainsString('isolated-wrap/site.test', $withCd);
+    $this->assertStringContainsString('npm install', $withCd);
+});

--- a/tests/Unit/SourceControlProviders/BitbucketV2Test.php
+++ b/tests/Unit/SourceControlProviders/BitbucketV2Test.php
@@ -1,180 +1,165 @@
 <?php
 
-namespace Tests\Unit\SourceControlProviders;
-
 use App\Models\SourceControl;
 use App\SourceControlProviders\BitbucketV2;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class BitbucketV2Test extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_id_returns_bitbucket_v2(): void
-    {
-        $this->assertSame('bitbucket-v2', BitbucketV2::id());
-    }
+test('id returns bitbucket v2', function () {
+    expect(BitbucketV2::id())->toBe('bitbucket-v2');
+});
 
-    public function test_default_bitbucket_repo_url(): void
-    {
-        $repo = 'test/repo';
-        $key = 'TEST_KEY';
+test('default bitbucket repo url', function () {
+    $repo = 'test/repo';
+    $key = 'TEST_KEY';
 
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => BitbucketV2::id(),
-                'provider_data' => [
-                    'key' => 'test-key',
-                    'secret' => 'test-secret',
-                ],
-            ]);
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => BitbucketV2::id(),
+            'provider_data' => [
+                'key' => 'test-key',
+                'secret' => 'test-secret',
+            ],
+        ]);
 
-        $bitbucketV2 = new BitbucketV2($sourceControlModel);
+    $bitbucketV2 = new BitbucketV2($sourceControlModel);
 
-        $this->assertSame('git@bitbucket.org-TEST_KEY:test/repo.git', $bitbucketV2->fullRepoUrl($repo, $key));
-    }
+    expect($bitbucketV2->fullRepoUrl($repo, $key))->toBe('git@bitbucket.org-TEST_KEY:test/repo.git');
+});
 
-    public function test_create_rules_returns_required_key_and_secret(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => BitbucketV2::id(),
-                'provider_data' => [
-                    'key' => 'test-key',
-                    'secret' => 'test-secret',
-                ],
-            ]);
+test('create rules returns required key and secret', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => BitbucketV2::id(),
+            'provider_data' => [
+                'key' => 'test-key',
+                'secret' => 'test-secret',
+            ],
+        ]);
 
-        $bitbucketV2 = new BitbucketV2($sourceControlModel);
+    $bitbucketV2 = new BitbucketV2($sourceControlModel);
 
-        $rules = $bitbucketV2->createRules([]);
+    $rules = $bitbucketV2->createRules([]);
 
-        $this->assertArrayHasKey('key', $rules);
-        $this->assertArrayHasKey('secret', $rules);
-        $this->assertSame('required', $rules['key']);
-        $this->assertSame('required', $rules['secret']);
-    }
+    expect($rules)->toHaveKey('key');
+    expect($rules)->toHaveKey('secret');
+    expect($rules['key'])->toBe('required');
+    expect($rules['secret'])->toBe('required');
+});
 
-    public function test_create_data_processes_input_correctly(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => BitbucketV2::id(),
-                'provider_data' => [
-                    'key' => 'test-key',
-                    'secret' => 'test-secret',
-                ],
-            ]);
+test('create data processes input correctly', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => BitbucketV2::id(),
+            'provider_data' => [
+                'key' => 'test-key',
+                'secret' => 'test-secret',
+            ],
+        ]);
 
-        $bitbucketV2 = new BitbucketV2($sourceControlModel);
+    $bitbucketV2 = new BitbucketV2($sourceControlModel);
 
-        $input = [
-            'key' => 'my-key',
-            'secret' => 'my-secret',
-        ];
+    $input = [
+        'key' => 'my-key',
+        'secret' => 'my-secret',
+    ];
 
-        $data = $bitbucketV2->createData($input);
+    $data = $bitbucketV2->createData($input);
 
-        $this->assertSame('my-key', $data['key']);
-        $this->assertSame('my-secret', $data['secret']);
-    }
+    expect($data['key'])->toBe('my-key');
+    expect($data['secret'])->toBe('my-secret');
+});
 
-    public function test_create_data_handles_missing_input(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => BitbucketV2::id(),
-                'provider_data' => [
-                    'key' => 'test-key',
-                    'secret' => 'test-secret',
-                ],
-            ]);
+test('create data handles missing input', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => BitbucketV2::id(),
+            'provider_data' => [
+                'key' => 'test-key',
+                'secret' => 'test-secret',
+            ],
+        ]);
 
-        $bitbucketV2 = new BitbucketV2($sourceControlModel);
+    $bitbucketV2 = new BitbucketV2($sourceControlModel);
 
-        $data = $bitbucketV2->createData([]);
+    $data = $bitbucketV2->createData([]);
 
-        $this->assertSame('', $data['key']);
-        $this->assertSame('', $data['secret']);
-    }
+    expect($data['key'])->toBe('');
+    expect($data['secret'])->toBe('');
+});
 
-    public function test_data_retrieves_stored_provider_data(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => BitbucketV2::id(),
-                'provider_data' => [
-                    'key' => 'stored-key',
-                    'secret' => 'stored-secret',
-                ],
-            ]);
+test('data retrieves stored provider data', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => BitbucketV2::id(),
+            'provider_data' => [
+                'key' => 'stored-key',
+                'secret' => 'stored-secret',
+            ],
+        ]);
 
-        $bitbucketV2 = new BitbucketV2($sourceControlModel);
+    $bitbucketV2 = new BitbucketV2($sourceControlModel);
 
-        $data = $bitbucketV2->data();
+    $data = $bitbucketV2->data();
 
-        $this->assertSame('stored-key', $data['key']);
-        $this->assertSame('stored-secret', $data['secret']);
-    }
+    expect($data['key'])->toBe('stored-key');
+    expect($data['secret'])->toBe('stored-secret');
+});
 
-    public function test_data_handles_missing_provider_data(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => BitbucketV2::id(),
-                'provider_data' => [],
-            ]);
+test('data handles missing provider data', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => BitbucketV2::id(),
+            'provider_data' => [],
+        ]);
 
-        $bitbucketV2 = new BitbucketV2($sourceControlModel);
+    $bitbucketV2 = new BitbucketV2($sourceControlModel);
 
-        $data = $bitbucketV2->data();
+    $data = $bitbucketV2->data();
 
-        $this->assertSame('', $data['key']);
-        $this->assertSame('', $data['secret']);
-    }
+    expect($data['key'])->toBe('');
+    expect($data['secret'])->toBe('');
+});
 
-    public function test_get_webhook_branch_extracts_branch_from_payload(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => BitbucketV2::id(),
-                'provider_data' => [
-                    'key' => 'test-key',
-                    'secret' => 'test-secret',
-                ],
-            ]);
+test('get webhook branch extracts branch from payload', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => BitbucketV2::id(),
+            'provider_data' => [
+                'key' => 'test-key',
+                'secret' => 'test-secret',
+            ],
+        ]);
 
-        $bitbucketV2 = new BitbucketV2($sourceControlModel);
+    $bitbucketV2 = new BitbucketV2($sourceControlModel);
 
-        $payload = [
-            'push' => [
-                'changes' => [
-                    [
-                        'new' => [
-                            'name' => 'main',
-                        ],
+    $payload = [
+        'push' => [
+            'changes' => [
+                [
+                    'new' => [
+                        'name' => 'main',
                     ],
                 ],
             ],
-        ];
+        ],
+    ];
 
-        $this->assertSame('main', $bitbucketV2->getWebhookBranch($payload));
-    }
+    expect($bitbucketV2->getWebhookBranch($payload))->toBe('main');
+});
 
-    public function test_get_webhook_branch_returns_default_when_missing(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => BitbucketV2::id(),
-                'provider_data' => [
-                    'key' => 'test-key',
-                    'secret' => 'test-secret',
-                ],
-            ]);
+test('get webhook branch returns default when missing', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => BitbucketV2::id(),
+            'provider_data' => [
+                'key' => 'test-key',
+                'secret' => 'test-secret',
+            ],
+        ]);
 
-        $bitbucketV2 = new BitbucketV2($sourceControlModel);
+    $bitbucketV2 = new BitbucketV2($sourceControlModel);
 
-        $this->assertSame('default-branch', $bitbucketV2->getWebhookBranch([]));
-    }
-}
+    expect($bitbucketV2->getWebhookBranch([]))->toBe('default-branch');
+});

--- a/tests/Unit/SourceControlProviders/GiteaTest.php
+++ b/tests/Unit/SourceControlProviders/GiteaTest.php
@@ -1,350 +1,321 @@
 <?php
 
-namespace Tests\Unit\SourceControlProviders;
-
 use App\Models\SourceControl;
 use App\SourceControlProviders\Gitea;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class GiteaTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_id_returns_gitea(): void
-    {
-        $this->assertSame('gitea', Gitea::id());
-    }
+test('id returns gitea', function () {
+    expect(Gitea::id())->toBe('gitea');
+});
 
-    public function test_default_gitea_url(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-            ]);
-
-        $gitea = new Gitea($sourceControlModel);
-
-        $this->assertSame('https://gitea.com/api/v1', $gitea->getApiUrl());
-    }
-
-    public function test_default_gitea_repo_url(): void
-    {
-        $repo = 'test/repo';
-        $key = 'TEST_KEY';
-
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-            ]);
-
-        $gitea = new Gitea($sourceControlModel);
-
-        $this->assertSame('git@gitea.com-TEST_KEY:test/repo.git', $gitea->fullRepoUrl($repo, $key));
-    }
-
-    #[DataProvider('customUrlData')]
-    public function test_custom_url(string $url, string $expected): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-                'url' => $url,
-            ]);
-
-        $gitea = new Gitea($sourceControlModel);
-
-        $this->assertSame($expected, $gitea->getApiUrl());
-    }
-
-    #[DataProvider('customRepoUrlData')]
-    public function test_custom_full_repository_url(string $url, string $expected): void
-    {
-        $repo = 'test/repo';
-        $key = 'TEST_KEY';
-
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-                'url' => $url,
-            ]);
-
-        $gitea = new Gitea($sourceControlModel);
-
-        $this->assertSame($expected, $gitea->fullRepoUrl($repo, $key));
-    }
-
-    public function test_create_rules_returns_required_token_and_optional_url(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-            ]);
-
-        $gitea = new Gitea($sourceControlModel);
-
-        $rules = $gitea->createRules([]);
-
-        $this->assertArrayHasKey('token', $rules);
-        $this->assertSame('required', $rules['token']);
-        $this->assertArrayHasKey('url', $rules);
-        $this->assertIsArray($rules['url']);
-        $this->assertContains('nullable', $rules['url']);
-        $this->assertContains('url:http,https', $rules['url']);
-        $this->assertContains('ends_with:/', $rules['url']);
-    }
-
-    public function test_create_data_processes_input_correctly(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-            ]);
-
-        $gitea = new Gitea($sourceControlModel);
-
-        $input = [
-            'token' => 'my-token',
-            'url' => 'https://git.example.com/',
-        ];
-
-        $data = $gitea->createData($input);
-
-        $this->assertSame('my-token', $data['token']);
-    }
-
-    public function test_create_data_handles_missing_input(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-            ]);
-
-        $gitea = new Gitea($sourceControlModel);
-
-        $data = $gitea->createData([]);
-
-        $this->assertSame('', $data['token']);
-    }
-
-    public function test_data_retrieves_stored_provider_data(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-                'provider_data' => [
-                    'token' => 'stored-token',
-                ],
-            ]);
-
-        $gitea = new Gitea($sourceControlModel);
-
-        $data = $gitea->data();
-
-        $this->assertSame('stored-token', $data['token']);
-    }
-
-    public function test_data_handles_missing_provider_data(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-                'provider_data' => [],
-                'access_token' => null,
-            ]);
-
-        $gitea = new Gitea($sourceControlModel);
-
-        $data = $gitea->data();
-
-        $this->assertSame('', $data['token']);
-    }
-
-    public function test_get_webhook_branch_extracts_branch_from_payload(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-            ]);
-
-        $gitea = new Gitea($sourceControlModel);
-
-        $payload = [
-            'ref' => 'refs/heads/main',
-        ];
-
-        $this->assertSame('main', $gitea->getWebhookBranch($payload));
-    }
-
-    public function test_get_webhook_branch_returns_empty_when_missing(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-            ]);
-
-        $gitea = new Gitea($sourceControlModel);
-
-        $this->assertSame('', $gitea->getWebhookBranch([]));
-    }
-
-    public function test_get_repos_returns_cached_repos_when_cache_exists(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-                'provider_data' => [
-                    'token' => 'test-token',
-                ],
-            ]);
-
-        $gitea = new Gitea($sourceControlModel);
-        $cacheKey = 'gitea_repos_'.md5($gitea->getApiUrl().'test-token');
-        $cachedRepos = ['user/repo1', 'user/repo2'];
-
-        Cache::put($cacheKey, $cachedRepos, 900);
-
-        $repos = $gitea->getRepos();
-
-        $this->assertSame($cachedRepos, $repos);
-    }
-
-    public function test_get_repos_fetches_from_api_when_cache_missing(): void
-    {
-        Http::fake([
-            'gitea.com/api/v1/user/repos*' => Http::response([
-                ['full_name' => 'user/repo1'],
-                ['full_name' => 'user/repo2'],
-            ], 200),
+test('default gitea url', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
         ]);
 
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-                'provider_data' => [
-                    'token' => 'test-token',
-                ],
-            ]);
+    $gitea = new Gitea($sourceControlModel);
 
-        $gitea = new Gitea($sourceControlModel);
+    expect($gitea->getApiUrl())->toBe('https://gitea.com/api/v1');
+});
 
-        $repos = $gitea->getRepos(false);
+test('default gitea repo url', function () {
+    $repo = 'test/repo';
+    $key = 'TEST_KEY';
 
-        $this->assertSame(['user/repo1', 'user/repo2'], $repos);
-    }
-
-    public function test_get_repos_returns_empty_array_on_error(): void
-    {
-        Http::fake([
-            'gitea.com/api/v1/user/repos*' => Http::response([], 500),
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
         ]);
 
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-                'provider_data' => [
-                    'token' => 'test-token',
-                ],
-            ]);
+    $gitea = new Gitea($sourceControlModel);
 
-        $gitea = new Gitea($sourceControlModel);
+    expect($gitea->fullRepoUrl($repo, $key))->toBe('git@gitea.com-TEST_KEY:test/repo.git');
+});
 
-        $repos = $gitea->getRepos(false);
-
-        $this->assertSame([], $repos);
-    }
-
-    public function test_get_branches_returns_cached_branches_when_cache_exists(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-                'provider_data' => [
-                    'token' => 'test-token',
-                ],
-            ]);
-
-        $gitea = new Gitea($sourceControlModel);
-        $repo = 'user/repo';
-        $cacheKey = 'gitea_branches_'.md5($repo.$gitea->getApiUrl().'test-token');
-        $cachedBranches = ['main', 'develop'];
-
-        Cache::put($cacheKey, $cachedBranches, 900);
-
-        $branches = $gitea->getBranches($repo);
-
-        $this->assertSame($cachedBranches, $branches);
-    }
-
-    public function test_get_branches_fetches_from_api_when_cache_missing(): void
-    {
-        Http::fake([
-            'gitea.com/api/v1/repos/user/repo/branches*' => Http::response([
-                ['name' => 'main'],
-                ['name' => 'develop'],
-            ], 200),
+test('custom url', function (string $url, string $expected) {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+            'url' => $url,
         ]);
 
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-                'provider_data' => [
-                    'token' => 'test-token',
-                ],
-            ]);
+    $gitea = new Gitea($sourceControlModel);
 
-        $gitea = new Gitea($sourceControlModel);
+    expect($gitea->getApiUrl())->toBe($expected);
+})->with('customUrlData');
 
-        $branches = $gitea->getBranches('user/repo', false);
+test('custom full repository url', function (string $url, string $expected) {
+    $repo = 'test/repo';
+    $key = 'TEST_KEY';
 
-        $this->assertSame(['main', 'develop'], $branches);
-    }
-
-    public function test_get_branches_returns_empty_array_on_error(): void
-    {
-        Http::fake([
-            'gitea.com/api/v1/repos/user/repo/branches*' => Http::response([], 500),
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+            'url' => $url,
         ]);
 
-        $sourceControlModel = SourceControl::factory()
-            ->create([
-                'provider' => Gitea::id(),
-                'provider_data' => [
-                    'token' => 'test-token',
-                ],
-            ]);
+    $gitea = new Gitea($sourceControlModel);
 
-        $gitea = new Gitea($sourceControlModel);
+    expect($gitea->fullRepoUrl($repo, $key))->toBe($expected);
+})->with('customRepoUrlData');
 
-        $branches = $gitea->getBranches('user/repo', false);
+test('create rules returns required token and optional url', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+        ]);
 
-        $this->assertSame([], $branches);
-    }
+    $gitea = new Gitea($sourceControlModel);
 
-    /**
-     * @return array<int, array<int, string>>
-     */
-    public static function customRepoUrlData(): array
-    {
-        return [
-            ['https://git.example.com/', 'git@git.example.com-TEST_KEY:test/repo.git'],
-            ['https://git.test.example.com/', 'git@git.test.example.com-TEST_KEY:test/repo.git'],
-            ['https://git.example.co.uk/', 'git@git.example.co.uk-TEST_KEY:test/repo.git'],
-        ];
-    }
+    $rules = $gitea->createRules([]);
 
-    /**
-     * @return array<int, array<int, string>>
-     */
-    public static function customUrlData(): array
-    {
-        return [
-            ['https://git.example.com/', 'https://git.example.com/api/v1'],
-            ['https://git.test.example.com/', 'https://git.test.example.com/api/v1'],
-            ['https://git.example.co.uk/', 'https://git.example.co.uk/api/v1'],
-        ];
-    }
-}
+    expect($rules)->toHaveKey('token');
+    expect($rules['token'])->toBe('required');
+    expect($rules)->toHaveKey('url');
+    expect($rules['url'])->toBeArray();
+    expect($rules['url'])->toContain('nullable');
+    expect($rules['url'])->toContain('url:http,https');
+    expect($rules['url'])->toContain('ends_with:/');
+});
+
+test('create data processes input correctly', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+        ]);
+
+    $gitea = new Gitea($sourceControlModel);
+
+    $input = [
+        'token' => 'my-token',
+        'url' => 'https://git.example.com/',
+    ];
+
+    $data = $gitea->createData($input);
+
+    expect($data['token'])->toBe('my-token');
+});
+
+test('create data handles missing input', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+        ]);
+
+    $gitea = new Gitea($sourceControlModel);
+
+    $data = $gitea->createData([]);
+
+    expect($data['token'])->toBe('');
+});
+
+test('data retrieves stored provider data', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+            'provider_data' => [
+                'token' => 'stored-token',
+            ],
+        ]);
+
+    $gitea = new Gitea($sourceControlModel);
+
+    $data = $gitea->data();
+
+    expect($data['token'])->toBe('stored-token');
+});
+
+test('data handles missing provider data', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+            'provider_data' => [],
+            'access_token' => null,
+        ]);
+
+    $gitea = new Gitea($sourceControlModel);
+
+    $data = $gitea->data();
+
+    expect($data['token'])->toBe('');
+});
+
+test('get webhook branch extracts branch from payload', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+        ]);
+
+    $gitea = new Gitea($sourceControlModel);
+
+    $payload = [
+        'ref' => 'refs/heads/main',
+    ];
+
+    expect($gitea->getWebhookBranch($payload))->toBe('main');
+});
+
+test('get webhook branch returns empty when missing', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+        ]);
+
+    $gitea = new Gitea($sourceControlModel);
+
+    expect($gitea->getWebhookBranch([]))->toBe('');
+});
+
+test('get repos returns cached repos when cache exists', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+            'provider_data' => [
+                'token' => 'test-token',
+            ],
+        ]);
+
+    $gitea = new Gitea($sourceControlModel);
+    $cacheKey = 'gitea_repos_'.md5($gitea->getApiUrl().'test-token');
+    $cachedRepos = ['user/repo1', 'user/repo2'];
+
+    Cache::put($cacheKey, $cachedRepos, 900);
+
+    $repos = $gitea->getRepos();
+
+    expect($repos)->toBe($cachedRepos);
+});
+
+test('get repos fetches from api when cache missing', function () {
+    Http::fake([
+        'gitea.com/api/v1/user/repos*' => Http::response([
+            ['full_name' => 'user/repo1'],
+            ['full_name' => 'user/repo2'],
+        ], 200),
+    ]);
+
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+            'provider_data' => [
+                'token' => 'test-token',
+            ],
+        ]);
+
+    $gitea = new Gitea($sourceControlModel);
+
+    $repos = $gitea->getRepos(false);
+
+    expect($repos)->toBe(['user/repo1', 'user/repo2']);
+});
+
+test('get repos returns empty array on error', function () {
+    Http::fake([
+        'gitea.com/api/v1/user/repos*' => Http::response([], 500),
+    ]);
+
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+            'provider_data' => [
+                'token' => 'test-token',
+            ],
+        ]);
+
+    $gitea = new Gitea($sourceControlModel);
+
+    $repos = $gitea->getRepos(false);
+
+    expect($repos)->toBe([]);
+});
+
+test('get branches returns cached branches when cache exists', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+            'provider_data' => [
+                'token' => 'test-token',
+            ],
+        ]);
+
+    $gitea = new Gitea($sourceControlModel);
+    $repo = 'user/repo';
+    $cacheKey = 'gitea_branches_'.md5($repo.$gitea->getApiUrl().'test-token');
+    $cachedBranches = ['main', 'develop'];
+
+    Cache::put($cacheKey, $cachedBranches, 900);
+
+    $branches = $gitea->getBranches($repo);
+
+    expect($branches)->toBe($cachedBranches);
+});
+
+test('get branches fetches from api when cache missing', function () {
+    Http::fake([
+        'gitea.com/api/v1/repos/user/repo/branches*' => Http::response([
+            ['name' => 'main'],
+            ['name' => 'develop'],
+        ], 200),
+    ]);
+
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+            'provider_data' => [
+                'token' => 'test-token',
+            ],
+        ]);
+
+    $gitea = new Gitea($sourceControlModel);
+
+    $branches = $gitea->getBranches('user/repo', false);
+
+    expect($branches)->toBe(['main', 'develop']);
+});
+
+test('get branches returns empty array on error', function () {
+    Http::fake([
+        'gitea.com/api/v1/repos/user/repo/branches*' => Http::response([], 500),
+    ]);
+
+    $sourceControlModel = SourceControl::factory()
+        ->create([
+            'provider' => Gitea::id(),
+            'provider_data' => [
+                'token' => 'test-token',
+            ],
+        ]);
+
+    $gitea = new Gitea($sourceControlModel);
+
+    $branches = $gitea->getBranches('user/repo', false);
+
+    expect($branches)->toBe([]);
+});
+
+/**
+ * @return array<int, array<int, string>>
+ */
+dataset('customRepoUrlData', function () {
+    return [
+        ['https://git.example.com/', 'git@git.example.com-TEST_KEY:test/repo.git'],
+        ['https://git.test.example.com/', 'git@git.test.example.com-TEST_KEY:test/repo.git'],
+        ['https://git.example.co.uk/', 'git@git.example.co.uk-TEST_KEY:test/repo.git'],
+    ];
+});
+
+/**
+ * @return array<int, array<int, string>>
+ */
+dataset('customUrlData', function () {
+    return [
+        ['https://git.example.com/', 'https://git.example.com/api/v1'],
+        ['https://git.test.example.com/', 'https://git.test.example.com/api/v1'],
+        ['https://git.example.co.uk/', 'https://git.example.co.uk/api/v1'],
+    ];
+});

--- a/tests/Unit/SourceControlProviders/GithubTest.php
+++ b/tests/Unit/SourceControlProviders/GithubTest.php
@@ -1,272 +1,251 @@
 <?php
 
-namespace Tests\Unit\SourceControlProviders;
-
 use App\Models\SourceControl;
 use App\SourceControlProviders\Github;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
-use Tests\TestCase;
 
-class GithubTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_id_returns_github(): void
-    {
-        $this->assertSame('github', Github::id());
-    }
+test('id returns github', function () {
+    expect(Github::id())->toBe('github');
+});
 
-    public function test_default_github_repo_url(): void
-    {
-        $repo = 'test/repo';
-        $key = 'TEST_KEY';
+test('default github repo url', function () {
+    $repo = 'test/repo';
+    $key = 'TEST_KEY';
 
-        $sourceControlModel = SourceControl::factory()
-            ->github()
-            ->create();
+    $sourceControlModel = SourceControl::factory()
+        ->github()
+        ->create();
 
-        $github = new Github($sourceControlModel);
+    $github = new Github($sourceControlModel);
 
-        $this->assertSame('git@github.com-TEST_KEY:test/repo.git', $github->fullRepoUrl($repo, $key));
-    }
+    expect($github->fullRepoUrl($repo, $key))->toBe('git@github.com-TEST_KEY:test/repo.git');
+});
 
-    public function test_create_rules_returns_required_token(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->github()
-            ->create();
+test('create rules returns required token', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->github()
+        ->create();
 
-        $github = new Github($sourceControlModel);
+    $github = new Github($sourceControlModel);
 
-        $rules = $github->createRules([]);
+    $rules = $github->createRules([]);
 
-        $this->assertArrayHasKey('token', $rules);
-        $this->assertSame('required', $rules['token']);
-    }
+    expect($rules)->toHaveKey('token');
+    expect($rules['token'])->toBe('required');
+});
 
-    public function test_create_data_processes_input_correctly(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->github()
-            ->create();
+test('create data processes input correctly', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->github()
+        ->create();
 
-        $github = new Github($sourceControlModel);
+    $github = new Github($sourceControlModel);
 
-        $input = [
-            'token' => 'my-token',
-        ];
+    $input = [
+        'token' => 'my-token',
+    ];
 
-        $data = $github->createData($input);
+    $data = $github->createData($input);
 
-        $this->assertSame('my-token', $data['token']);
-    }
+    expect($data['token'])->toBe('my-token');
+});
 
-    public function test_create_data_handles_missing_input(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->github()
-            ->create();
+test('create data handles missing input', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->github()
+        ->create();
 
-        $github = new Github($sourceControlModel);
+    $github = new Github($sourceControlModel);
 
-        $data = $github->createData([]);
+    $data = $github->createData([]);
 
-        $this->assertSame('', $data['token']);
-    }
+    expect($data['token'])->toBe('');
+});
 
-    public function test_data_retrieves_stored_provider_data(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->github()
-            ->create([
-                'provider_data' => [
-                    'token' => 'stored-token',
-                ],
-            ]);
-
-        $github = new Github($sourceControlModel);
-
-        $data = $github->data();
-
-        $this->assertSame('stored-token', $data['token']);
-    }
-
-    public function test_data_handles_missing_provider_data(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->github()
-            ->create([
-                'provider_data' => [],
-                'access_token' => null,
-            ]);
-
-        $github = new Github($sourceControlModel);
-
-        $data = $github->data();
-
-        $this->assertSame('', $data['token']);
-    }
-
-    public function test_get_webhook_branch_extracts_branch_from_payload(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->github()
-            ->create();
-
-        $github = new Github($sourceControlModel);
-
-        $payload = [
-            'ref' => 'refs/heads/main',
-        ];
-
-        $this->assertSame('main', $github->getWebhookBranch($payload));
-    }
-
-    public function test_get_webhook_branch_returns_empty_when_missing(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->github()
-            ->create();
-
-        $github = new Github($sourceControlModel);
-
-        $this->assertSame('', $github->getWebhookBranch([]));
-    }
-
-    public function test_get_repos_returns_cached_repos_when_cache_exists(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->github()
-            ->create([
-                'provider_data' => [
-                    'token' => 'test-token',
-                ],
-            ]);
-
-        $github = new Github($sourceControlModel);
-        $cacheKey = 'github_repos_'.md5('test-token');
-        $cachedRepos = ['user/repo1', 'user/repo2'];
-
-        Cache::put($cacheKey, $cachedRepos, 900);
-
-        $repos = $github->getRepos();
-
-        $this->assertSame($cachedRepos, $repos);
-    }
-
-    public function test_get_repos_fetches_from_api_when_cache_missing(): void
-    {
-        Http::fake([
-            'api.github.com/user/repos*' => Http::sequence()
-                ->push([
-                    ['full_name' => 'user/repo1'],
-                    ['full_name' => 'user/repo2'],
-                ], 200, ['Link' => '']),
+test('data retrieves stored provider data', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->github()
+        ->create([
+            'provider_data' => [
+                'token' => 'stored-token',
+            ],
         ]);
 
-        $sourceControlModel = SourceControl::factory()
-            ->github()
-            ->create([
-                'provider_data' => [
-                    'token' => 'test-token',
-                ],
-            ]);
+    $github = new Github($sourceControlModel);
 
-        $github = new Github($sourceControlModel);
+    $data = $github->data();
 
-        $repos = $github->getRepos(false);
+    expect($data['token'])->toBe('stored-token');
+});
 
-        $this->assertSame(['user/repo1', 'user/repo2'], $repos);
-    }
-
-    public function test_get_repos_returns_empty_array_on_error(): void
-    {
-        Http::fake([
-            'api.github.com/user/repos*' => Http::response([], 500),
+test('data handles missing provider data', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->github()
+        ->create([
+            'provider_data' => [],
+            'access_token' => null,
         ]);
 
-        $sourceControlModel = SourceControl::factory()
-            ->github()
-            ->create([
-                'provider_data' => [
-                    'token' => 'test-token',
-                ],
-            ]);
+    $github = new Github($sourceControlModel);
 
-        $github = new Github($sourceControlModel);
+    $data = $github->data();
 
-        $repos = $github->getRepos(false);
+    expect($data['token'])->toBe('');
+});
 
-        $this->assertSame([], $repos);
-    }
+test('get webhook branch extracts branch from payload', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->github()
+        ->create();
 
-    public function test_get_branches_returns_cached_branches_when_cache_exists(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->github()
-            ->create([
-                'provider_data' => [
-                    'token' => 'test-token',
-                ],
-            ]);
+    $github = new Github($sourceControlModel);
 
-        $github = new Github($sourceControlModel);
-        $repo = 'user/repo';
-        $cacheKey = 'github_branches_'.md5($repo.'test-token');
-        $cachedBranches = ['main', 'develop'];
+    $payload = [
+        'ref' => 'refs/heads/main',
+    ];
 
-        Cache::put($cacheKey, $cachedBranches, 900);
+    expect($github->getWebhookBranch($payload))->toBe('main');
+});
 
-        $branches = $github->getBranches($repo);
+test('get webhook branch returns empty when missing', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->github()
+        ->create();
 
-        $this->assertSame($cachedBranches, $branches);
-    }
+    $github = new Github($sourceControlModel);
 
-    public function test_get_branches_fetches_from_api_when_cache_missing(): void
-    {
-        Http::fake([
-            'api.github.com/repos/user/repo/branches*' => Http::sequence()
-                ->push([
-                    ['name' => 'main'],
-                    ['name' => 'develop'],
-                ], 200, ['Link' => '']),
+    expect($github->getWebhookBranch([]))->toBe('');
+});
+
+test('get repos returns cached repos when cache exists', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->github()
+        ->create([
+            'provider_data' => [
+                'token' => 'test-token',
+            ],
         ]);
 
-        $sourceControlModel = SourceControl::factory()
-            ->github()
-            ->create([
-                'provider_data' => [
-                    'token' => 'test-token',
-                ],
-            ]);
+    $github = new Github($sourceControlModel);
+    $cacheKey = 'github_repos_'.md5('test-token');
+    $cachedRepos = ['user/repo1', 'user/repo2'];
 
-        $github = new Github($sourceControlModel);
+    Cache::put($cacheKey, $cachedRepos, 900);
 
-        $branches = $github->getBranches('user/repo', false);
+    $repos = $github->getRepos();
 
-        $this->assertSame(['main', 'develop'], $branches);
-    }
+    expect($repos)->toBe($cachedRepos);
+});
 
-    public function test_get_branches_returns_empty_array_on_error(): void
-    {
-        Http::fake([
-            'api.github.com/repos/user/repo/branches*' => Http::response([], 500),
+test('get repos fetches from api when cache missing', function () {
+    Http::fake([
+        'api.github.com/user/repos*' => Http::sequence()
+            ->push([
+                ['full_name' => 'user/repo1'],
+                ['full_name' => 'user/repo2'],
+            ], 200, ['Link' => '']),
+    ]);
+
+    $sourceControlModel = SourceControl::factory()
+        ->github()
+        ->create([
+            'provider_data' => [
+                'token' => 'test-token',
+            ],
         ]);
 
-        $sourceControlModel = SourceControl::factory()
-            ->github()
-            ->create([
-                'provider_data' => [
-                    'token' => 'test-token',
-                ],
-            ]);
+    $github = new Github($sourceControlModel);
 
-        $github = new Github($sourceControlModel);
+    $repos = $github->getRepos(false);
 
-        $branches = $github->getBranches('user/repo', false);
+    expect($repos)->toBe(['user/repo1', 'user/repo2']);
+});
 
-        $this->assertSame([], $branches);
-    }
-}
+test('get repos returns empty array on error', function () {
+    Http::fake([
+        'api.github.com/user/repos*' => Http::response([], 500),
+    ]);
+
+    $sourceControlModel = SourceControl::factory()
+        ->github()
+        ->create([
+            'provider_data' => [
+                'token' => 'test-token',
+            ],
+        ]);
+
+    $github = new Github($sourceControlModel);
+
+    $repos = $github->getRepos(false);
+
+    expect($repos)->toBe([]);
+});
+
+test('get branches returns cached branches when cache exists', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->github()
+        ->create([
+            'provider_data' => [
+                'token' => 'test-token',
+            ],
+        ]);
+
+    $github = new Github($sourceControlModel);
+    $repo = 'user/repo';
+    $cacheKey = 'github_branches_'.md5($repo.'test-token');
+    $cachedBranches = ['main', 'develop'];
+
+    Cache::put($cacheKey, $cachedBranches, 900);
+
+    $branches = $github->getBranches($repo);
+
+    expect($branches)->toBe($cachedBranches);
+});
+
+test('get branches fetches from api when cache missing', function () {
+    Http::fake([
+        'api.github.com/repos/user/repo/branches*' => Http::sequence()
+            ->push([
+                ['name' => 'main'],
+                ['name' => 'develop'],
+            ], 200, ['Link' => '']),
+    ]);
+
+    $sourceControlModel = SourceControl::factory()
+        ->github()
+        ->create([
+            'provider_data' => [
+                'token' => 'test-token',
+            ],
+        ]);
+
+    $github = new Github($sourceControlModel);
+
+    $branches = $github->getBranches('user/repo', false);
+
+    expect($branches)->toBe(['main', 'develop']);
+});
+
+test('get branches returns empty array on error', function () {
+    Http::fake([
+        'api.github.com/repos/user/repo/branches*' => Http::response([], 500),
+    ]);
+
+    $sourceControlModel = SourceControl::factory()
+        ->github()
+        ->create([
+            'provider_data' => [
+                'token' => 'test-token',
+            ],
+        ]);
+
+    $github = new Github($sourceControlModel);
+
+    $branches = $github->getBranches('user/repo', false);
+
+    expect($branches)->toBe([]);
+});

--- a/tests/Unit/SourceControlProviders/GitlabTest.php
+++ b/tests/Unit/SourceControlProviders/GitlabTest.php
@@ -1,90 +1,75 @@
 <?php
 
-namespace Tests\Unit\SourceControlProviders;
-
 use App\Models\SourceControl;
 use App\SourceControlProviders\Gitlab;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
-class GitlabTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_default_gitlab_url(): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->gitlab()
-            ->create();
+test('default gitlab url', function () {
+    $sourceControlModel = SourceControl::factory()
+        ->gitlab()
+        ->create();
 
-        $gitlab = new Gitlab($sourceControlModel);
+    $gitlab = new Gitlab($sourceControlModel);
 
-        $this->assertSame('https://gitlab.com/api/v4', $gitlab->getApiUrl());
-    }
+    expect($gitlab->getApiUrl())->toBe('https://gitlab.com/api/v4');
+});
 
-    public function test_default_gitlab_repo_url(): void
-    {
-        $repo = 'test/repo';
-        $key = 'TEST_KEY';
+test('default gitlab repo url', function () {
+    $repo = 'test/repo';
+    $key = 'TEST_KEY';
 
-        $sourceControlModel = SourceControl::factory()
-            ->gitlab()
-            ->create();
+    $sourceControlModel = SourceControl::factory()
+        ->gitlab()
+        ->create();
 
-        $gitlab = new Gitlab($sourceControlModel);
+    $gitlab = new Gitlab($sourceControlModel);
 
-        $this->assertSame('git@gitlab.com-TEST_KEY:test/repo.git', $gitlab->fullRepoUrl($repo, $key));
-    }
+    expect($gitlab->fullRepoUrl($repo, $key))->toBe('git@gitlab.com-TEST_KEY:test/repo.git');
+});
 
-    #[DataProvider('customUrlData')]
-    public function test_custom_url(string $url, string $expected): void
-    {
-        $sourceControlModel = SourceControl::factory()
-            ->gitlab()
-            ->create(['url' => $url]);
+test('custom url', function (string $url, string $expected) {
+    $sourceControlModel = SourceControl::factory()
+        ->gitlab()
+        ->create(['url' => $url]);
 
-        $gitlab = new Gitlab($sourceControlModel);
+    $gitlab = new Gitlab($sourceControlModel);
 
-        $this->assertSame($expected, $gitlab->getApiUrl());
-    }
+    expect($gitlab->getApiUrl())->toBe($expected);
+})->with('customUrlData');
 
-    #[DataProvider('customRepoUrlData')]
-    public function test_custom_full_repository_url(string $url, string $expected): void
-    {
-        $repo = 'test/repo';
-        $key = 'TEST_KEY';
+test('custom full repository url', function (string $url, string $expected) {
+    $repo = 'test/repo';
+    $key = 'TEST_KEY';
 
-        $sourceControlModel = SourceControl::factory()
-            ->gitlab()
-            ->create(['url' => $url]);
+    $sourceControlModel = SourceControl::factory()
+        ->gitlab()
+        ->create(['url' => $url]);
 
-        $gitlab = new Gitlab($sourceControlModel);
+    $gitlab = new Gitlab($sourceControlModel);
 
-        $this->assertSame($expected, $gitlab->fullRepoUrl($repo, $key));
-    }
+    expect($gitlab->fullRepoUrl($repo, $key))->toBe($expected);
+})->with('customRepoUrlData');
 
-    /**
-     * @return array<int, array<int, string>>
-     */
-    public static function customRepoUrlData(): array
-    {
-        return [
-            ['https://git.example.com/', 'git@git.example.com-TEST_KEY:test/repo.git'],
-            ['https://git.test.example.com/', 'git@git.test.example.com-TEST_KEY:test/repo.git'],
-            ['https://git.example.co.uk/', 'git@git.example.co.uk-TEST_KEY:test/repo.git'],
-        ];
-    }
+/**
+ * @return array<int, array<int, string>>
+ */
+dataset('customRepoUrlData', function () {
+    return [
+        ['https://git.example.com/', 'git@git.example.com-TEST_KEY:test/repo.git'],
+        ['https://git.test.example.com/', 'git@git.test.example.com-TEST_KEY:test/repo.git'],
+        ['https://git.example.co.uk/', 'git@git.example.co.uk-TEST_KEY:test/repo.git'],
+    ];
+});
 
-    /**
-     * @return array<int, array<int, string>>
-     */
-    public static function customUrlData(): array
-    {
-        return [
-            ['https://git.example.com/', 'https://git.example.com/api/v4'],
-            ['https://git.test.example.com/', 'https://git.test.example.com/api/v4'],
-            ['https://git.example.co.uk/', 'https://git.example.co.uk/api/v4'],
-        ];
-    }
-}
+/**
+ * @return array<int, array<int, string>>
+ */
+dataset('customUrlData', function () {
+    return [
+        ['https://git.example.com/', 'https://git.example.com/api/v4'],
+        ['https://git.test.example.com/', 'https://git.test.example.com/api/v4'],
+        ['https://git.example.co.uk/', 'https://git.example.co.uk/api/v4'],
+    ];
+});

--- a/tests/Unit/StorageProviders/DropboxTest.php
+++ b/tests/Unit/StorageProviders/DropboxTest.php
@@ -1,49 +1,40 @@
 <?php
 
-namespace Tests\Unit\StorageProviders;
-
 use App\Models\StorageProvider as StorageProviderModel;
 use App\StorageProviders\Dropbox;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
-use RuntimeException;
-use Tests\TestCase;
 
-class DropboxTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_access_token_refreshes_from_refresh_token(): void
-    {
-        Http::fake([
-            '*oauth2/token' => Http::response([
-                'access_token' => 'fresh-access',
-                'expires_in' => 14400,
-            ]),
-        ]);
+test('access token refreshes from refresh token', function () {
+    Http::fake([
+        '*oauth2/token' => Http::response([
+            'access_token' => 'fresh-access',
+            'expires_in' => 14400,
+        ]),
+    ]);
 
-        $storageProvider = StorageProviderModel::factory()->dropbox()->create();
+    $storageProvider = StorageProviderModel::factory()->dropbox()->create();
 
-        $provider = $storageProvider->provider();
-        $this->assertInstanceOf(Dropbox::class, $provider);
-        $this->assertSame('fresh-access', $provider->accessToken());
-    }
+    $provider = $storageProvider->provider();
+    expect($provider)->toBeInstanceOf(Dropbox::class);
+    expect($provider->accessToken())->toBe('fresh-access');
+});
 
-    public function test_access_token_throws_when_credentials_incomplete(): void
-    {
-        $storageProvider = StorageProviderModel::factory()->create([
-            'provider' => Dropbox::id(),
-            'credentials' => [
-                'token' => 'legacy-token',
-            ],
-        ]);
+test('access token throws when credentials incomplete', function () {
+    $storageProvider = StorageProviderModel::factory()->create([
+        'provider' => Dropbox::id(),
+        'credentials' => [
+            'token' => 'legacy-token',
+        ],
+    ]);
 
-        $provider = $storageProvider->provider();
-        $this->assertInstanceOf(Dropbox::class, $provider);
+    $provider = $storageProvider->provider();
+    expect($provider)->toBeInstanceOf(Dropbox::class);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Dropbox credentials are incomplete, please reconnect.');
+    $this->expectException(RuntimeException::class);
+    $this->expectExceptionMessage('Dropbox credentials are incomplete, please reconnect.');
 
-        $provider->accessToken();
-    }
-}
+    $provider->accessToken();
+});

--- a/tests/Unit/StorageProviders/S3Test.php
+++ b/tests/Unit/StorageProviders/S3Test.php
@@ -1,103 +1,95 @@
 <?php
 
-namespace Tests\Unit\StorageProviders;
-
 use App\Models\StorageProvider as StorageProviderModel;
 use App\StorageProviders\S3;
 use Aws\Command;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\S3Client;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class S3Test extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function test_s3_connect_successful(): void
-    {
-        $storageProvider = StorageProviderModel::factory()->create([
-            'provider' => S3::id(),
-            'credentials' => [
-                'api_url' => 'https://fake-bucket.s3.us-east-1.s3-compatible.com',
-                'key' => 'fake-key',
-                'secret' => 'fake-secret',
-                'region' => 'us-east-1',
-                'bucket' => 'fake-bucket',
-                'path' => '/',
-            ],
-        ]);
+test('s3 connect successful', function () {
+    $storageProvider = StorageProviderModel::factory()->create([
+        'provider' => S3::id(),
+        'credentials' => [
+            'api_url' => 'https://fake-bucket.s3.us-east-1.s3-compatible.com',
+            'key' => 'fake-key',
+            'secret' => 'fake-secret',
+            'region' => 'us-east-1',
+            'bucket' => 'fake-bucket',
+            'path' => '/',
+        ],
+    ]);
 
-        // Mock the S3Client
-        $s3ClientMock = $this->getMockBuilder(S3Client::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getCommand', 'execute'])
-            ->getMock();
+    // Mock the S3Client
+    $s3ClientMock = $this->getMockBuilder(S3Client::class)
+        ->disableOriginalConstructor()
+        ->onlyMethods(['getCommand', 'execute'])
+        ->getMock();
 
-        // Mock the getCommand method
-        $s3ClientMock->expects($this->once())
-            ->method('getCommand')
-            ->with('listBuckets')
-            ->willReturn(new Command('listBuckets'));
+    // Mock the getCommand method
+    $s3ClientMock->expects($this->once())
+        ->method('getCommand')
+        ->with('listBuckets')
+        ->willReturn(new Command('listBuckets'));
 
-        // Mock the execute method
-        $s3ClientMock->expects($this->once())
-            ->method('execute')
-            ->willReturn(['Buckets' => []]);
+    // Mock the execute method
+    $s3ClientMock->expects($this->once())
+        ->method('execute')
+        ->willReturn(['Buckets' => []]);
 
-        // Mock the S3 class to return the mocked S3Client
-        $s3 = $this->getMockBuilder(S3::class)
-            ->setConstructorArgs([$storageProvider])
-            ->onlyMethods(['getClient'])
-            ->getMock();
+    // Mock the S3 class to return the mocked S3Client
+    $s3 = $this->getMockBuilder(S3::class)
+        ->setConstructorArgs([$storageProvider])
+        ->onlyMethods(['getClient'])
+        ->getMock();
 
-        $s3->expects($this->once())
-            ->method('getClient')
-            ->willReturn($s3ClientMock);
+    $s3->expects($this->once())
+        ->method('getClient')
+        ->willReturn($s3ClientMock);
 
-        $this->assertTrue($s3->connect());
-    }
+    expect($s3->connect())->toBeTrue();
+});
 
-    public function test_s3_connect_failure(): void
-    {
-        $storageProvider = StorageProviderModel::factory()->create([
-            'provider' => S3::id(),
-            'credentials' => [
-                'key' => 'fake-key',
-                'secret' => 'fake-secret',
-                'region' => 'us-east-1',
-                'bucket' => 'fake-bucket',
-                'path' => '/',
-            ],
-        ]);
+test('s3 connect failure', function () {
+    $storageProvider = StorageProviderModel::factory()->create([
+        'provider' => S3::id(),
+        'credentials' => [
+            'key' => 'fake-key',
+            'secret' => 'fake-secret',
+            'region' => 'us-east-1',
+            'bucket' => 'fake-bucket',
+            'path' => '/',
+        ],
+    ]);
 
-        // Mock the S3Client
-        $s3ClientMock = $this->getMockBuilder(S3Client::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getCommand', 'execute'])
-            ->getMock();
+    // Mock the S3Client
+    $s3ClientMock = $this->getMockBuilder(S3Client::class)
+        ->disableOriginalConstructor()
+        ->onlyMethods(['getCommand', 'execute'])
+        ->getMock();
 
-        // Mock the getCommand method
-        $s3ClientMock->expects($this->once())
-            ->method('getCommand')
-            ->with('listBuckets')
-            ->willReturn(new Command('listBuckets'));
+    // Mock the getCommand method
+    $s3ClientMock->expects($this->once())
+        ->method('getCommand')
+        ->with('listBuckets')
+        ->willReturn(new Command('listBuckets'));
 
-        // Mock the execute method to throw an S3Exception
-        $s3ClientMock->expects($this->once())
-            ->method('execute')
-            ->willThrowException(new S3Exception('Error', new Command('ListBuckets')));
+    // Mock the execute method to throw an S3Exception
+    $s3ClientMock->expects($this->once())
+        ->method('execute')
+        ->willThrowException(new S3Exception('Error', new Command('ListBuckets')));
 
-        // Mock the S3 class to return the mocked S3Client
-        $s3 = $this->getMockBuilder(S3::class)
-            ->setConstructorArgs([$storageProvider])
-            ->onlyMethods(['getClient'])
-            ->getMock();
+    // Mock the S3 class to return the mocked S3Client
+    $s3 = $this->getMockBuilder(S3::class)
+        ->setConstructorArgs([$storageProvider])
+        ->onlyMethods(['getClient'])
+        ->getMock();
 
-        $s3->expects($this->once())
-            ->method('getClient')
-            ->willReturn($s3ClientMock);
+    $s3->expects($this->once())
+        ->method('getClient')
+        ->willReturn($s3ClientMock);
 
-        $this->assertFalse($s3->connect());
-    }
-}
+    expect($s3->connect())->toBeFalse();
+});


### PR DESCRIPTION
Replace the direct PHPUnit setup with Pest 5 and its Laravel plugin, convert the existing feature and unit tests to Pest syntax, and update test configuration, tooling, scripts, dependencies, and documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidance and credits to reference Pest 5 and PHPUnit 13.
* **Chores**
  * Replaced PHPUnit development tooling with Pest 5 and its Laravel plugin.
  * Updated the test command to `sail pest`.
  * Removed parallel PHPUnit test tooling.
* **Tests**
  * Migrated the feature and unit test suites to Pest while retaining existing coverage and behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->