### PR TITLE
[Fix] WebSocket handshake broken by guzzlehttp/psr7 3.x

### DIFF
--- a/app/WebSocket/HandshakeResponse.php
+++ b/app/WebSocket/HandshakeResponse.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\WebSocket;
+
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\MessageInterface;
+
+/**
+ * PSR-7 response that tolerates scalar header values.
+ *
+ * `Ratchet\RFC6455\Handshake\ServerNegotiator::handshake()` sets
+ * `Sec-WebSocket-Version` from `getVersionNumber(): int`. guzzlehttp/psr7 3.x
+ * rejects non-string header values, which aborts every handshake.
+ */
+class HandshakeResponse extends Response
+{
+    /**
+     * @param  string|int|float|bool|string[]  $value
+     */
+    public function withHeader(string $name, $value): MessageInterface
+    {
+        return parent::withHeader($name, $this->stringifyScalar($value));
+    }
+
+    /**
+     * @param  string|int|float|bool|string[]  $value
+     */
+    public function withAddedHeader(string $name, $value): MessageInterface
+    {
+        return parent::withAddedHeader($name, $this->stringifyScalar($value));
+    }
+
+    /**
+     * @param  string|int|float|bool|string[]  $value
+     * @return string|string[]
+     */
+    private function stringifyScalar($value): string|array
+    {
+        if (is_scalar($value) && ! is_string($value)) {
+            return (string) $value;
+        }
+
+        return $value;
+    }
+}

--- a/app/WebSocket/HandshakeResponseFactory.php
+++ b/app/WebSocket/HandshakeResponseFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\WebSocket;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class HandshakeResponseFactory implements ResponseFactoryInterface
+{
+    public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface
+    {
+        return new HandshakeResponse($code, [], null, '1.1', $reasonPhrase);
+    }
+}

--- a/app/WebSocket/WebSocketServer.php
+++ b/app/WebSocket/WebSocketServer.php
@@ -2,7 +2,6 @@
 
 namespace App\WebSocket;
 
-use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\Message;
 use Illuminate\Support\Facades\Log;
 use Psr\Http\Message\RequestInterface;
@@ -43,7 +42,7 @@ class WebSocketServer
     ) {
         $this->negotiator = new ServerNegotiator(
             new RequestVerifier,
-            new HttpFactory,
+            new HandshakeResponseFactory,
         );
         $this->maxConnections = $maxConnections;
 

--- a/tests/Unit/WebSocket/HandshakeResponseTest.php
+++ b/tests/Unit/WebSocket/HandshakeResponseTest.php
@@ -2,14 +2,28 @@
 
 use App\WebSocket\HandshakeResponseFactory;
 use GuzzleHttp\Psr7\Request as PsrRequest;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Ratchet\RFC6455\Handshake\RequestVerifier;
 use Ratchet\RFC6455\Handshake\ServerNegotiator;
+
+uses(RefreshDatabase::class);
 
 test('scalar header values are accepted despite psr7 strict validation', function () {
     $response = (new HandshakeResponseFactory)->createResponse();
 
     expect($response->withHeader('Sec-WebSocket-Version', 13)->getHeaderLine('Sec-WebSocket-Version'))
         ->toBe('13');
+});
+
+/**
+ * `withAddedHeader()` needs the same treatment as `withHeader()`: Ratchet appends
+ * `Sec-WebSocket-Extensions` through it when permessage-deflate is negotiated.
+ */
+test('scalar values appended to an existing header are stringified too', function () {
+    $response = (new HandshakeResponseFactory)->createResponse()->withHeader('Sec-WebSocket-Version', 13);
+
+    expect($response->withAddedHeader('Sec-WebSocket-Version', 8)->getHeaderLine('Sec-WebSocket-Version'))
+        ->toBe('13, 8');
 });
 
 /**

--- a/tests/Unit/WebSocket/HandshakeResponseTest.php
+++ b/tests/Unit/WebSocket/HandshakeResponseTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\WebSocket\HandshakeResponseFactory;
+use GuzzleHttp\Psr7\Request as PsrRequest;
+use Ratchet\RFC6455\Handshake\RequestVerifier;
+use Ratchet\RFC6455\Handshake\ServerNegotiator;
+
+test('scalar header values are accepted despite psr7 strict validation', function () {
+    $response = (new HandshakeResponseFactory)->createResponse();
+
+    expect($response->withHeader('Sec-WebSocket-Version', 13)->getHeaderLine('Sec-WebSocket-Version'))
+        ->toBe('13');
+});
+
+/**
+ * Intentionally end-to-end through the vendor negotiator: this is the regression
+ * guard for the guzzlehttp/psr7 3.x upgrade, which broke every handshake.
+ */
+test('the negotiator completes a websocket handshake with 101', function () {
+    $negotiator = new ServerNegotiator(new RequestVerifier, new HandshakeResponseFactory);
+
+    $request = new PsrRequest('GET', 'http://127.0.0.1:8085/ws/events?token=x', [
+        'Host' => '127.0.0.1:8085',
+        'Upgrade' => 'websocket',
+        'Connection' => 'Upgrade',
+        'Sec-WebSocket-Key' => base64_encode(random_bytes(16)),
+        'Sec-WebSocket-Version' => '13',
+    ]);
+
+    $response = $negotiator->handshake($request);
+
+    expect($response->getStatusCode())->toBe(101)
+        ->and($response->getHeaderLine('Upgrade'))->toBe('websocket')
+        ->and($response->getHeaderLine('Sec-WebSocket-Accept'))->not->toBe('');
+});


### PR DESCRIPTION
## Problem

WebSocket connections fail on `4.x` since #1243 bumped `guzzlehttp/psr7` from `2.13.0` to `3.1.0`.

`Ratchet\RFC6455\Handshake\ServerNegotiator::handshake()` builds the upgrade response with:

```php
->withHeader('Sec-WebSocket-Version', $this->getVersionNumber())
```

`getVersionNumber()` is typed `: int`. psr7 2.x accepted scalar header values and cast them; 3.x rejects anything that is not a string or an array of strings.

Reproduced against the current lock file:

```php
$response = (new GuzzleHttp\Psr7\HttpFactory)->createResponse();
$response->withHeader('Sec-WebSocket-Version', 13);

// InvalidArgumentException: Header value must be a string or array of strings but int provided.
```

Because `WebSocketServer` calls `handshake()` inside a `try`, the exception is swallowed by the `catch (\Throwable $e)` and logged as `WebSocket handshake error`. Every client is dropped at the upgrade, so no real-time updates reach the UI.

`ratchet/rfc6455` is pinned at `v0.4.1` and has had no release since, so the value has to be normalised on our side.

## Fix

- `App\WebSocket\HandshakeResponse` — a PSR-7 response that stringifies scalar header values before delegating to Guzzle's `Response`.
- `App\WebSocket\HandshakeResponseFactory` — a `ResponseFactoryInterface` handed to `ServerNegotiator` in place of `GuzzleHttp\Psr7\HttpFactory`.

Scoped to the handshake only: vendor code is untouched, and the rest of the application keeps using Guzzle's factory and strict header validation.

## Tests

`tests/Unit/WebSocket/HandshakeResponseTest.php` covers both the unit behaviour (an `int` header value comes back as `'13'`) and, deliberately end-to-end through the vendor negotiator, a full handshake returning `101` with a valid `Sec-WebSocket-Accept`. The second test fails on `4.x` as it stands today, which makes it the regression guard for the psr7 upgrade.

Verified locally: Pint, PHPStan and the test suite all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebSocket handshake compatibility with stricter response handling.
  - WebSocket handshakes now correctly accept and return numeric header values.
  - Resolved failures that could prevent successful WebSocket connections after upgrading the underlying HTTP library.
  - Improved reliability when establishing connections requiring standard WebSocket negotiation headers.

- **Tests**
  - Added coverage for header serialisation and complete WebSocket handshake responses.
  - Added regression checks for successful connection upgrades and required handshake headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->