### PR TITLE
[Fix] API Keys: enforce project scope on provider endpoints

### DIFF
--- a/app/Actions/DNSProvider/CreateDNSProvider.php
+++ b/app/Actions/DNSProvider/CreateDNSProvider.php
@@ -11,7 +11,7 @@ use Illuminate\Validation\ValidationException;
 
 class CreateDNSProvider
 {
-    public function create(User $user, array $input): DNSProvider
+    public function create(User $user, array $input, ?int $projectId): DNSProvider
     {
         $this->validate($input);
 
@@ -30,7 +30,7 @@ class CreateDNSProvider
         $dnsProvider->name = $input['name'];
         $dnsProvider->provider = $input['provider'];
         $dnsProvider->credentials = $provider->credentialData($input);
-        $dnsProvider->project_id = isset($input['global']) && $input['global'] ? null : $user->currentProject?->id;
+        $dnsProvider->project_id = $projectId;
         $dnsProvider->connected = true;
         $dnsProvider->save();
 

--- a/app/Actions/DNSProvider/EditDNSProvider.php
+++ b/app/Actions/DNSProvider/EditDNSProvider.php
@@ -13,7 +13,7 @@ class EditDNSProvider
      *
      * @throws ValidationException
      */
-    public function edit(DNSProvider $dnsProvider, array $input): DNSProvider
+    public function edit(DNSProvider $dnsProvider, array $input, ?int $projectId): DNSProvider
     {
         $provider = $dnsProvider->provider();
 
@@ -25,7 +25,7 @@ class EditDNSProvider
         Validator::make($input, $rules)->validate();
 
         $dnsProvider->name = $input['name'];
-        $dnsProvider->project_id = isset($input['global']) && $input['global'] ? null : $dnsProvider->user->currentProject?->id;
+        $dnsProvider->project_id = $projectId;
 
         [$newCredentials, $needsReconnect] = $provider->mergeEditData($input);
 

--- a/app/Actions/GithubApp/EditGithubAppSourceControl.php
+++ b/app/Actions/GithubApp/EditGithubAppSourceControl.php
@@ -9,11 +9,9 @@ class EditGithubAppSourceControl
     /**
      * @param  array<string, mixed>  $input
      */
-    public function edit(SourceControl $sourceControl, array $input): SourceControl
+    public function edit(SourceControl $sourceControl, array $input, ?int $projectId): SourceControl
     {
-        $sourceControl->project_id = isset($input['global']) && $input['global']
-            ? null
-            : $sourceControl->user->currentProject?->id;
+        $sourceControl->project_id = $projectId;
 
         $sourceControl->save();
 

--- a/app/Actions/ServerProvider/CreateServerProvider.php
+++ b/app/Actions/ServerProvider/CreateServerProvider.php
@@ -21,7 +21,7 @@ class CreateServerProvider
      *
      * @throws ValidationException
      */
-    public function create(User $user, array $input): ServerProvider
+    public function create(User $user, array $input, ?int $projectId): ServerProvider
     {
         $this->validate($input);
 
@@ -42,7 +42,7 @@ class CreateServerProvider
         $serverProvider->profile = $input['name'];
         $serverProvider->provider = $input['provider'];
         $serverProvider->credentials = $provider->credentialData($input);
-        $serverProvider->project_id = isset($input['global']) && $input['global'] ? null : $user->currentProject?->id;
+        $serverProvider->project_id = $projectId;
         $serverProvider->save();
 
         SocketEvent::dispatch(new SocketEventDTO(

--- a/app/Actions/ServerProvider/EditServerProvider.php
+++ b/app/Actions/ServerProvider/EditServerProvider.php
@@ -13,7 +13,7 @@ class EditServerProvider
     /**
      * @param  array<string, mixed>  $input
      */
-    public function edit(ServerProvider $serverProvider, array $input): ServerProvider
+    public function edit(ServerProvider $serverProvider, array $input, ?int $projectId): ServerProvider
     {
         Validator::make($input, [
             'name' => [
@@ -22,7 +22,7 @@ class EditServerProvider
         ])->validate();
 
         $serverProvider->profile = $input['name'];
-        $serverProvider->project_id = isset($input['global']) && $input['global'] ? null : $serverProvider->user->currentProject?->id;
+        $serverProvider->project_id = $projectId;
 
         $serverProvider->save();
 

--- a/app/Actions/SourceControl/ConnectSourceControl.php
+++ b/app/Actions/SourceControl/ConnectSourceControl.php
@@ -15,7 +15,7 @@ class ConnectSourceControl
      *
      * @throws ValidationException
      */
-    public function connect(User $user, array $input): SourceControl
+    public function connect(User $user, array $input, ?int $projectId): SourceControl
     {
         $this->validate($input);
 
@@ -23,7 +23,7 @@ class ConnectSourceControl
             'provider' => $input['provider'],
             'profile' => $input['name'],
             'url' => isset($input['url']) && $input['url'] ? $input['url'] : null,
-            'project_id' => isset($input['global']) && $input['global'] ? null : $user->currentProject?->id,
+            'project_id' => $projectId,
             'user_id' => $user->id,
         ]);
 

--- a/app/Actions/SourceControl/EditSourceControl.php
+++ b/app/Actions/SourceControl/EditSourceControl.php
@@ -13,7 +13,7 @@ class EditSourceControl
      *
      * @throws ValidationException
      */
-    public function edit(SourceControl $sourceControl, array $input): SourceControl
+    public function edit(SourceControl $sourceControl, array $input, ?int $projectId): SourceControl
     {
         Validator::make($input, array_merge(
             ['name' => ['required']],
@@ -21,9 +21,7 @@ class EditSourceControl
         ))->validate();
 
         $sourceControl->profile = $input['name'];
-        $sourceControl->project_id = isset($input['global']) && $input['global']
-            ? null
-            : $sourceControl->user->currentProject?->id;
+        $sourceControl->project_id = $projectId;
         $sourceControl->provider_data = $sourceControl->provider()->editData($input);
 
         $sourceControl->save();

--- a/app/Actions/StorageProvider/ConnectDropbox.php
+++ b/app/Actions/StorageProvider/ConnectDropbox.php
@@ -22,10 +22,11 @@ class ConnectDropbox
 
     /**
      * @param  array<string, mixed>  $input
+     * @param  ?int  $projectId  The project the provider will belong to, or null for a global one.
      *
      * @throws ValidationException
      */
-    public function redirectUrl(array $input): string
+    public function redirectUrl(array $input, ?int $projectId): string
     {
         Validator::make($input, [
             'name' => ['required'],
@@ -40,7 +41,7 @@ class ConnectDropbox
             'name' => $input['name'],
             'app_key' => $input['app_key'],
             'app_secret' => $input['app_secret'],
-            'global' => isset($input['global']) && $input['global'],
+            'project_id' => $projectId,
         ]);
 
         return self::AUTHORIZE_URL.'?'.http_build_query([
@@ -85,13 +86,16 @@ class ConnectDropbox
             (string) $pending['app_secret'],
         );
 
+        /** @var ?int $projectId */
+        $projectId = $pending['project_id'] ?? null;
+
         return app(CreateStorageProvider::class)->create($user, [
             'provider' => Dropbox::id(),
             'name' => $pending['name'],
             'app_key' => $pending['app_key'],
             'app_secret' => $pending['app_secret'],
             'refresh_token' => $refreshToken,
-        ], $pending['global'] ? null : $user->currentProject?->id);
+        ], $projectId);
     }
 
     public function redirectUri(): string

--- a/app/Actions/StorageProvider/ConnectDropbox.php
+++ b/app/Actions/StorageProvider/ConnectDropbox.php
@@ -91,8 +91,7 @@ class ConnectDropbox
             'app_key' => $pending['app_key'],
             'app_secret' => $pending['app_secret'],
             'refresh_token' => $refreshToken,
-            'global' => $pending['global'],
-        ]);
+        ], $pending['global'] ? null : $user->currentProject?->id);
     }
 
     public function redirectUri(): string

--- a/app/Actions/StorageProvider/CreateStorageProvider.php
+++ b/app/Actions/StorageProvider/CreateStorageProvider.php
@@ -17,7 +17,7 @@ class CreateStorageProvider
      *
      * @throws ValidationException
      */
-    public function create(User $user, array $input): StorageProvider
+    public function create(User $user, array $input, ?int $projectId): StorageProvider
     {
         $this->validate($input);
 
@@ -25,7 +25,7 @@ class CreateStorageProvider
             'user_id' => $user->id,
             'provider' => $input['provider'],
             'profile' => $input['name'],
-            'project_id' => isset($input['global']) && $input['global'] ? null : $user->currentProject?->id,
+            'project_id' => $projectId,
         ]);
 
         $storageProvider->credentials = $storageProvider->provider()->credentialData($input);

--- a/app/Actions/StorageProvider/EditStorageProvider.php
+++ b/app/Actions/StorageProvider/EditStorageProvider.php
@@ -16,7 +16,7 @@ class EditStorageProvider
      *
      * @throws ValidationException
      */
-    public function edit(StorageProvider $storageProvider, array $input): StorageProvider
+    public function edit(StorageProvider $storageProvider, array $input, ?int $projectId): StorageProvider
     {
         if (! $storageProvider->hasProviderHandler()) {
             throw ValidationException::withMessages([
@@ -40,7 +40,7 @@ class EditStorageProvider
         }
 
         $storageProvider->profile = $input['name'];
-        $storageProvider->project_id = isset($input['global']) && $input['global'] ? null : $storageProvider->user->currentProject?->id;
+        $storageProvider->project_id = $projectId;
 
         if ($credentials !== $storageProvider->credentials) {
             $storageProvider->credentials = $credentials;

--- a/app/Http/Controllers/API/DNSProviderController.php
+++ b/app/Http/Controllers/API/DNSProviderController.php
@@ -27,7 +27,7 @@ class DNSProviderController extends Controller
     {
         $this->authorize('viewAny', DNSProvider::class);
 
-        $dnsProviders = user()->dnsProviders()->simplePaginate(25);
+        $dnsProviders = DNSProvider::getByTokenProjects(user())->simplePaginate(25);
 
         return DNSProviderResource::collection($dnsProviders);
     }
@@ -38,7 +38,11 @@ class DNSProviderController extends Controller
         $this->authorize('create', DNSProvider::class);
 
         $user = user();
-        $dnsProvider = app(CreateDNSProvider::class)->create($user, $request->all());
+        $projectId = $request->boolean('global') ? null : $user->currentProject?->id;
+
+        $this->authorize('assignToProject', [DNSProvider::class, $projectId]);
+
+        $dnsProvider = app(CreateDNSProvider::class)->create($user, $request->all(), $projectId);
 
         return new DNSProviderResource($dnsProvider);
     }
@@ -56,7 +60,11 @@ class DNSProviderController extends Controller
     {
         $this->authorize('update', $dnsProvider);
 
-        app(EditDNSProvider::class)->edit($dnsProvider, $request->all());
+        $projectId = $request->boolean('global') ? null : user()->currentProject?->id;
+
+        $this->authorize('assignToProject', [DNSProvider::class, $projectId]);
+
+        app(EditDNSProvider::class)->edit($dnsProvider, $request->all(), $projectId);
 
         return new DNSProviderResource($dnsProvider);
     }

--- a/app/Http/Controllers/API/ProjectController.php
+++ b/app/Http/Controllers/API/ProjectController.php
@@ -7,7 +7,6 @@ use App\Actions\Projects\DeleteProject;
 use App\Actions\Projects\UpdateProject;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\ProjectResource;
-use App\Models\PersonalAccessToken;
 use App\Models\Project;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\ResourceCollection;
@@ -28,12 +27,10 @@ class ProjectController extends Controller
 
         $projects = user()->projects();
 
-        $token = user()->currentAccessToken();
-        if ($token instanceof PersonalAccessToken && $token->exists) {
-            $scopedProjectIds = $token->getProjectIds();
-            if (! empty($scopedProjectIds)) {
-                $projects->whereIn('projects.id', $scopedProjectIds);
-            }
+        $scopedProjectIds = user()->tokenProjectIds();
+
+        if ($scopedProjectIds !== []) {
+            $projects->whereIn('projects.id', $scopedProjectIds);
         }
 
         return ProjectResource::collection($projects->get());

--- a/app/Http/Controllers/API/ServerProviderController.php
+++ b/app/Http/Controllers/API/ServerProviderController.php
@@ -48,8 +48,11 @@ class ServerProviderController extends Controller
     {
         $this->authorize('create', ServerProvider::class);
 
-        $user = user();
-        $serverProvider = app(CreateServerProvider::class)->create($user, $request->all());
+        $projectId = $request->boolean('global') ? null : $project->id;
+
+        $this->authorize('assignToProject', [ServerProvider::class, $projectId]);
+
+        $serverProvider = app(CreateServerProvider::class)->create(user(), $request->all(), $projectId);
 
         return new ServerProviderResource($serverProvider);
     }
@@ -77,7 +80,11 @@ class ServerProviderController extends Controller
 
         $this->validateRoute($project, $serverProvider);
 
-        $serverProvider = app(EditServerProvider::class)->edit($serverProvider, $request->all());
+        $projectId = $request->boolean('global') ? null : $project->id;
+
+        $this->authorize('assignToProject', [ServerProvider::class, $projectId]);
+
+        $serverProvider = app(EditServerProvider::class)->edit($serverProvider, $request->all(), $projectId);
 
         return new ServerProviderResource($serverProvider);
     }

--- a/app/Http/Controllers/API/SourceControlController.php
+++ b/app/Http/Controllers/API/SourceControlController.php
@@ -48,7 +48,11 @@ class SourceControlController extends Controller
     {
         $this->authorize('create', SourceControl::class);
 
-        $sourceControl = app(ConnectSourceControl::class)->connect(user(), $request->all());
+        $projectId = $request->boolean('global') ? null : $project->id;
+
+        $this->authorize('assignToProject', [SourceControl::class, $projectId]);
+
+        $sourceControl = app(ConnectSourceControl::class)->connect(user(), $request->all(), $projectId);
 
         return new SourceControlResource($sourceControl);
     }
@@ -76,9 +80,13 @@ class SourceControlController extends Controller
 
         $this->validateRoute($project, $sourceControl);
 
+        $projectId = $request->boolean('global') ? null : $project->id;
+
+        $this->authorize('assignToProject', [SourceControl::class, $projectId]);
+
         $sourceControl = $sourceControl->isGithubApp()
-            ? app(EditGithubAppSourceControl::class)->edit($sourceControl, $request->all())
-            : app(EditSourceControl::class)->edit($sourceControl, $request->all());
+            ? app(EditGithubAppSourceControl::class)->edit($sourceControl, $request->all(), $projectId)
+            : app(EditSourceControl::class)->edit($sourceControl, $request->all(), $projectId);
 
         return new SourceControlResource($sourceControl);
     }

--- a/app/Http/Controllers/API/StorageProviderController.php
+++ b/app/Http/Controllers/API/StorageProviderController.php
@@ -47,8 +47,11 @@ class StorageProviderController extends Controller
     {
         $this->authorize('create', StorageProvider::class);
 
-        $user = user();
-        $storageProvider = app(CreateStorageProvider::class)->create($user, $request->all());
+        $projectId = $request->boolean('global') ? null : $project->id;
+
+        $this->authorize('assignToProject', [StorageProvider::class, $projectId]);
+
+        $storageProvider = app(CreateStorageProvider::class)->create(user(), $request->all(), $projectId);
 
         return new StorageProviderResource($storageProvider);
     }
@@ -76,7 +79,11 @@ class StorageProviderController extends Controller
 
         $this->validateRoute($project, $storageProvider);
 
-        $storageProvider = app(EditStorageProvider::class)->edit($storageProvider, $request->all());
+        $projectId = $request->boolean('global') ? null : $project->id;
+
+        $this->authorize('assignToProject', [StorageProvider::class, $projectId]);
+
+        $storageProvider = app(EditStorageProvider::class)->edit($storageProvider, $request->all(), $projectId);
 
         return new StorageProviderResource($storageProvider);
     }

--- a/app/Http/Controllers/API/UserServerProviderController.php
+++ b/app/Http/Controllers/API/UserServerProviderController.php
@@ -28,7 +28,7 @@ class UserServerProviderController extends Controller
     {
         $this->authorize('viewAny', ServerProvider::class);
 
-        $serverProviders = user()->serverProviders()->simplePaginate(25);
+        $serverProviders = ServerProvider::getByTokenProjects(user())->simplePaginate(25);
 
         return ServerProviderResource::collection($serverProviders);
     }
@@ -39,7 +39,11 @@ class UserServerProviderController extends Controller
         $this->authorize('create', ServerProvider::class);
 
         $user = user();
-        $serverProvider = app(CreateServerProvider::class)->create($user, $request->all());
+        $projectId = $request->boolean('global') ? null : $user->currentProject?->id;
+
+        $this->authorize('assignToProject', [ServerProvider::class, $projectId]);
+
+        $serverProvider = app(CreateServerProvider::class)->create($user, $request->all(), $projectId);
 
         return new ServerProviderResource($serverProvider);
     }
@@ -67,7 +71,11 @@ class UserServerProviderController extends Controller
             abort(404, 'Server provider not found');
         }
 
-        $serverProvider = app(EditServerProvider::class)->edit($serverProvider, $request->all());
+        $projectId = $request->boolean('global') ? null : user()->currentProject?->id;
+
+        $this->authorize('assignToProject', [ServerProvider::class, $projectId]);
+
+        $serverProvider = app(EditServerProvider::class)->edit($serverProvider, $request->all(), $projectId);
 
         return new ServerProviderResource($serverProvider);
     }

--- a/app/Http/Controllers/API/UserSourceControlController.php
+++ b/app/Http/Controllers/API/UserSourceControlController.php
@@ -27,7 +27,7 @@ class UserSourceControlController extends Controller
     {
         $this->authorize('viewAny', SourceControl::class);
 
-        $sourceControls = user()->sourceControls()->simplePaginate(25);
+        $sourceControls = SourceControl::getByTokenProjects(user())->simplePaginate(25);
 
         return SourceControlResource::collection($sourceControls);
     }
@@ -38,7 +38,11 @@ class UserSourceControlController extends Controller
         $this->authorize('create', SourceControl::class);
 
         $user = user();
-        $sourceControl = app(ConnectSourceControl::class)->connect($user, $request->all());
+        $projectId = $request->boolean('global') ? null : $user->currentProject?->id;
+
+        $this->authorize('assignToProject', [SourceControl::class, $projectId]);
+
+        $sourceControl = app(ConnectSourceControl::class)->connect($user, $request->all(), $projectId);
 
         return new SourceControlResource($sourceControl);
     }
@@ -66,7 +70,11 @@ class UserSourceControlController extends Controller
             abort(404, 'Source control not found');
         }
 
-        $sourceControl = app(EditSourceControl::class)->edit($sourceControl, $request->all());
+        $projectId = $request->boolean('global') ? null : user()->currentProject?->id;
+
+        $this->authorize('assignToProject', [SourceControl::class, $projectId]);
+
+        $sourceControl = app(EditSourceControl::class)->edit($sourceControl, $request->all(), $projectId);
 
         return new SourceControlResource($sourceControl);
     }

--- a/app/Http/Controllers/API/UserStorageProviderController.php
+++ b/app/Http/Controllers/API/UserStorageProviderController.php
@@ -27,7 +27,7 @@ class UserStorageProviderController extends Controller
     {
         $this->authorize('viewAny', StorageProvider::class);
 
-        $storageProviders = user()->storageProviders()->simplePaginate(25);
+        $storageProviders = StorageProvider::getByTokenProjects(user())->simplePaginate(25);
 
         return StorageProviderResource::collection($storageProviders);
     }
@@ -38,7 +38,11 @@ class UserStorageProviderController extends Controller
         $this->authorize('create', StorageProvider::class);
 
         $user = user();
-        $storageProvider = app(CreateStorageProvider::class)->create($user, $request->all());
+        $projectId = $request->boolean('global') ? null : $user->currentProject?->id;
+
+        $this->authorize('assignToProject', [StorageProvider::class, $projectId]);
+
+        $storageProvider = app(CreateStorageProvider::class)->create($user, $request->all(), $projectId);
 
         return new StorageProviderResource($storageProvider);
     }
@@ -66,7 +70,11 @@ class UserStorageProviderController extends Controller
             abort(404, 'Storage provider not found');
         }
 
-        $storageProvider = app(EditStorageProvider::class)->edit($storageProvider, $request->all());
+        $projectId = $request->boolean('global') ? null : user()->currentProject?->id;
+
+        $this->authorize('assignToProject', [StorageProvider::class, $projectId]);
+
+        $storageProvider = app(EditStorageProvider::class)->edit($storageProvider, $request->all(), $projectId);
 
         return new StorageProviderResource($storageProvider);
     }

--- a/app/Http/Controllers/DNSProviderController.php
+++ b/app/Http/Controllers/DNSProviderController.php
@@ -51,7 +51,11 @@ class DNSProviderController extends Controller
     {
         $this->authorize('create', DNSProvider::class);
 
-        app(CreateDNSProvider::class)->create(user(), $request->all());
+        $projectId = $request->boolean('global') ? null : user()->currentProject?->id;
+
+        $this->authorize('assignToProject', [DNSProvider::class, $projectId]);
+
+        app(CreateDNSProvider::class)->create(user(), $request->all(), $projectId);
 
         return back()->with('success', 'DNS provider created.');
     }
@@ -61,7 +65,11 @@ class DNSProviderController extends Controller
     {
         $this->authorize('update', $dnsProvider);
 
-        app(EditDNSProvider::class)->edit($dnsProvider, $request->all());
+        $projectId = $request->boolean('global') ? null : user()->currentProject?->id;
+
+        $this->authorize('assignToProject', [DNSProvider::class, $projectId]);
+
+        app(EditDNSProvider::class)->edit($dnsProvider, $request->all(), $projectId);
 
         return back()->with('success', 'DNS provider updated.');
     }

--- a/app/Http/Controllers/ServerProviderController.php
+++ b/app/Http/Controllers/ServerProviderController.php
@@ -54,7 +54,11 @@ class ServerProviderController extends Controller
     {
         $this->authorize('create', ServerProvider::class);
 
-        app(CreateServerProvider::class)->create(user(), $request->all());
+        $projectId = $request->boolean('global') ? null : user()->currentProject?->id;
+
+        $this->authorize('assignToProject', [ServerProvider::class, $projectId]);
+
+        app(CreateServerProvider::class)->create(user(), $request->all(), $projectId);
 
         return back()->with('success', 'Server provider created.');
     }
@@ -64,7 +68,11 @@ class ServerProviderController extends Controller
     {
         $this->authorize('update', $serverProvider);
 
-        app(EditServerProvider::class)->edit($serverProvider, $request->all());
+        $projectId = $request->boolean('global') ? null : user()->currentProject?->id;
+
+        $this->authorize('assignToProject', [ServerProvider::class, $projectId]);
+
+        app(EditServerProvider::class)->edit($serverProvider, $request->all(), $projectId);
 
         return back()->with('success', 'Server provider updated.');
     }

--- a/app/Http/Controllers/SourceControlController.php
+++ b/app/Http/Controllers/SourceControlController.php
@@ -92,8 +92,11 @@ class SourceControlController extends Controller
         $this->authorize('create', SourceControl::class);
 
         $user = user();
+        $projectId = $request->boolean('global') ? null : $user->currentProject?->id;
 
-        app(ConnectSourceControl::class)->connect($user, $request->all());
+        $this->authorize('assignToProject', [SourceControl::class, $projectId]);
+
+        app(ConnectSourceControl::class)->connect($user, $request->all(), $projectId);
 
         return back()->with('success', 'Source control created.');
     }
@@ -103,10 +106,14 @@ class SourceControlController extends Controller
     {
         $this->authorize('update', $sourceControl);
 
+        $projectId = $request->boolean('global') ? null : user()->currentProject?->id;
+
+        $this->authorize('assignToProject', [SourceControl::class, $projectId]);
+
         if ($sourceControl->isGithubApp()) {
-            app(EditGithubAppSourceControl::class)->edit($sourceControl, $request->all());
+            app(EditGithubAppSourceControl::class)->edit($sourceControl, $request->all(), $projectId);
         } else {
-            app(EditSourceControl::class)->edit($sourceControl, $request->all());
+            app(EditSourceControl::class)->edit($sourceControl, $request->all(), $projectId);
         }
 
         return back()->with('success', 'Source control updated.');

--- a/app/Http/Controllers/StorageProviderController.php
+++ b/app/Http/Controllers/StorageProviderController.php
@@ -60,7 +60,11 @@ class StorageProviderController extends Controller
     {
         $this->authorize('create', StorageProvider::class);
 
-        app(CreateStorageProvider::class)->create(user(), $request->all());
+        $projectId = $request->boolean('global') ? null : user()->currentProject?->id;
+
+        $this->authorize('assignToProject', [StorageProvider::class, $projectId]);
+
+        app(CreateStorageProvider::class)->create(user(), $request->all(), $projectId);
 
         return back()->with('success', 'Storage provider created.');
     }
@@ -96,7 +100,11 @@ class StorageProviderController extends Controller
     {
         $this->authorize('update', $storageProvider);
 
-        app(EditStorageProvider::class)->edit($storageProvider, $request->all());
+        $projectId = $request->boolean('global') ? null : user()->currentProject?->id;
+
+        $this->authorize('assignToProject', [StorageProvider::class, $projectId]);
+
+        app(EditStorageProvider::class)->edit($storageProvider, $request->all(), $projectId);
 
         return back()->with('success', 'Storage provider updated.');
     }

--- a/app/Http/Controllers/StorageProviderController.php
+++ b/app/Http/Controllers/StorageProviderController.php
@@ -74,7 +74,11 @@ class StorageProviderController extends Controller
     {
         $this->authorize('create', StorageProvider::class);
 
-        return Inertia::location($action->redirectUrl($request->all()));
+        $projectId = $request->boolean('global') ? null : user()->currentProject?->id;
+
+        $this->authorize('assignToProject', [StorageProvider::class, $projectId]);
+
+        return Inertia::location($action->redirectUrl($request->all(), $projectId));
     }
 
     #[Get('/dropbox/callback', name: 'storage-providers.dropbox.callback')]

--- a/app/Models/DNSProvider.php
+++ b/app/Models/DNSProvider.php
@@ -23,6 +23,7 @@ class DNSProvider extends AbstractModel
 {
     /** @use HasFactory<DNSProviderFactory> */
     use HasFactory;
+
     use HasProjectScopedQueries;
 
     protected $table = 'dns_providers';

--- a/app/Models/DNSProvider.php
+++ b/app/Models/DNSProvider.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
+use App\Traits\HasProjectScopedQueries;
 use Database\Factories\DNSProviderFactory;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -23,6 +23,7 @@ class DNSProvider extends AbstractModel
 {
     /** @use HasFactory<DNSProviderFactory> */
     use HasFactory;
+    use HasProjectScopedQueries;
 
     protected $table = 'dns_providers';
 
@@ -98,20 +99,5 @@ class DNSProvider extends AbstractModel
     public function project(): BelongsTo
     {
         return $this->belongsTo(Project::class);
-    }
-
-    /**
-     * @return Builder<DNSProvider>
-     */
-    public static function getByProjectId(int $projectId, User $user): Builder
-    {
-        /** @var Builder<DNSProvider> $query */
-        $query = static::query();
-
-        return $query
-            ->where('user_id', $user->id)
-            ->where(function (Builder $query) use ($projectId): void {
-                $query->where('project_id', $projectId)->orWhereNull('project_id');
-            });
     }
 }

--- a/app/Models/PersonalAccessToken.php
+++ b/app/Models/PersonalAccessToken.php
@@ -49,4 +49,24 @@ class PersonalAccessToken extends SanctumPersonalAccessToken
 
         return in_array($project->id, $projectIds);
     }
+
+    /**
+     * Check if the token may reach a resource that belongs to the given project.
+     * A null project id means the resource is global: every project may read it,
+     * but writing it would affect projects outside the token's scope.
+     */
+    public function allowsProjectId(?int $projectId, bool $write = false): bool
+    {
+        $projectIds = $this->getProjectIds();
+
+        if ($projectIds === []) {
+            return true;
+        }
+
+        if ($projectId === null) {
+            return ! $write;
+        }
+
+        return in_array($projectId, $projectIds, true);
+    }
 }

--- a/app/Models/ServerProvider.php
+++ b/app/Models/ServerProvider.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
+use App\Traits\HasProjectScopedQueries;
 use Database\Factories\ServerProviderFactory;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -24,6 +24,7 @@ class ServerProvider extends AbstractModel
 {
     /** @use HasFactory<ServerProviderFactory> */
     use HasFactory;
+    use HasProjectScopedQueries;
 
     protected $fillable = [
         'user_id',
@@ -81,21 +82,6 @@ class ServerProvider extends AbstractModel
     public function project(): BelongsTo
     {
         return $this->belongsTo(Project::class);
-    }
-
-    /**
-     * @return Builder<ServerProvider>
-     */
-    public static function getByProjectId(int $projectId, User $user): Builder
-    {
-        /** @var Builder<ServerProvider> $query */
-        $query = static::query();
-
-        return $query
-            ->where('user_id', $user->id)
-            ->where(function (Builder $query) use ($projectId): void {
-                $query->where('project_id', $projectId)->orWhereNull('project_id');
-            });
     }
 
     /**

--- a/app/Models/ServerProvider.php
+++ b/app/Models/ServerProvider.php
@@ -24,6 +24,7 @@ class ServerProvider extends AbstractModel
 {
     /** @use HasFactory<ServerProviderFactory> */
     use HasFactory;
+
     use HasProjectScopedQueries;
 
     protected $fillable = [

--- a/app/Models/SourceControl.php
+++ b/app/Models/SourceControl.php
@@ -3,8 +3,8 @@
 namespace App\Models;
 
 use App\SourceControlProviders\SourceControlProvider;
+use App\Traits\HasProjectScopedQueries;
 use Database\Factories\SourceControlFactory;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -29,6 +29,7 @@ class SourceControl extends AbstractModel
 
     /** @use HasFactory<SourceControlFactory> */
     use HasFactory;
+    use HasProjectScopedQueries;
 
     use SoftDeletes;
 
@@ -118,20 +119,5 @@ class SourceControl extends AbstractModel
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
-    }
-
-    /**
-     * @return Builder<SourceControl>
-     */
-    public static function getByProjectId(int $projectId, User $user): Builder
-    {
-        /** @var Builder<SourceControl> $query */
-        $query = static::query();
-
-        return $query
-            ->where('user_id', $user->id)
-            ->where(function (Builder $query) use ($projectId): void {
-                $query->where('project_id', $projectId)->orWhereNull('project_id');
-            });
     }
 }

--- a/app/Models/SourceControl.php
+++ b/app/Models/SourceControl.php
@@ -29,8 +29,8 @@ class SourceControl extends AbstractModel
 
     /** @use HasFactory<SourceControlFactory> */
     use HasFactory;
-    use HasProjectScopedQueries;
 
+    use HasProjectScopedQueries;
     use SoftDeletes;
 
     protected $fillable = [

--- a/app/Models/StorageProvider.php
+++ b/app/Models/StorageProvider.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
+use App\Traits\HasProjectScopedQueries;
 use Database\Factories\StorageProviderFactory;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -20,6 +20,7 @@ class StorageProvider extends AbstractModel
 {
     /** @use HasFactory<StorageProviderFactory> */
     use HasFactory;
+    use HasProjectScopedQueries;
 
     protected $fillable = [
         'user_id',
@@ -83,20 +84,5 @@ class StorageProvider extends AbstractModel
     public function project(): BelongsTo
     {
         return $this->belongsTo(Project::class);
-    }
-
-    /**
-     * @return Builder<StorageProvider>
-     */
-    public static function getByProjectId(int $projectId, User $user): Builder
-    {
-        /** @var Builder<StorageProvider> $query */
-        $query = static::query();
-
-        return $query
-            ->where('user_id', $user->id)
-            ->where(function (Builder $query) use ($projectId): void {
-                $query->where('project_id', $projectId)->orWhereNull('project_id');
-            });
     }
 }

--- a/app/Models/StorageProvider.php
+++ b/app/Models/StorageProvider.php
@@ -20,6 +20,7 @@ class StorageProvider extends AbstractModel
 {
     /** @use HasFactory<StorageProviderFactory> */
     use HasFactory;
+
     use HasProjectScopedQueries;
 
     protected $fillable = [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -161,6 +161,37 @@ class User extends Authenticatable
         return $this->HasOne(Project::class, 'id', 'current_project_id');
     }
 
+    /**
+     * Project IDs the request's API token is limited to. An empty array means
+     * the caller is not limited to any subset of projects.
+     *
+     * @return array<int>
+     */
+    public function tokenProjectIds(): array
+    {
+        return $this->currentApiToken()?->getProjectIds() ?? [];
+    }
+
+    /**
+     * Whether the request's API token may reach a resource in the given project.
+     * A null project id means the resource is global.
+     */
+    public function tokenAllowsProject(?int $projectId, bool $write = false): bool
+    {
+        return $this->currentApiToken()?->allowsProjectId($projectId, $write) ?? true;
+    }
+
+    /**
+     * The persisted API token behind the request, if the caller is using one.
+     * Session callers and transient tokens carry no project restrictions.
+     */
+    private function currentApiToken(): ?PersonalAccessToken
+    {
+        $token = $this->currentAccessToken();
+
+        return $token instanceof PersonalAccessToken && $token->exists ? $token : null;
+    }
+
     public function ensureHasDefaultProject(): Project
     {
         /** @var ?Project $project */

--- a/app/Policies/DNSProviderPolicy.php
+++ b/app/Policies/DNSProviderPolicy.php
@@ -5,10 +5,13 @@ namespace App\Policies;
 use App\Models\DNSProvider;
 use App\Models\PersonalAccessToken;
 use App\Models\User;
+use App\Traits\ChecksTokenProjectScope;
 use Laravel\Sanctum\TransientToken;
 
 class DNSProviderPolicy
 {
+    use ChecksTokenProjectScope;
+
     /**
      * Determine whether the user can view any models.
      */
@@ -22,7 +25,8 @@ class DNSProviderPolicy
      */
     public function view(User $user, DNSProvider $dnsProvider): bool
     {
-        return $user->id === $dnsProvider->user_id;
+        return $user->id === $dnsProvider->user_id
+            && $user->tokenAllowsProject($dnsProvider->project_id);
     }
 
     /**
@@ -38,7 +42,8 @@ class DNSProviderPolicy
      */
     public function update(User $user, DNSProvider $dnsProvider): bool
     {
-        return $user->id === $dnsProvider->user_id;
+        return $user->id === $dnsProvider->user_id
+            && $user->tokenAllowsProject($dnsProvider->project_id, write: true);
     }
 
     /**
@@ -62,6 +67,7 @@ class DNSProviderPolicy
      */
     public function delete(User $user, DNSProvider $dnsProvider): bool
     {
-        return $user->id === $dnsProvider->user_id;
+        return $user->id === $dnsProvider->user_id
+            && $user->tokenAllowsProject($dnsProvider->project_id, write: true);
     }
 }

--- a/app/Policies/ServerProviderPolicy.php
+++ b/app/Policies/ServerProviderPolicy.php
@@ -10,7 +10,6 @@ use Illuminate\Auth\Access\HandlesAuthorization;
 class ServerProviderPolicy
 {
     use ChecksTokenProjectScope;
-
     use HandlesAuthorization;
 
     public function viewAny(User $user): bool

--- a/app/Policies/ServerProviderPolicy.php
+++ b/app/Policies/ServerProviderPolicy.php
@@ -4,10 +4,13 @@ namespace App\Policies;
 
 use App\Models\ServerProvider;
 use App\Models\User;
+use App\Traits\ChecksTokenProjectScope;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class ServerProviderPolicy
 {
+    use ChecksTokenProjectScope;
+
     use HandlesAuthorization;
 
     public function viewAny(User $user): bool
@@ -17,7 +20,8 @@ class ServerProviderPolicy
 
     public function view(User $user, ServerProvider $serverProvider): bool
     {
-        return $user->id === $serverProvider->user_id;
+        return $user->id === $serverProvider->user_id
+            && $user->tokenAllowsProject($serverProvider->project_id);
     }
 
     public function create(User $user): bool
@@ -27,11 +31,13 @@ class ServerProviderPolicy
 
     public function update(User $user, ServerProvider $serverProvider): bool
     {
-        return $user->id === $serverProvider->user_id;
+        return $user->id === $serverProvider->user_id
+            && $user->tokenAllowsProject($serverProvider->project_id, write: true);
     }
 
     public function delete(User $user, ServerProvider $serverProvider): bool
     {
-        return $user->id === $serverProvider->user_id;
+        return $user->id === $serverProvider->user_id
+            && $user->tokenAllowsProject($serverProvider->project_id, write: true);
     }
 }

--- a/app/Policies/SourceControlPolicy.php
+++ b/app/Policies/SourceControlPolicy.php
@@ -10,7 +10,6 @@ use Illuminate\Auth\Access\HandlesAuthorization;
 class SourceControlPolicy
 {
     use ChecksTokenProjectScope;
-
     use HandlesAuthorization;
 
     public function viewAny(User $user): bool

--- a/app/Policies/SourceControlPolicy.php
+++ b/app/Policies/SourceControlPolicy.php
@@ -4,10 +4,13 @@ namespace App\Policies;
 
 use App\Models\SourceControl;
 use App\Models\User;
+use App\Traits\ChecksTokenProjectScope;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class SourceControlPolicy
 {
+    use ChecksTokenProjectScope;
+
     use HandlesAuthorization;
 
     public function viewAny(User $user): bool
@@ -17,7 +20,8 @@ class SourceControlPolicy
 
     public function view(User $user, SourceControl $sourceControl): bool
     {
-        return $user->id === $sourceControl->user_id;
+        return $user->id === $sourceControl->user_id
+            && $user->tokenAllowsProject($sourceControl->project_id);
     }
 
     public function create(User $user): bool
@@ -27,7 +31,8 @@ class SourceControlPolicy
 
     public function update(User $user, SourceControl $sourceControl): bool
     {
-        return $user->id === $sourceControl->user_id;
+        return $user->id === $sourceControl->user_id
+            && $user->tokenAllowsProject($sourceControl->project_id, write: true);
     }
 
     public function delete(User $user, SourceControl $sourceControl): bool
@@ -36,6 +41,7 @@ class SourceControlPolicy
             return false;
         }
 
-        return $user->id === $sourceControl->user_id;
+        return $user->id === $sourceControl->user_id
+            && $user->tokenAllowsProject($sourceControl->project_id, write: true);
     }
 }

--- a/app/Policies/StorageProviderPolicy.php
+++ b/app/Policies/StorageProviderPolicy.php
@@ -5,11 +5,14 @@ namespace App\Policies;
 use App\Models\PersonalAccessToken;
 use App\Models\StorageProvider;
 use App\Models\User;
+use App\Traits\ChecksTokenProjectScope;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Laravel\Sanctum\TransientToken;
 
 class StorageProviderPolicy
 {
+    use ChecksTokenProjectScope;
+
     use HandlesAuthorization;
 
     public function viewAny(User $user): bool
@@ -19,7 +22,8 @@ class StorageProviderPolicy
 
     public function view(User $user, StorageProvider $storageProvider): bool
     {
-        return $user->id === $storageProvider->user_id;
+        return $user->id === $storageProvider->user_id
+            && $user->tokenAllowsProject($storageProvider->project_id);
     }
 
     public function create(User $user): bool
@@ -29,7 +33,8 @@ class StorageProviderPolicy
 
     public function update(User $user, StorageProvider $storageProvider): bool
     {
-        return $user->id === $storageProvider->user_id;
+        return $user->id === $storageProvider->user_id
+            && $user->tokenAllowsProject($storageProvider->project_id, write: true);
     }
 
     /**
@@ -50,6 +55,7 @@ class StorageProviderPolicy
 
     public function delete(User $user, StorageProvider $storageProvider): bool
     {
-        return $user->id === $storageProvider->user_id;
+        return $user->id === $storageProvider->user_id
+            && $user->tokenAllowsProject($storageProvider->project_id, write: true);
     }
 }

--- a/app/Policies/StorageProviderPolicy.php
+++ b/app/Policies/StorageProviderPolicy.php
@@ -12,7 +12,6 @@ use Laravel\Sanctum\TransientToken;
 class StorageProviderPolicy
 {
     use ChecksTokenProjectScope;
-
     use HandlesAuthorization;
 
     public function viewAny(User $user): bool

--- a/app/Traits/ChecksTokenProjectScope.php
+++ b/app/Traits/ChecksTokenProjectScope.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\User;
+
+trait ChecksTokenProjectScope
+{
+    /**
+     * Determine whether the user can place the resource in the given project.
+     * A null project id means the resource would become global, which a
+     * project-scoped API token may never write.
+     */
+    public function assignToProject(User $user, ?int $projectId): bool
+    {
+        return $user->tokenAllowsProject($projectId, write: true);
+    }
+}

--- a/app/Traits/HasProjectScopedQueries.php
+++ b/app/Traits/HasProjectScopedQueries.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+
+trait HasProjectScopedQueries
+{
+    /**
+     * The user's records in the given project, plus the global ones that belong
+     * to every project.
+     *
+     * @return Builder<static>
+     */
+    public static function getByProjectId(int $projectId, User $user): Builder
+    {
+        return self::scopedToProjects($user, [$projectId]);
+    }
+
+    /**
+     * The user's records that the request's API token is allowed to reach. A
+     * token without project restrictions reaches all of them.
+     *
+     * @return Builder<static>
+     */
+    public static function getByTokenProjects(User $user): Builder
+    {
+        return self::scopedToProjects($user, $user->tokenProjectIds());
+    }
+
+    /**
+     * @param  array<int>  $projectIds  An empty list applies no project filter.
+     * @return Builder<static>
+     */
+    private static function scopedToProjects(User $user, array $projectIds): Builder
+    {
+        /** @var Builder<static> $query */
+        $query = static::query();
+
+        $query->where('user_id', $user->id);
+
+        if ($projectIds !== []) {
+            $query->where(function (Builder $query) use ($projectIds): void {
+                $query->whereIn('project_id', $projectIds)->orWhereNull('project_id');
+            });
+        }
+
+        return $query;
+    }
+}

--- a/public/api-docs/openapi/base.yaml
+++ b/public/api-docs/openapi/base.yaml
@@ -3,4 +3,9 @@ components:
     bearerAuth:
       type: http
       scheme: bearer
-      description: Laravel Sanctum personal access token. Pass the opaque token in the Authorization header as `Bearer <token>`.
+      description: |
+        Laravel Sanctum personal access token. Pass the opaque token in the Authorization header as `Bearer <token>`.
+
+        A key scoped to specific projects can only reach resources in those projects. Resources that are not tied to a
+        project (marked `global`) stay readable by every key, but a project-scoped key cannot create, update or delete
+        them. Out-of-scope resources are omitted from listings and answered with `403` when addressed directly.

--- a/tests/Feature/API/ApiKeyProviderScopeTest.php
+++ b/tests/Feature/API/ApiKeyProviderScopeTest.php
@@ -1,0 +1,397 @@
+<?php
+
+use App\Enums\UserRole;
+use App\Models\DNSProvider;
+use App\Models\Project;
+use App\Models\ServerProvider;
+use App\Models\SourceControl;
+use App\Models\StorageProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    /** @var Project $outsideProject */
+    $outsideProject = Project::factory()->create();
+    $outsideProject->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
+
+    $this->outsideProject = $outsideProject;
+    $this->scopedProject = $this->user->currentProject;
+});
+
+function scopedToken(string $permission = 'read'): string
+{
+    $abilities = $permission === 'write'
+        ? ['read', 'write', 'project:'.test()->scopedProject->id]
+        : ['read', 'project:'.test()->scopedProject->id];
+
+    return test()->user->createToken('scoped', $abilities)->plainTextToken;
+}
+
+test('scoped token does not list source controls from other projects', function (): void {
+    $inside = SourceControl::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->scopedProject->id,
+        'profile' => 'inside-profile',
+    ]);
+    $outside = SourceControl::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->outsideProject->id,
+        'profile' => 'outside-profile',
+    ]);
+    $global = SourceControl::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => null,
+        'profile' => 'global-profile',
+    ]);
+
+    $this->withToken(scopedToken())
+        ->json('GET', route('api.user.source-controls'))
+        ->assertSuccessful()
+        ->assertJsonFragment(['id' => $inside->id])
+        ->assertJsonFragment(['id' => $global->id])
+        ->assertJsonMissing(['id' => $outside->id]);
+});
+
+test('scoped token does not list storage, server and dns providers from other projects', function (): void {
+    $storage = StorageProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->outsideProject->id,
+    ]);
+    $server = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->outsideProject->id,
+    ]);
+    $dns = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->outsideProject->id,
+    ]);
+
+    $token = scopedToken();
+
+    $this->withToken($token)
+        ->json('GET', route('api.user.storage-providers'))
+        ->assertSuccessful()
+        ->assertJsonMissing(['id' => $storage->id]);
+
+    $this->withToken($token)
+        ->json('GET', route('api.user.server-providers'))
+        ->assertSuccessful()
+        ->assertJsonMissing(['id' => $server->id]);
+
+    $this->withToken($token)
+        ->json('GET', route('api.dns-providers'))
+        ->assertSuccessful()
+        ->assertJsonMissing(['id' => $dns->id]);
+});
+
+test('scoped token cannot show a provider from another project', function (): void {
+    $sourceControl = SourceControl::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->outsideProject->id,
+    ]);
+    $dns = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->outsideProject->id,
+    ]);
+
+    $token = scopedToken();
+
+    $this->withToken($token)
+        ->json('GET', route('api.user.source-controls.show', ['sourceControl' => $sourceControl->id]))
+        ->assertForbidden();
+
+    $this->withToken($token)
+        ->json('GET', route('api.dns-providers.show', ['dnsProvider' => $dns->id]))
+        ->assertForbidden();
+});
+
+test('scoped token cannot delete a provider from another project', function (): void {
+    $sourceControl = SourceControl::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->outsideProject->id,
+    ]);
+    $storage = StorageProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->outsideProject->id,
+    ]);
+    $server = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->outsideProject->id,
+    ]);
+    $dns = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->outsideProject->id,
+    ]);
+
+    $token = scopedToken('write');
+
+    $this->withToken($token)
+        ->json('DELETE', route('api.user.source-controls.delete', ['sourceControl' => $sourceControl->id]))
+        ->assertForbidden();
+
+    $this->withToken($token)
+        ->json('DELETE', route('api.user.storage-providers.delete', ['storageProvider' => $storage->id]))
+        ->assertForbidden();
+
+    $this->withToken($token)
+        ->json('DELETE', route('api.user.server-providers.delete', ['serverProvider' => $server->id]))
+        ->assertForbidden();
+
+    $this->withToken($token)
+        ->json('DELETE', route('api.dns-providers.destroy', ['dnsProvider' => $dns->id]))
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('source_controls', ['id' => $sourceControl->id, 'deleted_at' => null]);
+    $this->assertDatabaseHas('storage_providers', ['id' => $storage->id]);
+    $this->assertDatabaseHas('server_providers', ['id' => $server->id]);
+    $this->assertDatabaseHas('dns_providers', ['id' => $dns->id]);
+});
+
+test('scoped token cannot update a provider from another project', function (): void {
+    $server = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->outsideProject->id,
+        'profile' => 'outside-profile',
+    ]);
+
+    $this->withToken(scopedToken('write'))
+        ->json('PUT', route('api.user.server-providers.update', ['serverProvider' => $server->id]), [
+            'name' => 'renamed',
+        ])
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('server_providers', [
+        'id' => $server->id,
+        'profile' => 'outside-profile',
+    ]);
+});
+
+test('scoped token cannot write to a global provider', function (): void {
+    $server = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => null,
+        'profile' => 'global-profile',
+    ]);
+
+    $token = scopedToken('write');
+
+    $this->withToken($token)
+        ->json('PUT', route('api.user.server-providers.update', ['serverProvider' => $server->id]), [
+            'name' => 'renamed',
+        ])
+        ->assertForbidden();
+
+    $this->withToken($token)
+        ->json('DELETE', route('api.user.server-providers.delete', ['serverProvider' => $server->id]))
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('server_providers', [
+        'id' => $server->id,
+        'profile' => 'global-profile',
+    ]);
+});
+
+test('scoped token can read a global provider', function (): void {
+    $server = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => null,
+    ]);
+
+    $this->withToken(scopedToken())
+        ->json('GET', route('api.user.server-providers.show', ['serverProvider' => $server->id]))
+        ->assertSuccessful()
+        ->assertJsonFragment(['id' => $server->id]);
+});
+
+test('scoped token cannot create a global provider', function (): void {
+    Http::fake();
+
+    $this->withToken(scopedToken('write'))
+        ->json('POST', route('api.user.source-controls.create'), [
+            'name' => 'new-global',
+            'provider' => 'github',
+            'token' => 'token',
+            'global' => true,
+        ])
+        ->assertForbidden();
+
+    $this->assertDatabaseMissing('source_controls', [
+        'profile' => 'new-global',
+    ]);
+});
+
+test('scoped token cannot create a provider outside its projects', function (): void {
+    Http::fake();
+
+    $this->user->update(['current_project_id' => $this->outsideProject->id]);
+
+    $this->withToken(scopedToken('write'))
+        ->json('POST', route('api.user.source-controls.create'), [
+            'name' => 'new-outside',
+            'provider' => 'github',
+            'token' => 'token',
+        ])
+        ->assertForbidden();
+
+    $this->assertDatabaseMissing('source_controls', [
+        'profile' => 'new-outside',
+    ]);
+});
+
+test('scoped token cannot move a provider out of its projects by going global', function (): void {
+    $server = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->scopedProject->id,
+    ]);
+
+    $this->withToken(scopedToken('write'))
+        ->json('PUT', route('api.user.server-providers.update', ['serverProvider' => $server->id]), [
+            'name' => 'renamed',
+            'global' => true,
+        ])
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('server_providers', [
+        'id' => $server->id,
+        'project_id' => $this->scopedProject->id,
+    ]);
+});
+
+test('scoped token cannot move a provider out of its projects by switching current project', function (): void {
+    $server = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->scopedProject->id,
+    ]);
+
+    $this->user->update(['current_project_id' => $this->outsideProject->id]);
+
+    $this->withToken(scopedToken('write'))
+        ->json('PUT', route('api.user.server-providers.update', ['serverProvider' => $server->id]), [
+            'name' => 'renamed',
+        ])
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('server_providers', [
+        'id' => $server->id,
+        'project_id' => $this->scopedProject->id,
+    ]);
+});
+
+test('the deprecated project endpoint creates the provider in the requested project', function (): void {
+    Http::fake();
+
+    $this->user->update(['current_project_id' => $this->outsideProject->id]);
+
+    $this->withToken(scopedToken('write'))
+        ->json('POST', route('api.projects.source-controls.create', ['project' => $this->scopedProject->id]), [
+            'name' => 'requested-project',
+            'provider' => 'github',
+            'token' => 'token',
+        ])
+        ->assertSuccessful();
+
+    $this->assertDatabaseHas('source_controls', [
+        'profile' => 'requested-project',
+        'project_id' => $this->scopedProject->id,
+    ]);
+});
+
+test('a non-boolean global flag cannot smuggle a provider out of scope', function (string $global): void {
+    Http::fake();
+
+    $this->withToken(scopedToken('write'))
+        ->json('POST', route('api.user.source-controls.create'), [
+            'name' => 'sneaky-global',
+            'provider' => 'github',
+            'token' => 'token',
+            'global' => $global,
+        ]);
+
+    $this->assertDatabaseMissing('source_controls', [
+        'profile' => 'sneaky-global',
+        'project_id' => null,
+    ]);
+})->with(['false', 'off', 'no', '0', 'banana']);
+
+test('scoped token can create a provider inside its own project', function (): void {
+    Http::fake();
+
+    $this->withToken(scopedToken('write'))
+        ->json('POST', route('api.user.source-controls.create'), [
+            'name' => 'in-scope',
+            'provider' => 'github',
+            'token' => 'token',
+        ])
+        ->assertSuccessful();
+
+    $this->assertDatabaseHas('source_controls', [
+        'profile' => 'in-scope',
+        'project_id' => $this->scopedProject->id,
+    ]);
+});
+
+test('scoped token can update and delete a provider inside its own project', function (): void {
+    $server = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->scopedProject->id,
+    ]);
+    $dns = DNSProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->scopedProject->id,
+    ]);
+
+    $token = scopedToken('write');
+
+    $this->withToken($token)
+        ->json('PUT', route('api.user.server-providers.update', ['serverProvider' => $server->id]), [
+            'name' => 'renamed',
+        ])
+        ->assertSuccessful();
+
+    $this->assertDatabaseHas('server_providers', [
+        'id' => $server->id,
+        'profile' => 'renamed',
+        'project_id' => $this->scopedProject->id,
+    ]);
+
+    $this->withToken($token)
+        ->json('DELETE', route('api.dns-providers.destroy', ['dnsProvider' => $dns->id]))
+        ->assertSuccessful();
+
+    $this->assertDatabaseMissing('dns_providers', ['id' => $dns->id]);
+});
+
+test('scoped token can read a provider inside its own project', function (): void {
+    $storage = StorageProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->scopedProject->id,
+    ]);
+
+    $this->withToken(scopedToken())
+        ->json('GET', route('api.user.storage-providers.show', ['storageProvider' => $storage->id]))
+        ->assertSuccessful()
+        ->assertJsonFragment(['id' => $storage->id]);
+});
+
+test('an unscoped token keeps full access to every project', function (): void {
+    $outside = SourceControl::factory()->create([
+        'user_id' => $this->user->id,
+        'project_id' => $this->outsideProject->id,
+    ]);
+
+    $token = $this->user->createToken('full', ['read', 'write'])->plainTextToken;
+
+    $this->withToken($token)
+        ->json('GET', route('api.user.source-controls'))
+        ->assertSuccessful()
+        ->assertJsonFragment(['id' => $outside->id]);
+
+    $this->withToken($token)
+        ->json('DELETE', route('api.user.source-controls.delete', ['sourceControl' => $outside->id]))
+        ->assertSuccessful();
+});

--- a/tests/Feature/StorageProvidersTest.php
+++ b/tests/Feature/StorageProvidersTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Facades\FTP;
 use App\Facades\SFTP;
 use App\Models\Backup;
 use App\Models\Database;
+use App\Models\Project;
 use App\Models\StorageProvider as StorageProviderModel;
 use App\Models\User;
 use App\StorageProviders\Dropbox;
@@ -69,6 +71,66 @@ test('dropbox oauth redirect', function () {
     expect(session('dropbox_oauth.state'))->not->toBeEmpty();
 });
 
+test('dropbox oauth redirect resolves the target project before leaving for dropbox', function (mixed $global, bool $expectGlobal) {
+    $this->actingAs($this->user);
+
+    $this->post(route('storage-providers.dropbox.redirect'), [
+        'provider' => Dropbox::id(),
+        'name' => 'dropbox-test',
+        'app_key' => 'my-app-key',
+        'app_secret' => 'my-app-secret',
+        'global' => $global,
+    ])->assertRedirect();
+
+    expect(session('dropbox_oauth.project_id'))
+        ->toBe($expectGlobal ? null : $this->user->current_project_id);
+})->with([
+    'string false stays project scoped' => ['false', false],
+    'string off stays project scoped' => ['off', false],
+    'zero stays project scoped' => ['0', false],
+    'true goes global' => [true, true],
+    'string one goes global' => ['1', true],
+]);
+
+test('dropbox callback keeps the project chosen at redirect time', function () {
+    $this->actingAs($this->user);
+
+    Http::fake([
+        '*oauth2/token' => Http::response([
+            'access_token' => 'fresh-access',
+            'expires_in' => 14400,
+            'refresh_token' => 'the-refresh-token',
+        ]),
+        '*' => Http::response([], 200),
+    ]);
+
+    $chosenProject = $this->user->current_project_id;
+
+    /** @var Project $otherProject */
+    $otherProject = Project::factory()->create();
+    $otherProject->users()->create([
+        'user_id' => $this->user->id,
+        'role' => UserRole::ADMIN,
+    ]);
+    $this->user->update(['current_project_id' => $otherProject->id]);
+
+    $this->withSession([
+        'dropbox_oauth' => [
+            'state' => 'state-123',
+            'name' => 'dropbox-switched',
+            'app_key' => 'my-app-key',
+            'app_secret' => 'my-app-secret',
+            'project_id' => $chosenProject,
+        ],
+    ])->get(route('storage-providers.dropbox.callback', ['code' => 'auth-code', 'state' => 'state-123']))
+        ->assertRedirect(route('storage-providers'));
+
+    $this->assertDatabaseHas('storage_providers', [
+        'profile' => 'dropbox-switched',
+        'project_id' => $chosenProject,
+    ]);
+});
+
 test('dropbox callback creates provider', function () {
     $this->actingAs($this->user);
 
@@ -87,7 +149,7 @@ test('dropbox callback creates provider', function () {
             'name' => 'dropbox-test',
             'app_key' => 'my-app-key',
             'app_secret' => 'my-app-secret',
-            'global' => false,
+            'project_id' => $this->user->current_project_id,
         ],
     ])->get(route('storage-providers.dropbox.callback', ['code' => 'auth-code', 'state' => 'state-123']));
 
@@ -98,6 +160,7 @@ test('dropbox callback creates provider', function () {
         'provider' => Dropbox::id(),
         'profile' => 'dropbox-test',
         'user_id' => $this->user->id,
+        'project_id' => $this->user->current_project_id,
     ]);
 
     $provider = StorageProviderModel::query()->where('profile', 'dropbox-test')->firstOrFail();


### PR DESCRIPTION
Fixes #1231.

## Problem

API keys can carry `project:<id>` abilities, and the UI promises "Leave empty for access to all projects" — so selecting projects is meant to restrict the key. That was only enforced by `CanSeeProjectMiddleware` on `/api/projects/{project}/...` routes. The user-level provider endpoints enforced nothing:

- `GET|POST /api/source-controls`, `GET|PUT|DELETE /api/source-controls/{id}`
- `GET|POST /api/storage-providers`, `GET|PUT|DELETE /api/storage-providers/{id}`
- `GET|POST /api/server-providers`, `GET|PUT|DELETE /api/server-providers/{id}`
- `GET|POST /api/dns-providers`, `GET|PUT|DELETE /api/dns-providers/{id}`

They filter on `user_id` alone, and the four provider policies only checked `$user->id === $model->user_id`, so the token's project abilities were never consulted. A key scoped to project A could list, read, update and delete provider records — including stored credentials — belonging to project B.

## The boundary this establishes

| Caller | Read in-scope | Read global | Write in-scope | Write global |
|---|---|---|---|---|
| Session / web | ✅ | ✅ | ✅ | ✅ |
| Key with no `project:` abilities | ✅ | ✅ | ✅ | ✅ |
| Project-scoped key | ✅ | ✅ | ✅ | ❌ |
| Project-scoped key, other project | ❌ | — | ❌ | — |

Global providers (`project_id IS NULL`) stay **readable** by a scoped key — it needs them to build in its own project — but not **writable**, since mutating one affects every other project. Out-of-scope records are omitted from listings and answered `403` when addressed directly.

## Additional vectors found beyond the report

The original report and PR #1232 covered listing/read/delete. Three further holes would have left the fix bypassable:

1. **`global: true` on update** — a scoped key could flip its own project's provider to global, escaping scope in one write.
2. **Switching `current_project_id`** — the Edit actions reassigned `project_id` from the user's *current* project, so a scoped key could move a provider into an unscoped project.
3. **`global: "false"`** — controllers guarded with `$request->boolean('global')` while the Actions used PHP truthiness, where the string `"false"` is truthy. Guard and write disagreed.

## ⚠️ Behaviour change

Project-scoped API keys can no longer update or delete global providers, nor create them. That is the intended boundary, but it will break integrations relying on today's permissiveness — worth a release note.

## Credit

Reported and originally fixed by @9Insomnie in #1231 / #1232. That PR's head repo was deleted, so the work was rebuilt here; they are credited as commit co-author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added project-scoped API access for DNS, server, source-control and storage providers.
  - Scoped API keys can view permitted project resources and read global resources.
  - Provider listings now reflect API-key project access.
  - Global and cross-project changes require appropriate permissions.
  - Dropbox connections retain the project selected during authorisation.

- **Bug Fixes**
  - Prevented scope bypasses through project switching, legacy endpoints and invalid global values.

- **Documentation**
  - Updated API authentication guidance for project scoping and forbidden responses.

- **Tests**
  - Added comprehensive coverage for permitted and restricted operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->