### PR TITLE
[Fix] Server install spins unbounded while waiting for the provider

### DIFF
--- a/app/Actions/Server/InstallServer.php
+++ b/app/Actions/Server/InstallServer.php
@@ -18,6 +18,8 @@ use Illuminate\Support\Sleep;
 
 class InstallServer
 {
+    private const MAX_WAIT_SECONDS = 180;
+
     protected Server $server;
 
     /**
@@ -27,20 +29,33 @@ class InstallServer
     {
         $this->server = $server;
 
-        $maxWait = 180;
+        $maxWait = self::MAX_WAIT_SECONDS;
+        $connected = false;
+        $lastError = null;
+
         while ($maxWait > 0) {
-            if (! $this->server->provider()->isRunning()) {
-                continue;
+            if ($this->server->provider()->isRunning()) {
+                try {
+                    $this->server->ssh()->connect();
+                    $connected = true;
+
+                    break;
+                } catch (SSHConnectionError $e) {
+                    $lastError = $e;
+                }
             }
-            try {
-                $this->server->ssh()->connect();
-                break;
-            } catch (SSHConnectionError) {
-                // ignore
-            }
+
             Sleep::sleep(10);
             $maxWait -= 10;
         }
+
+        if (! $connected) {
+            throw new SSHConnectionError(
+                'The server did not become reachable within '.self::MAX_WAIT_SECONDS.' seconds.',
+                previous: $lastError,
+            );
+        }
+
         $this->install();
         $this->server->update([
             'status' => ServerStatus::READY,

--- a/tests/Feature/Jobs/ServerInstallJobTest.php
+++ b/tests/Feature/Jobs/ServerInstallJobTest.php
@@ -1,9 +1,17 @@
 <?php
 
+use App\Actions\Server\InstallServer;
 use App\Enums\ServerStatus;
+use App\Exceptions\SSHConnectionError;
+use App\Facades\SSH;
 use App\Jobs\Server\InstallJob;
+use App\Models\ServerProvider;
+use App\ServerProviders\DigitalOcean;
+use Carbon\CarbonInterval as Duration;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Sleep;
 
 uses(RefreshDatabase::class);
 
@@ -23,4 +31,93 @@ test('install job failed sets status to installation failed and logs', function 
         'server_id' => $this->server->id,
         'type' => 'server-installation-failed',
     ]);
+});
+
+test('waiting for the provider is bounded and paced when the instance never becomes active', function () {
+    SSH::fake();
+
+    $polls = 0;
+    Http::fake([
+        'api.digitalocean.com/v2/droplets/*' => function () use (&$polls) {
+            $polls++;
+
+            if ($polls > 50) {
+                throw new Error('isRunning() was polled '.$polls.' times: the wait loop is unbounded.');
+            }
+
+            return Http::response([
+                'droplet' => [
+                    'id' => 599103218,
+                    'status' => 'new',
+                    'networks' => ['v4' => []],
+                ],
+            ]);
+        },
+        '*' => Http::response([]),
+    ]);
+
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => DigitalOcean::id(),
+        'credentials' => ['token' => 'secret-token'],
+    ]);
+
+    $this->server->update([
+        'provider' => DigitalOcean::id(),
+        'provider_id' => $serverProvider->id,
+        'provider_data' => ['plan' => 's-1vcpu-512mb-10gb', 'region' => 'nyc1', 'droplet_id' => 599103218],
+        'ip' => '',
+        'status' => ServerStatus::INSTALLING,
+    ]);
+
+    expect(fn () => app(InstallServer::class)->run($this->server->refresh()))
+        ->toThrow(SSHConnectionError::class, 'The server did not become reachable within 180 seconds.');
+
+    expect($polls)->toBe(18);
+
+    Sleep::assertSleptTimes(18);
+    Sleep::assertSlept(fn (Duration $duration) => (int) $duration->totalSeconds === 10, 18);
+
+    $this->server->refresh();
+
+    expect($this->server->status)->toEqual(ServerStatus::INSTALLING);
+});
+
+test('the underlying ssh failure is preserved when the server never becomes reachable', function () {
+    SSH::fake()->connectionWillFail();
+
+    Http::fake([
+        'api.digitalocean.com/v2/droplets/*' => Http::response([
+            'droplet' => [
+                'id' => 599103218,
+                'status' => 'active',
+                'networks' => ['v4' => [['type' => 'public', 'ip_address' => '164.92.1.1']]],
+            ],
+        ]),
+        '*' => Http::response([]),
+    ]);
+
+    $serverProvider = ServerProvider::factory()->create([
+        'user_id' => $this->user->id,
+        'provider' => DigitalOcean::id(),
+        'credentials' => ['token' => 'secret-token'],
+    ]);
+
+    $this->server->update([
+        'provider' => DigitalOcean::id(),
+        'provider_id' => $serverProvider->id,
+        'provider_data' => ['plan' => 's-1vcpu-512mb-10gb', 'region' => 'nyc1', 'droplet_id' => 599103218],
+        'ip' => '',
+        'status' => ServerStatus::INSTALLING,
+    ]);
+
+    try {
+        app(InstallServer::class)->run($this->server->refresh());
+
+        $this->fail('Expected InstallServer to throw.');
+    } catch (SSHConnectionError $e) {
+        expect($e->getMessage())->toBe('The server did not become reachable within 180 seconds.')
+            ->and($e->getPrevious())->toBeInstanceOf(SSHConnectionError::class)
+            ->and($e->getPrevious()?->getMessage())->toBe('Connection failed');
+    }
 });


### PR DESCRIPTION
## Problem

`InstallServer::run()` waits for the provider instance to come up before connecting over SSH:

```php
$maxWait = 180;
while ($maxWait > 0) {
    if (! $this->server->provider()->isRunning()) {
        continue;
    }
    ...
    Sleep::sleep(10);
    $maxWait -= 10;
}
```

The `continue` skips both `Sleep::sleep(10)` and the `$maxWait` decrement, so while the instance is not running yet the loop never pauses and never expires. `isRunning()` calls the provider API on every iteration, so the worker spins at full speed hammering the provider.

In the common case the instance becomes active after a few seconds and the loop escapes, having burned CPU and provider rate limit in the meantime. If the instance never reaches a running state — a provisioning failure, a quota rejection, an instance deleted out from under us — the job never returns and the `ssh` queue worker is stuck on it indefinitely.

## Fix

Poll inside the bounded part of the loop so every iteration sleeps and decrements, and track whether a connection was actually established. If the timeout is reached without one, throw `SSHConnectionError` instead of falling through to `install()`.

Falling through was the previous behaviour once the loop did expire: `install()` would fail on its first SSH call with a less obvious error. Throwing at the point the wait gives up names the actual cause, and `InstallJob::failed()` still handles it the same way — the server is marked installation-failed and the notification is sent.

The `180` literal moved to a `MAX_WAIT_SECONDS` constant so the message and the loop cannot drift apart.

## Tests

`tests/Feature/Jobs/ServerInstallJobTest.php` fakes a DigitalOcean droplet that stays in `new` forever and counts how many times the provider is polled. The fake throws once polling passes 50, which is what makes the test terminate at all on the current code rather than hanging.

Against `4.x` as it stands the test fails with:

```
isRunning() was polled 51 times: the wait loop is unbounded.
```

With the fix, polling is bounded to the 18 iterations the 180s budget allows, `SSHConnectionError` is raised, and the server is left in `installing` for `InstallJob::failed()` to transition.

Verified locally: Pint, PHPStan and the test suite all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Server installation attempts now stop reliably when a new server does not become reachable within the expected waiting period.
  - Users receive a clear connection error instead of an installation process that could continue indefinitely.
  - Underlying SSH connection errors are preserved when installation fails.
  - Server status remains marked as **Installing** when the connection attempt fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->