### PR TITLE
[Fix] Prevent database users page crash when a linked database is deleted

### DIFF
--- a/app/Models/Database.php
+++ b/app/Models/Database.php
@@ -50,7 +50,7 @@ class Database extends AbstractModel
                 $databases = $user->databases;
                 if ($databases && in_array($database->name, $databases)) {
                     unset($databases[array_search($database->name, $databases)]);
-                    $user->databases = $databases;
+                    $user->databases = array_values($databases);
                     $user->save();
                 }
             });

--- a/database/migrations/2026_08_01_090402_reindex_database_users_databases.php
+++ b/database/migrations/2026_08_01_090402_reindex_database_users_databases.php
@@ -5,9 +5,6 @@ use Illuminate\Support\Facades\DB;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         DB::table('database_users')->whereNotNull('databases')->orderBy('id')->chunkById(100, function ($databaseUsers) {
@@ -25,9 +22,6 @@ return new class extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         //

--- a/database/migrations/2026_08_01_090402_reindex_database_users_databases.php
+++ b/database/migrations/2026_08_01_090402_reindex_database_users_databases.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('database_users')->whereNotNull('databases')->orderBy('id')->chunkById(100, function ($databaseUsers) {
+            foreach ($databaseUsers as $databaseUser) {
+                $decoded = json_decode((string) $databaseUser->databases, true);
+
+                if (! is_array($decoded) || array_is_list($decoded)) {
+                    continue;
+                }
+
+                DB::table('database_users')->where('id', $databaseUser->id)->update([
+                    'databases' => json_encode(array_values($decoded)),
+                ]);
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/resources/js/components/database-user-databases.tsx
+++ b/resources/js/components/database-user-databases.tsx
@@ -2,7 +2,8 @@ import type { CellComponentProps } from '@forjedio/inertia-table-react';
 import { Badge } from '@/components/ui/badge';
 
 export function DatabaseUserDatabases({ value }: CellComponentProps) {
-  const databases = Array.isArray(value) ? (value as string[]) : Object.values((value as Record<string, string> | null) ?? {});
+  const items = value !== null && typeof value === 'object' ? Object.values(value as Record<string, unknown>) : [];
+  const databases = items.every((item) => typeof item === 'string') ? (items as string[]) : [];
 
   if (databases.length === 0) {
     return <span className="text-muted-foreground">-</span>;

--- a/resources/js/components/database-user-databases.tsx
+++ b/resources/js/components/database-user-databases.tsx
@@ -2,7 +2,7 @@ import type { CellComponentProps } from '@forjedio/inertia-table-react';
 import { Badge } from '@/components/ui/badge';
 
 export function DatabaseUserDatabases({ value }: CellComponentProps) {
-  const databases = (value as string[] | null) ?? [];
+  const databases = Array.isArray(value) ? (value as string[]) : Object.values((value as Record<string, string> | null) ?? {});
 
   if (databases.length === 0) {
     return <span className="text-muted-foreground">-</span>;

--- a/tests/Feature/DatabaseTest.php
+++ b/tests/Feature/DatabaseTest.php
@@ -137,6 +137,47 @@ class DatabaseTest extends TestCase
         ]);
     }
 
+    public function test_delete_database_keeps_linked_user_databases_a_list(): void
+    {
+        $this->actingAs($this->user);
+
+        SSH::fake();
+
+        foreach (['db_one', 'db_two', 'db_three'] as $name) {
+            Database::factory()->create([
+                'server_id' => $this->server->id,
+                'name' => $name,
+            ]);
+        }
+
+        /** @var DatabaseUser $databaseUser */
+        $databaseUser = DatabaseUser::factory()->create([
+            'server_id' => $this->server->id,
+            'databases' => ['db_one', 'db_two', 'db_three'],
+        ]);
+
+        /** @var Database $middle */
+        $middle = Database::query()->where('name', 'db_two')->firstOrFail();
+
+        $this->delete(route('databases.destroy', [
+            'server' => $this->server,
+            'database' => $middle,
+        ]))->assertSessionDoesntHaveErrors();
+
+        $databaseUser->refresh();
+
+        $this->assertSame(['db_one', 'db_three'], $databaseUser->databases);
+        $this->assertSame('["db_one","db_three"]', json_encode($databaseUser->databases));
+
+        $this->get(route('database-users', $this->server))
+            ->assertSuccessful()
+            ->assertInertia(function (AssertableInertia $page): void {
+                $rows = $page->toArray()['props']['databaseUsers']['data'];
+
+                $this->assertSame('["db_one","db_three"]', json_encode($rows[0]['databases']));
+            });
+    }
+
     public function test_sync_databases(): void
     {
         $this->actingAs($this->user);

--- a/tests/Feature/DatabaseUserDatabasesMigrationTest.php
+++ b/tests/Feature/DatabaseUserDatabasesMigrationTest.php
@@ -45,20 +45,32 @@ class DatabaseUserDatabasesMigrationTest extends TestCase
 
     public function test_manual_recovery_statement_reindexes_rows(): void
     {
-        $databaseUser = DatabaseUser::factory()->create([
-            'server_id' => $this->server->id,
-        ]);
+        $databaseUser = DatabaseUser::factory()->create(['server_id' => $this->server->id]);
+        $nullUser = DatabaseUser::factory()->create(['server_id' => $this->server->id]);
+        $scalarUser = DatabaseUser::factory()->create(['server_id' => $this->server->id]);
 
         DB::table('database_users')->where('id', $databaseUser->id)->update([
             'databases' => '{"0":"db_one","2":"db_three","5":"db_six"}',
         ]);
+        DB::table('database_users')->where('id', $nullUser->id)->update(['databases' => null]);
+        DB::table('database_users')->where('id', $scalarUser->id)->update(['databases' => '"not-an-array"']);
 
-        DatabaseUser::all()->each(fn (DatabaseUser $u) => $u->update(['databases' => array_values($u->databases ?? [])]));
+        DatabaseUser::all()->filter(fn (DatabaseUser $u) => is_array($u->databases))->each(fn (DatabaseUser $u) => $u->update(['databases' => array_values($u->databases)]));
 
-        $this->assertSame(
-            '["db_one","db_three","db_six"]',
-            (string) DB::table('database_users')->where('id', $databaseUser->id)->value('databases')
-        );
+        $this->assertDatabaseHas('database_users', [
+            'id' => $databaseUser->id,
+            'databases' => '["db_one","db_three","db_six"]',
+        ]);
+
+        $this->assertDatabaseHas('database_users', [
+            'id' => $nullUser->id,
+            'databases' => null,
+        ]);
+
+        $this->assertDatabaseHas('database_users', [
+            'id' => $scalarUser->id,
+            'databases' => '"not-an-array"',
+        ]);
     }
 
     private function runMigration(): void

--- a/tests/Feature/DatabaseUserDatabasesMigrationTest.php
+++ b/tests/Feature/DatabaseUserDatabasesMigrationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\DatabaseUser;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class DatabaseUserDatabasesMigrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_transform_reindexes_rows_with_gaps(): void
+    {
+        $databaseUser = DatabaseUser::factory()->create([
+            'server_id' => $this->server->id,
+        ]);
+
+        DB::table('database_users')->where('id', $databaseUser->id)->update([
+            'databases' => '{"0":"db_one","2":"db_three","5":"db_six"}',
+        ]);
+
+        $this->runMigration();
+
+        $this->assertSame(
+            '["db_one","db_three","db_six"]',
+            (string) DB::table('database_users')->where('id', $databaseUser->id)->value('databases')
+        );
+    }
+
+    public function test_transform_leaves_valid_rows_untouched(): void
+    {
+        $databaseUser = DatabaseUser::factory()->create([
+            'server_id' => $this->server->id,
+            'databases' => ['db_one', 'db_two'],
+        ]);
+
+        $before = (string) DB::table('database_users')->where('id', $databaseUser->id)->value('databases');
+
+        $this->runMigration();
+
+        $this->assertSame($before, (string) DB::table('database_users')->where('id', $databaseUser->id)->value('databases'));
+    }
+
+    private function runMigration(): void
+    {
+        $paths = glob(database_path('migrations/*_reindex_database_users_databases.php')) ?: [];
+        $this->assertNotEmpty($paths, 'Database users databases migration not found.');
+
+        $migration = require $paths[0];
+        $migration->up();
+    }
+}

--- a/tests/Feature/DatabaseUserDatabasesMigrationTest.php
+++ b/tests/Feature/DatabaseUserDatabasesMigrationTest.php
@@ -43,6 +43,24 @@ class DatabaseUserDatabasesMigrationTest extends TestCase
         $this->assertSame($before, (string) DB::table('database_users')->where('id', $databaseUser->id)->value('databases'));
     }
 
+    public function test_manual_recovery_statement_reindexes_rows(): void
+    {
+        $databaseUser = DatabaseUser::factory()->create([
+            'server_id' => $this->server->id,
+        ]);
+
+        DB::table('database_users')->where('id', $databaseUser->id)->update([
+            'databases' => '{"0":"db_one","2":"db_three","5":"db_six"}',
+        ]);
+
+        DatabaseUser::all()->each(fn (DatabaseUser $u) => $u->update(['databases' => array_values($u->databases ?? [])]));
+
+        $this->assertSame(
+            '["db_one","db_three","db_six"]',
+            (string) DB::table('database_users')->where('id', $databaseUser->id)->value('databases')
+        );
+    }
+
     private function runMigration(): void
     {
         $paths = glob(database_path('migrations/*_reindex_database_users_databases.php')) ?: [];


### PR DESCRIPTION
Deleting a mid-list linked database left a gap in the user's `databases` array, which serialized to a JSON object instead of an array and crashed the database users page on render - reindexed on delete, added a migration to heal existing rows, and hardened the cell component.

Single line tinker fix for 4.0.1 implementations unable or unwilling to update, however, if the root cause happens again, this will need to be rerun, use at your own risk, run a backup first.

``` 
php artisan tinker --execute="App\Models\DatabaseUser::all()->filter(fn (\$u) => is_array(\$u->databases))->each(fn (\$u) => \$u->update(['databases' => array_values(\$u->databases)]));"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database removal so linked users’ remaining database entries are retained and displayed consistently.
  * Improved handling of database lists stored in different JSON formats.

* **Data Migration**
  * Reindexed database lists with gaps into correctly ordered lists.
  * Preserved valid list data while skipping invalid or unsupported values.
  * Added safeguards for null, scalar, and mixed-value entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->