### PR TITLE
[Feat] Architecture tests: enforce documented standards

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,8 +34,9 @@ Vito is a self-hosted server management tool. Stack: Laravel 13 (L10 structure),
 - `TestCase` provides `$this->user`, `$this->server`, `$this->site` with services pre-configured.
 - Use `SSH::fake()` for SSH operations, `Http::fake()` for HTTP calls.
 - Don't over-test trivial logic that PHP handles natively.
+- **Architecture tests:** `tests/Arch/` enforces the standards in this file as executable rules. A failing rule means the code is wrong — fix the code. Exceptions live in one registry, `ArchTestCase::EXCEPTIONS`, and **adding to it requires the maintainer's explicit permission**; see `.github/instructions/architecture-tests.instructions.md`.
 - **Coverage:** PRs must cover at least 75% of their new/changed `app/` lines (enforced on PRs by the `tests` workflow via `diff-cover`). Run `composer test:coverage` locally (needs PCOV, or `XDEBUG_MODE=coverage`) to generate a report — or the variant for your local dev environment: `test:coverage:herd`, `test:coverage:lerd`, or `test:coverage:yerd`. `composer test:coverage-diff` (after `pip install diff-cover`) previews the patch-coverage gate against `origin/4.x`; after a framework variant, run `composer coverage:diff` for the gate alone.
 
 ## Topic-specific guidelines
 
-See `.github/instructions/` for detailed standards on PHP/Laravel, frontend, and security.
+See `.github/instructions/` for detailed standards on PHP/Laravel, frontend, security, and architecture tests.

--- a/.github/instructions/architecture-tests.instructions.md
+++ b/.github/instructions/architecture-tests.instructions.md
@@ -1,0 +1,74 @@
+---
+applyTo: "tests/Arch/**,tests/ArchTestCase.php"
+description: "Architecture test suite and the rules governing its exception registry"
+---
+
+# Architecture Tests
+
+`tests/Arch/` is a Pest 5 architecture suite that enforces the standards in
+`.github/copilot-instructions.md` and `.github/instructions/*.md` as executable
+rules. It runs as the `Arch` testsuite and is included in `php artisan test`.
+
+## The exception registry
+
+Every deviation the current implementation relies on lives in **one place**:
+`ArchTestCase::EXCEPTIONS` in `tests/ArchTestCase.php`. Rules reference it by
+key:
+
+```php
+arch('models extend AbstractModel')
+    ->expect('App\Models')
+    ->classes()
+    ->toExtend(AbstractModel::class)
+    ->ignoring(ArchTestCase::except('models.not-on-abstract-model'));
+```
+
+Each key holds a `reason` and an `entries` list. `except()` throws on an unknown
+key, so typos fail loudly rather than silently exempting nothing.
+
+## Adding to EXCEPTIONS requires explicit permission
+
+**Never add an entry to `ArchTestCase::EXCEPTIONS` on your own initiative, and
+never add one to make a failing rule pass.** A failing architecture rule means
+the code is wrong, not the rule.
+
+The only acceptable reason to add entries is when you are **adding a new rule or
+changing an existing one**, and existing code cannot be brought into line within
+that change. Even then, ask first.
+
+Before asking, tell the user plainly:
+
+- **Which rule** stops applying, and **to which classes**.
+- **What that rule was protecting against**, and what can now happen unnoticed
+  in those classes.
+- That the entry is permanent until someone deliberately removes it, so the
+  drift becomes invisible to every future reviewer and agent.
+- The alternative: fixing the code so no exception is needed, and what that
+  would cost.
+
+Then wait for an explicit yes. Silence, "sounds good", or a general approval of
+the surrounding work is not permission.
+
+## When a rule fails
+
+1. Fix the code. This is almost always the right answer.
+2. If the rule is wrong — too broad, encoding a convention that was never
+   agreed, or vacuous — say so and propose changing or deleting the rule.
+3. Only then consider an exception, following the permission process above.
+
+Exception lists may shrink freely. Removing an entry after fixing the code needs
+no permission — that is the intended direction of travel.
+
+## Writing rules
+
+- **One source namespace per expectation.** Pest's negative dependency
+  expectations (`not->toUse`, `not->toBeUsedIn`) **silently pass** when given an
+  array of source namespaces. Arrays are fine on the destination side.
+- **Verify a new rule can fail.** Add a class that violates it, confirm the rule
+  goes red, then remove the class. A rule that cannot fail is worse than no rule
+  — it reads as coverage.
+- **Prefer tight negative rules over broad allowlists.** `not->toBeUsedIn([read
+  and decision layers])` states an invariant; `toOnlyBeUsedIn([ten namespaces])`
+  just records today's call graph and churns on every new file.
+- **Do not encode conventions that are not in the instruction files.** If it is
+  worth enforcing, document it there first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,15 @@ Vito has a specific architecture. Match these patterns exactly:
 - Use `SSH::fake()` for SSH operations and `Http::fake()` for HTTP — never make real connections.
 - Use `assertDatabaseHas()` for DB assertions.
 
+## Architecture Tests
+
+- `tests/Arch/` enforces the rules in this file as executable Pest tests. **A failing architecture rule means the code is wrong — fix the code, don't exempt it.**
+- Every exception lives in ONE registry: `ArchTestCase::EXCEPTIONS` in `tests/ArchTestCase.php`, keyed and referenced via `ArchTestCase::except('key')`.
+- **NEVER add an entry to `EXCEPTIONS` without the user's explicit permission.** The only acceptable case is when you are adding or changing a rule and existing code cannot be brought into line in that same change.
+- Before asking permission, tell the user: which rule stops applying and to which classes, what that rule was protecting against, that the exemption is permanent until deliberately removed, and what fixing the code instead would cost. A general "sounds good" on surrounding work is not permission.
+- Removing entries after fixing the code needs no permission — lists may shrink freely, never grow.
+- **Read `.github/instructions/architecture-tests.instructions.md` before adding or changing any architecture rule.** It covers the Pest gotcha where negative dependency rules silently pass when given an array of source namespaces, and the requirement to prove a new rule can actually fail.
+
 ## API
 
 - Consider API endpoints for new features but ask user first.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,9 @@
     <testsuite name="Unit">
       <directory suffix="Test.php">./tests/Unit</directory>
     </testsuite>
+    <testsuite name="Arch">
+      <directory suffix="Test.php">./tests/Arch</directory>
+    </testsuite>
   </testsuites>
   <coverage/>
   <php>

--- a/tests/Arch/ActionsTest.php
+++ b/tests/Arch/ActionsTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Tests\ArchTestCase;
+
+arch('actions do not render responses')
+    ->expect('App\Actions')
+    ->not->toUse([
+        'Inertia\Inertia',
+        'Illuminate\Http\RedirectResponse',
+        'Illuminate\Routing\Redirector',
+    ]);
+
+arch('actions take arrays, not requests')
+    ->expect('App\Actions')
+    ->not->toUse(['Illuminate\Http\Request', 'request'])
+    ->ignoring(ArchTestCase::except('actions.accepting-request'));
+
+arch('actions do not depend on controllers')
+    ->expect('App\Actions')
+    ->not->toUse('App\Http\Controllers');

--- a/tests/Arch/ConventionsTest.php
+++ b/tests/Arch/ConventionsTest.php
@@ -54,9 +54,13 @@ it('busts the bootstrap version whenever bootstrap-backed state is written', fun
             $writes = Str::contains($contents, [
                 "{$model}::create(",
                 "{$model}::query()->create(",
+                "{$model}::updateOrCreate(",
+                "{$model}::query()->update(",
                 'new '.$model.'(',
                 '$'.lcfirst($model).'->save()',
+                '$'.lcfirst($model).'->update([',
                 '$'.lcfirst($model).'->delete()',
+                '$'.lcfirst($model).'->forceDelete()',
             ]);
 
             if ($writes && ! Str::contains($contents, 'forgetVersion()')) {

--- a/tests/Arch/ConventionsTest.php
+++ b/tests/Arch/ConventionsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Events\SocketEvent;
+use Illuminate\Support\Str;
+use Tests\ArchTestCase;
+
+/**
+ * Models whose rows are reflected in GetBootstrap::configs(). In production the
+ * bootstrap version is cached forever, so any write here has to bust it.
+ *
+ * @var array<string, string>
+ */
+const BOOTSTRAP_BACKED_MODELS = [
+    'GithubApp' => 'Actions/GithubApp',
+    'Plugin' => 'Actions/Plugins',
+];
+
+arch('broadcasting never happens from a read or decision layer')
+    ->expect(SocketEvent::class)
+    ->not->toBeUsedIn([
+        'App\DTOs',
+        'App\Enums',
+        'App\Http\Resources',
+        'App\Policies',
+        'App\ValidationRules',
+    ]);
+
+arch('DTOs stay free of infrastructure')
+    ->expect('App\DTOs')
+    ->not->toUse([
+        'App\Http\Controllers',
+        'App\Jobs',
+        'Illuminate\Support\Facades\DB',
+        'Illuminate\Support\Facades\Http',
+        'Inertia\Inertia',
+    ]);
+
+arch('listeners expose a handle method')
+    ->expect('App\Listeners')
+    ->classes()
+    ->toHaveMethod('handle');
+
+arch('console commands stay thin and delegate to actions')
+    ->expect('App\Console\Commands')
+    ->not->toUse(['App\Http\Controllers', 'Inertia\Inertia']);
+
+it('busts the bootstrap version whenever bootstrap-backed state is written', function (): void {
+    $offenders = [];
+
+    foreach (BOOTSTRAP_BACKED_MODELS as $model => $namespace) {
+        foreach (vitoArchFiles($namespace) as $file) {
+            $contents = (string) file_get_contents($file->getRealPath());
+
+            $writes = Str::contains($contents, [
+                "{$model}::create(",
+                "{$model}::query()->create(",
+                'new '.$model.'(',
+                '$'.lcfirst($model).'->save()',
+                '$'.lcfirst($model).'->delete()',
+            ]);
+
+            if ($writes && ! Str::contains($contents, 'forgetVersion()')) {
+                $offenders[] = $file->getRelativePathname();
+            }
+        }
+    }
+
+    $exempt = ArchTestCase::except('conventions.writes-without-bootstrap-bust');
+
+    expect(array_values(array_diff($offenders, $exempt)))->toBe([]);
+});

--- a/tests/Arch/ConventionsTest.php
+++ b/tests/Arch/ConventionsTest.php
@@ -51,11 +51,10 @@ it('busts the bootstrap version whenever bootstrap-backed state is written', fun
         foreach (vitoArchFiles($namespace) as $file) {
             $contents = (string) file_get_contents($file->getRealPath());
 
-            $writes = Str::contains($contents, [
-                "{$model}::create(",
-                "{$model}::query()->create(",
-                "{$model}::updateOrCreate(",
-                "{$model}::query()->update(",
+            $writes = preg_match(
+                '/\b'.$model.'::(?:[a-zA-Z_]+\([^;]{0,200}\)->)*(?:create|updateOrCreate|update|delete|forceDelete)\(/',
+                $contents
+            ) === 1 || Str::contains($contents, [
                 'new '.$model.'(',
                 '$'.lcfirst($model).'->save()',
                 '$'.lcfirst($model).'->update([',

--- a/tests/Arch/EnumsTest.php
+++ b/tests/Arch/EnumsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Contracts\VitoEnum;
+use Illuminate\Support\Str;
+
+arch('everything in the enums namespace is an enum')
+    ->expect('App\Enums')
+    ->toBeEnums();
+
+arch('enums implement the VitoEnum contract')
+    ->expect('App\Enums')
+    ->toImplement(VitoEnum::class);
+
+arch('enums stay free of infrastructure dependencies')
+    ->expect('App\Enums')
+    ->not->toUse([
+        'App\Actions',
+        'App\Http',
+        'App\Jobs',
+        'App\Models',
+        'Illuminate\Support\Facades\DB',
+    ]);
+
+it('backs every enum with a string', function (): void {
+    $offenders = [];
+
+    foreach (vitoEnumClasses() as $enum) {
+        $reflection = new ReflectionEnum($enum);
+
+        if ((string) $reflection->getBackingType() !== 'string') {
+            $offenders[] = $enum;
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});
+
+it('returns a non empty colour and label for every enum case', function (): void {
+    $offenders = [];
+
+    foreach (vitoEnumClasses() as $enum) {
+        foreach ($enum::cases() as $case) {
+            if ($case->getColor() === '' || $case->getText() === '') {
+                $offenders[] = "{$enum}::{$case->name}";
+            }
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});
+
+/**
+ * @return array<int, class-string<VitoEnum&UnitEnum>>
+ */
+function vitoEnumClasses(): array
+{
+    $enums = [];
+
+    foreach (vitoArchFiles('Enums') as $file) {
+        $enum = 'App\\Enums\\'.Str::of($file->getRelativePathname())
+            ->replace(['/', '.php'], ['\\', ''])
+            ->toString();
+
+        if (enum_exists($enum)) {
+            $enums[] = $enum;
+        }
+    }
+
+    return $enums;
+}

--- a/tests/Arch/ExceptionsTest.php
+++ b/tests/Arch/ExceptionsTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Tests\ArchTestCase;
 
@@ -69,8 +68,5 @@ it('rejects an unknown architecture exception key', function (): void {
  */
 function vitoArchTestFiles(): array
 {
-    return iterator_to_array(
-        Finder::create()->files()->in(__DIR__)->name('*.php'),
-        false
-    );
+    return vitoArchFiles('', __DIR__);
 }

--- a/tests/Arch/ExceptionsTest.php
+++ b/tests/Arch/ExceptionsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+use Tests\ArchTestCase;
+
+it('gives every architecture exception a reason and at least one entry', function (): void {
+    $offenders = [];
+
+    foreach (ArchTestCase::EXCEPTIONS as $key => $exception) {
+        if (trim($exception['reason']) === '') {
+            $offenders[] = "{$key} has no reason";
+        }
+
+        if ($exception['entries'] === []) {
+            $offenders[] = "{$key} is empty and should be removed";
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});
+
+it('references every architecture exception from a rule', function (): void {
+    $rules = '';
+
+    foreach (vitoArchTestFiles() as $file) {
+        $rules .= (string) file_get_contents($file->getRealPath());
+    }
+
+    $offenders = [];
+
+    foreach (array_keys(ArchTestCase::EXCEPTIONS) as $key) {
+        if (! str_contains($rules, "except('{$key}')")) {
+            $offenders[] = $key;
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});
+
+it('points every namespaced exception entry at code that still exists', function (): void {
+    $offenders = [];
+
+    foreach (ArchTestCase::EXCEPTIONS as $key => $exception) {
+        foreach ($exception['entries'] as $entry) {
+            if (! str_starts_with($entry, 'App\\')) {
+                continue;
+            }
+
+            $path = base_path(str_replace(['App\\', '\\'], ['app/', '/'], $entry));
+
+            if (is_dir($path) || is_file($path.'.php')) {
+                continue;
+            }
+
+            $offenders[] = "{$key}: {$entry}";
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});
+
+it('rejects an unknown architecture exception key', function (): void {
+    ArchTestCase::except('does.not.exist');
+})->throws(InvalidArgumentException::class);
+
+/**
+ * @return array<int, SplFileInfo>
+ */
+function vitoArchTestFiles(): array
+{
+    return iterator_to_array(
+        Finder::create()->files()->in(__DIR__)->name('*.php'),
+        false
+    );
+}

--- a/tests/Arch/ExtensionPointsTest.php
+++ b/tests/Arch/ExtensionPointsTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use App\DNSProviders\AbstractDNSProvider;
+use App\NotificationChannels\AbstractNotificationChannel;
+use App\ServerProviders\AbstractProvider;
+use App\Services\AbstractService;
+use App\SiteTypes\AbstractSiteType;
+use App\SourceControlProviders\AbstractSourceControlProvider;
+use App\StorageProviders\AbstractStorageProvider;
+use App\Tooling\AbstractTooling;
+use App\WorkflowActions\AbstractWorkflowAction;
+use Forjed\InertiaTable\Table;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Notifications\Notification;
+use Tests\ArchTestCase;
+
+/**
+ * Each source namespace needs its own expectation — Pest's negative dependency
+ * expectations silently pass when given an array of source namespaces.
+ */
+const PRESENTATION_LAYER = ['App\Http\Controllers', 'Inertia\Inertia'];
+
+arch('server providers extend the abstract server provider')
+    ->expect('App\ServerProviders')
+    ->classes()
+    ->toExtend(AbstractProvider::class);
+
+arch('dns providers extend the abstract dns provider')
+    ->expect('App\DNSProviders')
+    ->classes()
+    ->toExtend(AbstractDNSProvider::class);
+
+arch('source control providers extend the abstract source control provider')
+    ->expect('App\SourceControlProviders')
+    ->classes()
+    ->toExtend(AbstractSourceControlProvider::class);
+
+arch('storage providers extend the abstract storage provider')
+    ->expect('App\StorageProviders')
+    ->classes()
+    ->toExtend(AbstractStorageProvider::class);
+
+arch('services extend the abstract service')
+    ->expect('App\Services')
+    ->classes()
+    ->toExtend(AbstractService::class);
+
+arch('site types extend the abstract site type')
+    ->expect('App\SiteTypes')
+    ->classes()
+    ->toExtend(AbstractSiteType::class);
+
+arch('workflow actions extend the abstract workflow action')
+    ->expect('App\WorkflowActions')
+    ->classes()
+    ->toExtend(AbstractWorkflowAction::class);
+
+arch('tooling extends the abstract tooling')
+    ->expect('App\Tooling')
+    ->classes()
+    ->toExtend(AbstractTooling::class)
+    ->ignoring(ArchTestCase::except('extension-points.non-tooling-classes'));
+
+arch('notification channels extend the abstract notification channel')
+    ->expect('App\NotificationChannels')
+    ->classes()
+    ->toExtend(AbstractNotificationChannel::class)
+    ->ignoring(ArchTestCase::except('extension-points.non-channel-classes'));
+
+arch('notifications extend the framework notification')
+    ->expect('App\Notifications')
+    ->classes()
+    ->toExtend(Notification::class);
+
+arch('validation rules implement the validation rule contract')
+    ->expect('App\ValidationRules')
+    ->classes()
+    ->toImplement(ValidationRule::class);
+
+arch('tables extend the inertia table')
+    ->expect('App\Tables')
+    ->classes()
+    ->toExtend(Table::class);
+
+arch('tables are suffixed with Table')
+    ->expect('App\Tables')
+    ->classes()
+    ->toHaveSuffix('Table');
+
+arch('console commands extend the framework command')
+    ->expect('App\Console\Commands')
+    ->classes()
+    ->toExtend('Illuminate\Console\Command');
+
+arch('console commands expose a handle method')
+    ->expect('App\Console\Commands')
+    ->classes()
+    ->toHaveMethod('handle');
+
+arch('service providers are suffixed with ServiceProvider')
+    ->expect('App\Providers')
+    ->toHaveSuffix('ServiceProvider');
+
+arch('dns providers do not reach into the http layer')
+    ->expect('App\DNSProviders')
+    ->not->toUse(PRESENTATION_LAYER);
+
+arch('server providers do not reach into the http layer')
+    ->expect('App\ServerProviders')
+    ->not->toUse(PRESENTATION_LAYER);
+
+arch('source control providers do not reach into the http layer')
+    ->expect('App\SourceControlProviders')
+    ->not->toUse(PRESENTATION_LAYER);
+
+arch('storage providers do not reach into the http layer')
+    ->expect('App\StorageProviders')
+    ->not->toUse(PRESENTATION_LAYER);
+
+arch('tooling does not reach into the http layer')
+    ->expect('App\Tooling')
+    ->not->toUse(PRESENTATION_LAYER);

--- a/tests/Arch/FoundationTest.php
+++ b/tests/Arch/FoundationTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use Tests\ArchTestCase;
+
+arch('php best practices are followed')
+    ->preset()
+    ->php()
+    ->ignoring(ArchTestCase::except('foundation.var-export'));
+
+arch('security sensitive functions are not used')
+    ->preset()
+    ->security()
+    ->ignoring([
+        ...ArchTestCase::except('foundation.non-cryptographic-hashing'),
+        ...ArchTestCase::except('foundation.local-shell'),
+        ...ArchTestCase::except('foundation.assert'),
+    ]);
+
+arch('laravel debugging helpers never reach the codebase')
+    ->expect(['dd', 'ddd', 'exit'])
+    ->not->toBeUsed();
+
+arch('env() is only read from config files')
+    ->expect('env')
+    ->not->toBeUsed();
+
+arch('sleeping is done through the Sleep facade so tests can fake it')
+    ->expect(['sleep', 'usleep'])
+    ->not->toBeUsed()
+    ->ignoring(ArchTestCase::except('foundation.blocking-sleep'));
+
+arch('traits live in the traits namespace')
+    ->expect('App\Traits')
+    ->toBeTraits();
+
+arch('contracts are interfaces')
+    ->expect('App\Contracts')
+    ->toBeInterfaces();
+
+arch('enums only live in the enums namespace')
+    ->expect('App')
+    ->not->toBeEnums()
+    ->ignoring('App\Enums');
+
+arch('exceptions are throwable and live in the exceptions namespace')
+    ->expect('App\Exceptions')
+    ->classes()
+    ->toImplement(Throwable::class)
+    ->ignoring(ArchTestCase::except('foundation.non-throwable-in-exceptions'));
+
+arch('nothing outside the exceptions namespace is throwable')
+    ->expect('App')
+    ->not->toImplement(Throwable::class)
+    ->ignoring('App\Exceptions');
+
+it('declares an explicit return type on every method', function (): void {
+    $exempt = ArchTestCase::except('foundation.missing-return-type');
+    $offenders = [];
+
+    foreach (vitoArchClasses() as $class) {
+        if (in_array($class, $exempt, true)) {
+            continue;
+        }
+
+        $reflection = new ReflectionClass($class);
+
+        foreach ($reflection->getMethods() as $method) {
+            if ($method->getFileName() !== $reflection->getFileName() || $method->isConstructor()) {
+                continue;
+            }
+
+            if (! $method->hasReturnType()) {
+                $offenders[] = "{$class}::{$method->getName()}()";
+            }
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});

--- a/tests/Arch/FoundationTest.php
+++ b/tests/Arch/FoundationTest.php
@@ -57,7 +57,7 @@ it('declares an explicit return type on every method', function (): void {
     $exempt = ArchTestCase::except('foundation.missing-return-type');
     $offenders = [];
 
-    foreach (vitoArchClasses() as $class) {
+    foreach (vitoArchTypes() as $class) {
         if (in_array($class, $exempt, true)) {
             continue;
         }
@@ -77,3 +77,24 @@ it('declares an explicit return type on every method', function (): void {
 
     expect($offenders)->toBe([]);
 });
+
+/**
+ * Every concrete class plus every app-owned trait, so methods flattened from
+ * App\Traits are checked in the file that declares them.
+ *
+ * @return array<int, class-string>
+ */
+function vitoArchTypes(): array
+{
+    $types = vitoArchClasses();
+
+    foreach (vitoArchFiles('Traits') as $file) {
+        $trait = 'App\\Traits\\'.str_replace('.php', '', $file->getRelativePathname());
+
+        if (trait_exists($trait)) {
+            $types[] = $trait;
+        }
+    }
+
+    return $types;
+}

--- a/tests/Arch/FoundationTest.php
+++ b/tests/Arch/FoundationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Str;
 use Tests\ArchTestCase;
 
 arch('php best practices are followed')
@@ -79,20 +80,28 @@ it('declares an explicit return type on every method', function (): void {
 });
 
 /**
- * Every concrete class plus every app-owned trait, so methods flattened from
- * App\Traits are checked in the file that declares them.
+ * Every type declared under app/ — classes, interfaces, enums and traits, at any
+ * nesting depth — so a method is checked in the file that declares it.
  *
  * @return array<int, class-string>
  */
 function vitoArchTypes(): array
 {
-    $types = vitoArchClasses();
+    $types = [];
 
-    foreach (vitoArchFiles('Traits') as $file) {
-        $trait = 'App\\Traits\\'.str_replace('.php', '', $file->getRelativePathname());
+    foreach (vitoArchFiles() as $file) {
+        if (preg_match('/^(?:final |abstract |readonly )*(?:class|interface|enum|trait) /m', $file->getContents()) !== 1) {
+            continue;
+        }
 
-        if (trait_exists($trait)) {
-            $types[] = $trait;
+        $type = Str::of($file->getRealPath())
+            ->after(app_path().DIRECTORY_SEPARATOR)
+            ->replace([DIRECTORY_SEPARATOR, '.php'], ['\\', ''])
+            ->prepend('App\\')
+            ->toString();
+
+        if (class_exists($type) || interface_exists($type) || enum_exists($type) || trait_exists($type)) {
+            $types[] = $type;
         }
     }
 

--- a/tests/Arch/HttpTest.php
+++ b/tests/Arch/HttpTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Tests\ArchTestCase;
+
+arch('controllers are suffixed with Controller')
+    ->expect('App\Http\Controllers')
+    ->classes()
+    ->toHaveSuffix('Controller');
+
+arch('nothing outside the controllers namespace is suffixed with Controller')
+    ->expect('App')
+    ->not->toHaveSuffix('Controller')
+    ->ignoring('App\Http\Controllers');
+
+arch('controllers extend the base controller')
+    ->expect('App\Http\Controllers')
+    ->classes()
+    ->toExtend(Controller::class)
+    ->ignoring(Controller::class);
+
+arch('controllers do not validate — actions do')
+    ->expect('App\Http\Controllers')
+    ->not->toUse('Illuminate\Support\Facades\Validator')
+    ->ignoring(ArchTestCase::except('http.controllers-validating'));
+
+arch('controllers do not talk to the database directly')
+    ->expect('App\Http\Controllers')
+    ->not->toUse('Illuminate\Support\Facades\DB')
+    ->ignoring(ArchTestCase::except('http.controllers-querying'));
+
+arch('controllers do not dispatch jobs directly — actions own that')
+    ->expect('App\Http\Controllers')
+    ->not->toUse('App\Jobs')
+    ->ignoring(ArchTestCase::except('http.controllers-dispatching-jobs'));
+
+arch('form requests are not used — validation lives in actions')
+    ->expect('App')
+    ->not->toExtend('Illuminate\Foundation\Http\FormRequest');
+
+arch('resources are suffixed with Resource and extend JsonResource')
+    ->expect('App\Http\Resources')
+    ->classes()
+    ->toHaveSuffix('Resource')
+    ->toExtend(JsonResource::class);
+
+arch('resources are read models and never mutate state')
+    ->expect('App\Http\Resources')
+    ->not->toUse([
+        'App\Actions',
+        'App\Jobs',
+        'Illuminate\Support\Facades\DB',
+        'Illuminate\Support\Facades\Validator',
+    ])
+    ->ignoring(ArchTestCase::except('http.resources-calling-actions'));
+
+arch('controllers are only referenced by routing and the http layer itself')
+    ->expect('App\Http\Controllers')
+    ->toOnlyBeUsedIn(['App\Http', 'App\Providers']);
+
+it('never whitelists fields with parent::toArray()', function (): void {
+    $offenders = [];
+
+    foreach (vitoArchFiles('Http/Resources') as $file) {
+        if (str_contains((string) file_get_contents($file->getRealPath()), 'parent::toArray')) {
+            $offenders[] = $file->getRelativePathname();
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});

--- a/tests/Arch/JobsTest.php
+++ b/tests/Arch/JobsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Traits\UniqueQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Tests\ArchTestCase;
+
+arch('jobs are queued')
+    ->expect('App\Jobs')
+    ->classes()
+    ->toImplement(ShouldQueue::class);
+
+arch('jobs are suffixed with Job')
+    ->expect('App\Jobs')
+    ->classes()
+    ->toHaveSuffix('Job');
+
+arch('jobs expose a handle method')
+    ->expect('App\Jobs')
+    ->classes()
+    ->toHaveMethod('handle');
+
+arch('jobs do not reach into the presentation layer')
+    ->expect('App\Jobs')
+    ->not->toUse([
+        'App\Http\Controllers',
+        'Inertia\Inertia',
+        'Illuminate\Http\Request',
+    ]);
+
+it('uses the Queueable and UniqueQueue traits on every job', function (): void {
+    $exempt = ArchTestCase::except('jobs.without-unique-queue');
+    $offenders = [];
+
+    foreach (vitoArchClasses('Jobs') as $job) {
+        $traits = class_uses_recursive($job);
+
+        if (! in_array(Queueable::class, $traits, true)) {
+            $offenders[] = "{$job} is missing Queueable";
+        }
+
+        if (! in_array(UniqueQueue::class, $traits, true) && ! in_array($job, $exempt, true)) {
+            $offenders[] = "{$job} is missing UniqueQueue";
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});
+
+it('handles its own failure on every job', function (): void {
+    $offenders = [];
+
+    foreach (vitoArchClasses('Jobs') as $job) {
+        if (! method_exists($job, 'failed')) {
+            $offenders[] = $job;
+        }
+    }
+
+    $exempt = ArchTestCase::except('jobs.without-failure-handler');
+
+    expect(array_values(array_diff($offenders, $exempt)))->toBe([]);
+});
+
+it('wraps work in the unique queue lock wherever the trait is used', function (): void {
+    $offenders = [];
+
+    foreach (vitoArchFiles('Jobs') as $file) {
+        $contents = (string) file_get_contents($file->getRealPath());
+
+        if (! str_contains($contents, 'use UniqueQueue;')) {
+            continue;
+        }
+
+        if (! str_contains($contents, '$this->run(')) {
+            $offenders[] = $file->getRelativePathname();
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});

--- a/tests/Arch/MigrationsTest.php
+++ b/tests/Arch/MigrationsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * Tokens that mean a migration is doing more than schema and data work.
+ *
+ * @var array<string, string>
+ */
+const FORBIDDEN_MIGRATION_TOKENS = [
+    'dispatch(' => 'dispatches a job',
+    'App\Jobs' => 'references a job',
+    'SSH::' => 'opens an SSH connection',
+    'App\Facades\SSH' => 'opens an SSH connection',
+    'Http::' => 'makes an HTTP call',
+    'Bus::' => 'touches the bus',
+    'Queue::' => 'touches the queue',
+    'SocketEvent::' => 'broadcasts an event',
+    'broadcast(' => 'broadcasts an event',
+    'Notification::' => 'sends a notification',
+    'Mail::' => 'sends mail',
+];
+
+it('keeps migrations free of runtime side effects', function (): void {
+    $offenders = [];
+
+    foreach (migrationFiles() as $file) {
+        $contents = (string) file_get_contents($file->getRealPath());
+
+        foreach (FORBIDDEN_MIGRATION_TOKENS as $token => $reason) {
+            if (str_contains($contents, $token)) {
+                $offenders[] = "{$file->getFilename()} {$reason}";
+            }
+        }
+    }
+
+    expect(array_values(array_unique($offenders)))->toBe([]);
+});
+
+/**
+ * @return array<int, SplFileInfo>
+ */
+function migrationFiles(): array
+{
+    return iterator_to_array(
+        Finder::create()->files()->in(database_path('migrations'))->name('*.php'),
+        false
+    );
+}

--- a/tests/Arch/ModelsTest.php
+++ b/tests/Arch/ModelsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Contracts\VitoEnum;
+use App\Models\AbstractModel;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Tests\ArchTestCase;
+
+arch('models extend AbstractModel')
+    ->expect('App\Models')
+    ->classes()
+    ->toExtend(AbstractModel::class)
+    ->ignoring([
+        AbstractModel::class,
+        ...ArchTestCase::except('models.foreign-base-class'),
+        ...ArchTestCase::except('models.not-on-abstract-model'),
+    ]);
+
+arch('eloquent models only live in the models namespace')
+    ->expect('App')
+    ->not->toExtend(Model::class)
+    ->ignoring('App\Models');
+
+arch('models are not suffixed with Model')
+    ->expect('App\Models')
+    ->classes()
+    ->not->toHaveSuffix('Model')
+    ->ignoring(AbstractModel::class);
+
+arch('models do not reach into the http layer')
+    ->expect('App\Models')
+    ->not->toUse([
+        'App\Http\Controllers',
+        'Inertia\Inertia',
+        'Illuminate\Http\Request',
+        'Illuminate\Support\Facades\Validator',
+    ]);
+
+arch('models do not depend on actions')
+    ->expect('App\Models')
+    ->not->toUse('App\Actions')
+    ->ignoring(ArchTestCase::except('models.calling-actions'));
+
+it('casts every enum attribute to an enum implementing VitoEnum', function (): void {
+    $offenders = [];
+
+    foreach (vitoModelClasses() as $model) {
+        $instance = new $model;
+
+        foreach ($instance->getCasts() as $attribute => $cast) {
+            $cast = Str::before($cast, ':');
+
+            if (! enum_exists($cast)) {
+                continue;
+            }
+
+            if (! is_subclass_of($cast, VitoEnum::class)) {
+                $offenders[] = "{$model}::\${$attribute} casts to {$cast}";
+            }
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});
+
+it('encrypts every attribute that stores credentials', function (): void {
+    $sensitive = ['credentials', 'secrets', 'token', 'access_token', 'refresh_token', 'password'];
+    $offenders = [];
+
+    foreach (vitoModelClasses() as $model) {
+        $casts = (new $model)->getCasts();
+
+        foreach ($sensitive as $attribute) {
+            if (! array_key_exists($attribute, $casts)) {
+                continue;
+            }
+
+            if (! Str::startsWith($casts[$attribute], ['encrypted', 'hashed'])) {
+                $offenders[] = "{$model}::\${$attribute} is cast as {$casts[$attribute]}";
+            }
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});
+
+/**
+ * @return array<int, class-string<Model>>
+ */
+function vitoModelClasses(): array
+{
+    return array_values(array_filter(
+        vitoArchClasses('Models'),
+        fn (string $model): bool => is_subclass_of($model, Model::class),
+    ));
+}

--- a/tests/Arch/PoliciesTest.php
+++ b/tests/Arch/PoliciesTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Models\User;
+use App\Traits\HasRolePolicies;
+use Tests\ArchTestCase;
+
+arch('policies are suffixed with Policy')
+    ->expect('App\Policies')
+    ->classes()
+    ->toHaveSuffix('Policy');
+
+arch('nothing outside the policies namespace is suffixed with Policy')
+    ->expect('App')
+    ->not->toHaveSuffix('Policy')
+    ->ignoring('App\Policies');
+
+arch('policies decide, they do not act')
+    ->expect('App\Policies')
+    ->not->toUse([
+        'App\Http\Controllers',
+        'App\Jobs',
+        'Illuminate\Support\Facades\DB',
+        'Illuminate\Support\Facades\Validator',
+        'Inertia\Inertia',
+    ]);
+
+arch('policies are resolved through the gate, never called directly')
+    ->expect('App\Policies')
+    ->toOnlyBeUsedIn(['App\Policies', 'App\Providers']);
+
+it('checks project roles through HasRolePolicies', function (): void {
+    $offenders = [];
+
+    foreach (vitoArchClasses('Policies') as $policy) {
+        if (in_array(HasRolePolicies::class, class_uses_recursive($policy), true)) {
+            continue;
+        }
+
+        $offenders[] = $policy;
+    }
+
+    $exempt = ArchTestCase::except('policies.user-owned');
+
+    expect(array_values(array_diff($offenders, $exempt)))->toBe([]);
+});
+
+it('takes a User as the first argument of every policy method and returns bool', function (): void {
+    $offenders = [];
+
+    foreach (vitoArchClasses('Policies') as $policy) {
+        $reflection = new ReflectionClass($policy);
+
+        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->getFileName() !== $reflection->getFileName()) {
+                continue;
+            }
+
+            $parameters = $method->getParameters();
+            $returnType = $method->getReturnType();
+
+            if ($parameters === [] || (string) $parameters[0]->getType() !== User::class) {
+                $offenders[] = "{$policy}::{$method->getName()}() does not take a User first";
+            }
+
+            if (! $returnType instanceof ReflectionNamedType || $returnType->getName() !== 'bool') {
+                $offenders[] = "{$policy}::{$method->getName()}() does not return bool";
+            }
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});
+
+it('maps every policy to an existing model', function (): void {
+    $offenders = [];
+
+    foreach (vitoArchClasses('Policies') as $policy) {
+        $model = str_replace(['App\\Policies\\', 'Policy'], ['App\\Models\\', ''], $policy);
+
+        if (! class_exists($model)) {
+            $offenders[] = "{$policy} has no matching model";
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});

--- a/tests/Arch/RoutingTest.php
+++ b/tests/Arch/RoutingTest.php
@@ -100,5 +100,17 @@ function applicationRoutes(): array
 
 function isPublicRoute(Route $route): bool
 {
-    return Str::startsWith($route->uri(), ArchTestCase::except('routing.public-endpoints')) || $route->uri() === '/';
+    $uri = $route->uri();
+
+    if ($uri === '/') {
+        return true;
+    }
+
+    foreach (ArchTestCase::except('routing.public-endpoints') as $prefix) {
+        if ($uri === $prefix || str_starts_with($uri, $prefix.'/')) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/tests/Arch/RoutingTest.php
+++ b/tests/Arch/RoutingTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Route as RouteFacade;
+use Illuminate\Support\Str;
+use Tests\ArchTestCase;
+
+it('names every application route', function (): void {
+    $offenders = [];
+
+    foreach (applicationRoutes() as $route) {
+        if ($route->getName() === null) {
+            $offenders[] = $route->methods()[0].' /'.$route->uri();
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});
+
+it('gives every route a unique name', function (): void {
+    $names = [];
+
+    foreach (applicationRoutes() as $route) {
+        if ($route->getName() !== null) {
+            $names[] = $route->getName();
+        }
+    }
+
+    expect(array_values(array_diff_assoc($names, array_unique($names))))->toBe([]);
+});
+
+it('authenticates every route that is not deliberately public', function (): void {
+    $offenders = [];
+
+    foreach (applicationRoutes() as $route) {
+        if (isPublicRoute($route)) {
+            continue;
+        }
+
+        $middleware = $route->gatherMiddleware();
+        $authenticates = array_filter(
+            $middleware,
+            fn (mixed $item): bool => is_string($item) && Str::startsWith($item, ['auth', 'signed']),
+        );
+
+        if ($authenticates === []) {
+            $offenders[] = $route->methods()[0].' /'.$route->uri();
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});
+
+it('scopes every api route to a token ability', function (): void {
+    $offenders = [];
+
+    foreach (applicationRoutes() as $route) {
+        if (! Str::startsWith($route->uri(), 'api/') || isPublicRoute($route)) {
+            continue;
+        }
+
+        $middleware = array_filter($route->gatherMiddleware(), 'is_string');
+
+        if (! Str::contains(implode(' ', $middleware), 'ability:')) {
+            $offenders[] = $route->methods()[0].' /'.$route->uri();
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});
+
+it('scopes every project api route to the project boundary', function (): void {
+    $offenders = [];
+
+    foreach (applicationRoutes() as $route) {
+        if (! Str::startsWith($route->uri(), 'api/projects/{project}')) {
+            continue;
+        }
+
+        $middleware = array_filter($route->gatherMiddleware(), 'is_string');
+
+        if (! in_array('can-see-project', $middleware, true)) {
+            $offenders[] = $route->methods()[0].' /'.$route->uri();
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});
+
+/**
+ * @return array<int, Route>
+ */
+function applicationRoutes(): array
+{
+    return array_values(array_filter(
+        RouteFacade::getRoutes()->getRoutes(),
+        fn (Route $route): bool => ! Str::startsWith($route->uri(), ['_debugbar', 'storage/']),
+    ));
+}
+
+function isPublicRoute(Route $route): bool
+{
+    return Str::startsWith($route->uri(), ArchTestCase::except('routing.public-endpoints')) || $route->uri() === '/';
+}

--- a/tests/Arch/SecurityTest.php
+++ b/tests/Arch/SecurityTest.php
@@ -47,12 +47,16 @@ it('never logs a credential-shaped variable', function (): void {
                 continue;
             }
 
-            $statement = $line;
+            $statement = '';
+            $depth = 0;
             $cursor = $number;
 
-            while (! Str::contains($statement, ';') && isset($lines[$cursor + 1]) && $cursor - $number < 20) {
-                $statement .= $lines[++$cursor];
-            }
+            do {
+                $statement .= $lines[$cursor];
+                $bare = preg_replace('/([\'"])(?:\\\\.|(?!\\1).)*\\1/', '', $lines[$cursor]) ?? '';
+                $depth += substr_count($bare, '(') - substr_count($bare, ')');
+                $cursor++;
+            } while ($depth > 0 && isset($lines[$cursor]) && $cursor - $number < 50);
 
             foreach ($sensitive as $needle) {
                 if (Str::contains($statement, ['$'.$needle, "'".$needle."'", '->'.$needle])) {

--- a/tests/Arch/SecurityTest.php
+++ b/tests/Arch/SecurityTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Support\Str;
+use Tests\ArchTestCase;
+
+/**
+ * Layers that answer questions or shape output. Nothing here may reach a
+ * server or otherwise cause a side effect.
+ *
+ * Each source namespace needs its own expectation — Pest's negative dependency
+ * expectations silently pass when given an array of source namespaces.
+ */
+const READ_AND_DECISION_LAYERS = [
+    'App\DTOs',
+    'App\Enums',
+    'App\Http\Resources',
+    'App\Policies',
+];
+
+arch('remote commands never shell out')
+    ->expect([
+        'Symfony\Component\Process\Process',
+        'Illuminate\Support\Facades\Process',
+        'proc_open',
+        'popen',
+    ])
+    ->not->toBeUsed()
+    ->ignoring(ArchTestCase::except('security.local-process'));
+
+arch('the ssh facade is never reached from a read or decision layer')
+    ->expect('App\Facades\SSH')
+    ->not->toBeUsedIn(READ_AND_DECISION_LAYERS);
+
+arch('the ssh helper is never reached from a read or decision layer')
+    ->expect('App\Helpers\SSH')
+    ->not->toBeUsedIn(READ_AND_DECISION_LAYERS);
+
+it('never logs a credential-shaped variable', function (): void {
+    $sensitive = ['password', 'token', 'secret', 'private_key', 'credentials', 'api_key', 'pk'];
+    $offenders = [];
+
+    foreach (vitoArchFiles() as $file) {
+        foreach (file($file->getRealPath()) ?: [] as $number => $line) {
+            if (! Str::contains($line, ['Log::', 'logger(', 'info(', 'error(', 'warning(', 'debug('])) {
+                continue;
+            }
+
+            foreach ($sensitive as $needle) {
+                if (Str::contains($line, ['$'.$needle, "'".$needle."'", '->'.$needle])) {
+                    $offenders[] = "{$file->getRelativePathname()}:".($number + 1);
+                }
+            }
+        }
+    }
+
+    expect(array_values(array_unique($offenders)))->toBe([]);
+});
+
+it('does not expose filesystem paths of keys and certificates through resources', function (): void {
+    $offenders = [];
+
+    foreach (vitoArchFiles('Http/Resources') as $file) {
+        $contents = (string) file_get_contents($file->getRealPath());
+
+        preg_match_all("/'(?<key>[a-z_]+_path)' =>/", $contents, $matches, PREG_SET_ORDER);
+
+        foreach ($matches as $match) {
+            $offenders[] = "{$file->getRelativePathname()}: {$match['key']}";
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});

--- a/tests/Arch/SecurityTest.php
+++ b/tests/Arch/SecurityTest.php
@@ -36,17 +36,26 @@ arch('the ssh helper is never reached from a read or decision layer')
     ->not->toBeUsedIn(READ_AND_DECISION_LAYERS);
 
 it('never logs a credential-shaped variable', function (): void {
-    $sensitive = ['password', 'token', 'secret', 'private_key', 'credentials', 'api_key', 'pk'];
+    $sensitive = ['password', 'token', 'access_token', 'refresh_token', 'secret', 'private_key', 'credentials', 'api_key'];
     $offenders = [];
 
     foreach (vitoArchFiles() as $file) {
-        foreach (file($file->getRealPath()) ?: [] as $number => $line) {
+        $lines = file($file->getRealPath()) ?: [];
+
+        foreach ($lines as $number => $line) {
             if (! Str::contains($line, ['Log::', 'logger(', 'info(', 'error(', 'warning(', 'debug('])) {
                 continue;
             }
 
+            $statement = $line;
+            $cursor = $number;
+
+            while (! Str::contains($statement, ';') && isset($lines[$cursor + 1]) && $cursor - $number < 20) {
+                $statement .= $lines[++$cursor];
+            }
+
             foreach ($sensitive as $needle) {
-                if (Str::contains($line, ['$'.$needle, "'".$needle."'", '->'.$needle])) {
+                if (Str::contains($statement, ['$'.$needle, "'".$needle."'", '->'.$needle])) {
                     $offenders[] = "{$file->getRelativePathname()}:".($number + 1);
                 }
             }

--- a/tests/ArchTestCase.php
+++ b/tests/ArchTestCase.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use InvalidArgumentException;
+
+/**
+ * Base case for the architecture suite, and the single registry of exceptions
+ * to its rules.
+ *
+ * Read `.github/instructions/architecture-tests.instructions.md` before
+ * touching EXCEPTIONS. Entries may only be added with the maintainer's explicit
+ * permission, and only when a rule is added or changed — never to make a
+ * failing rule pass.
+ */
+abstract class ArchTestCase extends BaseTestCase
+{
+    use CreatesApplication;
+
+    /**
+     * Every deviation from an architecture rule that the current implementation
+     * relies on. Each entry exempts real code from a real standard, so the rule
+     * stops protecting it. Lists may shrink freely; they may not grow.
+     *
+     * @var array<string, array{reason: string, entries: array<int, string>}>
+     */
+    public const array EXCEPTIONS = [
+        'foundation.var-export' => [
+            'reason' => 'Renders booleans as literal true/false for the Supervisor config file.',
+            'entries' => [
+                'App\Services\ProcessManager\Supervisor',
+            ],
+        ],
+        'foundation.non-cryptographic-hashing' => [
+            'reason' => 'Hashes for cache keys and content fingerprints only — never for authentication, signing or password storage.',
+            'entries' => [
+                'App\Actions\Bootstrap\GetBootstrap',
+                'App\Actions\Ziggy\GetZiggyRoutes',
+                'App\Helpers\Apr1Hasher',
+                'App\SourceControlProviders',
+            ],
+        ],
+        'foundation.local-shell' => [
+            'reason' => 'Runs exec()/shell_exec() on the Vito host itself for key generation and binary discovery, not against a managed server.',
+            'entries' => [
+                'App\Support\helpers',
+                'App\Console\Commands\GenerateKeysCommand',
+            ],
+        ],
+        'foundation.assert' => [
+            'reason' => 'Uses assert() to narrow a provider type for static analysis.',
+            'entries' => [
+                'App\Actions\StorageProvider\DeleteStorageProvider',
+            ],
+        ],
+        'foundation.blocking-sleep' => [
+            'reason' => 'Polls Let\'s Encrypt with a blocking sleep() loop, so Sleep::fake() cannot intercept it and the test suite really waits.',
+            'entries' => [
+                'App\Jobs\SSL\CreateLetsEncryptWildcardSslJob',
+            ],
+        ],
+        'foundation.non-throwable-in-exceptions' => [
+            'reason' => 'The framework exception handler lives in the exceptions namespace but is not itself throwable.',
+            'entries' => [
+                'App\Exceptions\Handler',
+            ],
+        ],
+        'foundation.missing-return-type' => [
+            'reason' => 'Agent overrides an untyped third-party base class; the other two are drift.',
+            'entries' => [
+                'App\Helpers\Agent',
+                'App\Helpers\SSH',
+                'App\Http\Controllers\Admin\PluginController',
+            ],
+        ],
+        'actions.accepting-request' => [
+            'reason' => 'Reads the OAuth callback Request directly instead of receiving an input array.',
+            'entries' => [
+                'App\Actions\StorageProvider\ConnectDropbox',
+            ],
+        ],
+        'http.controllers-validating' => [
+            'reason' => 'Validates in the controller instead of delegating to the Action.',
+            'entries' => [
+                'App\Http\Controllers\API\ServerController',
+            ],
+        ],
+        'http.controllers-querying' => [
+            'reason' => 'Builds cross-model search queries with the DB facade rather than Eloquent.',
+            'entries' => [
+                'App\Http\Controllers\SearchController',
+            ],
+        ],
+        'http.controllers-dispatching-jobs' => [
+            'reason' => 'Dispatches jobs straight from the controller, so the orchestration is invisible to the Action layer.',
+            'entries' => [
+                'App\Http\Controllers\HostedDomainController',
+                'App\Http\Controllers\NetworkController',
+                'App\Http\Controllers\SiteStatsController',
+            ],
+        ],
+        'http.resources-calling-actions' => [
+            'reason' => 'Runs a stranding check while serialising, so rendering the resource does work.',
+            'entries' => [
+                'App\Http\Resources\NetworkResource',
+            ],
+        ],
+        'models.foreign-base-class' => [
+            'reason' => 'Extends an authentication or Sanctum base class that AbstractModel cannot sit under.',
+            'entries' => [
+                'App\Models\User',
+                'App\Models\PersonalAccessToken',
+            ],
+        ],
+        'models.not-on-abstract-model' => [
+            'reason' => 'Extends Model directly, so it misses HasTimezoneTimestamps and jsonUpdate().',
+            'entries' => [
+                'App\Models\Metric',
+                'App\Models\Plugin',
+                'App\Models\PluginError',
+                'App\Models\Project',
+                'App\Models\UserProject',
+                'App\Models\Workflow',
+                'App\Models\WorkflowRun',
+            ],
+        ],
+        'models.calling-actions' => [
+            'reason' => 'Invokes business logic from the model layer instead of from an Action, Job or Controller.',
+            'entries' => [
+                'App\Models\BackupFile',
+                'App\Models\Metric',
+                'App\Models\Server',
+                'App\Models\ServerIpAddress',
+                'App\Models\Service',
+            ],
+        ],
+        'jobs.without-unique-queue' => [
+            'reason' => 'Read-only polling or teardown work with no UniqueQueue lock, so concurrent runs are possible.',
+            'entries' => [
+                'App\Jobs\HostedDomain\CheckDomainJob',
+                'App\Jobs\SSL\CheckSslExpiryJob',
+                'App\Jobs\SSL\DeleteSiteSslJob',
+            ],
+        ],
+        'jobs.without-failure-handler' => [
+            'reason' => 'Has no failed() hook, so a failure leaves no trace on the owning record.',
+            'entries' => [
+                'App\Jobs\HostedDomain\CheckDomainJob',
+                'App\Jobs\SSL\CheckSslExpiryJob',
+                'App\Jobs\Server\CheckForUpdatesJob',
+            ],
+        ],
+        'policies.user-owned' => [
+            'reason' => 'Guards a user-owned resource rather than a project-scoped one, so project role checks do not apply.',
+            'entries' => [
+                'App\Policies\DNSProviderPolicy',
+                'App\Policies\NotificationChannelPolicy',
+                'App\Policies\PersonalAccessTokenPolicy',
+                'App\Policies\ServerProviderPolicy',
+                'App\Policies\ServerTemplatePolicy',
+                'App\Policies\SourceControlPolicy',
+                'App\Policies\SshKeyPolicy',
+                'App\Policies\StorageProviderPolicy',
+                'App\Policies\UserPolicy',
+            ],
+        ],
+        'conventions.writes-without-bootstrap-bust' => [
+            'reason' => 'Writes a bootstrap-backed model without calling GetBootstrap::forgetVersion(). BootPlugins, CheckForUpdates and InstallGithubPlugin only touch non-catalogue fields or delegate; DiscoverPlugins adds and removes plugins, so in production clients can keep a stale catalogue forever.',
+            'entries' => [
+                'BootPlugins.php',
+                'DiscoverPlugins.php',
+                'Github/CheckForUpdates.php',
+                'Github/InstallGithubPlugin.php',
+            ],
+        ],
+        'extension-points.non-tooling-classes' => [
+            'reason' => 'Registry and state helpers that live in the tooling namespace without being a tool.',
+            'entries' => [
+                'App\Tooling\ToolingRegistry',
+                'App\Tooling\SiteToolingState',
+            ],
+        ],
+        'extension-points.non-channel-classes' => [
+            'reason' => 'A Mailable that ships with the email channel rather than being a channel itself.',
+            'entries' => [
+                'App\NotificationChannels\Email\NotificationMail',
+            ],
+        ],
+        'security.local-process' => [
+            'reason' => 'Runs the Process component on the Vito host to install plugins, not against a managed server.',
+            'entries' => [
+                'App\Plugins\LegacyPlugins',
+            ],
+        ],
+        'routing.public-endpoints' => [
+            'reason' => 'Reachable without an authenticated session: the auth flow, public documentation, and machine callbacks that verify their own signature or shared secret inside the controller.',
+            'entries' => [
+                'api.yaml',
+                'api/docs',
+                'api/health',
+                'api/git-hooks',
+                'api/github-hooks',
+                'api/servers/{server}/agent',
+                'api/webhooks',
+                'ziggy',
+                'login',
+                'logout',
+                'register',
+                'forgot-password',
+                'reset-password',
+                'verify-email',
+                'email',
+                'user/confirm-password',
+                'user/confirmed-password-status',
+                'two-factor-challenge',
+                'invitations',
+                'sanctum',
+                'up',
+                '_ignition',
+                'horizon',
+            ],
+        ],
+    ];
+
+    /**
+     * @return array<int, string>
+     */
+    public static function except(string $key): array
+    {
+        if (! array_key_exists($key, self::EXCEPTIONS)) {
+            throw new InvalidArgumentException("Unknown architecture exception key [{$key}].");
+        }
+
+        return self::EXCEPTIONS[$key]['entries'];
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -28,14 +28,17 @@ pest()->extend(TestCase::class)->in(
 );
 
 /**
- * Every PHP file under the given app/ sub-directory.
+ * Every PHP file under the given sub-directory, relative to app/ unless another
+ * base directory is given.
  *
  * @return array<int, SplFileInfo>
  */
-function vitoArchFiles(string $directory = ''): array
+function vitoArchFiles(string $directory = '', ?string $base = null): array
 {
+    $path = ($base ?? app_path()).($directory === '' ? '' : DIRECTORY_SEPARATOR.$directory);
+
     return iterator_to_array(
-        Finder::create()->files()->in(app_path($directory))->name('*.php'),
+        Finder::create()->files()->in($path)->name('*.php'),
         false
     );
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -8,7 +8,13 @@ use App\SiteTypes\NodeSite;
 use App\SiteTypes\PHPBlank;
 use App\SiteTypes\PHPMyAdmin;
 use App\SiteTypes\Wordpress;
+use Illuminate\Support\Str;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+use Tests\ArchTestCase;
 use Tests\TestCase;
+
+pest()->extend(ArchTestCase::class)->in('Arch');
 
 pest()->extend(TestCase::class)->in(
     'Feature',
@@ -20,6 +26,49 @@ pest()->extend(TestCase::class)->in(
     'Unit/SiteEnvPathTest.php',
     'Unit/SiteShellEnvironmentTest.php',
 );
+
+/**
+ * Every PHP file under the given app/ sub-directory.
+ *
+ * @return array<int, SplFileInfo>
+ */
+function vitoArchFiles(string $directory = ''): array
+{
+    return iterator_to_array(
+        Finder::create()->files()->in(app_path($directory))->name('*.php'),
+        false
+    );
+}
+
+/**
+ * Every concrete, autoloadable class under the given app/ sub-directory.
+ *
+ * @return array<int, class-string>
+ */
+function vitoArchClasses(string $directory = ''): array
+{
+    $classes = [];
+
+    foreach (vitoArchFiles($directory) as $file) {
+        if (preg_match('/^(?:final |abstract |readonly )*class /m', $file->getContents()) !== 1) {
+            continue;
+        }
+
+        $class = Str::of($file->getRealPath())
+            ->after(app_path().DIRECTORY_SEPARATOR)
+            ->replace([DIRECTORY_SEPARATOR, '.php'], ['\\', ''])
+            ->prepend('App\\')
+            ->toString();
+
+        if (! class_exists($class) || (new ReflectionClass($class))->isAbstract()) {
+            continue;
+        }
+
+        $classes[] = $class;
+    }
+
+    return $classes;
+}
 
 /**
  * @return array<array<array<string, mixed>>>


### PR DESCRIPTION
Adds tests/Arch/ - 92 Pest v5 architecture tests that turn the standards in .github/copilot-instructions.md and .github/instructions/*.md into executable rules, each verified to fail against an injected violation, with all pre-existing deviations recorded in a single permission-gated registry (ArchTestCase::EXCEPTIONS) rather than papered over.

### RoutingTest - 5 tests

Boots the app and inspects the real route collection.

| Test | Value |
| --- | --- |
| it authenticates every route that is not deliberately public | Every endpoint carries `auth`/`signed` middleware unless explicitly listed as public. A new controller shipped without middleware is an unauthenticated endpoint on a server-management tool. |
| it scopes every project api route to the project boundary | Enforces `can-see-project` on `api/projects/{project}/*`, preventing cross-tenant data access. |
| it scopes every api route to a token ability | Every API route declares `ability:read`/`ability:write`, so a read-scoped token cannot perform writes. |
| it gives every route a unique name | Duplicate route names silently override each other, so URL generation points at the wrong endpoint with no error. |
| it names every application route | Ziggy and the frontend resolve routes by name; an unnamed route is unreachable from the UI. |

### SecurityTest - 5 tests

| Test | Value |
| --- | --- |
| remote commands never shell out | Bans `Process`, `proc_open` and `popen` outside two host-local allowances. Shelling out bypasses the SSH facade, sidesteps `SSH::fake()` in tests, and opens command-injection paths. |
| it never logs a credential-shaped variable | Scans every `Log::`/`logger()` line for password, token, secret, private_key, credentials, api_key and pk. Prevents plaintext secrets landing in log files. |
| the ssh facade is never reached from a read or decision layer | No SSH from Resources, Policies, DTOs or Enums. Serialising a response or answering an authorization check must never open a server connection. |
| the ssh helper is never reached from a read or decision layer | Same invariant for the concrete helper, which bypasses the facade. Split from the rule above because Pest silently passes when given an array of source namespaces. |
| it does not expose filesystem paths of keys and certificates through resources | Blocks any `*_path` key in an API Resource, preventing disclosure of CSR and private-key locations on the managed server. |

### ModelsTest - 7 tests

| Test | Value |
| --- | --- |
| it encrypts every attribute that stores credentials | Any attribute named credentials, secrets, token, access_token, refresh_token or password must be cast `encrypted*` or `hashed`. Catches provider credentials persisted in plaintext. |
| it casts every enum attribute to an enum implementing VitoEnum | A cast to a non-VitoEnum enum fatals every API Resource that calls `getText()`/`getColor()` on it. |
| models do not depend on actions | Keeps business logic out of the model layer where it is invisible to controllers and jobs. Currently exempts 5 models. |
| models extend AbstractModel | Guarantees `HasTimezoneTimestamps` and `jsonUpdate()`. Currently exempts 7 models that extend `Model` directly. |
| models do not reach into the http layer | No Request, Validator or Inertia in models, keeping them usable from console and queue contexts. |
| eloquent models only live in the models namespace | Stops models being defined outside `App\Models` where factories and policies will not find them. |
| models are not suffixed with Model | Naming consistency. |

### HttpTest - 11 tests

| Test | Value |
| --- | --- |
| it never whitelists fields with parent::toArray() | `parent::toArray()` serialises every model attribute, including encrypted credentials and internal columns. The single highest-value rule in the HTTP layer. |
| controllers do not validate - actions do | Validation belongs in Actions so it applies identically from web, API, console and workflows, and always returns 422. |
| form requests are not used - validation lives in actions | A FormRequest would validate before the Action runs, silently bypassing the Action's own rules. Distinctive to Vito. |
| resources are read models and never mutate state | No Actions, Jobs, DB or Validator in Resources. Prevents work and N+1 queries during serialisation. |
| controllers extend the base controller | Required for `$this->authorize()`; a controller without it silently loses policy enforcement. |
| controllers do not talk to the database directly | Keeps queries in Actions and models where they can be tested and eager-loaded. |
| controllers do not dispatch jobs directly - actions own that | Keeps orchestration visible in the Action layer. Currently exempts 3 controllers. |
| controllers are only referenced by routing and the http layer itself | Controllers must not become a shared service layer. Tight two-namespace rule. |
| resources are suffixed with Resource and extend JsonResource | Guarantees consistent JSON envelopes across the API. |
| controllers are suffixed with Controller | Naming consistency for route attribute discovery. |
| nothing outside the controllers namespace is suffixed with Controller | Prevents controller-shaped classes hiding outside the HTTP layer. |

### FoundationTest - 11 tests

| Test | Value |
| --- | --- |
| env() is only read from config files | `env()` returns null once config is cached, so this breaks in production only. Classic deploy-day outage. |
| security sensitive functions are not used | Pest security preset: bans eval, unserialize, extract, shell_exec, and weak randomness. |
| laravel debugging helpers never reach the codebase | A stray `dd()` leaks internal state and truncates the response. |
| sleeping is done through the Sleep facade so tests can fake it | Blocking `sleep()` holds a queue worker and makes the test suite really wait. |
| php best practices are followed | Pest PHP preset: bans var_dump, print_r, die, echo, goto and friends. |
| it declares an explicit return type on every method | Documented standard, enforced across all of `app/`. Only 6 known offenders. |
| exceptions are throwable and live in the exceptions namespace | A non-throwable class in `App\Exceptions` is dead weight that reads as an exception. |
| nothing outside the exceptions namespace is throwable | Keeps the exception surface discoverable in one place. |
| enums only live in the enums namespace | Stops enums scattering outside `App\Enums` where the VitoEnum rules do not reach them. |
| traits live in the traits namespace | Namespace hygiene. |
| contracts are interfaces | Namespace hygiene. |

### JobsTest - 7 tests

| Test | Value |
| --- | --- |
| it uses the Queueable and UniqueQueue traits on every job | UniqueQueue's cache lock is what stops two jobs running SSH against the same server concurrently. Exempts 3 read-only or teardown jobs. |
| it wraps work in the unique queue lock wherever the trait is used | Using the trait without calling `$this->run()` gives a lock that never engages - the failure is completely silent. |
| it handles its own failure on every job | Without `failed()`, a failed job leaves its record stuck in an in-progress status forever. Exempts 3 jobs. |
| jobs are queued | A job missing `ShouldQueue` runs synchronously in the request, blocking the response on SSH. |
| jobs do not reach into the presentation layer | No Request or Inertia in a queue context where neither exists. |
| jobs expose a handle method | Framework contract. |
| jobs are suffixed with Job | Naming consistency. |

### PoliciesTest - 7 tests

| Test | Value |
| --- | --- |
| it takes a User as the first argument of every policy method and returns bool | A policy method returning a non-bool truthy value silently authorises the request. Also enforces the User-first signature the gate depends on. |
| it checks project roles through HasRolePolicies | Role checks must go through the shared trait rather than drifting into inline comparisons. Exempts 9 user-owned policies. |
| it maps every policy to an existing model | Catches a model rename that silently unregisters its policy, leaving the resource unguarded. |
| policies are resolved through the gate, never called directly | Calling a policy directly skips `before()` hooks and admin overrides. Tight two-namespace rule. |
| policies decide, they do not act | No Jobs, DB, Validator or Inertia in a policy - authorization must be side-effect free. |
| policies are suffixed with Policy | Laravel's policy auto-discovery resolves by naming convention. |
| nothing outside the policies namespace is suffixed with Policy | Prevents policy-shaped classes that the gate will never discover. |

### ConventionsTest - 5 tests

| Test | Value |
| --- | --- |
| it busts the bootstrap version whenever bootstrap-backed state is written | In production the bootstrap version is `rememberForever`, so a write that skips `GetBootstrap::forgetVersion()` leaves every client with a stale catalogue permanently. |
| broadcasting never happens from a read or decision layer | No SocketEvent from Resources, Policies, DTOs, Enums or ValidationRules. |
| DTOs stay free of infrastructure | Keeps DTOs portable and cheap to construct in tests. |
| console commands stay thin and delegate to actions | Prevents scheduled commands growing a second copy of business logic. |
| listeners expose a handle method | Framework contract. |

### EnumsTest - 5 tests

| Test | Value |
| --- | --- |
| it returns a non empty colour and label for every enum case | Executes `getColor()` and `getText()` on every case of every enum, so a case added without a matching `match` arm fails here instead of throwing UnhandledMatchError in production. |
| enums implement the VitoEnum contract | Every API Resource calls `getText()`/`getColor()`; an enum without the contract breaks serialisation. |
| it backs every enum with a string | An int-backed enum silently changes DB column values and the JSON payload the frontend reads. |
| enums stay free of infrastructure dependencies | Keeps enums pure value objects with no Models, Actions, Jobs or DB. |
| everything in the enums namespace is an enum | Namespace hygiene. |

### ExceptionsTest - 4 tests

Guards the exception registry itself.

| Test | Value |
| --- | --- |
| it rejects an unknown architecture exception key | A mistyped key throws instead of silently exempting nothing and leaving the rule looking enforced. |
| it points every namespaced exception entry at code that still exists | Catches entries left stale by a rename, which would otherwise sit in the registry granting nothing. |
| it references every architecture exception from a rule | No orphan entries surviving after the rule that used them was deleted. |
| it gives every architecture exception a reason and at least one entry | Every exemption must carry its justification; empty lists must be deleted rather than left as dead weight. |

### MigrationsTest - 1 test

| Test | Value |
| --- | --- |
| it keeps migrations free of runtime side effects | Bans dispatch, SSH, HTTP, Bus, Queue, broadcast, Notification and Mail from migrations. A migration that fires jobs or SSH runs against live servers during deploy and cannot be rolled back. |

### ExtensionPointsTest - 21 tests

Plugin and extension-point contracts. Mostly single-expectation rules; each guarantees a new implementation inherits the abstract's registration, validation and lifecycle wiring.

| Test | Value |
| --- | --- |
| services extend the abstract service | New service inherits install/uninstall/manage lifecycle and the `id()`/`type()` contract. |
| server providers extend the abstract server provider | New provider inherits credential handling and the provider contract. |
| site types extend the abstract site type | New site type inherits deployment and vhost wiring. |
| dns providers extend the abstract dns provider | New DNS provider inherits the record sync contract. |
| source control providers extend the abstract source control provider | New source control inherits repo, branch and webhook handling. |
| storage providers extend the abstract storage provider | New storage provider inherits upload, download and delete handling. |
| workflow actions extend the abstract workflow action | New workflow action inherits input resolution and run reporting. |
| dns providers do not reach into the http layer | Provider stays usable from console and queue contexts. |
| server providers do not reach into the http layer | Provider stays usable from console and queue contexts. |
| source control providers do not reach into the http layer | Provider stays usable from console and queue contexts. |
| storage providers do not reach into the http layer | Provider stays usable from console and queue contexts. |
| tooling does not reach into the http layer | Tooling stays usable from console and queue contexts. |
| tooling extends the abstract tooling | New tool inherits mise install and version resolution. |
| notification channels extend the abstract notification channel | New channel inherits the connect and send contract. |
| validation rules implement the validation rule contract | Guarantees the rule is usable by `Validator::make()`. |
| notifications extend the framework notification | Guarantees channel routing works. |
| tables extend the inertia table | Guarantees pagination, sorting and search wiring. |
| console commands extend the framework command | Guarantees registration and signature parsing. |
| console commands expose a handle method | Framework contract. |
| tables are suffixed with Table | Naming consistency. |
| service providers are suffixed with ServiceProvider | Naming consistency. |

### ActionsTest - 3 tests

| Test | Value |
| --- | --- |
| actions take arrays, not requests | Actions accept input arrays so they are callable identically from web, API, console, jobs and workflows. Exempts one OAuth callback Action. |
| actions do not render responses | No Inertia or redirects in an Action, keeping business logic reusable outside the HTTP layer. |
| actions do not depend on controllers | Prevents an inverted dependency where the business layer reaches back into HTTP. |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive automated architecture checks covering application structure, naming, dependencies, security, routing, migrations, and extension points.
  * Added a dedicated architecture test suite with centralised exception handling and reusable discovery utilities.

* **Documentation**
  * Documented architecture-testing standards, exemption requirements, execution guidance, and coverage expectations.

* **Tests**
  * Added safeguards for HTTP boundaries, queued jobs, models, policies, enums, actions, and other core application conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->