### PR TITLE
[Feature] ClickHouse database support

### DIFF
--- a/app/Providers/ServiceTypeServiceProvider.php
+++ b/app/Providers/ServiceTypeServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Plugins\RegisterServiceType;
+use App\Services\Database\Clickhouse;
 use App\Services\Database\Mariadb;
 use App\Services\Database\Mysql;
 use App\Services\Database\Postgresql;
@@ -141,6 +142,28 @@ class ServiceTypeServiceProvider extends ServiceProvider
                 [
                     'name' => '50-server.cnf',
                     'path' => '/etc/mysql/mariadb.conf.d/50-server.cnf',
+                    'sudo' => true,
+                ],
+            ])
+            ->register();
+        RegisterServiceType::make(Clickhouse::id())
+            ->type(Clickhouse::type())
+            ->label('ClickHouse')
+            ->handler(Clickhouse::class)
+            ->versions([
+                '24.8',
+                '24.3',
+                '23.8',
+            ])
+            ->configPaths([
+                [
+                    'name' => 'config.xml',
+                    'path' => '/etc/clickhouse-server/config.xml',
+                    'sudo' => true,
+                ],
+                [
+                    'name' => 'users.xml',
+                    'path' => '/etc/clickhouse-server/users.xml',
                     'sudo' => true,
                 ],
             ])

--- a/app/Services/Database/Clickhouse.php
+++ b/app/Services/Database/Clickhouse.php
@@ -19,7 +19,7 @@ class Clickhouse extends AbstractDatabase implements HasLogs, SupportsNetworking
 
     protected array $systemUsers = ['default'];
 
-    protected string $defaultCharset = 'UTF-8';
+    protected string $defaultCharset = 'UTF8';
 
     protected int $headerLines = 1;
 

--- a/app/Services/Database/Clickhouse.php
+++ b/app/Services/Database/Clickhouse.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Services\Database;
+
+use App\DTOs\ServiceLog;
+use App\Exceptions\SSHCommandError;
+use App\Exceptions\SSHError;
+use App\Models\DatabaseUser;
+use App\Models\Server;
+use App\Services\HasLogs;
+use App\Services\SupportsNetworking;
+use Illuminate\Contracts\View\View;
+
+class Clickhouse extends AbstractDatabase implements HasLogs, SupportsNetworking
+{
+    use ManagesDatabaseNetworking;
+
+    protected array $systemDbs = ['system', 'information_schema', 'INFORMATION_SCHEMA'];
+
+    protected array $systemUsers = ['default'];
+
+    protected string $defaultCharset = 'UTF-8';
+
+    protected int $headerLines = 1;
+
+    public function usesHost(): bool
+    {
+        return false;
+    }
+
+    public function databaseUserExists(Server $server, string $username, string $host, ?DatabaseUser $ignore = null): bool
+    {
+        return $server->databaseUsers()
+            ->where('username', $username)
+            ->when($ignore, fn ($query) => $query->whereKeyNot($ignore->id))
+            ->exists();
+    }
+
+    public static function id(): string
+    {
+        return 'clickhouse';
+    }
+
+    public static function type(): string
+    {
+        return 'database';
+    }
+
+    public function unit(): string
+    {
+        return 'clickhouse-server';
+    }
+
+    protected function installScript(): View
+    {
+        return view($this->getScriptView('install'), [
+            'version' => $this->service->version,
+        ]);
+    }
+
+    public function versionCommand(): ?string
+    {
+        return 'clickhouse-client --version | grep -oE \'[0-9]+\.[0-9]+(\.[0-9]+)?\' | head -n 1';
+    }
+
+    public function networkingPort(): int
+    {
+        return 9000;
+    }
+
+    /**
+     * @throws SSHError
+     */
+    protected function writeNetworkingConfig(bool $enable): void
+    {
+        $this->service->server->ssh()->exec(
+            view($this->getNetworkingScriptView('write-networking'), [
+                ...$this->networkingScriptData(),
+                'address' => $enable ? '0.0.0.0' : '127.0.0.1',
+            ]),
+            ($enable ? 'enable' : 'disable').'-clickhouse-networking'
+        );
+    }
+
+    /**
+     * @throws SSHError
+     */
+    protected function runNetworkingRollback(): void
+    {
+        $this->service->server->ssh()->exec(
+            view($this->getNetworkingScriptView('rollback-networking'), $this->networkingScriptData()),
+            'rollback-clickhouse-networking'
+        );
+    }
+
+    /**
+     * @throws SSHError
+     */
+    protected function verifyNetworking(bool $expectedOpen): void
+    {
+        $expected = $expectedOpen ? '0.0.0.0' : '127.0.0.1';
+
+        if (! $this->networkingValueMatches($this->networkingListenAddress(), $expected)) {
+            throw new SSHCommandError("{$this->service->name} is not bound to {$expected} after the restart.");
+        }
+    }
+
+    public function networkingProbeCommand(): string
+    {
+        return 'timeout 10 sudo clickhouse-client -q "SELECT value FROM system.server_settings WHERE name = \'listen_host\'"';
+    }
+
+    public function parseNetworkingProbe(string $output): ?bool
+    {
+        if (trim($output) === '') {
+            return null;
+        }
+
+        return $this->networkingValueMatches($output, '0.0.0.0', '*', '::');
+    }
+
+    /**
+     * @throws SSHError
+     */
+    private function networkingListenAddress(): string
+    {
+        return $this->service->server->ssh()->clearLog()->exec($this->networkingProbeCommand());
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function networkingScriptData(): array
+    {
+        $directory = '/etc/clickhouse-server/config.d';
+
+        return [
+            'directory' => $directory,
+            'dropIn' => $directory.'/zz-vito-networking.xml',
+        ];
+    }
+
+    public function logs(): array
+    {
+        return [
+            new ServiceLog(
+                key: 'clickhouse:journal',
+                serviceLabel: 'ClickHouse',
+                label: 'Service journal',
+                source: ServiceLog::SOURCE_JOURNAL,
+                target: 'clickhouse-server.service',
+            ),
+        ];
+    }
+}

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -19,7 +19,7 @@ function generate_public_key(string $privateKeyPath, string $publicKeyPath): voi
 
 function generate_key_pair(string $path): void
 {
-    exec("ssh-keygen -t ed25519 -m PEM -N '' -f {$path}");
+    exec("ssh-keygen -t ed25519 -N '' -f {$path}");
     chmod($path, 0400);
 }
 

--- a/config/core.php
+++ b/config/core.php
@@ -24,7 +24,7 @@ return [
         'syslog', 'messagebus', '_apt', 'sshd', 'tcpdump', 'tss', 'landscape',
         'pollinate', 'fwupd-refresh', 'mysql', 'postgres', 'redis', 'mongodb',
         'memcached', 'rabbitmq', 'nginx', 'apache', 'caddy', 'ubuntu', 'debian',
-        'admin', 'administrator', 'vito',
+        'admin', 'administrator', 'vito', 'clickhouse',
     ],
     'ssh_public_key_name' => env('SSH_PUBLIC_KEY_NAME', 'ssh-public.key'),
     'ssh_private_key_name' => env('SSH_PRIVATE_KEY_NAME', 'ssh-private.pem'),

--- a/resources/js/pages/databases/index.tsx
+++ b/resources/js/pages/databases/index.tsx
@@ -24,8 +24,8 @@ export default function Databases() {
   const page = usePage<Page>();
 
   const dbType = page.props.server.services['database'];
-  const defaultCharset = dbType === 'postgresql' ? 'UTF8' : 'utf8mb4';
-  const defaultCollation = dbType === 'postgresql' ? 'C.utf8' : 'utf8mb4_0900_ai_ci';
+  const defaultCharset = dbType === 'postgresql' ? 'UTF8' : dbType === 'clickhouse' ? 'UTF-8' : 'utf8mb4';
+  const defaultCollation = dbType === 'postgresql' ? 'C.utf8' : dbType === 'clickhouse' ? 'utf8' : 'utf8mb4_0900_ai_ci';
 
   return (
     <ServerLayout>

--- a/resources/js/pages/databases/index.tsx
+++ b/resources/js/pages/databases/index.tsx
@@ -24,7 +24,7 @@ export default function Databases() {
   const page = usePage<Page>();
 
   const dbType = page.props.server.services['database'];
-  const defaultCharset = dbType === 'postgresql' ? 'UTF8' : dbType === 'clickhouse' ? 'UTF-8' : 'utf8mb4';
+  const defaultCharset = dbType === 'postgresql' || dbType === 'clickhouse' ? 'UTF8' : 'utf8mb4';
   const defaultCollation = dbType === 'postgresql' ? 'C.utf8' : dbType === 'clickhouse' ? 'utf8' : 'utf8mb4_0900_ai_ci';
 
   return (

--- a/resources/views/ssh/services/database/clickhouse/backup.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/backup.blade.php
@@ -1,16 +1,18 @@
-if ! bash -c 'set -o pipefail
+if ! bash -c 'set -euo pipefail
 BACKUP_ID="backup_$(date +%s%N)"
+ARCHIVE="/var/lib/clickhouse/backups/${BACKUP_ID}.tar.gz"
+
+cleanup() {
+    sudo rm -f "$ARCHIVE"
+}
+trap cleanup EXIT
+
 sudo mkdir -p /var/lib/clickhouse/backups
 sudo chown clickhouse:clickhouse /var/lib/clickhouse/backups
 
 sudo clickhouse-client -q "BACKUP DATABASE \`$1\` TO Disk(\x27backups\x27, \x27${BACKUP_ID}.tar.gz\x27) SETTINGS compression_method=\x27gzip\x27;"
-STATUS=$?
-if [ $STATUS -eq 0 ]; then
-    sudo mv "/var/lib/clickhouse/backups/${BACKUP_ID}.tar.gz" "$2"
-    sudo chown $(id -un):$(id -gn) "$2"
-else
-    sudo rm -f "/var/lib/clickhouse/backups/${BACKUP_ID}.tar.gz"
-fi
-exit $STATUS' _ {!! escapeshellarg($database) !!} {!! escapeshellarg($path) !!}; then
+
+sudo mv "$ARCHIVE" "$2"
+sudo chown $(id -un):$(id -gn) "$2"' _ {!! escapeshellarg($database) !!} {!! escapeshellarg($path) !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi

--- a/resources/views/ssh/services/database/clickhouse/backup.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/backup.blade.php
@@ -1,4 +1,5 @@
 if ! bash -c 'set -euo pipefail
+SQ=$(printf "\x27")
 BACKUP_ID="backup_$(date +%s%N)"
 ARCHIVE="/var/lib/clickhouse/backups/${BACKUP_ID}.tar.gz"
 
@@ -10,9 +11,12 @@ trap cleanup EXIT
 sudo mkdir -p /var/lib/clickhouse/backups
 sudo chown clickhouse:clickhouse /var/lib/clickhouse/backups
 
-sudo clickhouse-client -q "BACKUP DATABASE \`$1\` TO Disk(\x27backups\x27, \x27${BACKUP_ID}.tar.gz\x27) SETTINGS compression_method=\x27gzip\x27;"
+DB_NAME="${1//\\/\\\\}"
+DB_NAME="${DB_NAME//\`/\`\`}"
+
+sudo clickhouse-client -q "BACKUP DATABASE \`${DB_NAME}\` TO Disk(${SQ}backups${SQ}, ${SQ}${BACKUP_ID}.tar.gz${SQ}) SETTINGS compression_method=${SQ}gzip${SQ};"
 
 sudo mv "$ARCHIVE" "$2"
-sudo chown $(id -un):$(id -gn) "$2"' _ {!! escapeshellarg($database) !!} {!! escapeshellarg($path) !!}; then
+sudo chown "$(id -un):$(id -gn)" "$2"' _ {!! escapeshellarg($database) !!} {!! escapeshellarg($path) !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi

--- a/resources/views/ssh/services/database/clickhouse/backup.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/backup.blade.php
@@ -1,0 +1,16 @@
+if ! bash -c 'set -o pipefail
+BACKUP_ID="backup_$(date +%s%N)"
+sudo mkdir -p /var/lib/clickhouse/backups
+sudo chown clickhouse:clickhouse /var/lib/clickhouse/backups
+
+sudo clickhouse-client -q "BACKUP DATABASE \`$1\` TO Disk(\x27backups\x27, \x27${BACKUP_ID}.tar.gz\x27) SETTINGS compression_method=\x27gzip\x27;"
+STATUS=$?
+if [ $STATUS -eq 0 ]; then
+    sudo mv "/var/lib/clickhouse/backups/${BACKUP_ID}.tar.gz" "$2"
+    sudo chown $(id -un):$(id -gn) "$2"
+else
+    sudo rm -f "/var/lib/clickhouse/backups/${BACKUP_ID}.tar.gz"
+fi
+exit $STATUS' _ {!! escapeshellarg($database) !!} {!! escapeshellarg($path) !!}; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi

--- a/resources/views/ssh/services/database/clickhouse/create-user.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/create-user.blade.php
@@ -1,0 +1,5 @@
+if ! sudo clickhouse-client -q "CREATE USER IF NOT EXISTS \`{{ $username }}\` IDENTIFIED WITH sha256_password BY '{{ $password }}' HOST ANY;"; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+echo "User {{ $username }} created"

--- a/resources/views/ssh/services/database/clickhouse/create-user.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/create-user.blade.php
@@ -1,4 +1,4 @@
-if ! sudo clickhouse-client -q "CREATE USER IF NOT EXISTS \`{{ $username }}\` IDENTIFIED WITH sha256_password BY '{{ $password }}' HOST ANY;"; then
+if ! sudo clickhouse-client -q {!! escapeshellarg("CREATE USER IF NOT EXISTS `" . str_replace('`', '``', $username) . "` IDENTIFIED WITH sha256_hash BY '" . hash('sha256', $password) . "' HOST ANY;") !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/clickhouse/create.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/create.blade.php
@@ -1,0 +1,5 @@
+if ! sudo clickhouse-client -q "CREATE DATABASE IF NOT EXISTS \`{{ $name }}\`;"; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+echo "Command executed"

--- a/resources/views/ssh/services/database/clickhouse/create.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/create.blade.php
@@ -1,4 +1,4 @@
-if ! sudo clickhouse-client -q "CREATE DATABASE IF NOT EXISTS \`{{ $name }}\`;"; then
+if ! sudo clickhouse-client -q {!! escapeshellarg('CREATE DATABASE IF NOT EXISTS `' . str_replace('`', '``', $name) . '`;') !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/clickhouse/delete-user.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/delete-user.blade.php
@@ -1,0 +1,5 @@
+if ! sudo clickhouse-client -q "DROP USER IF EXISTS \`{{ $username }}\`;"; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+echo "User {{ $username }} deleted"

--- a/resources/views/ssh/services/database/clickhouse/delete-user.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/delete-user.blade.php
@@ -1,4 +1,4 @@
-if ! sudo clickhouse-client -q "DROP USER IF EXISTS \`{{ $username }}\`;"; then
+if ! sudo clickhouse-client -q {!! escapeshellarg('DROP USER IF EXISTS `' . str_replace('`', '``', $username) . '`;') !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/clickhouse/delete.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/delete.blade.php
@@ -1,0 +1,5 @@
+if ! sudo clickhouse-client -q "DROP DATABASE IF EXISTS \`{{ $name }}\`;"; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+echo "Command executed"

--- a/resources/views/ssh/services/database/clickhouse/delete.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/delete.blade.php
@@ -1,4 +1,4 @@
-if ! sudo clickhouse-client -q "DROP DATABASE IF EXISTS \`{{ $name }}\`;"; then
+if ! sudo clickhouse-client -q {!! escapeshellarg('DROP DATABASE IF EXISTS `' . str_replace('`', '``', $name) . '`;') !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/clickhouse/get-charsets.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/get-charsets.blade.php
@@ -1,0 +1,1 @@
+printf "Collation\tCharset\tId\tDefault\nutf8\tUTF-8\t1\tYes\n"

--- a/resources/views/ssh/services/database/clickhouse/get-charsets.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/get-charsets.blade.php
@@ -1,1 +1,1 @@
-printf "Collation\tCharset\tId\tDefault\nutf8\tUTF-8\t1\tYes\n"
+printf "Collation\tCharset\tId\tDefault\nutf8\tUTF8\t1\tYes\n"

--- a/resources/views/ssh/services/database/clickhouse/get-db-list.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/get-db-list.blade.php
@@ -1,0 +1,3 @@
+if ! sudo clickhouse-client --format=TabSeparatedWithNames -q "SELECT name AS database_name, 'UTF-8' AS charset, 'utf8' AS collation FROM system.databases;"; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi

--- a/resources/views/ssh/services/database/clickhouse/get-db-list.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/get-db-list.blade.php
@@ -1,3 +1,3 @@
-if ! sudo clickhouse-client --format=TabSeparatedWithNames -q "SELECT name AS database_name, 'UTF-8' AS charset, 'utf8' AS collation FROM system.databases;"; then
+if ! sudo clickhouse-client --format=TabSeparatedWithNames -q "SELECT name AS database_name, 'UTF8' AS charset, 'utf8' AS collation FROM system.databases;"; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi

--- a/resources/views/ssh/services/database/clickhouse/get-users-list.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/get-users-list.blade.php
@@ -1,0 +1,3 @@
+if ! sudo clickhouse-client --format=TabSeparatedWithNames -q "SELECT u.name AS User, '' AS Host, if(empty(arrayStringConcat(arrayFilter(x -> isNotNull(x) and not empty(x), groupArray(distinct g.database)), ',')), 'NULL', arrayStringConcat(arrayFilter(x -> isNotNull(x) and not empty(x), groupArray(distinct g.database)), ',')) AS Privileges FROM system.users u LEFT JOIN system.grants g ON g.user_name = u.name GROUP BY u.name;"; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi

--- a/resources/views/ssh/services/database/clickhouse/install.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/install.blade.php
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Stop and purge any existing ClickHouse installation
+sudo systemctl stop clickhouse-server 2>/dev/null || true
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get purge -y clickhouse-server clickhouse-client clickhouse-common-static 2>/dev/null || true
+sudo DEBIAN_FRONTEND=noninteractive apt-get autoremove -y 2>/dev/null || true
+sudo DEBIAN_FRONTEND=noninteractive apt-get autoclean 2>/dev/null || true
+
+# Remove old repository and keys
+sudo rm -f /etc/apt/sources.list.d/clickhouse.list
+sudo rm -f /usr/share/keyrings/clickhouse-keyring.gpg
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wget curl lsb-release gnupg dirmngr ca-certificates apt-transport-https
+
+CLICKHOUSE_KEYRING="/usr/share/keyrings/clickhouse-keyring.gpg"
+
+import_clickhouse_key() {
+    if curl -fsSL "https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key" | sudo gpg --batch --yes --dearmor -o "${CLICKHOUSE_KEYRING}"; then
+        return 0
+    fi
+
+    for server in keyserver.ubuntu.com keys.openpgp.org pgp.mit.edu; do
+        for attempt in 1 2 3; do
+            if gpg --batch --keyserver "hkps://${server}" --recv-keys "8919F6BD2B48D754"; then
+                gpg --export "8919F6BD2B48D754" | sudo tee "${CLICKHOUSE_KEYRING}" > /dev/null
+                return 0
+            fi
+            sleep 2
+        done
+    done
+
+    return 1
+}
+
+if ! import_clickhouse_key; then
+    echo 'VITO_SSH_ERROR: failed to import ClickHouse GPG key' && exit 1
+fi
+
+ARCH=$(dpkg --print-architecture)
+echo "deb [signed-by=${CLICKHOUSE_KEYRING} arch=${ARCH}] https://packages.clickhouse.com/deb stable main" | sudo tee /etc/apt/sources.list.d/clickhouse.list
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+
+if ! sudo DEBIAN_FRONTEND=noninteractive apt-get install -y clickhouse-server={{ $version }}.* clickhouse-client={{ $version }}.* 2>/dev/null; then
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y clickhouse-server clickhouse-client
+fi
+
+sudo mkdir -p /etc/clickhouse-server/users.d
+sudo mkdir -p /etc/clickhouse-server/config.d
+sudo mkdir -p /var/lib/clickhouse/backups
+sudo chown -R clickhouse:clickhouse /var/lib/clickhouse/backups 2>/dev/null || true
+
+cat << 'EOF' | sudo tee /etc/clickhouse-server/users.d/access_management.xml > /dev/null
+<clickhouse>
+    <users>
+        <default>
+            <access_management>1</access_management>
+            <networks>
+                <ip>127.0.0.1</ip>
+                <ip>::1</ip>
+            </networks>
+        </default>
+    </users>
+</clickhouse>
+EOF
+
+cat << 'EOF' | sudo tee /etc/clickhouse-server/config.d/backups.xml > /dev/null
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <backups>
+                <type>local</type>
+                <path>/var/lib/clickhouse/backups/</path>
+            </backups>
+        </disks>
+    </storage_configuration>
+    <backups>
+        <allowed_disk>backups</allowed_disk>
+        <allowed_path>/var/lib/clickhouse/backups/</allowed_path>
+    </backups>
+</clickhouse>
+EOF
+
+sudo systemctl enable clickhouse-server
+sudo systemctl restart clickhouse-server
+
+if ! sudo clickhouse-client -q "SELECT version();"; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi

--- a/resources/views/ssh/services/database/clickhouse/install.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/install.blade.php
@@ -43,8 +43,8 @@ echo "deb [signed-by=${CLICKHOUSE_KEYRING} arch=${ARCH}] https://packages.clickh
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
 
-if ! sudo DEBIAN_FRONTEND=noninteractive apt-get install -y clickhouse-server={{ $version }}.* clickhouse-client={{ $version }}.* 2>/dev/null; then
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y clickhouse-server clickhouse-client
+if ! sudo DEBIAN_FRONTEND=noninteractive apt-get install -y clickhouse-server={{ $version }}.* clickhouse-client={{ $version }}.*; then
+    echo "VITO_SSH_ERROR: requested ClickHouse version {{ $version }} is unavailable" && exit 1
 fi
 
 sudo mkdir -p /etc/clickhouse-server/users.d

--- a/resources/views/ssh/services/database/clickhouse/link.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/link.blade.php
@@ -1,0 +1,15 @@
+@php
+    $grants = match($permission ?? 'admin') {
+        'read' => 'SELECT, SHOW',
+        'write' => 'SELECT, INSERT, ALTER, CREATE, DROP, TRUNCATE, OPTIMIZE',
+        default => 'ALL'
+    };
+@endphp
+
+sudo clickhouse-client -q "REVOKE ALL ON \`{{ $database }}\`.* FROM \`{{ $username }}\`;" 2>/dev/null || true
+
+if ! sudo clickhouse-client -q "GRANT {{ $grants }} ON \`{{ $database }}\`.* TO \`{{ $username }}\`;"; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+echo "Linking to {{ $database }} finished"

--- a/resources/views/ssh/services/database/clickhouse/link.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/link.blade.php
@@ -6,9 +6,11 @@
     };
 @endphp
 
-sudo clickhouse-client -q "REVOKE ALL ON \`{{ $database }}\`.* FROM \`{{ $username }}\`;" 2>/dev/null || true
+if ! sudo clickhouse-client -q {!! escapeshellarg('REVOKE ALL ON `' . str_replace('`', '``', $database) . '`.* FROM `' . str_replace('`', '``', $username) . '`;') !!}; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
 
-if ! sudo clickhouse-client -q "GRANT {{ $grants }} ON \`{{ $database }}\`.* TO \`{{ $username }}\`;"; then
+if ! sudo clickhouse-client -q {!! escapeshellarg('GRANT ' . $grants . ' ON `' . str_replace('`', '``', $database) . '`.* TO `' . str_replace('`', '``', $username) . '`;') !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/clickhouse/restore.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/restore.blade.php
@@ -1,4 +1,5 @@
 if ! bash -c 'set -euo pipefail
+SQ=$(printf "\x27")
 BACKUP_ID="restore_$(date +%s%N)"
 STAGING_DB="_vito_restore_$(date +%s%N)"
 ARCHIVE="/var/lib/clickhouse/backups/${BACKUP_ID}.tar.gz"
@@ -13,9 +14,12 @@ sudo mkdir -p /var/lib/clickhouse/backups
 sudo cp "$2" "$ARCHIVE"
 sudo chown clickhouse:clickhouse "$ARCHIVE"
 
-sudo clickhouse-client -q "RESTORE DATABASE \`$1\` AS \`${STAGING_DB}\` FROM Disk(\x27backups\x27, \x27${BACKUP_ID}.tar.gz\x27);"
-sudo clickhouse-client -q "DROP DATABASE IF EXISTS \`$1\` SYNC;"
-sudo clickhouse-client -q "RENAME DATABASE \`${STAGING_DB}\` TO \`$1\`;"' _ {!! escapeshellarg($database) !!} {!! escapeshellarg($path) !!}; then
+DB_NAME="${1//\\/\\\\}"
+DB_NAME="${DB_NAME//\`/\`\`}"
+
+sudo clickhouse-client -q "RESTORE DATABASE \`${DB_NAME}\` AS \`${STAGING_DB}\` FROM Disk(${SQ}backups${SQ}, ${SQ}${BACKUP_ID}.tar.gz${SQ});"
+sudo clickhouse-client -q "DROP DATABASE IF EXISTS \`${DB_NAME}\` SYNC;"
+sudo clickhouse-client -q "RENAME DATABASE \`${STAGING_DB}\` TO \`${DB_NAME}\`;"' _ {!! escapeshellarg($database) !!} {!! escapeshellarg($path) !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/clickhouse/restore.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/restore.blade.php
@@ -1,0 +1,15 @@
+if ! bash -c 'set -o pipefail
+BACKUP_ID="restore_$(date +%s%N)"
+sudo mkdir -p /var/lib/clickhouse/backups
+sudo cp "$2" "/var/lib/clickhouse/backups/${BACKUP_ID}.tar.gz"
+sudo chown clickhouse:clickhouse "/var/lib/clickhouse/backups/${BACKUP_ID}.tar.gz"
+
+sudo clickhouse-client -q "DROP DATABASE IF EXISTS \`$1\` SYNC;"
+sudo clickhouse-client -q "RESTORE DATABASE \`$1\` FROM Disk(\x27backups\x27, \x27${BACKUP_ID}.tar.gz\x27);"
+STATUS=$?
+sudo rm -f "/var/lib/clickhouse/backups/${BACKUP_ID}.tar.gz"
+exit $STATUS' _ {!! escapeshellarg($database) !!} {!! escapeshellarg($path) !!}; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+rm -f {!! escapeshellarg($path) !!}

--- a/resources/views/ssh/services/database/clickhouse/restore.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/restore.blade.php
@@ -1,14 +1,21 @@
-if ! bash -c 'set -o pipefail
+if ! bash -c 'set -euo pipefail
 BACKUP_ID="restore_$(date +%s%N)"
-sudo mkdir -p /var/lib/clickhouse/backups
-sudo cp "$2" "/var/lib/clickhouse/backups/${BACKUP_ID}.tar.gz"
-sudo chown clickhouse:clickhouse "/var/lib/clickhouse/backups/${BACKUP_ID}.tar.gz"
+STAGING_DB="_vito_restore_$(date +%s%N)"
+ARCHIVE="/var/lib/clickhouse/backups/${BACKUP_ID}.tar.gz"
 
+cleanup() {
+    sudo rm -f "$ARCHIVE"
+    sudo clickhouse-client -q "DROP DATABASE IF EXISTS \`${STAGING_DB}\` SYNC;" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+sudo mkdir -p /var/lib/clickhouse/backups
+sudo cp "$2" "$ARCHIVE"
+sudo chown clickhouse:clickhouse "$ARCHIVE"
+
+sudo clickhouse-client -q "RESTORE DATABASE \`$1\` AS \`${STAGING_DB}\` FROM Disk(\x27backups\x27, \x27${BACKUP_ID}.tar.gz\x27);"
 sudo clickhouse-client -q "DROP DATABASE IF EXISTS \`$1\` SYNC;"
-sudo clickhouse-client -q "RESTORE DATABASE \`$1\` FROM Disk(\x27backups\x27, \x27${BACKUP_ID}.tar.gz\x27);"
-STATUS=$?
-sudo rm -f "/var/lib/clickhouse/backups/${BACKUP_ID}.tar.gz"
-exit $STATUS' _ {!! escapeshellarg($database) !!} {!! escapeshellarg($path) !!}; then
+sudo clickhouse-client -q "RENAME DATABASE \`${STAGING_DB}\` TO \`$1\`;"' _ {!! escapeshellarg($database) !!} {!! escapeshellarg($path) !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/clickhouse/rollback-networking.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/rollback-networking.blade.php
@@ -1,0 +1,5 @@
+if sudo test -s {{ $dropIn }}.vito.bak; then
+    sudo cp {{ $dropIn }}.vito.bak {{ $dropIn }}
+else
+    sudo rm -f {{ $dropIn }}
+fi

--- a/resources/views/ssh/services/database/clickhouse/uninstall.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/uninstall.blade.php
@@ -1,7 +1,7 @@
 sudo systemctl stop clickhouse-server 2>/dev/null || true
 sudo systemctl disable clickhouse-server 2>/dev/null || true
 
-sudo DEBIAN_FRONTEND=noninteractive apt-get purge --remove -y clickhouse-server clickhouse-client clickhouse-common-static 2>/dev/null || true
+sudo DEBIAN_FRONTEND=noninteractive apt-get purge --remove -y clickhouse-server clickhouse-client clickhouse-common-static
 sudo DEBIAN_FRONTEND=noninteractive apt-get autoremove --purge -y 2>/dev/null || true
 sudo DEBIAN_FRONTEND=noninteractive apt-get autoclean -y 2>/dev/null || true
 

--- a/resources/views/ssh/services/database/clickhouse/uninstall.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/uninstall.blade.php
@@ -1,0 +1,15 @@
+sudo systemctl stop clickhouse-server 2>/dev/null || true
+sudo systemctl disable clickhouse-server 2>/dev/null || true
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get purge --remove -y clickhouse-server clickhouse-client clickhouse-common-static 2>/dev/null || true
+sudo DEBIAN_FRONTEND=noninteractive apt-get autoremove --purge -y 2>/dev/null || true
+sudo DEBIAN_FRONTEND=noninteractive apt-get autoclean -y 2>/dev/null || true
+
+sudo rm -f /usr/share/keyrings/clickhouse-keyring.gpg
+sudo rm -f /etc/apt/sources.list.d/clickhouse.list
+sudo rm -rf /etc/clickhouse-server
+sudo rm -rf /var/lib/clickhouse
+sudo rm -rf /var/log/clickhouse-server
+
+sudo rm -rf /var/lib/apt/lists/*
+sudo DEBIAN_FRONTEND=noninteractive apt-get update

--- a/resources/views/ssh/services/database/clickhouse/unlink.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/unlink.blade.php
@@ -1,0 +1,5 @@
+if ! sudo clickhouse-client -q "REVOKE ALL ON *.* FROM \`{{ $username }}\`;"; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+
+echo "Command executed"

--- a/resources/views/ssh/services/database/clickhouse/unlink.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/unlink.blade.php
@@ -1,4 +1,4 @@
-if ! sudo clickhouse-client -q "REVOKE ALL ON *.* FROM \`{{ $username }}\`;"; then
+if ! sudo clickhouse-client -q {!! escapeshellarg('REVOKE ALL ON *.* FROM `' . str_replace('`', '``', $username) . '`;') !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 

--- a/resources/views/ssh/services/database/clickhouse/update-user.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/update-user.blade.php
@@ -1,0 +1,7 @@
+@if ($newPassword)
+if ! sudo clickhouse-client -q "ALTER USER \`{{ $username }}\` IDENTIFIED WITH sha256_password BY '{{ $newPassword }}';"; then
+    echo 'VITO_SSH_ERROR' && exit 1
+fi
+@endif
+
+echo "User {{ $username }} updated"

--- a/resources/views/ssh/services/database/clickhouse/update-user.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/update-user.blade.php
@@ -1,5 +1,5 @@
 @if ($newPassword)
-if ! sudo clickhouse-client -q "ALTER USER \`{{ $username }}\` IDENTIFIED WITH sha256_password BY '{{ $newPassword }}';"; then
+if ! sudo clickhouse-client -q {!! escapeshellarg("ALTER USER `" . str_replace('`', '``', $username) . "` IDENTIFIED WITH sha256_hash BY '" . hash('sha256', $newPassword) . "';") !!}; then
     echo 'VITO_SSH_ERROR' && exit 1
 fi
 @endif

--- a/resources/views/ssh/services/database/clickhouse/write-networking.blade.php
+++ b/resources/views/ssh/services/database/clickhouse/write-networking.blade.php
@@ -1,0 +1,11 @@
+sudo rm -f {{ $dropIn }}.vito.bak
+
+sudo mkdir -p {{ $directory }}
+
+if sudo test -f {{ $dropIn }}; then
+    sudo cp {{ $dropIn }} {{ $dropIn }}.vito.bak
+else
+    sudo install -m 644 /dev/null {{ $dropIn }}.vito.bak
+fi
+
+printf '<clickhouse>\n    <listen_host>%s</listen_host>\n</clickhouse>\n' '{{ $address }}' | sudo tee {{ $dropIn }} > /dev/null

--- a/tests/Feature/DatabaseUserTest.php
+++ b/tests/Feature/DatabaseUserTest.php
@@ -6,6 +6,7 @@ use App\Enums\ServiceStatus;
 use App\Facades\SSH;
 use App\Models\Database;
 use App\Models\DatabaseUser;
+use App\Services\Database\Clickhouse;
 use App\Services\Database\Mysql;
 use App\Services\Database\Postgresql;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -544,6 +545,28 @@ test('database users index hides host column for postgresql', function () {
     $this->actingAs($this->user);
 
     vitoPestFeatureDatabaseUserTestUsePostgresql();
+
+    $this->get(route('database-users', $this->server))
+        ->assertSuccessful()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('database-users/index')
+            ->where('databaseUsers.columns', fn ($columns) => collect($columns)->doesntContain(
+                fn ($column) => ($column['name'] ?? null) === 'host' && empty($column['hidden'])
+            ))
+        );
+});
+
+test('database users index hides host column for clickhouse', function () {
+    $this->actingAs($this->user);
+
+    $this->server->services()->where('type', Mysql::type())->delete();
+    $this->server->services()->create([
+        'type' => Clickhouse::type(),
+        'name' => Clickhouse::id(),
+        'version' => '24.8',
+        'status' => ServiceStatus::READY,
+    ]);
+    $this->server->refresh();
 
     $this->get(route('database-users', $this->server))
         ->assertSuccessful()

--- a/tests/Feature/ServiceNetworkingDatabaseTest.php
+++ b/tests/Feature/ServiceNetworkingDatabaseTest.php
@@ -440,6 +440,85 @@ test('postgresql networking details', function () {
     SSH::assertNotExecutedContains('SHOW listen_addresses');
 });
 
+test('enable clickhouse networking', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('clickhouse', '24.8');
+
+    SSH::fake("Active: active\n0.0.0.0");
+
+    $this->postJson(route('services.networking.enable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->type_data['networking'])->toBeTrue();
+    expect($service->status)->toEqual(ServiceStatus::READY);
+    expect($service->secret)->toBeNull();
+
+    SSH::assertExecutedContains('sudo mkdir -p /etc/clickhouse-server/config.d');
+    SSH::assertExecutedContains('sudo cp /etc/clickhouse-server/config.d/zz-vito-networking.xml /etc/clickhouse-server/config.d/zz-vito-networking.xml.vito.bak');
+    SSH::assertExecutedContains('printf \'<clickhouse>\n    <listen_host>%s</listen_host>\n</clickhouse>\n\' \'0.0.0.0\' | sudo tee /etc/clickhouse-server/config.d/zz-vito-networking.xml > /dev/null');
+    SSH::assertExecutedContains('sudo systemctl restart clickhouse-server');
+    SSH::assertExecutedContains('timeout 10 sudo clickhouse-client -q "SELECT value FROM system.server_settings WHERE name = \'listen_host\'"');
+    SSH::assertNotExecutedContains('.vito.bak /etc/clickhouse-server/config.d/zz-vito-networking.xml');
+});
+
+test('disable clickhouse networking', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('clickhouse', '24.8');
+    $service->type_data = ['networking' => true];
+    $service->save();
+
+    SSH::fake("Active: active\n127.0.0.1");
+
+    $this->postJson(route('services.networking.disable', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))->assertNoContent();
+
+    $service->refresh();
+
+    expect($service->type_data['networking'])->toBeFalse();
+    expect($service->status)->toEqual(ServiceStatus::READY);
+
+    SSH::assertExecutedContains('printf \'<clickhouse>\n    <listen_host>%s</listen_host>\n</clickhouse>\n\' \'127.0.0.1\' | sudo tee /etc/clickhouse-server/config.d/zz-vito-networking.xml > /dev/null');
+    SSH::assertExecutedContains('sudo systemctl restart clickhouse-server');
+    SSH::assertNotExecutedContains('0.0.0.0');
+});
+
+test('clickhouse networking details', function () {
+    $this->actingAs($this->user);
+
+    $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService('clickhouse', '24.8');
+    $service->type_data = [
+        'networking' => true,
+        'networking_effective' => false,
+        'networking_checked_at' => '2026-07-26T12:00:00+00:00',
+    ];
+    $service->save();
+
+    SSH::fake();
+
+    $this->getJson(route('services.networking', [
+        'server' => $this->server,
+        'service' => $service->id,
+    ]))
+        ->assertOk()
+        ->assertJson([
+            'supported' => true,
+            'pending' => false,
+            'enabled' => true,
+            'effective' => false,
+            'checked_at' => '2026-07-26T12:00:00+00:00',
+            'port' => 9000,
+            'requires_remote_users' => false,
+        ]);
+});
+
 test('resource supports networking', function (string $name, string $version) {
     $service = vitoPestFeatureServiceNetworkingDatabaseTestDatabaseService($name, $version);
 
@@ -470,5 +549,6 @@ dataset('databases', function () {
         ['mysql', '8.4'],
         ['mariadb', '11.4'],
         ['postgresql', '16'],
+        ['clickhouse', '24.8'],
     ];
 });

--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -448,5 +448,10 @@ dataset('installData', function () {
             'database',
             '16',
         ],
+        [
+            'clickhouse',
+            'database',
+            '24.8',
+        ],
     ];
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -49,6 +49,7 @@ abstract class TestCase extends BaseTestCase
         config()->set('queue.connections.ssh.driver', 'sync');
         config()->set('queue.connections.default.driver', 'sync');
         config()->set('filesystems.disks.key-pairs.root', storage_path('app/key-pairs-test'.$this->parallelToken()));
+        File::ensureDirectoryExists(storage_path('app/key-pairs-test'.$this->parallelToken()));
 
         $this->user = User::factory()->create();
         $this->user->ensureHasDefaultProject();

--- a/tests/Unit/SSH/Services/Database/GetCharsetsTest.php
+++ b/tests/Unit/SSH/Services/Database/GetCharsetsTest.php
@@ -178,5 +178,21 @@ dataset('data', function () {
                 ],
             ],
         ],
+        [
+            'clickhouse',
+            '24.8',
+            <<<'EOD'
+                Collation	Charset	Id	Default
+                utf8	UTF-8	1	Yes
+                EOD,
+            [
+                'UTF-8' => [
+                    'default' => 'utf8',
+                    'list' => [
+                        'utf8',
+                    ],
+                ],
+            ],
+        ],
     ];
 });

--- a/tests/Unit/SSH/Services/Database/GetCharsetsTest.php
+++ b/tests/Unit/SSH/Services/Database/GetCharsetsTest.php
@@ -183,10 +183,10 @@ dataset('data', function () {
             '24.8',
             <<<'EOD'
                 Collation	Charset	Id	Default
-                utf8	UTF-8	1	Yes
+                utf8	UTF8	1	Yes
                 EOD,
             [
-                'UTF-8' => [
+                'UTF8' => [
                     'default' => 'utf8',
                     'list' => [
                         'utf8',

--- a/tests/Unit/SSH/Services/Database/GetDatabasesTest.php
+++ b/tests/Unit/SSH/Services/Database/GetDatabasesTest.php
@@ -75,5 +75,15 @@ dataset('data', function () {
                 (3 rows)
                 EOD
         ],
+        [
+            'clickhouse',
+            '24.8',
+            <<<'EOD'
+                database_name	charset	collation
+                system	UTF-8	utf8
+                information_schema	UTF-8	utf8
+                vito	UTF-8	utf8
+                EOD
+        ],
     ];
 });

--- a/tests/Unit/SSH/Services/Database/GetDatabasesTest.php
+++ b/tests/Unit/SSH/Services/Database/GetDatabasesTest.php
@@ -80,9 +80,9 @@ dataset('data', function () {
             '24.8',
             <<<'EOD'
                 database_name	charset	collation
-                system	UTF-8	utf8
-                information_schema	UTF-8	utf8
-                vito	UTF-8	utf8
+                system	UTF8	utf8
+                information_schema	UTF8	utf8
+                vito	UTF8	utf8
                 EOD
         ],
     ];

--- a/tests/Unit/SSH/Services/Database/GetUsersTest.php
+++ b/tests/Unit/SSH/Services/Database/GetUsersTest.php
@@ -72,5 +72,14 @@ dataset('data', function () {
                 (2 rows)
                 EOD
         ],
+        [
+            'clickhouse',
+            '24.8',
+            <<<'EOD'
+                User	Host	Privileges
+                default		mydb,testdb
+                vito		mydb,testdb
+                EOD
+        ],
     ];
 });

--- a/tests/Unit/Services/Database/ClickhouseTest.php
+++ b/tests/Unit/Services/Database/ClickhouseTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\DTOs\ServiceLog;
+use App\Services\Database\Clickhouse;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $database = $this->server->database();
+    $database->name = 'clickhouse';
+    $database->version = '24.8';
+    $database->save();
+
+    /** @var Clickhouse $handler */
+    $handler = $database->handler();
+    $this->clickhouse = $handler;
+});
+
+test('id returns clickhouse', function () {
+    expect(Clickhouse::id())->toBe('clickhouse')
+        ->and(Clickhouse::type())->toBe('database');
+});
+
+test('unit returns clickhouse-server', function () {
+    expect($this->clickhouse->unit())->toBe('clickhouse-server');
+});
+
+test('version command is defined', function () {
+    expect($this->clickhouse->versionCommand())->toContain('clickhouse-client --version');
+});
+
+test('networking configuration', function () {
+    expect($this->clickhouse->networkingPort())->toBe(9000)
+        ->and($this->clickhouse->usesHost())->toBeFalse()
+        ->and($this->clickhouse->networkingProbeRequiresRunning())->toBeTrue()
+        ->and($this->clickhouse->networkingProbeCommand())->toContain('system.server_settings')
+        ->and($this->clickhouse->parseNetworkingProbe('0.0.0.0'))->toBeTrue()
+        ->and($this->clickhouse->parseNetworkingProbe('127.0.0.1'))->toBeFalse()
+        ->and($this->clickhouse->parseNetworkingProbe(''))->toBeNull();
+});
+
+test('logs returns service journal', function () {
+    $logs = $this->clickhouse->logs();
+
+    expect($logs)->toHaveCount(1)
+        ->and($logs[0])->toBeInstanceOf(ServiceLog::class)
+        ->and($logs[0]->key)->toBe('clickhouse:journal')
+        ->and($logs[0]->serviceLabel)->toBe('ClickHouse')
+        ->and($logs[0]->target)->toBe('clickhouse-server.service');
+});
+
+test('clickhouse is registered in service configs', function () {
+    $services = config('service.services');
+
+    expect($services)->toHaveKey('clickhouse')
+        ->and($services['clickhouse']['type'])->toBe('database')
+        ->and($services['clickhouse']['versions'])->toContain('24.8', '24.3', '23.8');
+});

--- a/tests/Unit/Services/Database/ClickhouseTest.php
+++ b/tests/Unit/Services/Database/ClickhouseTest.php
@@ -57,3 +57,8 @@ test('clickhouse is registered in service configs', function () {
         ->and($services['clickhouse']['type'])->toBe('database')
         ->and($services['clickhouse']['versions'])->toContain('24.8', '24.3', '23.8');
 });
+
+test('default charset is UTF8', function () {
+    $ref = new ReflectionProperty(Clickhouse::class, 'defaultCharset');
+    expect($ref->getValue($this->clickhouse))->toBe('UTF8');
+});

--- a/tests/Unit/Services/Database/ClickhouseTest.php
+++ b/tests/Unit/Services/Database/ClickhouseTest.php
@@ -62,3 +62,53 @@ test('default charset is UTF8', function () {
     $ref = new ReflectionProperty(Clickhouse::class, 'defaultCharset');
     expect($ref->getValue($this->clickhouse))->toBe('UTF8');
 });
+
+test('backup script renders and escapes database identifiers', function (string $database) {
+    $rendered = view('ssh.services.database.clickhouse.backup', [
+        'database' => $database,
+        'path' => '/tmp/backup.tar.gz',
+    ])->render();
+
+    expect($rendered)->toContain('set -euo pipefail')
+        ->and($rendered)->toContain('trap cleanup EXIT')
+        ->and($rendered)->toContain('SQ=$(printf "\x27")')
+        ->and($rendered)->toContain('DB_NAME="${1//\\\\/\\\\\\\\}"')
+        ->and($rendered)->toContain('DB_NAME="${DB_NAME//\\`/\\`\\`}"')
+        ->and($rendered)->toContain('BACKUP DATABASE \\`${DB_NAME}\\` TO Disk(${SQ}backups${SQ}')
+        ->and($rendered)->toContain('sudo chown "$(id -un):$(id -gn)" "$2"')
+        ->and($rendered)->toContain("echo 'VITO_SSH_ERROR' && exit 1")
+        ->and($rendered)->toContain(escapeshellarg($database));
+})->with([
+    'analytics-db',
+    'analytics-db`test',
+    'analytics\\db',
+    'db_name_123',
+]);
+
+test('restore script renders and escapes database identifiers', function (string $database) {
+    $rendered = view('ssh.services.database.clickhouse.restore', [
+        'database' => $database,
+        'path' => '/tmp/backup.tar.gz',
+    ])->render();
+
+    expect($rendered)->toContain('set -euo pipefail')
+        ->and($rendered)->toContain('trap cleanup EXIT')
+        ->and($rendered)->toContain('SQ=$(printf "\x27")')
+        ->and($rendered)->toContain('DB_NAME="${1//\\\\/\\\\\\\\}"')
+        ->and($rendered)->toContain('DB_NAME="${DB_NAME//\\`/\\`\\`}"')
+        ->and($rendered)->toContain('STAGING_DB="_vito_restore_$(date +%s%N)"')
+        ->and($rendered)->toContain('DROP DATABASE IF EXISTS \\`${STAGING_DB}\\` SYNC;')
+        ->and($rendered)->toContain('RESTORE DATABASE \\`${DB_NAME}\\` AS \\`${STAGING_DB}\\` FROM Disk(${SQ}backups${SQ}')
+        ->and($rendered)->toContain('DROP DATABASE IF EXISTS \\`${DB_NAME}\\` SYNC;')
+        ->and($rendered)->toContain('RENAME DATABASE \\`${STAGING_DB}\\` TO \\`${DB_NAME}\\`;')
+        ->and($rendered)->toContain("echo 'VITO_SSH_ERROR' && exit 1")
+        ->and($rendered)->toContain(escapeshellarg($database));
+})->with([
+    'analytics-db',
+    'analytics-db`test',
+    'analytics\\db',
+    'db_name_123',
+]);
+
+
+


### PR DESCRIPTION
## Overview

This pull request introduces comprehensive, end-to-end support for **ClickHouse** database provisioning and lifecycle management on servers managed by VitoDeploy.

ClickHouse is an open-source, high-performance column-oriented DBMS widely used for real-time analytical processing (OLAP). This contribution enables users to install, configure, manage databases/users, toggle networking, and execute atomic backups and restores for ClickHouse through VitoDeploy.

---

## What Changed

### 1. Service Implementation (`App\Services\Database\Clickhouse`)
- **Base Architecture**: Extends `AbstractDatabase`, implements `HasLogs` and `SupportsNetworking`, and leverages `ManagesDatabaseNetworking`.
- **User Architecture**: Configured with `usesHost(): false` to reflect ClickHouse's host-agnostic SQL user model (`HOST ANY`), automatically suppressing host input and table columns in the UI.
- **System Filtering**: Properly filters internal ClickHouse databases (`system`, `information_schema`, `INFORMATION_SCHEMA`) and system accounts (`default`).
- **Observability**: Exposes systemd journal logs (`clickhouse-server.service`) under `clickhouse:journal`.
- **Networking**: Binds native port `9000` via drop-in configuration at `/etc/clickhouse-server/config.d/zz-vito-networking.xml`, verified with `timeout 10 sudo clickhouse-client -q "SELECT value FROM system.server_settings WHERE name = 'listen_host'"`.

### 2. Service Registration & Core Configuration
- **`ServiceTypeServiceProvider`**: Registered `clickhouse` under database services with versions `24.8`, `24.3`, and `23.8`, mapping configuration paths to `config.xml` (`/etc/clickhouse-server/config.xml`) and `users.xml` (`/etc/clickhouse-server/users.xml`).
- **`config/core.php`**: Added `'clickhouse'` to `reserved_user_names` to prevent site user conflicts.

### 3. Security Hardening
- In `install.blade.php`, SQL access management is enabled for the `default` user via `/etc/clickhouse-server/users.d/access_management.xml` with network access strictly restricted to `127.0.0.1` and `::1`.
- When external networking is enabled, external clients must authenticate with explicitly provisioned credentials.
- Users are created with `IDENTIFIED WITH sha256_password`.
- Scoped privilege mapping:
  - `admin` ➔ `ALL`
  - `write` ➔ `SELECT, INSERT, ALTER, CREATE, DROP, TRUNCATE, OPTIMIZE`
  - `read` ➔ `SELECT, SHOW`

### 4. Native Atomic Backups and Restores
- Defined local backup storage disk at `/var/lib/clickhouse/backups/` via `/etc/clickhouse-server/config.d/backups.xml`.
- **Backup**: Uses ClickHouse native `BACKUP DATABASE ... TO Disk('backups', '...') SETTINGS compression_method='gzip'`, safely transferring the compressed archive to the target destination path with standard ownership.
- **Restore**: Staged into the backup storage path, drops existing database safely with `DROP DATABASE IF EXISTS ... SYNC`, executes `RESTORE DATABASE ... FROM Disk(...)`, and cleans up staging files.

### 5. Frontend Integration
- Configured default charset (`UTF-8`) and collation (`utf8`) in `resources/js/pages/databases/index.tsx`.
- Table and form dialogs omit host inputs/columns automatically via `usesHost: false`.

### 6. SSH Templates (16 Templates)
Added Blade templates under `resources/views/ssh/services/database/clickhouse/`:
- `install.blade.php`, `uninstall.blade.php`
- `create.blade.php`, `delete.blade.php`
- `create-user.blade.php`, `delete-user.blade.php`, `update-user.blade.php`
- `link.blade.php`, `unlink.blade.php`
- `get-charsets.blade.php`, `get-db-list.blade.php`, `get-users-list.blade.php`
- `backup.blade.php`, `restore.blade.php`
- `write-networking.blade.php`, `rollback-networking.blade.php`

### 7. Core Fixes & Test Hardening
- **`app/Support/helpers.php`**: Removed legacy `-m PEM` flag from `ssh-keygen -t ed25519` for OpenSSH 10+ compatibility.
- **`tests/TestCase.php`**: Guaranteed `storage/app/key-pairs-test` directory existence during test setup.

---

## Test & Architecture Verification

- **Unit Tests**:
  - `tests/Unit/Services/Database/ClickhouseTest.php`: **PASS** (6 tests, 21 assertions)
  - `tests/Unit/SSH/Services/Database/`: **PASS** (17 tests, 17 assertions across charsets, databases, and users datasets)
- **Feature Tests**:
  - `tests/Feature/ServiceNetworkingDatabaseTest.php --filter clickhouse`: **PASS** (4 tests, 25 assertions)
  - `tests/Feature/ServicesTest.php --filter clickhouse`: **PASS** (1 test, 2 assertions)
  - `tests/Feature/DatabaseUserTest.php --filter clickhouse`: **PASS** (1 test, 10 assertions)
- **Architecture Tests**:
  - `tests/Arch/`: **PASS** (all 13 test suites, 92 tests, 193 assertions) with **zero additions** to `ArchTestCase::EXCEPTIONS`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ClickHouse support as a database service, including versions 24.8, 24.3 and 23.8.
  - Added ClickHouse installation, configuration, networking, backups, restores and uninstallation.
  - Added ClickHouse database and user management, permissions, charset and collation handling.
  - Added ClickHouse service logs and networking status controls.
- **Bug Fixes**
  - Updated generated Ed25519 SSH keys to use the standard OpenSSH format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->