### PR TITLE
[Fix] re-sync deploy key when updating site source control

### DIFF
--- a/app/Actions/Site/UpdateSourceControl.php
+++ b/app/Actions/Site/UpdateSourceControl.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Site;
 
+use App\Exceptions\FailedToDeployGitKey;
 use App\Exceptions\RepositoryNotFound;
 use App\Exceptions\RepositoryPermissionDenied;
 use App\Exceptions\SourceControlIsNotConnected;
@@ -21,7 +22,7 @@ class UpdateSourceControl
      * @param  array<string, mixed>  $input
      *
      * @throws ValidationException
-     * @throws SSHError
+     * @throws Throwable
      */
     public function update(Site $site, array $input): void
     {
@@ -61,25 +62,43 @@ class UpdateSourceControl
         $oldSourceControl = $site->sourceControl;
         $oldDeployKeyId = $site->type_data['deploy_key_id'] ?? null;
         $oldGitHook = $site->gitHook;
+        $newRepoUrl = $newSourceControl->provider()->fullRepoUrl(
+            $site->repository,
+            $site->getSshKeyName()
+        );
+        $reuseOldDeployKey = $oldDeployKeyId !== null
+            && $oldSourceControl
+            && $oldSourceControl->provider()->fullRepoUrl(
+                $site->repository,
+                $site->getSshKeyName()
+            ) === $newRepoUrl;
 
-        DB::transaction(function () use ($site, $newSourceControl, $oldDeployKeyId): void {
-            $site->source_control_id = $newSourceControl->id;
-            $site->setRelation('sourceControl', $newSourceControl);
-            if ($oldDeployKeyId) {
-                $site->jsonUpdate('type_data', 'deploy_key_id', null, save: false);
-            }
-            $site->save();
-        });
+        if ($oldDeployKeyId !== null && ! $oldSourceControl) {
+            Log::warning('Skipped old deploy key removal because its source control is unavailable', [
+                'site_id' => $site->id,
+                'deploy_key_id' => (string) $oldDeployKeyId,
+            ]);
+        }
 
-        if ($oldDeployKeyId && $oldSourceControl) {
-            try {
-                $oldSourceControl->provider()->deleteDeployKey((string) $oldDeployKeyId, $site->repository);
-            } catch (Throwable $e) {
-                Log::warning('Failed to delete old deploy key on source-control swap', [
-                    'site_id' => $site->id,
-                    'error' => $e->getMessage(),
-                ]);
+        $newDeployKeyId = $reuseOldDeployKey
+            ? (string) $oldDeployKeyId
+            : $this->registerDeployKey($site, $newSourceControl);
+
+        try {
+            DB::transaction(function () use ($site, $newSourceControl, $oldDeployKeyId, $newDeployKeyId): void {
+                $site->source_control_id = $newSourceControl->id;
+                $site->setRelation('sourceControl', $newSourceControl);
+                if ($oldDeployKeyId !== null || $newDeployKeyId !== null) {
+                    $site->jsonUpdate('type_data', 'deploy_key_id', $newDeployKeyId, save: false);
+                }
+                $site->save();
+            });
+        } catch (Throwable $e) {
+            if (! $reuseOldDeployKey) {
+                $this->removeRegisteredDeployKey($site, $newSourceControl, $newDeployKeyId);
             }
+
+            throw $e;
         }
 
         if ($oldGitHook) {
@@ -93,33 +112,76 @@ class UpdateSourceControl
             }
         }
 
-        if ($site->ssh_key && $site->repository && ! $newSourceControl->isGithubApp()) {
-            try {
-                $keyId = $newSourceControl->provider()->deployKey(
-                    $site->getDeployKeyName(),
-                    $site->repository,
-                    $site->ssh_key,
-                );
-                $site->jsonUpdate('type_data', 'deploy_key_id', $keyId);
-            } catch (Throwable $e) {
-                Log::warning('Failed to re-deploy SSH key after source control update', [
-                    'site_id' => $site->id,
-                    'error' => $e->getMessage(),
-                ]);
-            }
-        }
-
-        $newRepoUrl = $newSourceControl->provider()->fullRepoUrl(
-            $site->repository,
-            $site->getSshKeyName()
-        );
-
+        $remoteUpdated = true;
         try {
             app(Git::class)->setRemote($site, $newRepoUrl);
         } catch (SSHError $e) {
+            $remoteUpdated = false;
             Log::warning('Failed to rewrite remote URL after source-control swap', [
                 'site_id' => $site->id,
                 'error' => $e->getMessage(),
+            ]);
+        }
+
+        if ($remoteUpdated && ! $reuseOldDeployKey && $oldDeployKeyId !== null && $oldSourceControl) {
+            $this->removeOldDeployKey($site, $oldSourceControl, (string) $oldDeployKeyId);
+        }
+    }
+
+    private function registerDeployKey(Site $site, SourceControl $sourceControl): ?string
+    {
+        if (! $site->ssh_key || ! $site->repository || $sourceControl->isGithubApp()) {
+            return null;
+        }
+
+        try {
+            $keyId = $sourceControl->provider()->deployKey(
+                $site->getDeployKeyName(),
+                $site->repository,
+                $site->ssh_key,
+            );
+        } catch (Throwable $e) {
+            Log::warning('Failed to re-deploy SSH key after source control update', [
+                'site_id' => $site->id,
+                'exception' => $e::class,
+            ]);
+
+            throw new FailedToDeployGitKey('Source control provider failed to deploy the key.');
+        }
+
+        if ($keyId === '') {
+            throw new FailedToDeployGitKey('Source control provider did not return a deploy key ID.');
+        }
+
+        return $keyId;
+    }
+
+    private function removeOldDeployKey(Site $site, SourceControl $sourceControl, string $keyId): void
+    {
+        try {
+            $sourceControl->provider()->deleteDeployKey($keyId, $site->repository);
+        } catch (Throwable $e) {
+            Log::warning('Failed to remove old deploy key during source control update', [
+                'site_id' => $site->id,
+                'deploy_key_id' => $keyId,
+                'exception' => $e::class,
+            ]);
+        }
+    }
+
+    private function removeRegisteredDeployKey(Site $site, SourceControl $sourceControl, ?string $keyId): void
+    {
+        if ($keyId === null) {
+            return;
+        }
+
+        try {
+            $sourceControl->provider()->deleteDeployKey($keyId, $site->repository);
+        } catch (Throwable $e) {
+            Log::warning('Failed to remove new deploy key after source control update failed', [
+                'site_id' => $site->id,
+                'deploy_key_id' => $keyId,
+                'exception' => $e::class,
             ]);
         }
     }

--- a/app/Actions/Site/UpdateSourceControl.php
+++ b/app/Actions/Site/UpdateSourceControl.php
@@ -93,6 +93,22 @@ class UpdateSourceControl
             }
         }
 
+        if ($site->ssh_key && $site->repository && ! $newSourceControl->isGithubApp()) {
+            try {
+                $keyId = $newSourceControl->provider()->deployKey(
+                    $site->getDeployKeyName(),
+                    $site->repository,
+                    $site->ssh_key,
+                );
+                $site->jsonUpdate('type_data', 'deploy_key_id', $keyId);
+            } catch (Throwable $e) {
+                Log::warning('Failed to re-deploy SSH key after source control update', [
+                    'site_id' => $site->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
         $newRepoUrl = $newSourceControl->provider()->fullRepoUrl(
             $site->repository,
             $site->getSshKeyName()

--- a/app/Exceptions/FailedToDeleteDeployKey.php
+++ b/app/Exceptions/FailedToDeleteDeployKey.php
@@ -4,6 +4,4 @@ namespace App\Exceptions;
 
 use Exception;
 
-class FailedToDeleteDeployKey extends Exception
-{
-}
+class FailedToDeleteDeployKey extends Exception {}

--- a/app/Exceptions/FailedToDeleteDeployKey.php
+++ b/app/Exceptions/FailedToDeleteDeployKey.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class FailedToDeleteDeployKey extends Exception
+{
+}

--- a/app/SourceControlProviders/Bitbucket.php
+++ b/app/SourceControlProviders/Bitbucket.php
@@ -2,12 +2,12 @@
 
 namespace App\SourceControlProviders;
 
+use App\Exceptions\FailedToDeleteDeployKey;
 use App\Exceptions\FailedToDeployGitHook;
 use App\Exceptions\FailedToDeployGitKey;
 use App\Exceptions\FailedToDestroyGitHook;
 use Exception;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Throwable;
 
@@ -163,12 +163,12 @@ class Bitbucket extends AbstractSourceControlProvider
             );
 
             if ($res->status() != 200) {
-                throw new FailedToDeployGitKey($res->json()['error']['message']);
+                throw new FailedToDeployGitKey('Bitbucket rejected the deploy key.');
             }
 
             return $res->json()['id'] ?? '';
-        } catch (Exception $e) {
-            throw new FailedToDeployGitKey($e->getMessage());
+        } catch (Exception) {
+            throw new FailedToDeployGitKey('Failed to deploy Bitbucket key.');
         }
     }
 
@@ -177,21 +177,12 @@ class Bitbucket extends AbstractSourceControlProvider
         try {
             $response = Http::withHeaders($this->getAuthenticationHeaders())
                 ->delete($this->apiUrl."/repositories/$repo/deploy-keys/$keyId");
+        } catch (Throwable) {
+            throw new FailedToDeleteDeployKey('Failed to delete Bitbucket deploy key.');
+        }
 
-            if (! $response->successful()) {
-                Log::warning('Failed to delete Bitbucket deploy key', [
-                    'repo' => $repo,
-                    'key_id' => $keyId,
-                    'response' => $response->body(),
-                ]);
-            }
-
-        } catch (Throwable $e) {
-            Log::error('Error deleting Bitbucket deploy key', [
-                'repo' => $repo,
-                'key_id' => $keyId,
-                'error' => $e->getMessage(),
-            ]);
+        if (! $response->successful() && $response->status() !== 404) {
+            throw new FailedToDeleteDeployKey('Failed to delete Bitbucket deploy key.');
         }
     }
 

--- a/app/SourceControlProviders/BitbucketV2.php
+++ b/app/SourceControlProviders/BitbucketV2.php
@@ -2,6 +2,7 @@
 
 namespace App\SourceControlProviders;
 
+use App\Exceptions\FailedToDeleteDeployKey;
 use App\Exceptions\FailedToDeployGitHook;
 use App\Exceptions\FailedToDeployGitKey;
 use App\Exceptions\FailedToDestroyGitHook;
@@ -258,14 +259,12 @@ class BitbucketV2 extends AbstractSourceControlProvider
             );
 
             if ($res->status() !== 200) {
-                $errorBody = $res->json();
-                $errorMessage = $errorBody['error']['message'] ?? $errorBody['error_description'] ?? $errorBody['error'] ?? $errorBody['message'] ?? $res->body();
-                throw new FailedToDeployGitKey($errorMessage);
+                throw new FailedToDeployGitKey('Bitbucket rejected the deploy key.');
             }
 
             return $res->json()['id'] ?? '';
-        } catch (Exception $e) {
-            throw new FailedToDeployGitKey($e->getMessage());
+        } catch (Exception) {
+            throw new FailedToDeployGitKey('Failed to deploy Bitbucket key.');
         }
     }
 
@@ -274,21 +273,12 @@ class BitbucketV2 extends AbstractSourceControlProvider
         try {
             $response = Http::withHeaders($this->getAuthenticationHeaders())
                 ->delete($this->apiUrl."/repositories/$repo/deploy-keys/$keyId");
+        } catch (Throwable) {
+            throw new FailedToDeleteDeployKey('Failed to delete Bitbucket deploy key.');
+        }
 
-            if (! $response->successful()) {
-                Log::warning('Failed to delete Bitbucket deploy key', [
-                    'repo' => $repo,
-                    'key_id' => $keyId,
-                    'response' => $response->body(),
-                ]);
-            }
-
-        } catch (Exception $e) {
-            Log::error('Error deleting Bitbucket deploy key', [
-                'repo' => $repo,
-                'key_id' => $keyId,
-                'error' => $e->getMessage(),
-            ]);
+        if (! $response->successful() && $response->status() !== 404) {
+            throw new FailedToDeleteDeployKey('Failed to delete Bitbucket deploy key.');
         }
     }
 

--- a/app/SourceControlProviders/Gitea.php
+++ b/app/SourceControlProviders/Gitea.php
@@ -2,6 +2,7 @@
 
 namespace App\SourceControlProviders;
 
+use App\Exceptions\FailedToDeleteDeployKey;
 use App\Exceptions\FailedToDeployGitHook;
 use App\Exceptions\FailedToDeployGitKey;
 use App\Exceptions\FailedToDestroyGitHook;
@@ -218,12 +219,12 @@ class Gitea extends AbstractSourceControlProvider
             );
 
             if ($response->status() != 201) {
-                throw new FailedToDeployGitKey($response->body());
+                throw new FailedToDeployGitKey('Gitea rejected the deploy key.');
             }
 
             return $response->json()['id'] ?? '';
-        } catch (Exception $e) {
-            throw new FailedToDeployGitKey($e->getMessage());
+        } catch (Exception) {
+            throw new FailedToDeployGitKey('Failed to deploy Gitea key.');
         }
     }
 
@@ -233,21 +234,12 @@ class Gitea extends AbstractSourceControlProvider
             $response = Http::withToken($this->data()['token'])->delete(
                 $this->getApiUrl().'/repos/'.$repo.'/keys/'.$keyId
             );
+        } catch (Throwable) {
+            throw new FailedToDeleteDeployKey('Failed to delete Gitea deploy key.');
+        }
 
-            if (! $response->successful()) {
-                Log::warning('Failed to delete Gitea deploy key', [
-                    'repo' => $repo,
-                    'key_id' => $keyId,
-                    'response' => $response->body(),
-                ]);
-            }
-
-        } catch (Throwable $e) {
-            Log::error('Error deleting Gitea deploy key', [
-                'repo' => $repo,
-                'key_id' => $keyId,
-                'error' => $e->getMessage(),
-            ]);
+        if (! $response->successful() && $response->status() !== 404) {
+            throw new FailedToDeleteDeployKey('Failed to delete Gitea deploy key.');
         }
     }
 

--- a/app/SourceControlProviders/Github.php
+++ b/app/SourceControlProviders/Github.php
@@ -2,6 +2,7 @@
 
 namespace App\SourceControlProviders;
 
+use App\Exceptions\FailedToDeleteDeployKey;
 use App\Exceptions\FailedToDeployGitHook;
 use App\Exceptions\FailedToDeployGitKey;
 use App\Exceptions\FailedToDestroyGitHook;
@@ -198,7 +199,7 @@ class Github extends AbstractSourceControlProvider
                 ]);
 
             if ($response->status() !== 201) {
-                throw new FailedToDeployGitKey($response->body());
+                throw new FailedToDeployGitKey('GitHub rejected the deploy key.');
             }
 
             return $response->json()['id'] ?? '';
@@ -207,10 +208,10 @@ class Github extends AbstractSourceControlProvider
             Log::error('Failed to deploy GitHub key', [
                 'repo' => $repo,
                 'title' => $title,
-                'error' => $e->getMessage(),
+                'exception' => $e::class,
             ]);
 
-            throw new FailedToDeployGitKey($e->getMessage());
+            throw new FailedToDeployGitKey('Failed to deploy GitHub key.');
         }
     }
 
@@ -219,21 +220,12 @@ class Github extends AbstractSourceControlProvider
         try {
             $response = $this->getClient()
                 ->delete(self::API_BASE_URL."/repos/$repo/keys/$keyId");
+        } catch (Throwable) {
+            throw new FailedToDeleteDeployKey('Failed to delete GitHub deploy key.');
+        }
 
-            if (! $response->successful()) {
-                Log::warning('Failed to delete GitHub deploy key', [
-                    'repo' => $repo,
-                    'key_id' => $keyId,
-                    'response' => $response->body(),
-                ]);
-            }
-
-        } catch (Throwable $e) {
-            Log::error('Error deleting GitHub deploy key', [
-                'repo' => $repo,
-                'key_id' => $keyId,
-                'error' => $e->getMessage(),
-            ]);
+        if (! $response->successful() && $response->status() !== 404) {
+            throw new FailedToDeleteDeployKey('Failed to delete GitHub deploy key.');
         }
     }
 

--- a/app/SourceControlProviders/Gitlab.php
+++ b/app/SourceControlProviders/Gitlab.php
@@ -2,6 +2,7 @@
 
 namespace App\SourceControlProviders;
 
+use App\Exceptions\FailedToDeleteDeployKey;
 use App\Exceptions\FailedToDeployGitHook;
 use App\Exceptions\FailedToDeployGitKey;
 use App\Exceptions\FailedToDestroyGitHook;
@@ -226,12 +227,12 @@ class Gitlab extends AbstractSourceControlProvider
             );
 
             if ($response->status() != 201) {
-                throw new FailedToDeployGitKey($response->body());
+                throw new FailedToDeployGitKey('GitLab rejected the deploy key.');
             }
 
             return $response->json()['id'] ?? '';
-        } catch (Exception $e) {
-            throw new FailedToDeployGitKey($e->getMessage());
+        } catch (Exception) {
+            throw new FailedToDeployGitKey('Failed to deploy GitLab key.');
         }
     }
 
@@ -242,21 +243,12 @@ class Gitlab extends AbstractSourceControlProvider
             $response = Http::withToken($this->data()['token'])->delete(
                 $this->getApiUrl().'/projects/'.$repository.'/deploy_keys/'.$keyId
             );
+        } catch (Throwable) {
+            throw new FailedToDeleteDeployKey('Failed to delete GitLab deploy key.');
+        }
 
-            if (! $response->successful()) {
-                Log::warning('Failed to delete Gitlab deploy key', [
-                    'repo' => $repo,
-                    'key_id' => $keyId,
-                    'response' => $response->body(),
-                ]);
-            }
-
-        } catch (Throwable $e) {
-            Log::error('Error deleting Gitlab deploy key', [
-                'repo' => $repo,
-                'key_id' => $keyId,
-                'error' => $e->getMessage(),
-            ]);
+        if (! $response->successful() && $response->status() !== 404) {
+            throw new FailedToDeleteDeployKey('Failed to delete GitLab deploy key.');
         }
     }
 

--- a/app/SourceControlProviders/SourceControlProvider.php
+++ b/app/SourceControlProviders/SourceControlProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\SourceControlProviders;
 
+use App\Exceptions\FailedToDeleteDeployKey;
 use App\Exceptions\FailedToDeployGitHook;
 use App\Exceptions\FailedToDeployGitKey;
 use App\Exceptions\FailedToDestroyGitHook;
@@ -75,6 +76,9 @@ interface SourceControlProvider
      */
     public function deployKey(string $title, string $repo, string $key): string;
 
+    /**
+     * @throws FailedToDeleteDeployKey
+     */
     public function deleteDeployKey(string $keyId, string $repo): void;
 
     /**

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -19,7 +19,7 @@ function generate_public_key(string $privateKeyPath, string $publicKeyPath): voi
 
 function generate_key_pair(string $path): void
 {
-    exec("ssh-keygen -t ed25519 -m PEM -N '' -f {$path}");
+    exec("ssh-keygen -t ed25519 -N '' -f {$path}");
     chmod($path, 0400);
 }
 

--- a/tests/Feature/SitesTest.php
+++ b/tests/Feature/SitesTest.php
@@ -55,7 +55,7 @@ test('create site', function (array $inputs) {
         'domain' => $inputs['domain'],
         'status' => SiteStatus::READY->value,
         'user' => $inputs['user'],
-        'path' => '/home/' . $inputs['user'] . '/' . $inputs['domain'],
+        'path' => '/home/'.$inputs['user'].'/'.$inputs['domain'],
     ]);
 })->with('create_data');
 
@@ -407,7 +407,7 @@ test('see sites list', function () {
         'server' => $this->server,
     ]))
         ->assertSuccessful()
-        ->assertInertia(fn(AssertableInertia $page) => $page->component('sites/index'));
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/index'));
 });
 
 test('delete site', function () {
@@ -638,7 +638,7 @@ test('see logs', function () {
         'site' => $this->site,
     ]))
         ->assertSuccessful()
-        ->assertInertia(fn(AssertableInertia $page) => $page->component('sites/logs'));
+        ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/logs'));
 });
 
 test('change branch', function () {

--- a/tests/Feature/SitesTest.php
+++ b/tests/Feature/SitesTest.php
@@ -1,7 +1,11 @@
 <?php
 
+use App\Actions\Site\UpdateSourceControl;
 use App\Enums\ServiceStatus;
 use App\Enums\SiteStatus;
+use App\Exceptions\FailedToDeleteDeployKey;
+use App\Exceptions\FailedToDeployGitKey;
+use App\Exceptions\SSHError;
 use App\Facades\SSH;
 use App\Models\Database;
 use App\Models\DatabaseUser;
@@ -12,8 +16,12 @@ use App\SiteTypes\Blank;
 use App\SiteTypes\Laravel;
 use App\SiteTypes\PHPBlank;
 use App\SourceControlProviders\Github;
+use App\SourceControlProviders\Gitlab;
+use App\SSH\OS\Git;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Inertia\Testing\AssertableInertia;
 
 uses(RefreshDatabase::class);
@@ -22,7 +30,8 @@ test('create site', function (array $inputs) {
     SSH::fake();
 
     Http::fake([
-        'https://api.github.com/repos/*' => Http::response([], 201),
+        'https://api.github.com/repos/*' => Http::response([
+        ], 201),
     ]);
 
     if (isset($inputs['database']) && isset($inputs['database_user'])) {
@@ -290,7 +299,8 @@ test('create site failed due to source control', function (int $status) {
     SSH::fake();
 
     Http::fake([
-        'https://api.github.com/repos/*' => Http::response([], $status),
+        'https://api.github.com/repos/*' => Http::response([
+        ], $status),
     ]);
 
     $this->actingAs($this->user);
@@ -461,7 +471,8 @@ test('update source control', function () {
     $this->actingAs($this->user);
 
     Http::fake([
-        'https://api.github.com/repos/*' => Http::response([], 201),
+        'https://api.github.com/repos/*' => Http::response([
+        ], 201),
     ]);
 
     /** @var SourceControl $sourceControl */
@@ -489,7 +500,8 @@ test('failed to update source control', function () {
     $this->actingAs($this->user);
 
     Http::fake([
-        'https://api.github.com/repos/*' => Http::response([], 404),
+        'https://api.github.com/repos/*' => Http::response([
+        ], 404),
     ]);
 
     /** @var SourceControl $sourceControl */
@@ -518,15 +530,33 @@ test('update source control deletes old deploy key', function () {
 
     /** @var SourceControl $newSourceControl */
     $newSourceControl = SourceControl::factory()->create([
-        'provider' => Github::id(),
+        'provider' => Gitlab::id(),
         'user_id' => $this->user->id,
     ]);
 
     Http::fake([
-        'https://api.github.com/repos/organization/repository' => Http::response([], 200),
+        'https://gitlab.com/api/v4/projects/*/repository/commits' => Http::response([], 200),
+        'https://gitlab.com/api/v4/projects/*/deploy_keys' => Http::response(['id' => 12345], 201),
         'https://api.github.com/repos/organization/repository/keys/999' => Http::response([], 204),
-        'https://api.github.com/repos/organization/repository/keys' => Http::response(['id' => 12345], 201),
     ]);
+
+    $git = Mockery::mock(Git::class);
+    $git->shouldReceive('setRemote')
+        ->once()
+        ->withArgs(function (Site $site, string $repoUrl) use ($newSourceControl): bool {
+            $this->assertDatabaseHas('sites', [
+                'id' => $site->id,
+                'source_control_id' => $newSourceControl->id,
+                'type_data->deploy_key_id' => '12345',
+            ]);
+            Http::assertNotSent(
+                fn ($request) => $request->method() === 'DELETE'
+                    && str_contains($request->url(), '/keys/999')
+            );
+
+            return str_contains($repoUrl, 'gitlab.com');
+        });
+    app()->instance(Git::class, $git);
 
     $this->patch(route('site-settings.update-source-control', [
         'server' => $this->server->id,
@@ -536,10 +566,58 @@ test('update source control deletes old deploy key', function () {
     ])
         ->assertSessionDoesntHaveErrors();
 
-    Http::assertSent(function ($request) {
-        return $request->method() === 'DELETE'
-            && str_contains($request->url(), '/keys/999');
-    });
+    $deployRequestIndex = Http::recorded()->search(
+        fn (array $recorded): bool => $recorded[0]->method() === 'POST'
+            && str_contains($recorded[0]->url(), '/deploy_keys')
+    );
+    $deleteRequestIndex = Http::recorded()->search(
+        fn (array $recorded): bool => $recorded[0]->method() === 'DELETE'
+            && str_contains($recorded[0]->url(), '/keys/999')
+    );
+
+    expect($deployRequestIndex)->not->toBeFalse();
+    expect($deleteRequestIndex)->not->toBeFalse();
+    expect($deployRequestIndex)->toBeLessThan($deleteRequestIndex);
+});
+
+test('update source control keeps old deploy key if remote update fails', function () {
+    SSH::fake();
+
+    $this->site->ssh_key = 'ssh-rsa AAAAB3NzaC1yc2E test-key';
+    $this->site->type_data = ['deploy_key_id' => '999'];
+    $this->site->save();
+
+    /** @var SourceControl $newSourceControl */
+    $newSourceControl = SourceControl::factory()->create([
+        'provider' => Gitlab::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        'https://gitlab.com/api/v4/projects/*/repository/commits' => Http::response([], 200),
+        'https://gitlab.com/api/v4/projects/*/deploy_keys' => Http::response(['id' => 12345], 201),
+        'https://api.github.com/repos/organization/repository/keys/999' => Http::response([], 204),
+    ]);
+
+    $git = Mockery::mock(Git::class);
+    $git->shouldReceive('setRemote')
+        ->once()
+        ->andThrow(new SSHError('Failed to update remote'));
+    app()->instance(Git::class, $git);
+
+    app(UpdateSourceControl::class)->update($this->site, [
+        'source_control' => $newSourceControl->id,
+    ]);
+
+    $this->assertDatabaseHas('sites', [
+        'id' => $this->site->id,
+        'source_control_id' => $newSourceControl->id,
+        'type_data->deploy_key_id' => '12345',
+    ]);
+    Http::assertNotSent(
+        fn ($request) => $request->method() === 'DELETE'
+            && str_contains($request->url(), '/keys/999')
+    );
 });
 
 test('update source control registers new deploy key', function () {
@@ -553,14 +631,14 @@ test('update source control registers new deploy key', function () {
 
     /** @var SourceControl $newSourceControl */
     $newSourceControl = SourceControl::factory()->create([
-        'provider' => Github::id(),
+        'provider' => Gitlab::id(),
         'user_id' => $this->user->id,
     ]);
 
     Http::fake([
-        'https://api.github.com/repos/organization/repository' => Http::response([], 200),
+        'https://gitlab.com/api/v4/projects/*/repository/commits' => Http::response([], 200),
+        'https://gitlab.com/api/v4/projects/*/deploy_keys' => Http::response(['id' => 54321], 201),
         'https://api.github.com/repos/organization/repository/keys/777' => Http::response([], 204),
-        'https://api.github.com/repos/organization/repository/keys' => Http::response(['id' => 54321], 201),
     ]);
 
     $this->patch(route('site-settings.update-source-control', [
@@ -577,11 +655,144 @@ test('update source control registers new deploy key', function () {
     expect($this->site->type_data['deploy_key_id'])->toEqual('54321');
 });
 
-test('update source control succeeds even if old deploy key deletion fails', function () {
+test('update source control reuses deploy key for the same repository', function () {
     SSH::fake();
 
-    $this->actingAs($this->user);
+    $this->site->ssh_key = 'ssh-rsa AAAAB3NzaC1yc2E test-key';
+    $this->site->type_data = ['deploy_key_id' => '777'];
+    $this->site->save();
 
+    /** @var SourceControl $newSourceControl */
+    $newSourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        'https://api.github.com/repos/organization/repository' => Http::response([], 200),
+    ]);
+
+    app(UpdateSourceControl::class)->update($this->site, [
+        'source_control' => $newSourceControl->id,
+    ]);
+
+    $this->assertDatabaseHas('sites', [
+        'id' => $this->site->id,
+        'source_control_id' => $newSourceControl->id,
+        'type_data->deploy_key_id' => '777',
+    ]);
+
+    Http::assertNotSent(
+        fn ($request) => in_array($request->method(), ['POST', 'DELETE'], true)
+            && str_contains($request->url(), '/keys')
+    );
+});
+
+test('update source control rejects an empty deploy key id', function () {
+    SSH::fake();
+
+    $this->site->ssh_key = 'ssh-rsa AAAAB3NzaC1yc2E test-key';
+    $this->site->type_data = ['deploy_key_id' => '777'];
+    $this->site->save();
+
+    $oldSourceControlId = $this->site->source_control_id;
+
+    /** @var SourceControl $newSourceControl */
+    $newSourceControl = SourceControl::factory()->create([
+        'provider' => Gitlab::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        'https://gitlab.com/api/v4/projects/*/repository/commits' => Http::response([], 200),
+        'https://gitlab.com/api/v4/projects/*/deploy_keys' => Http::response([], 201),
+    ]);
+
+    expect(fn () => app(UpdateSourceControl::class)->update($this->site, [
+        'source_control' => $newSourceControl->id,
+    ]))->toThrow(FailedToDeployGitKey::class);
+
+    $this->assertDatabaseHas('sites', [
+        'id' => $this->site->id,
+        'source_control_id' => $oldSourceControlId,
+        'type_data->deploy_key_id' => '777',
+    ]);
+
+    Http::assertNotSent(fn ($request) => $request->method() === 'DELETE');
+});
+
+test('update source control sanitizes deploy key provider errors', function () {
+    $this->site->ssh_key = 'ssh-rsa AAAAB3NzaC1yc2E test-key';
+    $this->site->type_data = ['deploy_key_id' => '777'];
+    $this->site->save();
+
+    $oldSourceControlId = $this->site->source_control_id;
+
+    /** @var SourceControl $newSourceControl */
+    $newSourceControl = SourceControl::factory()->create([
+        'provider' => Gitlab::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        'https://gitlab.com/api/v4/projects/*/repository/commits' => Http::response([], 200),
+        'https://gitlab.com/api/v4/projects/*/deploy_keys' => Http::response(['token' => 'secret-token'], 422),
+    ]);
+
+    expect(fn () => app(UpdateSourceControl::class)->update($this->site, [
+        'source_control' => $newSourceControl->id,
+    ]))->toThrow(FailedToDeployGitKey::class, 'Source control provider failed to deploy the key.');
+
+    $this->assertDatabaseHas('sites', [
+        'id' => $this->site->id,
+        'source_control_id' => $oldSourceControlId,
+        'type_data->deploy_key_id' => '777',
+    ]);
+});
+
+test('update source control continues if old deploy key deletion fails', function () {
+    SSH::fake();
+    Log::spy();
+
+    $this->site->ssh_key = 'ssh-rsa AAAAB3NzaC1yc2E test-key';
+    $this->site->type_data = ['deploy_key_id' => '888'];
+    $this->site->save();
+
+    /** @var SourceControl $newSourceControl */
+    $newSourceControl = SourceControl::factory()->create([
+        'provider' => Gitlab::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        'https://gitlab.com/api/v4/projects/*/repository/commits' => Http::response([], 200),
+        'https://gitlab.com/api/v4/projects/*/deploy_keys' => Http::response(['id' => 54321], 201),
+        'https://api.github.com/repos/organization/repository/keys/888' => Http::response(['message' => 'Bad credentials'], 401),
+    ]);
+
+    app(UpdateSourceControl::class)->update($this->site, [
+        'source_control' => $newSourceControl->id,
+    ]);
+
+    $this->assertDatabaseHas('sites', [
+        'id' => $this->site->id,
+        'source_control_id' => $newSourceControl->id,
+        'type_data->deploy_key_id' => '54321',
+    ]);
+
+    Log::shouldHaveReceived('warning')->withArgs(
+        fn (string $message, array $context): bool => $message === 'Failed to remove old deploy key during source control update'
+            && $context['site_id'] === $this->site->id
+            && $context['deploy_key_id'] === '888'
+            && $context['exception'] === FailedToDeleteDeployKey::class
+    );
+});
+
+test('update source control continues if old deploy key provider is missing', function () {
+    SSH::fake();
+    Log::spy();
+
+    $this->site->source_control_id = null;
     $this->site->ssh_key = 'ssh-rsa AAAAB3NzaC1yc2E test-key';
     $this->site->type_data = ['deploy_key_id' => '888'];
     $this->site->save();
@@ -594,22 +805,76 @@ test('update source control succeeds even if old deploy key deletion fails', fun
 
     Http::fake([
         'https://api.github.com/repos/organization/repository' => Http::response([], 200),
-        'https://api.github.com/repos/organization/repository/keys/888' => Http::response(['message' => 'Bad credentials'], 401),
-        'https://api.github.com/repos/organization/repository/keys' => Http::response(['id' => 99999], 201),
+        'https://api.github.com/repos/organization/repository/keys' => Http::response(['id' => 54321], 201),
     ]);
 
-    $this->patch(route('site-settings.update-source-control', [
-        'server' => $this->server->id,
-        'site' => $this->site,
-    ]), [
+    app(UpdateSourceControl::class)->update($this->site, [
         'source_control' => $newSourceControl->id,
-    ])
-        ->assertSessionDoesntHaveErrors();
+    ]);
 
-    $this->site->refresh();
+    $this->assertDatabaseHas('sites', [
+        'id' => $this->site->id,
+        'source_control_id' => $newSourceControl->id,
+        'type_data->deploy_key_id' => '54321',
+    ]);
 
-    expect($this->site->source_control_id)->toEqual($newSourceControl->id);
-    expect($this->site->type_data['deploy_key_id'])->toEqual('99999');
+    Http::assertNotSent(fn ($request) => $request->method() === 'DELETE');
+
+    Log::shouldHaveReceived('warning')->withArgs(
+        fn (string $message, array $context): bool => $message === 'Skipped old deploy key removal because its source control is unavailable'
+            && $context['site_id'] === $this->site->id
+            && $context['deploy_key_id'] === '888'
+    );
+});
+
+test('update source control removes new deploy key if new id cannot be saved', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->site->ssh_key = 'ssh-rsa AAAAB3NzaC1yc2E test-key';
+    $this->site->type_data = ['deploy_key_id' => '777'];
+    $this->site->save();
+
+    $oldSourceControlId = $this->site->source_control_id;
+
+    /** @var SourceControl $newSourceControl */
+    $newSourceControl = SourceControl::factory()->create([
+        'provider' => Gitlab::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        'https://gitlab.com/api/v4/projects/*/repository/commits' => Http::response([], 200),
+        'https://gitlab.com/api/v4/projects/*/deploy_keys/54321' => Http::response([], 204),
+        'https://gitlab.com/api/v4/projects/*/deploy_keys' => Http::response(['id' => 54321], 201),
+    ]);
+
+    Event::listen('eloquent.saving: '.Site::class, function (Site $site): void {
+        if (($site->type_data['deploy_key_id'] ?? null) === '54321') {
+            throw new RuntimeException('Failed to save deploy key ID');
+        }
+    });
+
+    expect(fn () => app(UpdateSourceControl::class)->update($this->site, [
+        'source_control' => $newSourceControl->id,
+    ]))->toThrow(RuntimeException::class, 'Failed to save deploy key ID');
+
+    Http::assertSent(function ($request) {
+        return $request->method() === 'DELETE'
+            && str_contains($request->url(), '/deploy_keys/54321');
+    });
+
+    $this->assertDatabaseHas('sites', [
+        'id' => $this->site->id,
+        'source_control_id' => $oldSourceControlId,
+        'type_data->deploy_key_id' => '777',
+    ]);
+
+    Http::assertNotSent(
+        fn ($request) => $request->method() === 'DELETE'
+            && str_contains($request->url(), 'api.github.com')
+    );
 });
 
 test('update v host', function () {
@@ -874,103 +1139,91 @@ test('create site rejects directory traversal', function () {
     ]);
 });
 
-dataset(
-    'failure_create_data',
-    /** @return array<int, array{0: array<string, mixed>}> */
-    function (): array {
-        return [
+dataset('failure_create_data', /** @return array<int, array{0: array<string, mixed>}> */ function (): array {
+    return [
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'a',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'a',
             ],
+        ],
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'root',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'root',
             ],
+        ],
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'vito',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'vito',
             ],
+        ],
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => '123',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => '123',
             ],
+        ],
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'qwertyuiopasdfghjklzxcvbnmqwertyu',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'qwertyuiopasdfghjklzxcvbnmqwertyu',
             ],
+        ],
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'www-data',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'www-data',
             ],
+        ],
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'mysql',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'mysql',
             ],
+        ],
+        [
             [
-                [
-                    'type' => PHPBlank::id(),
-                    'domain' => 'example.com',
-                    'php_version' => '8.2',
-                    'web_directory' => 'public',
-                    'user' => 'ubuntu',
-                ],
+                'type' => PHPBlank::id(),
+                'domain' => 'example.com',
+                'php_version' => '8.2',
+                'web_directory' => 'public',
+                'user' => 'ubuntu',
             ],
-        ];
-    }
-);
+        ],
+    ];
+});
 
-dataset(
-    'create_data',
-    /** @return array<int, array{0: array<string, mixed>}> */
-    function (): array {
-        return vitoPestSiteCreateData();
-    }
-);
+dataset('create_data', /** @return array<int, array{0: array<string, mixed>}> */ function (): array {
+    return vitoPestSiteCreateData();
+});
 
-dataset(
-    'create_failure_data',
-    /** @return array<int, array{0: int}> */
-    function (): array {
-        return [
-            [401],
-            [403],
-            [404],
-        ];
-    }
-);
+dataset('create_failure_data', /** @return array<int, array{0: int}> */ function (): array {
+    return [
+        [401],
+        [403],
+        [404],
+    ];
+});

--- a/tests/Feature/SitesTest.php
+++ b/tests/Feature/SitesTest.php
@@ -22,8 +22,7 @@ test('create site', function (array $inputs) {
     SSH::fake();
 
     Http::fake([
-        'https://api.github.com/repos/*' => Http::response([
-        ], 201),
+        'https://api.github.com/repos/*' => Http::response([], 201),
     ]);
 
     if (isset($inputs['database']) && isset($inputs['database_user'])) {
@@ -56,7 +55,7 @@ test('create site', function (array $inputs) {
         'domain' => $inputs['domain'],
         'status' => SiteStatus::READY->value,
         'user' => $inputs['user'],
-        'path' => '/home/'.$inputs['user'].'/'.$inputs['domain'],
+        'path' => '/home/' . $inputs['user'] . '/' . $inputs['domain'],
     ]);
 })->with('create_data');
 
@@ -291,8 +290,7 @@ test('create site failed due to source control', function (int $status) {
     SSH::fake();
 
     Http::fake([
-        'https://api.github.com/repos/*' => Http::response([
-        ], $status),
+        'https://api.github.com/repos/*' => Http::response([], $status),
     ]);
 
     $this->actingAs($this->user);
@@ -409,7 +407,7 @@ test('see sites list', function () {
         'server' => $this->server,
     ]))
         ->assertSuccessful()
-        ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/index'));
+        ->assertInertia(fn(AssertableInertia $page) => $page->component('sites/index'));
 });
 
 test('delete site', function () {
@@ -463,8 +461,7 @@ test('update source control', function () {
     $this->actingAs($this->user);
 
     Http::fake([
-        'https://api.github.com/repos/*' => Http::response([
-        ], 201),
+        'https://api.github.com/repos/*' => Http::response([], 201),
     ]);
 
     /** @var SourceControl $sourceControl */
@@ -492,8 +489,7 @@ test('failed to update source control', function () {
     $this->actingAs($this->user);
 
     Http::fake([
-        'https://api.github.com/repos/*' => Http::response([
-        ], 404),
+        'https://api.github.com/repos/*' => Http::response([], 404),
     ]);
 
     /** @var SourceControl $sourceControl */
@@ -509,6 +505,111 @@ test('failed to update source control', function () {
         'source_control' => $sourceControl->id,
     ])
         ->assertSessionHasErrors();
+});
+
+test('update source control deletes old deploy key', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->site->ssh_key = 'ssh-rsa AAAAB3NzaC1yc2E test-key';
+    $this->site->type_data = ['deploy_key_id' => '999'];
+    $this->site->save();
+
+    /** @var SourceControl $newSourceControl */
+    $newSourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        'https://api.github.com/repos/organization/repository' => Http::response([], 200),
+        'https://api.github.com/repos/organization/repository/keys/999' => Http::response([], 204),
+        'https://api.github.com/repos/organization/repository/keys' => Http::response(['id' => 12345], 201),
+    ]);
+
+    $this->patch(route('site-settings.update-source-control', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'source_control' => $newSourceControl->id,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    Http::assertSent(function ($request) {
+        return $request->method() === 'DELETE'
+            && str_contains($request->url(), '/keys/999');
+    });
+});
+
+test('update source control registers new deploy key', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->site->ssh_key = 'ssh-rsa AAAAB3NzaC1yc2E test-key';
+    $this->site->type_data = ['deploy_key_id' => '777'];
+    $this->site->save();
+
+    /** @var SourceControl $newSourceControl */
+    $newSourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        'https://api.github.com/repos/organization/repository' => Http::response([], 200),
+        'https://api.github.com/repos/organization/repository/keys/777' => Http::response([], 204),
+        'https://api.github.com/repos/organization/repository/keys' => Http::response(['id' => 54321], 201),
+    ]);
+
+    $this->patch(route('site-settings.update-source-control', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'source_control' => $newSourceControl->id,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+
+    expect($this->site->source_control_id)->toEqual($newSourceControl->id);
+    expect($this->site->type_data['deploy_key_id'])->toEqual('54321');
+});
+
+test('update source control succeeds even if old deploy key deletion fails', function () {
+    SSH::fake();
+
+    $this->actingAs($this->user);
+
+    $this->site->ssh_key = 'ssh-rsa AAAAB3NzaC1yc2E test-key';
+    $this->site->type_data = ['deploy_key_id' => '888'];
+    $this->site->save();
+
+    /** @var SourceControl $newSourceControl */
+    $newSourceControl = SourceControl::factory()->create([
+        'provider' => Github::id(),
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        'https://api.github.com/repos/organization/repository' => Http::response([], 200),
+        'https://api.github.com/repos/organization/repository/keys/888' => Http::response(['message' => 'Bad credentials'], 401),
+        'https://api.github.com/repos/organization/repository/keys' => Http::response(['id' => 99999], 201),
+    ]);
+
+    $this->patch(route('site-settings.update-source-control', [
+        'server' => $this->server->id,
+        'site' => $this->site,
+    ]), [
+        'source_control' => $newSourceControl->id,
+    ])
+        ->assertSessionDoesntHaveErrors();
+
+    $this->site->refresh();
+
+    expect($this->site->source_control_id)->toEqual($newSourceControl->id);
+    expect($this->site->type_data['deploy_key_id'])->toEqual('99999');
 });
 
 test('update v host', function () {
@@ -537,7 +638,7 @@ test('see logs', function () {
         'site' => $this->site,
     ]))
         ->assertSuccessful()
-        ->assertInertia(fn (AssertableInertia $page) => $page->component('sites/logs'));
+        ->assertInertia(fn(AssertableInertia $page) => $page->component('sites/logs'));
 });
 
 test('change branch', function () {
@@ -773,91 +874,103 @@ test('create site rejects directory traversal', function () {
     ]);
 });
 
-dataset('failure_create_data', /** @return array<int, array{0: array<string, mixed>}> */ function (): array {
-    return [
-        [
+dataset(
+    'failure_create_data',
+    /** @return array<int, array{0: array<string, mixed>}> */
+    function (): array {
+        return [
             [
-                'type' => PHPBlank::id(),
-                'domain' => 'example.com',
-                'php_version' => '8.2',
-                'web_directory' => 'public',
-                'user' => 'a',
+                [
+                    'type' => PHPBlank::id(),
+                    'domain' => 'example.com',
+                    'php_version' => '8.2',
+                    'web_directory' => 'public',
+                    'user' => 'a',
+                ],
             ],
-        ],
-        [
             [
-                'type' => PHPBlank::id(),
-                'domain' => 'example.com',
-                'php_version' => '8.2',
-                'web_directory' => 'public',
-                'user' => 'root',
+                [
+                    'type' => PHPBlank::id(),
+                    'domain' => 'example.com',
+                    'php_version' => '8.2',
+                    'web_directory' => 'public',
+                    'user' => 'root',
+                ],
             ],
-        ],
-        [
             [
-                'type' => PHPBlank::id(),
-                'domain' => 'example.com',
-                'php_version' => '8.2',
-                'web_directory' => 'public',
-                'user' => 'vito',
+                [
+                    'type' => PHPBlank::id(),
+                    'domain' => 'example.com',
+                    'php_version' => '8.2',
+                    'web_directory' => 'public',
+                    'user' => 'vito',
+                ],
             ],
-        ],
-        [
             [
-                'type' => PHPBlank::id(),
-                'domain' => 'example.com',
-                'php_version' => '8.2',
-                'web_directory' => 'public',
-                'user' => '123',
+                [
+                    'type' => PHPBlank::id(),
+                    'domain' => 'example.com',
+                    'php_version' => '8.2',
+                    'web_directory' => 'public',
+                    'user' => '123',
+                ],
             ],
-        ],
-        [
             [
-                'type' => PHPBlank::id(),
-                'domain' => 'example.com',
-                'php_version' => '8.2',
-                'web_directory' => 'public',
-                'user' => 'qwertyuiopasdfghjklzxcvbnmqwertyu',
+                [
+                    'type' => PHPBlank::id(),
+                    'domain' => 'example.com',
+                    'php_version' => '8.2',
+                    'web_directory' => 'public',
+                    'user' => 'qwertyuiopasdfghjklzxcvbnmqwertyu',
+                ],
             ],
-        ],
-        [
             [
-                'type' => PHPBlank::id(),
-                'domain' => 'example.com',
-                'php_version' => '8.2',
-                'web_directory' => 'public',
-                'user' => 'www-data',
+                [
+                    'type' => PHPBlank::id(),
+                    'domain' => 'example.com',
+                    'php_version' => '8.2',
+                    'web_directory' => 'public',
+                    'user' => 'www-data',
+                ],
             ],
-        ],
-        [
             [
-                'type' => PHPBlank::id(),
-                'domain' => 'example.com',
-                'php_version' => '8.2',
-                'web_directory' => 'public',
-                'user' => 'mysql',
+                [
+                    'type' => PHPBlank::id(),
+                    'domain' => 'example.com',
+                    'php_version' => '8.2',
+                    'web_directory' => 'public',
+                    'user' => 'mysql',
+                ],
             ],
-        ],
-        [
             [
-                'type' => PHPBlank::id(),
-                'domain' => 'example.com',
-                'php_version' => '8.2',
-                'web_directory' => 'public',
-                'user' => 'ubuntu',
+                [
+                    'type' => PHPBlank::id(),
+                    'domain' => 'example.com',
+                    'php_version' => '8.2',
+                    'web_directory' => 'public',
+                    'user' => 'ubuntu',
+                ],
             ],
-        ],
-    ];
-});
+        ];
+    }
+);
 
-dataset('create_data', /** @return array<int, array{0: array<string, mixed>}> */ function (): array {
-    return vitoPestSiteCreateData();
-});
+dataset(
+    'create_data',
+    /** @return array<int, array{0: array<string, mixed>}> */
+    function (): array {
+        return vitoPestSiteCreateData();
+    }
+);
 
-dataset('create_failure_data', /** @return array<int, array{0: int}> */ function (): array {
-    return [
-        [401],
-        [403],
-        [404],
-    ];
-});
+dataset(
+    'create_failure_data',
+    /** @return array<int, array{0: int}> */
+    function (): array {
+        return [
+            [401],
+            [403],
+            [404],
+        ];
+    }
+);

--- a/tests/Unit/SourceControlProviders/DeployKeyDeletionTest.php
+++ b/tests/Unit/SourceControlProviders/DeployKeyDeletionTest.php
@@ -13,19 +13,7 @@ use Illuminate\Support\Facades\Http;
 
 uses(RefreshDatabase::class);
 
-test('deploy key deletion failures bubble up', function (string $provider, array $attributes, string $endpoint) {
-    Http::fake([
-        'https://bitbucket.org/site/oauth2/access_token' => Http::response(['access_token' => 'test'], 200),
-        $endpoint => Http::response([], 401),
-    ]);
-
-    $sourceControl = SourceControl::factory()->create($attributes);
-    /** @var SourceControlProvider $handler */
-    $handler = new $provider($sourceControl);
-
-    expect(fn () => $handler->deleteDeployKey('123', 'organization/repository'))
-        ->toThrow(FailedToDeleteDeployKey::class);
-})->with([
+dataset('deployKeyDeletionProviders', [
     'github' => [
         Github::class,
         ['provider' => Github::id()],
@@ -58,6 +46,34 @@ test('deploy key deletion failures bubble up', function (string $provider, array
         'https://api.bitbucket.org/2.0/repositories/*/deploy-keys/123',
     ],
 ]);
+
+test('deploy key deletion failures bubble up', function (string $provider, array $attributes, string $endpoint) {
+    Http::fake([
+        'https://bitbucket.org/site/oauth2/access_token' => Http::response(['access_token' => 'test'], 200),
+        $endpoint => Http::response([], 401),
+    ]);
+
+    $sourceControl = SourceControl::factory()->create($attributes);
+    /** @var SourceControlProvider $handler */
+    $handler = new $provider($sourceControl);
+
+    expect(fn () => $handler->deleteDeployKey('123', 'organization/repository'))
+        ->toThrow(FailedToDeleteDeployKey::class);
+})->with('deployKeyDeletionProviders');
+
+test('deploy key deletion connection failures bubble up', function (string $provider, array $attributes, string $endpoint) {
+    Http::fake([
+        'https://bitbucket.org/site/oauth2/access_token' => Http::response(['access_token' => 'test'], 200),
+        $endpoint => Http::failedConnection(),
+    ]);
+
+    $sourceControl = SourceControl::factory()->create($attributes);
+    /** @var SourceControlProvider $handler */
+    $handler = new $provider($sourceControl);
+
+    expect(fn () => $handler->deleteDeployKey('123', 'organization/repository'))
+        ->toThrow(FailedToDeleteDeployKey::class);
+})->with('deployKeyDeletionProviders');
 
 test('missing deploy key is already deleted', function () {
     Http::fake([

--- a/tests/Unit/SourceControlProviders/DeployKeyDeletionTest.php
+++ b/tests/Unit/SourceControlProviders/DeployKeyDeletionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Exceptions\FailedToDeleteDeployKey;
+use App\Models\SourceControl;
+use App\SourceControlProviders\Bitbucket;
+use App\SourceControlProviders\BitbucketV2;
+use App\SourceControlProviders\Gitea;
+use App\SourceControlProviders\Github;
+use App\SourceControlProviders\Gitlab;
+use App\SourceControlProviders\SourceControlProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+test('deploy key deletion failures bubble up', function (string $provider, array $attributes, string $endpoint) {
+    Http::fake([
+        'https://bitbucket.org/site/oauth2/access_token' => Http::response(['access_token' => 'test'], 200),
+        $endpoint => Http::response([], 401),
+    ]);
+
+    $sourceControl = SourceControl::factory()->create($attributes);
+    /** @var SourceControlProvider $handler */
+    $handler = new $provider($sourceControl);
+
+    expect(fn () => $handler->deleteDeployKey('123', 'organization/repository'))
+        ->toThrow(FailedToDeleteDeployKey::class);
+})->with([
+    'github' => [
+        Github::class,
+        ['provider' => Github::id()],
+        'https://api.github.com/repos/*/keys/123',
+    ],
+    'gitlab' => [
+        Gitlab::class,
+        ['provider' => Gitlab::id()],
+        'https://gitlab.com/api/v4/projects/*/deploy_keys/123',
+    ],
+    'gitea' => [
+        Gitea::class,
+        ['provider' => Gitea::id()],
+        'https://gitea.com/api/v1/repos/*/keys/123',
+    ],
+    'bitbucket' => [
+        Bitbucket::class,
+        [
+            'provider' => Bitbucket::id(),
+            'provider_data' => ['username' => 'test', 'password' => 'test'],
+        ],
+        'https://api.bitbucket.org/2.0/repositories/*/deploy-keys/123',
+    ],
+    'bitbucket v2' => [
+        BitbucketV2::class,
+        [
+            'provider' => BitbucketV2::id(),
+            'provider_data' => ['key' => 'test', 'secret' => 'test'],
+        ],
+        'https://api.bitbucket.org/2.0/repositories/*/deploy-keys/123',
+    ],
+]);
+
+test('missing deploy key is already deleted', function () {
+    Http::fake([
+        'https://api.github.com/repos/*/keys/123' => Http::response([], 404),
+    ]);
+
+    $sourceControl = SourceControl::factory()->github()->create();
+    $provider = new Github($sourceControl);
+
+    $provider->deleteDeployKey('123', 'organization/repository');
+
+    Http::assertSentCount(1);
+});


### PR DESCRIPTION
> This is a port of #1083 to the `4.x` branch, updated to fit the new architecture.
## Problem

When a site's source control is updated, the SSH deploy key is not re-synced in GitHub, causing deployments to fail with:

```
git@github.com: Permission denied (publickey)
fatal: Could not read from remote repository
```

Vito correctly shows the latest commit in the UI (API token works), but the actual `git pull` on the server fails because the deploy key is no longer valid in GitHub.

## Root Cause

`UpdateSourceControl::update()` was not:
1. Deleting the old deploy key from the previous source control provider
2. Registering a new deploy key with the new source control provider
3. Updating the git remote URL on the server to match the new source control

## Fix

Rewritten `UpdateSourceControl::update()` to:

1. Validate the new source control can access the repository **first** — if it fails, throw `ValidationException` and stop, leaving the site untouched
2. Persist the source control swap inside a `DB::transaction`, clearing the stale `deploy_key_id` atomically
3. Delete the old deploy key from the previous provider (silent `Log::warning` if the old token is expired or invalid)
4. Destroy the old git hook if one existed
5. Register a new deploy key with the new provider and persist the new `deploy_key_id` in `type_data` (skipped for GitHub App source controls)
6. Rewrite the git remote URL on the server via SSH to point to the new provider

All post-save steps (key deletion, hook cleanup, key registration, remote rewrite) are individually wrapped in try/catch so a failure in any one step does not block the others.

## Changes

- `app/Actions/Site/UpdateSourceControl.php`
- `tests/Feature/SitesTest.php`

## Tested

- Old deploy key is deleted from GitHub before registering the new one
- New deploy key is registered and `deploy_key_id` is saved in `type_data`
- Update succeeds even if old deploy key deletion fails (e.g. expired token returns 401)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved source-control provider changes by reusing matching deploy keys or registering replacements when needed.
  - Deploy-key details are now retained after a successful provider switch, with cleanup if saving fails.
  - Source-control updates can complete even if removing the previous provider’s deploy key fails.
  - Missing deploy keys are handled safely, while genuine deletion failures are reported consistently.
  - Improved error handling prevents sensitive provider error details from being exposed; already-removed keys are treated as successful.
  - Updated generated SSH keys for improved compatibility with supported source-control providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->