### PR TITLE
[Fix] Backups: one failing backup no longer aborts the whole scheduled run

### DIFF
--- a/app/Console/Commands/RunBackupCommand.php
+++ b/app/Console/Commands/RunBackupCommand.php
@@ -6,6 +6,8 @@ use App\Actions\Backup\RunBackup;
 use App\Models\Backup;
 use Cron\CronExpression;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class RunBackupCommand extends Command
 {
@@ -16,13 +18,14 @@ class RunBackupCommand extends Command
     public function handle(): void
     {
         $total = 0;
+        $failed = 0;
 
         Backup::query()
             ->where('enabled', true)
             ->whereNull('status')
             ->whereHas('server')
             ->with('server')
-            ->chunkById(100, function ($backups) use (&$total): void {
+            ->chunkById(100, function ($backups) use (&$total, &$failed): void {
                 /** @var Backup $backup */
                 foreach ($backups as $backup) {
                     if (! CronExpression::isValidExpression((string) $backup->interval)) {
@@ -30,12 +33,21 @@ class RunBackupCommand extends Command
                     }
 
                     if ((new CronExpression((string) $backup->interval))->isDue(now(), config('app.timezone'))) {
-                        app(RunBackup::class)->run($backup);
-                        $total++;
+                        try {
+                            app(RunBackup::class)->run($backup);
+                            $total++;
+                        } catch (Throwable $e) {
+                            Log::warning('Failed to run backup', [
+                                'backup_id' => $backup->id,
+                                'server_id' => $backup->server_id,
+                                'error' => $e->getMessage(),
+                            ]);
+                            $failed++;
+                        }
                     }
                 }
             });
 
-        $this->info("{$total} backups started");
+        $this->info("{$total} backups started, {$failed} failed");
     }
 }

--- a/database/migrations/2026_08_17_114119_delete_orphaned_backups_and_add_foreign_keys.php
+++ b/database/migrations/2026_08_17_114119_delete_orphaned_backups_and_add_foreign_keys.php
@@ -14,26 +14,26 @@ return new class extends Migration
      */
     public function up(): void
     {
-        DB::table('backups')
-            ->whereNotExists(fn (Builder $query) => $query
-                ->select(DB::raw(1))
-                ->from('servers')
-                ->whereColumn('servers.id', 'backups.server_id'))
-            ->delete();
+        DB::transaction(function (): void {
+            DB::table('backups')
+                ->whereNotExists(fn (Builder $query) => $query
+                    ->select(DB::raw(1))
+                    ->from('servers')
+                    ->whereColumn('servers.id', 'backups.server_id'))
+                ->delete();
 
-        DB::table('backup_files')
-            ->whereNotExists(fn (Builder $query) => $query
-                ->select(DB::raw(1))
-                ->from('backups')
-                ->whereColumn('backups.id', 'backup_files.backup_id'))
-            ->delete();
+            DB::table('backup_files')
+                ->whereNotExists(fn (Builder $query) => $query
+                    ->select(DB::raw(1))
+                    ->from('backups')
+                    ->whereColumn('backups.id', 'backup_files.backup_id'))
+                ->delete();
+        });
 
         Schema::table('backups', function (Blueprint $table): void {
             $table->foreign('server_id')->references('id')->on('servers')->cascadeOnDelete();
         });
 
-        // Widened before the foreign key is added: MySQL cannot MODIFY a column that is
-        // already a foreign-key child, and a 32-bit column cannot reference a bigint parent.
         Schema::table('backup_files', function (Blueprint $table): void {
             $table->unsignedBigInteger('backup_id')->change();
         });

--- a/database/migrations/2026_08_17_114119_delete_orphaned_backups_and_add_foreign_keys.php
+++ b/database/migrations/2026_08_17_114119_delete_orphaned_backups_and_add_foreign_keys.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Orphaned rows are deleted before the foreign keys are added, because a foreign key
+     * cannot be created on a table that already violates it.
+     */
+    public function up(): void
+    {
+        DB::table('backups')
+            ->whereNotExists(fn (Builder $query) => $query
+                ->select(DB::raw(1))
+                ->from('servers')
+                ->whereColumn('servers.id', 'backups.server_id'))
+            ->delete();
+
+        DB::table('backup_files')
+            ->whereNotExists(fn (Builder $query) => $query
+                ->select(DB::raw(1))
+                ->from('backups')
+                ->whereColumn('backups.id', 'backup_files.backup_id'))
+            ->delete();
+
+        Schema::table('backups', function (Blueprint $table): void {
+            $table->foreign('server_id')->references('id')->on('servers')->cascadeOnDelete();
+        });
+
+        // Widened before the foreign key is added: MySQL cannot MODIFY a column that is
+        // already a foreign-key child, and a 32-bit column cannot reference a bigint parent.
+        Schema::table('backup_files', function (Blueprint $table): void {
+            $table->unsignedBigInteger('backup_id')->change();
+        });
+
+        Schema::table('backup_files', function (Blueprint $table): void {
+            $table->foreign('backup_id')->references('id')->on('backups')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * The schema is fully reverted, but rows deleted by up() cannot be restored.
+     */
+    public function down(): void
+    {
+        Schema::table('backup_files', function (Blueprint $table): void {
+            $table->dropForeign(['backup_id']);
+        });
+
+        Schema::table('backups', function (Blueprint $table): void {
+            $table->dropForeign(['server_id']);
+        });
+
+        Schema::table('backup_files', function (Blueprint $table): void {
+            $table->unsignedInteger('backup_id')->change();
+        });
+    }
+};

--- a/tests/Feature/BackupTest.php
+++ b/tests/Feature/BackupTest.php
@@ -21,6 +21,7 @@ use App\Models\StorageProvider;
 use App\StorageProviders\Local;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Testing\TestResponse;
 use Illuminate\Validation\ValidationException;
@@ -554,6 +555,7 @@ test('cannot enable a backup being deleted', function () {
 });
 
 test('delete orphaned backup file hard deletes without dispatching job', function () {
+    DB::statement('PRAGMA defer_foreign_keys = ON');
     Bus::fake();
 
     $backup = Backup::factory()->create([
@@ -571,6 +573,29 @@ test('delete orphaned backup file hard deletes without dispatching job', functio
 
     $this->assertDatabaseMissing('backup_files', ['id' => $file->id]);
     Bus::assertNotDispatched(DeleteFileJob::class);
+});
+
+test('deleting a server row cascades to its backups and backup files', function () {
+    $server = Server::factory()->create([
+        'project_id' => $this->user->currentProject->id,
+        'user_id' => $this->user->id,
+    ]);
+    $backup = Backup::factory()->create([
+        'type' => BackupType::FILE,
+        'server_id' => $server->id,
+        'storage_id' => $this->storageProvider->id,
+        'path' => '/home/vito/y.com',
+        'status' => null,
+    ]);
+    $file = BackupFile::factory()->create([
+        'backup_id' => $backup->id,
+        'status' => BackupFileStatus::CREATED,
+    ]);
+
+    DB::table('servers')->where('id', $server->id)->delete();
+
+    $this->assertDatabaseMissing('backups', ['id' => $backup->id]);
+    $this->assertDatabaseMissing('backup_files', ['id' => $file->id]);
 });
 
 test('see global backups list scoped to current project', function () {

--- a/tests/Unit/Commands/RunBackupCommandTest.php
+++ b/tests/Unit/Commands/RunBackupCommandTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\Backup\RunBackup;
 use App\Enums\BackupFileStatus;
 use App\Enums\BackupStatus;
 use App\Facades\SSH;
@@ -10,7 +11,9 @@ use App\Models\StorageProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 uses(RefreshDatabase::class);
 
@@ -43,7 +46,7 @@ function vitoPestUnitCommandsRunBackupCommandTestCreateBackup(array $attributes)
 
 test('run without any backups', function () {
     $this->artisan('backups:run')
-        ->expectsOutput('0 backups started');
+        ->expectsOutput('0 backups started, 0 failed');
 });
 
 test('runs backups that are due', function () {
@@ -54,7 +57,7 @@ test('runs backups that are due', function () {
     vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '0 * * * *']);
 
     $this->artisan('backups:run')
-        ->expectsOutput('1 backups started');
+        ->expectsOutput('1 backups started, 0 failed');
 });
 
 test('does not run backups that are not due', function () {
@@ -64,7 +67,7 @@ test('does not run backups that are not due', function () {
     vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '30 * * * *']);
 
     $this->artisan('backups:run')
-        ->expectsOutput('0 backups started');
+        ->expectsOutput('0 backups started, 0 failed');
 });
 
 test('runs custom interval backups when due', function () {
@@ -75,7 +78,7 @@ test('runs custom interval backups when due', function () {
     vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '5 10 * * *']);
 
     $this->artisan('backups:run')
-        ->expectsOutput('1 backups started');
+        ->expectsOutput('1 backups started, 0 failed');
 });
 
 test('does not run disabled backups', function () {
@@ -85,7 +88,7 @@ test('does not run disabled backups', function () {
     vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '* * * * *', 'enabled' => false]);
 
     $this->artisan('backups:run')
-        ->expectsOutput('0 backups started');
+        ->expectsOutput('0 backups started, 0 failed');
 });
 
 test('does not run backups being deleted', function () {
@@ -95,7 +98,7 @@ test('does not run backups being deleted', function () {
     vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '* * * * *', 'status' => BackupStatus::DELETING]);
 
     $this->artisan('backups:run')
-        ->expectsOutput('0 backups started');
+        ->expectsOutput('0 backups started, 0 failed');
 });
 
 test('runs enabled backup even after a failed run', function () {
@@ -111,10 +114,47 @@ test('runs enabled backup even after a failed run', function () {
     ]);
 
     $this->artisan('backups:run')
-        ->expectsOutput('1 backups started');
+        ->expectsOutput('1 backups started, 0 failed');
+});
+
+test('continues to the next backup when one fails', function () {
+    SSH::fake();
+    Log::spy();
+    Carbon::setTestNow('2026-06-19 10:00:00');
+
+    $first = vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '0 * * * *']);
+    vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '0 * * * *']);
+
+    $calls = 0;
+    $this->mock(RunBackup::class, function ($mock) use (&$calls): void {
+        $mock->shouldReceive('run')
+            ->twice()
+            ->andReturnUsing(function (Backup $backup) use (&$calls): BackupFile {
+                $calls++;
+
+                if ($calls === 1) {
+                    throw new RuntimeException('boom');
+                }
+
+                return BackupFile::factory()->create([
+                    'backup_id' => $backup->id,
+                    'status' => BackupFileStatus::CREATED,
+                ]);
+            });
+    });
+
+    $this->artisan('backups:run')
+        ->expectsOutput('1 backups started, 1 failed');
+
+    Log::shouldHaveReceived('warning')->withArgs(
+        fn (string $message, array $context): bool => $context['backup_id'] === $first->id
+            && $context['server_id'] === $this->server->id
+            && $context['error'] === 'boom'
+    );
 });
 
 test('does not run backups whose server is missing', function () {
+    DB::statement('PRAGMA defer_foreign_keys = ON');
     SSH::fake();
     Bus::fake();
     Carbon::setTestNow('2026-06-19 10:00:00');
@@ -122,7 +162,7 @@ test('does not run backups whose server is missing', function () {
     $backup = vitoPestUnitCommandsRunBackupCommandTestCreateBackup(['interval' => '0 * * * *', 'server_id' => 999999]);
 
     $this->artisan('backups:run')
-        ->expectsOutput('0 backups started');
+        ->expectsOutput('0 backups started, 0 failed');
 
     $this->assertDatabaseHas('backups', ['id' => $backup->id, 'server_id' => 999999]);
     Bus::assertNothingDispatched();


### PR DESCRIPTION
Guards each backup inside `backups:run` so a single failure is logged and skipped rather than killing the command and silently skipping every later due backup, and adds a migration that clears pre-existing orphaned rows and constrains `backups.server_id` and `backup_files.backup_id` with cascading foreign keys so the condition cannot recur.

## The delete in the migration

The migration removes `backups` rows whose `server_id` matches no row in `servers`, then `backup_files` rows whose `backup_id` matches no row in `backups`. These are leftovers from before #1198, when deleting a server did not delete its backups and no foreign key existed to stop it — exactly the rows that produced `Attempt to read property "project_id" on null` and killed the nightly `backups:run`. The delete is not optional housekeeping: a foreign key cannot be added to a table that already violates it, so without it the migration fails outright on MySQL (`ERROR 1452`) and Postgres, breaking the upgrade. The second statement sweeps *all* dangling `backup_files`, not only those under the orphaned backups, because any dangling row blocks the `backup_files` foreign key regardless of how it got there.

It is safe for four reasons. It uses the query builder (`DB::table(...)->delete()`) rather than Eloquent, so no model events fire and `Backup::deleting` — which walks and deletes files — never runs; this was verified empirically by running `up()` under a wildcard event listener with `Bus::fake()` and `Queue::fake()`, giving zero Eloquent events, zero dispatched jobs and zero queue pushes. It is targeted rather than a truncate: both statements use `whereNotExists`, and a legitimate server → backup → backup_file chain was confirmed to survive intact. The rows it removes are unusable by definition — their server no longer exists, the schedule can never run again, and Vito has no route to the archives they reference. And it touches database rows only; the remote archives on S3/Dropbox/FTP/local are left untouched, which is both intended and enforced, since `tests/Arch/MigrationsTest.php` forbids `SSH::`, `Http::`, `dispatch(` and `App\Jobs` inside migrations.

Note that this half is not reversible: `down()` drops both foreign keys and restores the original column type, but deleted rows cannot be recovered from within the migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backup runs now report both started and failed backup totals.
  * Processing continues when an individual backup fails, with warning details recorded.

* **Bug Fixes**
  * Removed orphaned backups and backup files.
  * Deleting a server now also removes its associated backups and backup files automatically.
  * Improved handling of missing servers during backup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->